### PR TITLE
Fix contractmetav0 custom section not emitted

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -802,7 +802,7 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk"
-version = "0.0.2"
+version = "0.0.3"
 dependencies = [
  "ed25519-dalek",
  "hex",
@@ -815,7 +815,7 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk-macros"
-version = "0.0.2"
+version = "0.0.3"
 dependencies = [
  "darling",
  "itertools",

--- a/macros/src/derive_fn.rs
+++ b/macros/src/derive_fn.rs
@@ -174,6 +174,13 @@ pub fn derive_fn(
         pub mod #hidden_mod_ident {
             use super::*;
 
+            /// Exposing the env meta XDR ensures that the link section in the
+            /// SDK is included in the build for this contract function. See
+            /// [soroban_sdk::__env_meta_xdr] for more details.
+            pub fn env_meta_xdr() -> &'static[u8] {
+                soroban_sdk::__env_meta_xdr()
+            }
+
             #[deprecated(note = #deprecated_note)]
             #export_name
             pub fn invoke_raw(env: soroban_sdk::Env, #(#wrap_args),*) -> soroban_sdk::RawVal {

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -8,8 +8,18 @@ fn handle_panic(_: &core::panic::PanicInfo) -> ! {
     core::arch::wasm32::unreachable()
 }
 
-#[cfg_attr(target_family = "wasm", link_section = "contractenvmetav0")]
-static ENV_META_XDR: [u8; env::meta::XDR.len()] = env::meta::XDR;
+/// Env meta XDR returns the env meta XDR that describes the environment this
+/// SDK is built with. This link section exists inside an exported function
+/// which is imported by each contract function to ensure that the link section
+/// is referenced by every object file that gets built, to ensure the link
+/// section isn't only referenced in an object file that gets discarded.
+/// See https://github.com/stellar/rs-soroban-sdk/issues/383 for more details.
+#[doc(hidden)]
+pub fn __env_meta_xdr() -> &'static [u8] {
+    #[cfg_attr(target_family = "wasm", link_section = "contractenvmetav0")]
+    static __ENV_META_XDR: [u8; env::meta::XDR.len()] = env::meta::XDR;
+    &__ENV_META_XDR
+}
 
 pub use soroban_sdk_macros::{contractimpl, contracttype, ContractType};
 


### PR DESCRIPTION
### What
Move contractmetav0 custom section link section static variable into function that is exported instead of being a crate root static, and reference that exported function in the crates of contracts.

### Why
The custom section is not always in contracts when contracts are built with `codegen-units` greater than 1. Because the custom section is not in the contract crate itself, it could end up in an object file for the SDK that doesn't end up getting linked. When `codegen-units` is 1 this isn't an issue because there should only be one.

We recommend that `codegen-units` should always be 1 to improve the optimization of the contract builds, but this is an annoying footgun for anyone who misses that.

By moving the link section into an exported function that gets referenced in the contract crate, the object file should always be included in linking. We reference it in every contract function because there is no way to just do it once for all functions since macros have no contract state.

I tested this change with the examples to make sure that it didn't increase the size of the binary. No binaries changed.

Close https://github.com/stellar/rs-soroban-sdk/issues/383