### PR TITLE
Fix rust-version ci workflow

### DIFF
--- a/.github/workflows/rust-version.yml
+++ b/.github/workflows/rust-version.yml
@@ -29,8 +29,8 @@ jobs:
     - if: always() && steps.diff.conclusion == 'failure'
       id: commit
       run: |
-        git config --global user.email 'github-actions[bot]@users.noreply.github.com'
         git config --global user.name 'github-actions[bot]'
+        git config --global user.email 'github-actions[bot]@users.noreply.github.com'
         git checkout -b update-rust-version
         git add .
         git commit -m 'Update rust-version'

--- a/.github/workflows/rust-version.yml
+++ b/.github/workflows/rust-version.yml
@@ -29,6 +29,8 @@ jobs:
     - if: always() && steps.diff.conclusion == 'failure'
       id: commit
       run: |
+        git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+        git config --global user.name 'github-actions[bot]'
         git checkout -b update-rust-version
         git add .
         git commit -m 'Update rust-version'


### PR DESCRIPTION
### What
Add git config user.email and user.name configs to the rust-version ci workflow.

### Why
The ci job makes a commit when the rust-version needs updating, and it needs to have git configured to do that. The GitHub Actions bot email address is one to use that shows up as GitHub Actions being the committer.