### PR TITLE
Fix rust-version ci job

### DIFF
--- a/.github/workflows/rust-version.yml
+++ b/.github/workflows/rust-version.yml
@@ -42,11 +42,15 @@ jobs:
       uses: actions/github-script@v6
       with:
         script: |
+          const repo = github.rest.repos.get({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+          });
           await github.rest.pulls.create({
             title: 'Update rust-version',
             owner: context.repo.owner,
             repo: context.repo.repo,
             head: github.ref_name,
-            base: github.event.repository.default_branch,
+            base: repo.default_branch,
             body: '### What\nUpdate rust-version to latest stable.\n\n### Why\nTracking latest stable which receives security updates.'
           });


### PR DESCRIPTION
### What
Get the default branch name from the GitHub API in the rust-version ci job.

### Why
The ci job was getting it from the event payload inside a github-script, but the github script doesn't have access to it and even if it did, not all event payloads have it anyway.