### PR TITLE
Fix create_contract_from_contract

### DIFF
--- a/sdk/src/env.rs
+++ b/sdk/src/env.rs
@@ -191,8 +191,8 @@ impl Env {
     #[doc(hidden)]
     pub fn create_contract_from_contract(
         &self,
-        contract: FixedBinary<32>,
-        salt: Binary,
+        contract: Binary,
+        salt: FixedBinary<32>,
     ) -> FixedBinary<32> {
         let contract_obj: Object = RawVal::from(contract).try_into().unwrap();
         let salt_obj: Object = RawVal::from(salt).try_into().unwrap();

--- a/tests/create_contract/src/lib.rs
+++ b/tests/create_contract/src/lib.rs
@@ -7,7 +7,7 @@ pub struct Contract;
 impl Contract {
     // Note that anyone can create a contract here with any salt, so a users call to
     // this could be frontrun and the same salt taken.
-    pub fn create(e: Env, c: FixedBinary<32>, s: Binary) {
+    pub fn create(e: Env, c: Binary, s: FixedBinary<32>) {
         e.create_contract_from_contract(c, s);
     }
 }


### PR DESCRIPTION
### What

`create_contract_from_contract` had the wrong argument fixed length.

### Why

It's broken.

### Known limitations

None