### PR TITLE
Remove self-circular testutils deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -229,7 +229,6 @@ checksum = "3f107b87b6afc2a64fd13cac55fe06d6c8859f12d4b14cbcdd2c67d0976781be"
 name = "example_add_i32"
 version = "0.0.0"
 dependencies = [
- "example_add_i32",
  "proptest",
  "soroban-sdk",
 ]
@@ -238,7 +237,6 @@ dependencies = [
 name = "example_add_i64"
 version = "0.0.0"
 dependencies = [
- "example_add_i64",
  "soroban-sdk",
 ]
 
@@ -246,7 +244,6 @@ dependencies = [
 name = "example_contract_data"
 version = "0.0.0"
 dependencies = [
- "example_contract_data",
  "soroban-sdk",
 ]
 
@@ -254,7 +251,6 @@ dependencies = [
 name = "example_create_contract"
 version = "0.0.0"
 dependencies = [
- "example_create_contract",
  "soroban-sdk",
 ]
 
@@ -262,7 +258,6 @@ dependencies = [
 name = "example_invoke_contract"
 version = "0.0.0"
 dependencies = [
- "example_invoke_contract",
  "soroban-sdk",
 ]
 
@@ -270,7 +265,6 @@ dependencies = [
 name = "example_linear_memory"
 version = "0.0.0"
 dependencies = [
- "example_linear_memory",
  "soroban-sdk",
 ]
 
@@ -278,7 +272,6 @@ dependencies = [
 name = "example_udt"
 version = "0.0.0"
 dependencies = [
- "example_udt",
  "soroban-sdk",
 ]
 
@@ -286,7 +279,6 @@ dependencies = [
 name = "example_vec"
 version = "0.0.0"
 dependencies = [
- "example_vec",
  "soroban-sdk",
 ]
 

--- a/tests/add_i32/Cargo.toml
+++ b/tests/add_i32/Cargo.toml
@@ -16,7 +16,6 @@ soroban-sdk = {path = "../../soroban-sdk"}
 [dev-dependencies]
 proptest = "1.0.0"
 soroban-sdk = {path = "../../soroban-sdk", features = ["testutils"]}
-example_add_i32 = {path = ".", features = ["testutils"]}
 
 [features]
 testutils = ["soroban-sdk/testutils"]

--- a/tests/add_i64/Cargo.toml
+++ b/tests/add_i64/Cargo.toml
@@ -15,7 +15,6 @@ soroban-sdk = {path = "../../soroban-sdk"}
 
 [dev-dependencies]
 soroban-sdk = {path = "../../soroban-sdk", features = ["testutils"]}
-example_add_i64 = {path = ".", features = ["testutils"]}
 
 [features]
 testutils = ["soroban-sdk/testutils"]

--- a/tests/contract_data/Cargo.toml
+++ b/tests/contract_data/Cargo.toml
@@ -14,7 +14,6 @@ soroban-sdk = {path = "../../soroban-sdk"}
 
 [dev-dependencies]
 soroban-sdk = {path = "../../soroban-sdk", features = ["testutils"]}
-example_contract_data = {path = ".", features = ["testutils"]}
 
 [features]
 testutils = ["soroban-sdk/testutils"]

--- a/tests/create_contract/Cargo.toml
+++ b/tests/create_contract/Cargo.toml
@@ -16,7 +16,6 @@ soroban-sdk = {path = "../../soroban-sdk"}
 
 [dev-dependencies]
 soroban-sdk = {path = "../../soroban-sdk", features = ["testutils"]}
-example_create_contract = {path = ".", features = ["testutils"]}
 
 [features]
 testutils = ["soroban-sdk/testutils"]

--- a/tests/invoke_contract/Cargo.toml
+++ b/tests/invoke_contract/Cargo.toml
@@ -15,7 +15,6 @@ soroban-sdk = {path = "../../soroban-sdk"}
 
 [dev-dependencies]
 soroban-sdk = {path = "../../soroban-sdk", features = ["testutils"]}
-example_invoke_contract = {path = ".", features = ["testutils"]}
 
 [features]
 testutils = ["soroban-sdk/testutils"]

--- a/tests/linear_memory/Cargo.toml
+++ b/tests/linear_memory/Cargo.toml
@@ -14,7 +14,6 @@ soroban-sdk = {path = "../../soroban-sdk"}
 
 [dev-dependencies]
 soroban-sdk = {path = "../../soroban-sdk", features = ["testutils"]}
-example_linear_memory = {path = ".", features = ["testutils"]}
 
 [features]
 testutils = ["soroban-sdk/testutils"]

--- a/tests/udt/Cargo.toml
+++ b/tests/udt/Cargo.toml
@@ -15,7 +15,6 @@ soroban-sdk = {path = "../../soroban-sdk"}
 
 [dev-dependencies]
 soroban-sdk = {path = "../../soroban-sdk", features = ["testutils"]}
-example_udt = {path = ".", features = ["testutils"]}
 
 [features]
 default = ["export"]

--- a/tests/vec/Cargo.toml
+++ b/tests/vec/Cargo.toml
@@ -14,7 +14,6 @@ soroban-sdk = {path = "../../soroban-sdk"}
 
 [dev-dependencies]
 soroban-sdk = {path = "../../soroban-sdk", features = ["testutils"]}
-example_vec = {path = ".", features = ["testutils"]}
 
 [features]
 testutils = ["soroban-sdk/testutils"]


### PR DESCRIPTION
### What

Remove self-circular testutils dev dependencies.

### Why

It causes errors in rust-analyzer which doesn't expect the circular reference. It is also reasonably confusing to others because (e.g. @graydon had questions about it) and requires a decent amount of discussion to knowledge share why it exists.

The circular reference was added to activate things that are gated behind `testutils` feature, so that those things are always activated during tests. However, Rust provides a built-in way for us to do this today, without needing the circular reference. All we need to do is use the `#[cfg(test)]` attribute. If we have items that need to be testutils for externals and we want them to always be activated within the crates own tests, then we can use `#[cfg(any(test, feature = "testutils"))]`. We already use this pattern in the SDK macros for any `testutils`.

### Known limitations

N/A
