### PR TITLE
Fix rust-version ci job

### DIFF
--- a/.github/workflows/rust-version.yml
+++ b/.github/workflows/rust-version.yml
@@ -22,11 +22,12 @@ jobs:
     # this step will fail, triggering the following steps.
     - id: diff
       run: git diff --exit-code
+      continue-on-error: true
 
     # If the diff step failed, create a branch and push it to GitHub.  If the
     # branch already exists with a change the push should fail, and so we
     # shouldn't end up with multiple PRs.
-    - if: always() && steps.diff.conclusion == 'failure'
+    - if: steps.diff.conclusion == 'failure'
       id: commit
       run: |
         git config --global user.name 'github-actions[bot]'
@@ -37,7 +38,7 @@ jobs:
         git push origin update-rust-version
 
     # If the diff step failed, and the push succeeded, open a PR.
-    - if: always() && steps.diff.conclusion == 'failure' && steps.commit.conclusion == 'success'
+    - if: steps.diff.conclusion == 'failure'
       name: Create Pull Request
       uses: actions/github-script@v6
       with:


### PR DESCRIPTION
### What
Make the diff step in the rust-version ci workflow continue on error.

### Why
The step is allowed to fail, but without being marked as continue on error the workflow will be considered a fail because the step failed. By marking it as continue on error the workflow will ignore the steps failure, which is good because when the step fails we use that to run the following two steps to open the PR.