### PR TITLE
Fix rust-version ci job

### DIFF
--- a/.github/workflows/rust-version.yml
+++ b/.github/workflows/rust-version.yml
@@ -46,7 +46,7 @@ jobs:
             title: 'Update rust-version',
             owner: context.repo.owner,
             repo: context.repo.repo,
-            head: '${{ github.ref_name }}',
+            head: 'update-rust-version',
             base: 'main',
             body: '### What\nUpdate rust-version to latest stable.\n\n### Why\nTracking latest stable which receives security updates.'
           });


### PR DESCRIPTION
### What
Set the head for the PR opened by the rust-version ci job to the `update-rust-version` branch.

### Why
The rust-version ci job uses the current ref name, which is the main branch for scheduled and workflows. The intent is for the branch just pushed to be opened.