### PR TITLE
Update cargo-hack used in ci

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -70,7 +70,7 @@ jobs:
           ${{ github.job }}-target-
     - if: github.ref_protected
       run: rm -fr target
-    - run: cargo install --locked --version 0.5.14 cargo-hack
+    - run: cargo install --locked --version 0.5.16 cargo-hack
     - run: cargo check --profile ${{ matrix.sys.profile }} --target ${{ matrix.sys.target }} --lib
     - if: matrix.sys.test
       run: cargo hack --feature-powerset check --exclude-features docs --profile ${{ matrix.sys.profile }} --target ${{ matrix.sys.target }} --bins --tests --examples --benches


### PR DESCRIPTION
### What
Update cargo-hack used in ci to v0.5.16.

### Why
New version released.