### PR TITLE
Fix contractenvmetav0 not being emitted (again)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -761,7 +761,7 @@ dependencies = [
 [[package]]
 name = "soroban-env-guest"
 version = "0.0.3"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=79e55e4c#79e55e4ca4b1b7a9284b712039d7c9a930b17beb"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=21bc98a#21bc98a3735aa3bdacba0c4ed04baec2c6b8fce0"
 dependencies = [
  "soroban-env-common",
  "static_assertions",
@@ -770,7 +770,7 @@ dependencies = [
 [[package]]
 name = "soroban-env-host"
 version = "0.0.3"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=79e55e4c#79e55e4ca4b1b7a9284b712039d7c9a930b17beb"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=21bc98a#21bc98a3735aa3bdacba0c4ed04baec2c6b8fce0"
 dependencies = [
  "backtrace",
  "dyn-fmt",

--- a/macros/src/derive_fn.rs
+++ b/macros/src/derive_fn.rs
@@ -174,13 +174,6 @@ pub fn derive_fn(
         pub mod #hidden_mod_ident {
             use super::*;
 
-            /// Exposing the env meta XDR ensures that the link section in the
-            /// SDK is included in the build for this contract function. See
-            /// [soroban_sdk::__env_meta_xdr] for more details.
-            pub fn env_meta_xdr() -> &'static[u8] {
-                soroban_sdk::__env_meta_xdr()
-            }
-
             #[deprecated(note = #deprecated_note)]
             #export_name
             pub fn invoke_raw(env: soroban_sdk::Env, #(#wrap_args),*) -> soroban_sdk::RawVal {

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -8,17 +8,29 @@ fn handle_panic(_: &core::panic::PanicInfo) -> ! {
     core::arch::wasm32::unreachable()
 }
 
-/// Env meta XDR returns the env meta XDR that describes the environment this
-/// SDK is built with. This link section exists inside an exported function
-/// which is imported by each contract function to ensure that the link section
-/// is referenced by every object file that gets built, to ensure the link
-/// section isn't only referenced in an object file that gets discarded.
+/// __link_sections returns and does nothing, but it contains link sections that
+/// should be ensured end up in the final build of any contract using the SDK.
+///
+/// In Rust's build system ections only get included into the final build if the
+/// object file containing those sections are processed by the linker, but as an
+/// optimization step if no code is called in an object file it is discarded.
+/// This has the unfortunate effect of causing anything else in those object
+/// files, such as link sections, to be discarded. Placing anything that must be
+/// included in the build inside an exported function ensures the object files
+/// won't be discarded. wasm-bindgen does a similar thing to this, and so this
+/// seems to be a reasonably accepted way to work around this limitation in the
+/// build system.
+///
+/// This has an unfortunate side-effect that all contracts will have a function
+/// in the resulting WASM named `_`, however this function won't be rendered in
+/// the contract specification. The overhead of this is very minimal on file
+/// size.
+///
 /// See https://github.com/stellar/rs-soroban-sdk/issues/383 for more details.
-#[doc(hidden)]
-pub fn __env_meta_xdr() -> &'static [u8] {
+#[export_name = "_"]
+fn __link_sections() {
     #[cfg_attr(target_family = "wasm", link_section = "contractenvmetav0")]
     static __ENV_META_XDR: [u8; env::meta::XDR.len()] = env::meta::XDR;
-    &__ENV_META_XDR
 }
 
 pub use soroban_sdk_macros::{contractimpl, contracttype, ContractType};

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -11,15 +11,15 @@ fn handle_panic(_: &core::panic::PanicInfo) -> ! {
 /// __link_sections returns and does nothing, but it contains link sections that
 /// should be ensured end up in the final build of any contract using the SDK.
 ///
-/// In Rust's build system ections only get included into the final build if the
-/// object file containing those sections are processed by the linker, but as an
-/// optimization step if no code is called in an object file it is discarded.
-/// This has the unfortunate effect of causing anything else in those object
-/// files, such as link sections, to be discarded. Placing anything that must be
-/// included in the build inside an exported function ensures the object files
-/// won't be discarded. wasm-bindgen does a similar thing to this, and so this
-/// seems to be a reasonably accepted way to work around this limitation in the
-/// build system.
+/// In Rust's build system sections only get included into the final build if
+/// the object file containing those sections are processed by the linker, but
+/// as an optimization step if no code is called in an object file it is
+/// discarded.  This has the unfortunate effect of causing anything else in
+/// those object files, such as link sections, to be discarded. Placing anything
+/// that must be included in the build inside an exported function ensures the
+/// object files won't be discarded. wasm-bindgen does a similar thing to this,
+/// and so this seems to be a reasonably accepted way to work around this
+/// limitation in the build system.
 ///
 /// This has an unfortunate side-effect that all contracts will have a function
 /// in the resulting WASM named `_`, however this function won't be rendered in


### PR DESCRIPTION
### What
Move the link section for contractenvmetav0 into an exported function that is exported in every contract.

### Why

In Rust's build system sections only get included into the final build if the object file containing those sections are processed by the linker, but as an optimization step if no code is called in an object file it is discarded. This has the unfortunate effect of causing anything else in those object files, such as link sections, to be discarded. Placing anything that must be included in the build inside an exported function ensures the object files won't be discarded.

wasm-bindgen does a similar thing to this, and so this seems to be a reasonably accepted way to work around this limitation in the build system. (Some more details about their approach here: https://github.com/koute/cargo-web/issues/92#issuecomment-451254445.)

This has an unfortunate side-effect that all contracts will have a function in the resulting WASM named `_`, however this function won't be rendered in the contract specification. The overhead of this is very minimal on file size. Total overhead is still only 12 bytes on the token contract, and the XDR being embedded is also 12 bytes, so I'm not even sure how that happens, it's as if its free!

This is the second attempted fix to this problem. The first fix was #386. If this fix doesn't stick, I will suggest we simply tell people to always use `codegen-units = 1` as I don't think it is worth us to expend more time on working around the compiler.

Close #383