### PR TITLE
Set rust-version to 1.62

### DIFF
--- a/tests/contract_data/Cargo.toml
+++ b/tests/contract_data/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.0.0"
 authors = ["Stellar Development Foundation <info@stellar.org>"]
 license = "Apache-2.0"
 edition = "2021"
+rust-version = "1.62"
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/tests/udt/Cargo.toml
+++ b/tests/udt/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Stellar Development Foundation <info@stellar.org>"]
 license = "Apache-2.0"
 edition = "2021"
 publish = false
+rust-version = "1.62"
 
 [lib]
 crate-type = ["cdylib", "rlib"]


### PR DESCRIPTION
### What
Set the minimum rust version required to 1.62.

### Why
So that contract developers importing soroban-sdk know that they need to be using Rust 1.62 at least.