### PR TITLE
Fix rust-version ci job

### DIFF
--- a/.github/workflows/rust-version.yml
+++ b/.github/workflows/rust-version.yml
@@ -42,15 +42,11 @@ jobs:
       uses: actions/github-script@v6
       with:
         script: |
-          const repo = github.rest.repos.get({
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-          });
           await github.rest.pulls.create({
             title: 'Update rust-version',
             owner: context.repo.owner,
             repo: context.repo.repo,
-            head: github.ref_name,
-            base: repo.default_branch,
+            head: '${{ github.ref_name }}',
+            base: 'main',
             body: '### What\nUpdate rust-version to latest stable.\n\n### Why\nTracking latest stable which receives security updates.'
           });


### PR DESCRIPTION
### What
Set head and base in rust-version ci job PR creation.

### Why
They were being set but with values that were empty because they were being pulled from the wrong places.