### PR TITLE
Small refactor of contractimpl macros fn for collecting public methods

### DIFF
--- a/soroban-sdk-macros/src/syn_ext.rs
+++ b/soroban-sdk-macros/src/syn_ext.rs
@@ -1,0 +1,15 @@
+use syn::{ImplItem, ImplItemMethod, ItemImpl, Visibility};
+
+/// Gets methods from the implementation that have public visibility. For
+/// methods that are inherently implemented this is methods that have a pub
+/// visibility keyword. For methods that are implementing a trait the pub is
+/// assumed and so all methods are returned.
+pub fn impl_pub_methods(imp: &ItemImpl) -> impl Iterator<Item = &ImplItemMethod> {
+    imp.items
+        .iter()
+        .filter_map(|i| match i {
+            ImplItem::Method(m) => Some(m),
+            _ => None,
+        })
+        .filter(|m| imp.trait_.is_some() || matches!(m.vis, Visibility::Public(_)))
+}


### PR DESCRIPTION
### What
Move the function for collecting impl methods to a file for syn extensions, and bundle in the filtering for public functions into that function.

### Why
To move syn extensions out of the file containing our macros since they're a minor detail. Also, we are only ever interested in public methods and so bundling that filter into the function is helpful for preventing footguns where we export non-public functions (which happened once).

I'm doing some small refactors ahead of and as a part of https://github.com/stellar/rs-soroban-sdk/issues/118.