### PR TITLE
Remove BitSet from public interface

### DIFF
--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -27,6 +27,7 @@ pub use env::IntoVal;
 pub use env::TryFromVal;
 pub use env::TryIntoVal;
 
+pub use env::Status;
 pub use env::Symbol;
 
 mod envhidden {

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -27,8 +27,6 @@ pub use env::IntoVal;
 pub use env::TryFromVal;
 pub use env::TryIntoVal;
 
-pub use env::BitSet;
-pub use env::Status;
 pub use env::Symbol;
 
 mod envhidden {

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -27,7 +27,6 @@ pub use env::IntoVal;
 pub use env::TryFromVal;
 pub use env::TryIntoVal;
 
-pub use env::Status;
 pub use env::Symbol;
 
 mod envhidden {


### PR DESCRIPTION
### What
Remove the BitSet from the public interface for the moment.

### Why
We are likely to remove BitSet all together as a type.