### PR TITLE
Add .profraw and lcov.info to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 target/
 target-tiny/
+lcov.info
+*.profraw


### PR DESCRIPTION
### What
Add .profraw and lcov.info to gitignore.

### Why
The files are the common names of files generated by Rust tools that evaluate code coverage of tests.