### PR TITLE
Fix complete ci job

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,12 +11,10 @@ env:
 jobs:
 
   complete:
-    if: always()
     needs: [fmt, build-and-test, docs]
     runs-on: ubuntu-latest
     steps:
-    - if: contains(needs.*.result, 'failure')
-      run: exit 1
+    - run: exit 0
 
   fmt:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### What
Make the complete job fail for cancelled builds, by having it run only if all the prior jobs succeed.

### Why
The complete job checks if any of the jobs failed, but they might have been cancelled rather than failed. This causes the complete job to succeed when a needed job was cancelled. You can see how this build played out where a cancelled job resulted in a merged PR: stellar/rs-stellar-xdr#130.