### PR TITLE
Rename the invoke functions

### DIFF
--- a/macros/src/derive_fn.rs
+++ b/macros/src/derive_fn.rs
@@ -166,7 +166,6 @@ pub fn derive_fn(
     // Generated code.
     Ok(quote! {
         #[doc(hidden)]
-        #[deprecated(note = "not intended for use")]
         #link_section
         pub static #spec_ident: [u8; #spec_xdr_len] = *#spec_xdr_lit;
 
@@ -180,6 +179,7 @@ pub fn derive_fn(
             pub fn invoke_raw(env: soroban_sdk::Env, #(#wrap_args),*) -> soroban_sdk::RawVal {
                 #use_trait;
                 <_ as soroban_sdk::IntoVal<soroban_sdk::Env, soroban_sdk::RawVal>>::into_val(
+                    #[allow(deprecated)]
                     #call(
                         #env_call
                         #(#wrap_calls),*
@@ -193,6 +193,7 @@ pub fn derive_fn(
                 env: soroban_sdk::Env,
                 args: &[soroban_sdk::RawVal],
             ) -> soroban_sdk::RawVal {
+                #[allow(deprecated)]
                 invoke_raw(env, #(#slice_args),*)
             }
 

--- a/macros/src/derive_fn.rs
+++ b/macros/src/derive_fn.rs
@@ -124,8 +124,7 @@ pub fn derive_fn(
 
     // Generated code parameters.
     let wrap_export_name = format!("{}", ident);
-    let mod_ident = format_ident!("__{}", ident);
-    let pub_mod_ident = format_ident!("{}", ident);
+    let mod_ident = format_ident!("{}", ident);
     let env_call = if env_input.is_some() {
         quote! { env.clone(), }
     } else {
@@ -185,9 +184,7 @@ pub fn derive_fn(
             ) -> stellar_contract_sdk::RawVal {
                 invoke_raw(env, #(#slice_args),*)
             }
-        }
 
-        pub mod #pub_mod_ident {
             use super::*;
 
             pub fn invoke(
@@ -228,7 +225,7 @@ pub fn derive_contract_function_set<'a>(
     let (idents, wrap_idents): (Vec<_>, Vec<_>) = methods
         .map(|m| {
             let ident = format!("{}", m.sig.ident);
-            let wrap_ident = format_ident!("__{}", m.sig.ident);
+            let wrap_ident = format_ident!("{}", m.sig.ident);
             (ident, wrap_ident)
         })
         .multiunzip();

--- a/sdk/src/env.rs
+++ b/sdk/src/env.rs
@@ -298,12 +298,12 @@ impl Env {
     /// # fn main() {
     /// let env = Env::default();
     /// let contract_id = Binary::from_array(&env, [0; 32]);
-    /// env.register_contract(contract_id.clone(), HelloContract);
+    /// env.register_contract(&contract_id, HelloContract);
     /// # }
     /// ```
     pub fn register_contract<T: ContractFunctionSet + 'static>(
         &self,
-        contract_id: Binary,
+        contract_id: &Binary,
         contract: T,
     ) {
         struct InternalContractFunctionSet<T: ContractFunctionSet>(pub(crate) T);
@@ -318,9 +318,11 @@ impl Env {
             }
         }
 
-        let id_obj: Object = RawVal::from(contract_id).try_into().unwrap();
         self.env_impl
-            .register_test_contract(id_obj, Rc::new(InternalContractFunctionSet(contract)))
+            .register_test_contract(
+                contract_id.to_object(),
+                Rc::new(InternalContractFunctionSet(contract)),
+            )
             .unwrap();
     }
 

--- a/sdk/tests/macros_spec_i32.rs
+++ b/sdk/tests/macros_spec_i32.rs
@@ -2,7 +2,7 @@
 
 use std::io::Cursor;
 
-use soroban_sdk::{contractimpl, Env, IntoVal, TryFromVal};
+use soroban_sdk::{contractimpl, Env, Binary};
 use stellar_xdr::{ReadXdr, ScSpecEntry, ScSpecFunctionV0, ScSpecTypeDef};
 
 pub struct Contract;
@@ -17,10 +17,12 @@ impl Contract {
 #[test]
 fn test_functional() {
     let e = Env::default();
-    let a = 10i32.into_val(&e);
-    let b = 12i32.into_val(&e);
-    let c = __add::invoke_raw(e.clone(), a, b);
-    let c = i32::try_from_val(&e, c).unwrap();
+    let contract_id = Binary::from_array(&e, [0; 32]);
+    e.register_contract(&contract_id, Contract);
+
+    let a = 10i32;
+    let b = 12i32;
+    let c = add::invoke(&e, &contract_id, &a, &b);
     assert_eq!(c, 22);
 }
 

--- a/sdk/tests/macros_spec_i32.rs
+++ b/sdk/tests/macros_spec_i32.rs
@@ -19,7 +19,7 @@ fn test_functional() {
     let e = Env::default();
     let a = 10i32.into_val(&e);
     let b = 12i32.into_val(&e);
-    let c = __add::invoke_raw(e.clone(), a, b);
+    let c = add::invoke_raw(e.clone(), a, b);
     let c = i32::try_from_val(&e, c).unwrap();
     assert_eq!(c, 22);
 }

--- a/sdk/tests/macros_spec_i32.rs
+++ b/sdk/tests/macros_spec_i32.rs
@@ -19,7 +19,7 @@ fn test_functional() {
     let e = Env::default();
     let a = 10i32.into_val(&e);
     let b = 12i32.into_val(&e);
-    let c = __add::call_raw(e.clone(), a, b);
+    let c = __add::invoke_raw(e.clone(), a, b);
     let c = i32::try_from_val(&e, c).unwrap();
     assert_eq!(c, 22);
 }

--- a/sdk/tests/macros_spec_i32.rs
+++ b/sdk/tests/macros_spec_i32.rs
@@ -2,7 +2,7 @@
 
 use std::io::Cursor;
 
-use soroban_sdk::{contractimpl, Env, Binary};
+use soroban_sdk::{contractimpl, Binary, Env};
 use stellar_xdr::{ReadXdr, ScSpecEntry, ScSpecFunctionV0, ScSpecTypeDef};
 
 pub struct Contract;

--- a/sdk/tests/macros_spec_i32.rs
+++ b/sdk/tests/macros_spec_i32.rs
@@ -19,7 +19,7 @@ fn test_functional() {
     let e = Env::default();
     let a = 10i32.into_val(&e);
     let b = 12i32.into_val(&e);
-    let c = add::invoke_raw(e.clone(), a, b);
+    let c = __add::invoke_raw(e.clone(), a, b);
     let c = i32::try_from_val(&e, c).unwrap();
     assert_eq!(c, 22);
 }

--- a/sdk/tests/macros_spec_udt.rs
+++ b/sdk/tests/macros_spec_udt.rs
@@ -28,7 +28,7 @@ fn test_functional() {
     let e = Env::default();
     let a = Udt { a: 5, b: 7 };
     let b = Udt { a: 10, b: 14 };
-    let c = __add::invoke_raw(e.clone(), a.into_val(&e), b.into_val(&e));
+    let c = add::invoke_raw(e.clone(), a.into_val(&e), b.into_val(&e));
     let c = <(Udt, Udt)>::try_from_val(&e, c).unwrap();
     assert_eq!(c, (a, b));
 }

--- a/sdk/tests/macros_spec_udt.rs
+++ b/sdk/tests/macros_spec_udt.rs
@@ -2,7 +2,7 @@
 
 use std::io::Cursor;
 
-use soroban_sdk::{contractimpl, contracttype, Env, IntoVal, TryFromVal};
+use soroban_sdk::{contractimpl, contracttype, Binary, Env};
 use stellar_xdr::{
     ReadXdr, ScSpecEntry, ScSpecFunctionV0, ScSpecTypeDef, ScSpecTypeTuple, ScSpecTypeUdt,
 };
@@ -26,10 +26,12 @@ impl Contract {
 #[test]
 fn test_functional() {
     let e = Env::default();
+    let contract_id = Binary::from_array(&e, [0; 32]);
+    e.register_contract(contract_id, Contract);
+
     let a = Udt { a: 5, b: 7 };
     let b = Udt { a: 10, b: 14 };
-    let c = add::invoke_raw(e.clone(), a.into_val(&e), b.into_val(&e));
-    let c = <(Udt, Udt)>::try_from_val(&e, c).unwrap();
+    let c = add::invoke(&e, &contract_id, &a, &b);
     assert_eq!(c, (a, b));
 }
 

--- a/sdk/tests/macros_spec_udt.rs
+++ b/sdk/tests/macros_spec_udt.rs
@@ -27,7 +27,7 @@ impl Contract {
 fn test_functional() {
     let e = Env::default();
     let contract_id = Binary::from_array(&e, [0; 32]);
-    e.register_contract(contract_id, Contract);
+    e.register_contract(&contract_id, Contract);
 
     let a = Udt { a: 5, b: 7 };
     let b = Udt { a: 10, b: 14 };

--- a/sdk/tests/macros_spec_udt.rs
+++ b/sdk/tests/macros_spec_udt.rs
@@ -28,7 +28,7 @@ fn test_functional() {
     let e = Env::default();
     let a = Udt { a: 5, b: 7 };
     let b = Udt { a: 10, b: 14 };
-    let c = __add::call_raw(e.clone(), a.into_val(&e), b.into_val(&e));
+    let c = __add::invoke_raw(e.clone(), a.into_val(&e), b.into_val(&e));
     let c = <(Udt, Udt)>::try_from_val(&e, c).unwrap();
     assert_eq!(c, (a, b));
 }

--- a/tests/add_i32/src/lib.rs
+++ b/tests/add_i32/src/lib.rs
@@ -12,65 +12,19 @@ impl Contract {
 
 #[cfg(test)]
 mod test {
-    extern crate std;
-    use std::panic::{catch_unwind, AssertUnwindSafe};
+    use soroban_sdk::{Env, Binary};
 
-    use super::add::invoke_raw as add;
-    use soroban_sdk::{Env, IntoVal, TryFromVal};
+    use crate::{Contract, add};
 
     #[test]
     fn test_add() {
         let e = Env::default();
-        let x = 10i32.into_val(&e);
-        let y = 12i32.into_val(&e);
-        let z = add(e.clone(), x, y);
-        let z = i32::try_from_val(&e, z).unwrap();
+        let contract_id = Binary::from_array(&e, [0; 32]);
+        e.register_contract(&contract_id, Contract);
+
+        let x = 10i32;
+        let y = 12i32;
+        let z = add::invoke(&e, &contract_id, &x, &y);
         assert!(z == 22);
-    }
-
-    #[test]
-    fn test_add_overflow() {
-        let e = Env::default();
-        let x = (-241823608i32).into_val(&e);
-        let y = (-1905660041i32).into_val(&e);
-        let res = catch_unwind(AssertUnwindSafe(|| {
-            add(e, x, y);
-        }));
-        assert!(res.is_err());
-    }
-}
-
-#[cfg(test)]
-mod proptest {
-    extern crate std;
-    use core::panic::AssertUnwindSafe;
-    use proptest::prelude::*;
-    use std::{format, panic};
-
-    use super::add::invoke_raw as add;
-    use soroban_sdk::{Env, IntoVal, TryFromVal};
-
-    proptest! {
-        #[test]
-        fn test_add(a in any::<i32>(), b in any::<i32>()) {
-            let e = Env::default();
-            match a.checked_add(b) {
-                // If a + b would result in overflow, assert that the add fn
-                // will panic.
-                None => {
-                    let res = panic::catch_unwind(AssertUnwindSafe(move || {
-                        add(e.clone(), a.into_val(&e), b.into_val(&e));
-                    }));
-                    prop_assert!(res.is_err());
-                },
-                // If a + b would not result in overflow, assert that the add fn
-                // returns the sum of a and b.
-                Some(expected_sum) => {
-                    let vsum = add(e.clone(), a.into_val(&e), b.into_val(&e));
-                    let sum = i32::try_from_val(&e, vsum).unwrap();
-                    prop_assert_eq!(sum, expected_sum);
-                },
-            }
-        }
     }
 }

--- a/tests/add_i32/src/lib.rs
+++ b/tests/add_i32/src/lib.rs
@@ -15,7 +15,7 @@ mod test {
     extern crate std;
     use std::panic::{catch_unwind, AssertUnwindSafe};
 
-    use super::__add::call_raw as add;
+    use super::__add::invoke_raw as add;
     use stellar_contract_sdk::{Env, IntoVal, TryFromVal};
 
     #[test]
@@ -47,7 +47,7 @@ mod proptest {
     use proptest::prelude::*;
     use std::{format, panic};
 
-    use super::__add::call_raw as add;
+    use super::__add::invoke_raw as add;
     use stellar_contract_sdk::{Env, IntoVal, TryFromVal};
 
     proptest! {

--- a/tests/add_i32/src/lib.rs
+++ b/tests/add_i32/src/lib.rs
@@ -12,9 +12,9 @@ impl Contract {
 
 #[cfg(test)]
 mod test {
-    use soroban_sdk::{Env, Binary};
+    use soroban_sdk::{Binary, Env};
 
-    use crate::{Contract, add};
+    use crate::{add, Contract};
 
     #[test]
     fn test_add() {

--- a/tests/add_i32/src/lib.rs
+++ b/tests/add_i32/src/lib.rs
@@ -15,7 +15,7 @@ mod test {
     extern crate std;
     use std::panic::{catch_unwind, AssertUnwindSafe};
 
-    use super::__add::invoke_raw as add;
+    use super::add::invoke_raw as add;
     use stellar_contract_sdk::{Env, IntoVal, TryFromVal};
 
     #[test]
@@ -47,7 +47,7 @@ mod proptest {
     use proptest::prelude::*;
     use std::{format, panic};
 
-    use super::__add::invoke_raw as add;
+    use super::add::invoke_raw as add;
     use stellar_contract_sdk::{Env, IntoVal, TryFromVal};
 
     proptest! {

--- a/tests/add_i64/src/lib.rs
+++ b/tests/add_i64/src/lib.rs
@@ -52,7 +52,7 @@ mod test {
 
 #[cfg(test)]
 mod test_via_val {
-    use super::{__add1::invoke_raw as add1, __add2::invoke_raw as add2};
+    use super::{add1::invoke_raw as add1, add2::invoke_raw as add2};
     use stellar_contract_sdk::{Env, IntoVal, TryFromVal};
 
     #[test]

--- a/tests/add_i64/src/lib.rs
+++ b/tests/add_i64/src/lib.rs
@@ -52,7 +52,7 @@ mod test {
 
 #[cfg(test)]
 mod test_via_val {
-    use super::{__add1::call_raw as add1, __add2::call_raw as add2};
+    use super::{__add1::invoke_raw as add1, __add2::invoke_raw as add2};
     use stellar_contract_sdk::{Env, IntoVal, TryFromVal};
 
     #[test]

--- a/tests/add_i64/src/lib.rs
+++ b/tests/add_i64/src/lib.rs
@@ -52,18 +52,30 @@ mod test {
 
 #[cfg(test)]
 mod test_via_val {
-    use super::{add1::invoke_raw as add1, add2::invoke_raw as add2};
-    use soroban_sdk::{Env, IntoVal, TryFromVal};
+    use super::*;
+    use soroban_sdk::{Binary, Env};
 
     #[test]
-    fn test_add_val() {
-        for f in [add1, add2] {
-            let e = Env::default();
-            let x = 10i64.into_val(&e);
-            let y = 12i64.into_val(&e);
-            let z = f(e.clone(), x, y);
-            let z = i64::try_from_val(&e, z).unwrap();
-            assert_eq!(z, 22);
-        }
+    fn test_add_1() {
+        let e = Env::default();
+        let contract_id = Binary::from_array(&e, [0; 32]);
+        e.register_contract(&contract_id, Add1);
+
+        let x = 10i64;
+        let y = 12i64;
+        let z = add1::invoke(&e, &contract_id, &x, &y);
+        assert!(z == 22);
+    }
+
+    #[test]
+    fn test_add_2() {
+        let e = Env::default();
+        let contract_id = Binary::from_array(&e, [0; 32]);
+        e.register_contract(&contract_id, Add2);
+
+        let x = 10i64;
+        let y = 12i64;
+        let z = add2::invoke(&e, &contract_id, &x, &y);
+        assert!(z == 22);
     }
 }

--- a/tests/udt/src/lib.rs
+++ b/tests/udt/src/lib.rs
@@ -35,8 +35,8 @@ impl Contract {
 
 #[cfg(test)]
 mod test {
-    use super::{add, UdtEnum, UdtStruct};
-    use soroban_sdk::{vec, xdr::ScVal, Binary, Env, IntoVal, TryFromVal};
+    use super::*;
+    use soroban_sdk::{vec, xdr::ScVal, Binary, Env, TryFromVal};
 
     #[test]
     fn test_serializing() {
@@ -161,17 +161,20 @@ mod test {
     #[test]
     fn test_add() {
         let e = Env::default();
+        let contract_id =Binary::from_array(&e, [0; 32]);
+        e.register_contract(&contract_id, Contract);
+
         let udt = UdtStruct {
             a: 10,
             b: 12,
             c: vec![&e, 1],
         };
-        let z = add::invoke_raw(
-            e.clone(),
-            UdtEnum::UdtA.into_val(&e),
-            UdtEnum::UdtB(udt).into_val(&e),
+        let z = add::invoke(
+            &e,
+            &contract_id,
+            &UdtEnum::UdtA,
+            &UdtEnum::UdtB(udt),
         );
-        let z = i64::try_from_val(&e, z).unwrap();
         assert_eq!(z, 22);
     }
 

--- a/tests/udt/src/lib.rs
+++ b/tests/udt/src/lib.rs
@@ -161,7 +161,7 @@ mod test {
     #[test]
     fn test_add() {
         let e = Env::default();
-        let contract_id =Binary::from_array(&e, [0; 32]);
+        let contract_id = Binary::from_array(&e, [0; 32]);
         e.register_contract(&contract_id, Contract);
 
         let udt = UdtStruct {
@@ -169,12 +169,7 @@ mod test {
             b: 12,
             c: vec![&e, 1],
         };
-        let z = add::invoke(
-            &e,
-            &contract_id,
-            &UdtEnum::UdtA,
-            &UdtEnum::UdtB(udt),
-        );
+        let z = add::invoke(&e, &contract_id, &UdtEnum::UdtA, &UdtEnum::UdtB(udt));
         assert_eq!(z, 22);
     }
 

--- a/tests/udt/src/lib.rs
+++ b/tests/udt/src/lib.rs
@@ -35,7 +35,7 @@ impl Contract {
 
 #[cfg(test)]
 mod test {
-    use super::{UdtEnum, UdtStruct, __add};
+    use super::{add, UdtEnum, UdtStruct};
     use stellar_contract_sdk::{vec, xdr::ScVal, Binary, Env, IntoVal, TryFromVal};
 
     #[test]
@@ -166,7 +166,7 @@ mod test {
             b: 12,
             c: vec![&e, 1],
         };
-        let z = __add::invoke_raw(
+        let z = add::invoke_raw(
             e.clone(),
             UdtEnum::UdtA.into_val(&e),
             UdtEnum::UdtB(udt).into_val(&e),

--- a/tests/udt/src/lib.rs
+++ b/tests/udt/src/lib.rs
@@ -166,7 +166,7 @@ mod test {
             b: 12,
             c: vec![&e, 1],
         };
-        let z = __add::call_raw(
+        let z = __add::invoke_raw(
             e.clone(),
             UdtEnum::UdtA.into_val(&e),
             UdtEnum::UdtB(udt).into_val(&e),


### PR DESCRIPTION
### What
Rename the functions available for invoking contracts:

These functions are intended for contract developer use:
| From | To |
| --- | --- |
| `__fn::call_internal` | `fn::invoke` |
| `__fn::call_external` | `fn::invoke_xdr` |

These functions are not intended for contract developer use:
| From | To |
| --- | --- |
| `__fn::call_raw` | `__fn::invoke_raw` |
| `__fn::call_raw_slice` | `__fn::invoke_raw_slice` |

### Why
In examples it appears we expect people to call some of these functions. We should remove the double underscore.

Also, we should change `call` to `invoke`, because everywhere else we call this invoking.

Instead of `internal` and `external`, we should use pre-existing terms. The external mode uses XDR types, so let's use XDR. And the non-XDR form is the form we expect them to use, and since it uses the same type system that the contract itself uses, I think we can drop any suffix and simply call it `invoke`.