### PR TITLE
Implicitly specify whether contractimpl should be exported using CARGO_PRIMARY_PACKAGE

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -137,41 +137,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "darling"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4529658bdda7fd6769b8614be250cdcfc3aeb0ee72fe66f9e41e5e5eb73eac02"
-dependencies = [
- "darling_core",
- "darling_macro",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "649c91bc01e8b1eac09fb91e8dbc7d517684ca6be8ebc75bb9cafc894f9fdb6f"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim",
- "syn",
-]
-
-[[package]]
-name = "darling_macro"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddfc69c5bfcbd2fc09a0f38451d2daf0e372e367986a83906d1b0dbc88134fb5"
-dependencies = [
- "darling_core",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "digest"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -346,12 +311,6 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
-
-[[package]]
-name = "ident_case"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "im-rc"
@@ -809,7 +768,6 @@ dependencies = [
 name = "soroban-sdk-macros"
 version = "0.0.3"
 dependencies = [
- "darling",
  "itertools",
  "proc-macro2",
  "quote",
@@ -827,12 +785,6 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 name = "stellar-xdr"
 version = "0.0.1"
 source = "git+https://github.com/stellar/rs-stellar-xdr?rev=28a28dc0#28a28dc04056027a8814872932e84a71261e389a"
-
-[[package]]
-name = "strsim"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "subtle"

--- a/soroban-sdk-macros/Cargo.toml
+++ b/soroban-sdk-macros/Cargo.toml
@@ -19,4 +19,3 @@ syn = {version="1.0",features=["full"]}
 quote = "1.0"
 proc-macro2 = "1.0"
 itertools = "0.10.3"
-darling = "0.14.1"

--- a/soroban-sdk-macros/src/derive_fn.rs
+++ b/soroban-sdk-macros/src/derive_fn.rs
@@ -17,7 +17,7 @@ pub fn derive_fn(
     ident: &Ident,
     inputs: &Punctuated<FnArg, Comma>,
     output: &ReturnType,
-    feature: &Option<String>,
+    export: bool,
     trait_ident: &Option<&Ident>,
 ) -> Result<TokenStream2, TokenStream2> {
     // Collect errors as they are encountered and emit them at the end.
@@ -129,11 +129,7 @@ pub fn derive_fn(
     } else {
         quote! {}
     };
-    let export_name = if let Some(cfg_feature) = feature {
-        quote! { #[cfg_attr(feature = #cfg_feature, export_name = #wrap_export_name)] }
-    } else {
-        quote! { #[export_name = #wrap_export_name] }
-    };
+    let export_name = export.then(|| quote! { #[export_name = #wrap_export_name] });
     let slice_args: Vec<TokenStream2> = (0..wrap_args.len()).map(|n| quote! { args[#n] }).collect();
     let use_trait = if let Some(t) = trait_ident {
         quote! { use super::#t }
@@ -171,11 +167,8 @@ pub fn derive_fn(
     let spec_xdr_lit = proc_macro2::Literal::byte_string(spec_xdr.as_slice());
     let spec_xdr_len = spec_xdr.len();
     let spec_ident = format_ident!("__SPEC_XDR_{}", ident.to_string().to_uppercase());
-    let link_section = if let Some(cfg_feature) = feature {
-        quote! { #[cfg_attr(all(target_family = "wasm", feature = #cfg_feature), link_section = "contractspecv0")] }
-    } else {
-        quote! { #[cfg_attr(target_family = "wasm", link_section = "contractspecv0")] }
-    };
+    let link_section = export
+        .then(|| quote! { #[cfg_attr(target_family = "wasm", link_section = "contractspecv0")] });
 
     // If errors have occurred, render them instead.
     if !errors.is_empty() {

--- a/soroban-sdk-macros/src/lib.rs
+++ b/soroban-sdk-macros/src/lib.rs
@@ -5,6 +5,8 @@ mod derive_type;
 mod map_type;
 mod syn_ext;
 
+use std::env;
+
 use derive_fn::{derive_contract_function_set, derive_fn};
 use derive_type::{derive_type_enum, derive_type_struct};
 
@@ -20,7 +22,7 @@ pub fn contractimpl(_metadata: TokenStream, input: TokenStream) -> TokenStream {
     // crate containing a contract must export their types and functions
     // themselves so that dependency crates do not accidentally export their
     // contract implementations into a developers contract.
-    let export = option_env!("CARGO_PRIMARY_PACKAGE").is_some();
+    let export = env::var("CARGO_PRIMARY_PACKAGE").is_ok();
 
     let imp = parse_macro_input!(input as ItemImpl);
     let ty = &imp.self_ty;

--- a/soroban-sdk-macros/src/lib.rs
+++ b/soroban-sdk-macros/src/lib.rs
@@ -8,30 +8,23 @@ mod syn_ext;
 use derive_fn::{derive_contract_function_set, derive_fn};
 use derive_type::{derive_type_enum, derive_type_struct};
 
-use darling::FromMeta;
 use proc_macro::TokenStream;
 use quote::quote;
-use syn::{
-    parse_macro_input, spanned::Spanned, AttributeArgs, DeriveInput, Error, ItemImpl, Visibility,
-};
-
-#[derive(Debug, FromMeta)]
-struct ContractImplArgs {
-    #[darling(default)]
-    export_if: Option<String>,
-}
+use syn::{parse_macro_input, spanned::Spanned, DeriveInput, Error, ItemImpl, Visibility};
 
 #[proc_macro_attribute]
-pub fn contractimpl(metadata: TokenStream, input: TokenStream) -> TokenStream {
-    let args = parse_macro_input!(metadata as AttributeArgs);
-    let args = match ContractImplArgs::from_list(&args) {
-        Ok(v) => v,
-        Err(e) => return e.write_errors().into(),
-    };
+pub fn contractimpl(_metadata: TokenStream, input: TokenStream) -> TokenStream {
+    // Export the functions in the wasm and in the contract spec if the package
+    // is being built as the primary package. If the crate is imported to
+    // another package to reuse types, export will be false. We require that any
+    // crate containing a contract must export their types and functions
+    // themselves so that dependency crates do not accidentally export their
+    // contract implementations into a developers contract.
+    let export = option_env!("CARGO_PRIMARY_PACKAGE").is_some();
+
     let imp = parse_macro_input!(input as ItemImpl);
     let ty = &imp.self_ty;
-    let pub_methods: Vec<_> = syn_ext::impl_pub_methods(&imp)
-        .collect();
+    let pub_methods: Vec<_> = syn_ext::impl_pub_methods(&imp).collect();
     let derived: Result<proc_macro2::TokenStream, proc_macro2::TokenStream> = pub_methods
         .iter()
         .map(|m| {
@@ -43,7 +36,7 @@ pub fn contractimpl(metadata: TokenStream, input: TokenStream) -> TokenStream {
                 ident,
                 &m.sig.inputs,
                 &m.sig.output,
-                &args.export_if,
+                export,
                 &trait_ident,
             )
         })


### PR DESCRIPTION
### What
Base whether contractimpl functions are exported as callable wasm functions and in the contract spec on whether CARGO_PRIMARY_PACKAGE is set.

### Why
The environment variable CARGO_PRIMARY_PACKAGE is set when a crate is being built as the primary crate, and it isn't set when a crate is being built as a dependency.

It is not particularly intuitive that if you import a crate that contains a contract that the contractimpls of that crate will be exported as callable functions of your crate. In fact, I would go as far to say that this is so surprising that it could result in contract developers accidentally exposing functions from other contracts that they wish to wrap or import for shared types.

We support this use case today with the `export_if` attribute on `contractimpl` that allows a contract developer to specify a build feature that should be used to gate the exporting on. i.e. If the feature is enabled, the functions are exported. If the feature is disabled, the functions are not exported. This solution of using a feature flag provides flexibility, but at a cost of verbosity, and still relies on developers importing the package to remember to do the right thing by configuring the features appropriately. The solution of feature flags also requires developers to opt-in, which means a developer who doesn't choose to use `export_if` will break other contracts who import it.

It could be argued that using the `CARGO_PRIMARY_PACKAGE` is both magical and limiting since it is outside the developers control, but actually it is the same level of capability, it just flips what the default behavior is. With this change the default behavior is no contractimpl is reexported by the importing crate. A developer who wishes to reexport a dependencies contractimpl must do so explicitly by creating a contract type, writing an `impl` block, and calling through to the dependencies contract type. This is mildly inconvenient, and if there is shown to be significant demand for this type of code we can add a macro that simplifies the whole process.

Note that this change doesn't change whether `contracttype`s are exposed, since importing a crate that has `contracttype`s is likely to use those `contracttype`s. There's an assumption here that we can revisit at a later point.