### PR TITLE
Fix up the add_bigint example build

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -226,6 +226,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f107b87b6afc2a64fd13cac55fe06d6c8859f12d4b14cbcdd2c67d0976781be"
 
 [[package]]
+name = "example_add_bigint"
+version = "0.0.0"
+dependencies = [
+ "proptest",
+ "soroban-sdk",
+]
+
+[[package]]
 name = "example_add_i32"
 version = "0.0.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "soroban-sdk",
     "tests/add_i32",
     "tests/add_i64",
+    "tests/add_bigint",
     "tests/vec",
     "tests/invoke_contract",
     "tests/udt",

--- a/tests/add_bigint/Cargo.toml
+++ b/tests/add_bigint/Cargo.toml
@@ -4,9 +4,19 @@ version = "0.0.0"
 authors = ["Stellar Development Foundation <info@stellar.org>"]
 license = "Apache-2.0"
 edition = "2021"
+publish = false
+rust-version = "1.62"
 
 [lib]
 crate-type = ["cdylib", "rlib"]
+doctest = false
 
 [dependencies]
-stellar-contract-sdk = {path = "../../soroban-sdk"}
+soroban-sdk = {path = "../../soroban-sdk"}
+
+[dev-dependencies]
+proptest = "1.0.0"
+soroban-sdk = {path = "../../soroban-sdk", features = ["testutils"]}
+
+[features]
+testutils = ["soroban-sdk/testutils"]

--- a/tests/add_bigint/src/lib.rs
+++ b/tests/add_bigint/src/lib.rs
@@ -1,5 +1,5 @@
 #![no_std]
-use stellar_contract_sdk::{contractimpl, BigInt};
+use soroban_sdk::{contractimpl, BigInt};
 
 pub struct Contract;
 


### PR DESCRIPTION
### What

Fix the build for tests/add_bigint

### Why

So it gets built with the other examples

### Known limitations

[TODO or N/A]
