### PR TITLE
Use FixedBinary for contact IDs

### DIFF
--- a/macros/src/derive_fn.rs
+++ b/macros/src/derive_fn.rs
@@ -205,20 +205,20 @@ pub fn derive_fn(
 
             pub fn invoke(
                 e: &soroban_sdk::Env,
-                contract_id: &soroban_sdk::Binary,
+                contract_id: &soroban_sdk::FixedBinary<32>,
                 #(#invoke_args),*
             ) #output {
                 use soroban_sdk::{EnvVal, IntoVal, Symbol, Vec};
                 let mut args: Vec<EnvVal> = Vec::new(e);
                 #(args.push(#invoke_idents.clone().into_env_val(e));)*
-                e.invoke_contract(contract_id.clone(), Symbol::from_str(#wrap_export_name), args)
+                e.invoke_contract(contract_id, Symbol::from_str(#wrap_export_name), args)
             }
 
             #[cfg(feature = "testutils")]
             #[cfg_attr(feature = "docs", doc(cfg(feature = "testutils")))]
             pub fn invoke_xdr(
                 e: &soroban_sdk::Env,
-                contract_id: &soroban_sdk::Binary,
+                contract_id: &soroban_sdk::FixedBinary<32>,
                 #(#invoke_args),*
             ) #output {
                 use soroban_sdk::TryIntoVal;

--- a/macros/src/map_type.rs
+++ b/macros/src/map_type.rs
@@ -92,6 +92,8 @@ pub fn map_type(t: &Type) -> Result<ScSpecTypeDef, Error> {
                             value_type: Box::new(map_type(v)?),
                         })))
                     }
+                    // TODO: Add proper support for FixedBinary as a first class spec type.
+                    "FixedBinary" => Ok(ScSpecTypeDef::Binary),
                     _ => Err(Error::new(
                         angle_bracketed.span(),
                         "generics unsupported on user-defined types in contract functions",

--- a/sdk/src/env.rs
+++ b/sdk/src/env.rs
@@ -195,7 +195,11 @@ impl Env {
     }
 
     #[doc(hidden)]
-    pub fn create_contract_from_contract(&self, contract: FixedBinary<32>, salt: Binary) -> FixedBinary<32> {
+    pub fn create_contract_from_contract(
+        &self,
+        contract: FixedBinary<32>,
+        salt: Binary,
+    ) -> FixedBinary<32> {
         let contract_obj: Object = RawVal::from(contract).try_into().unwrap();
         let salt_obj: Object = RawVal::from(salt).try_into().unwrap();
         let id_obj = internal::Env::create_contract_from_contract(self, contract_obj, salt_obj);

--- a/sdk/src/env.rs
+++ b/sdk/src/env.rs
@@ -168,7 +168,7 @@ impl Env {
     }
 
     /// Computes a SHA-256 hash.
-    pub fn compute_hash_sha256(&self, msg: Binary) -> Binary {
+    pub fn compute_hash_sha256(&self, msg: Binary) -> FixedBinary<32> {
         let bin_obj = internal::Env::compute_hash_sha256(self, msg.into());
         bin_obj.in_env(self).try_into().unwrap()
     }
@@ -185,7 +185,7 @@ impl Env {
     /// ### TODO
     ///
     /// Return a [Result] instead of panicking.
-    pub fn verify_sig_ed25519(&self, sig: Binary, pk: Binary, msg: Binary) {
+    pub fn verify_sig_ed25519(&self, sig: FixedBinary<64>, pk: FixedBinary<32>, msg: Binary) {
         let sig_obj: Object = RawVal::from(sig).try_into().unwrap();
         let pk_obj: Object = RawVal::from(pk).try_into().unwrap();
         let msg_obj: Object = RawVal::from(msg).try_into().unwrap();

--- a/sdk/src/env.rs
+++ b/sdk/src/env.rs
@@ -185,11 +185,8 @@ impl Env {
     /// ### TODO
     ///
     /// Return a [Result] instead of panicking.
-    pub fn verify_sig_ed25519(&self, sig: FixedBinary<64>, pk: FixedBinary<32>, msg: Binary) {
-        let sig_obj: Object = RawVal::from(sig).try_into().unwrap();
-        let pk_obj: Object = RawVal::from(pk).try_into().unwrap();
-        let msg_obj: Object = RawVal::from(msg).try_into().unwrap();
-        internal::Env::verify_sig_ed25519(self, msg_obj, pk_obj, sig_obj)
+    pub fn verify_sig_ed25519(&self, pk: FixedBinary<32>, msg: Binary, sig: FixedBinary<64>) {
+        internal::Env::verify_sig_ed25519(self, msg.to_object(), pk.to_object(), sig.to_object())
             .try_into()
             .unwrap()
     }

--- a/sdk/src/env.rs
+++ b/sdk/src/env.rs
@@ -1,3 +1,4 @@
+use core::borrow::Borrow;
 use core::fmt::Debug;
 
 #[cfg(target_family = "wasm")]
@@ -90,16 +91,13 @@ impl Env {
     /// Return a [Result] instead of panic.
     pub fn invoke_contract<T: TryFromVal<Env, RawVal>>(
         &self,
-        contract_id: Binary,
-        func: Symbol,
+        contract_id: impl Borrow<FixedBinary<32>>,
+        func: impl Borrow<Symbol>,
         args: crate::vec::Vec<EnvVal>,
     ) -> T {
-        let rv = internal::Env::call(
-            self,
-            RawVal::from(contract_id).try_into().unwrap(),
-            func,
-            args.to_object(),
-        );
+        let contract_id = contract_id.borrow();
+        let func = func.borrow();
+        let rv = internal::Env::call(self, contract_id.to_object(), *func, args.to_object());
         T::try_from_val(&self, rv).map_err(|_| ()).unwrap()
     }
 
@@ -197,7 +195,7 @@ impl Env {
     }
 
     #[doc(hidden)]
-    pub fn create_contract_from_contract(&self, contract: Binary, salt: Binary) -> FixedBinary<32> {
+    pub fn create_contract_from_contract(&self, contract: FixedBinary<32>, salt: Binary) -> FixedBinary<32> {
         let contract_obj: Object = RawVal::from(contract).try_into().unwrap();
         let salt_obj: Object = RawVal::from(salt).try_into().unwrap();
         let id_obj = internal::Env::create_contract_from_contract(self, contract_obj, salt_obj);
@@ -284,7 +282,7 @@ impl Env {
     ///
     /// ### Examples
     /// ```
-    /// use soroban_sdk::{contractimpl, Binary, Env, Symbol};
+    /// use soroban_sdk::{contractimpl, FixedBinary, Env, Symbol};
     ///
     /// pub struct HelloContract;
     ///
@@ -297,13 +295,13 @@ impl Env {
     ///
     /// # fn main() {
     /// let env = Env::default();
-    /// let contract_id = Binary::from_array(&env, [0; 32]);
+    /// let contract_id = FixedBinary::from_array(&env, [0; 32]);
     /// env.register_contract(&contract_id, HelloContract);
     /// # }
     /// ```
     pub fn register_contract<T: ContractFunctionSet + 'static>(
         &self,
-        contract_id: &Binary,
+        contract_id: &FixedBinary<32>,
         contract: T,
     ) {
         struct InternalContractFunctionSet<T: ContractFunctionSet>(pub(crate) T);

--- a/sdk/tests/macros_spec_i32.rs
+++ b/sdk/tests/macros_spec_i32.rs
@@ -2,7 +2,7 @@
 
 use std::io::Cursor;
 
-use soroban_sdk::{contractimpl, Binary, Env};
+use soroban_sdk::{contractimpl, Env, FixedBinary};
 use stellar_xdr::{ReadXdr, ScSpecEntry, ScSpecFunctionV0, ScSpecTypeDef};
 
 pub struct Contract;
@@ -17,7 +17,7 @@ impl Contract {
 #[test]
 fn test_functional() {
     let e = Env::default();
-    let contract_id = Binary::from_array(&e, [0; 32]);
+    let contract_id = FixedBinary::from_array(&e, [0; 32]);
     e.register_contract(&contract_id, Contract);
 
     let a = 10i32;

--- a/sdk/tests/macros_spec_udt.rs
+++ b/sdk/tests/macros_spec_udt.rs
@@ -2,7 +2,7 @@
 
 use std::io::Cursor;
 
-use soroban_sdk::{contractimpl, contracttype, Binary, Env};
+use soroban_sdk::{contractimpl, contracttype, Env, FixedBinary};
 use stellar_xdr::{
     ReadXdr, ScSpecEntry, ScSpecFunctionV0, ScSpecTypeDef, ScSpecTypeTuple, ScSpecTypeUdt,
 };
@@ -26,7 +26,7 @@ impl Contract {
 #[test]
 fn test_functional() {
     let e = Env::default();
-    let contract_id = Binary::from_array(&e, [0; 32]);
+    let contract_id = FixedBinary::from_array(&e, [0; 32]);
     e.register_contract(&contract_id, Contract);
 
     let a = Udt { a: 5, b: 7 };

--- a/tests/add_i32/src/lib.rs
+++ b/tests/add_i32/src/lib.rs
@@ -12,14 +12,14 @@ impl Contract {
 
 #[cfg(test)]
 mod test {
-    use soroban_sdk::{Binary, Env};
+    use soroban_sdk::{Env, FixedBinary};
 
     use crate::{add, Contract};
 
     #[test]
     fn test_add() {
         let e = Env::default();
-        let contract_id = Binary::from_array(&e, [0; 32]);
+        let contract_id = FixedBinary::from_array(&e, [0; 32]);
         e.register_contract(&contract_id, Contract);
 
         let x = 10i32;

--- a/tests/add_i64/src/lib.rs
+++ b/tests/add_i64/src/lib.rs
@@ -53,12 +53,12 @@ mod test {
 #[cfg(test)]
 mod test_via_val {
     use super::*;
-    use soroban_sdk::{Binary, Env};
+    use soroban_sdk::{Env, FixedBinary};
 
     #[test]
     fn test_add_1() {
         let e = Env::default();
-        let contract_id = Binary::from_array(&e, [0; 32]);
+        let contract_id = FixedBinary::from_array(&e, [0; 32]);
         e.register_contract(&contract_id, Add1);
 
         let x = 10i64;
@@ -70,7 +70,7 @@ mod test_via_val {
     #[test]
     fn test_add_2() {
         let e = Env::default();
-        let contract_id = Binary::from_array(&e, [0; 32]);
+        let contract_id = FixedBinary::from_array(&e, [0; 32]);
         e.register_contract(&contract_id, Add2);
 
         let x = 10i64;

--- a/tests/create_contract/src/lib.rs
+++ b/tests/create_contract/src/lib.rs
@@ -1,5 +1,5 @@
 #![no_std]
-use soroban_sdk::{contractimpl, Binary, Env};
+use soroban_sdk::{contractimpl, Binary, Env, FixedBinary};
 
 pub struct Contract;
 
@@ -7,7 +7,7 @@ pub struct Contract;
 impl Contract {
     // Note that anyone can create a contract here with any salt, so a users call to
     // this could be frontrun and the same salt taken.
-    pub fn create(e: Env, c: Binary, s: Binary) {
+    pub fn create(e: Env, c: FixedBinary<32>, s: Binary) {
         e.create_contract_from_contract(c, s);
     }
 }

--- a/tests/invoke_contract/src/lib.rs
+++ b/tests/invoke_contract/src/lib.rs
@@ -1,5 +1,5 @@
 #![no_std]
-use soroban_sdk::{contractimpl, Env, IntoVal, Symbol, Vec};
+use soroban_sdk::{contractimpl, Env, FixedBinary, IntoVal, Symbol, Vec};
 
 pub struct Contract;
 
@@ -8,8 +8,9 @@ impl Contract {
     pub fn delegate(e: Env, val: u32) {
         let buff = [1u8; 32];
         let cid = e.binary_new_from_linear_memory(buff.as_ptr() as u32, 32);
+        let cid: FixedBinary<32> = cid.try_into().unwrap();
         let fun = Symbol::from_str("vec_err");
         let args = Vec::from_array(&e, [val.into_env_val(&e); 1]);
-        e.invoke_contract::<Vec<u32>>(cid, fun.into(), args);
+        let _: Vec<u32> = e.invoke_contract(cid, fun, args);
     }
 }

--- a/tests/udt/src/lib.rs
+++ b/tests/udt/src/lib.rs
@@ -36,7 +36,7 @@ impl Contract {
 #[cfg(test)]
 mod test {
     use super::*;
-    use soroban_sdk::{vec, xdr::ScVal, Binary, Env, TryFromVal};
+    use soroban_sdk::{vec, xdr::ScVal, Binary, Env, FixedBinary, TryFromVal};
 
     #[test]
     fn test_serializing() {
@@ -161,7 +161,7 @@ mod test {
     #[test]
     fn test_add() {
         let e = Env::default();
-        let contract_id = Binary::from_array(&e, [0; 32]);
+        let contract_id = FixedBinary::from_array(&e, [0; 32]);
         e.register_contract(&contract_id, Contract);
 
         let udt = UdtStruct {


### PR DESCRIPTION
### What
Use FixedBinary<32> for contract IDs.

### Why
It's annoying when writing contract tests and not realizing that the contract ID has to be a specific length. This tripped me up when writing my first contracts, and then dealing with panics. 

### Known Limitation
@jonjove has pointed out that use of FixedBinary is in general questionable because it adds one additional branch to any code that converts from another type into the FixedBinary. This is because of the length check that occurs. We should try and make FixedBinary as performant as Binary, or remove it in the future all together. Follow up issue for addressing this issue is https://github.com/stellar/rs-soroban-sdk/issues/369.