### PR TITLE
Fix rust-version ci job

### DIFF
--- a/.github/workflows/rust-version.yml
+++ b/.github/workflows/rust-version.yml
@@ -21,13 +21,15 @@ jobs:
     # Check if there is any diff resulting from updating the crates. If there is
     # this step will fail, triggering the following steps.
     - id: diff
-      run: git diff --exit-code
+      run: |
+        git diff --exit-code
+        echo "::set-output name=exitcode::$?"
       continue-on-error: true
 
     # If the diff step failed, create a branch and push it to GitHub.  If the
     # branch already exists with a change the push should fail, and so we
     # shouldn't end up with multiple PRs.
-    - if: steps.diff.conclusion == 'failure'
+    - if: steps.diff.outputs.exitcode == 1
       id: commit
       run: |
         git config --global user.name 'github-actions[bot]'
@@ -38,7 +40,7 @@ jobs:
         git push origin update-rust-version
 
     # If the diff step failed, and the push succeeded, open a PR.
-    - if: steps.diff.conclusion == 'failure'
+    - if: steps.diff.outputs.exitcode == 1
       name: Create Pull Request
       uses: actions/github-script@v6
       with:


### PR DESCRIPTION
### What
Use exit-code of diff job in rust-version ci workflow for determining if a diff exists.

### Why
Using the failure of the diff step no longer works since the last fix that changed the step to continue on error. The step always succeeds now, and its failure from the exit code is not visible to the subsequence steps.