### PR TITLE
Native contract

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -750,8 +750,7 @@ dependencies = [
 [[package]]
 name = "soroban-env-common"
 version = "0.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f2a07a2f4c8f684b5e0bc1013937339300d6c8112b76c6c46bbefc47bdd5905"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=556c75f#556c75fa80e3b6e5ff3dc09443b9dc66e3111a40"
 dependencies = [
  "soroban-env-macros",
  "static_assertions",
@@ -761,7 +760,7 @@ dependencies = [
 [[package]]
 name = "soroban-env-guest"
 version = "0.0.3"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=21bc98a#21bc98a3735aa3bdacba0c4ed04baec2c6b8fce0"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=556c75f#556c75fa80e3b6e5ff3dc09443b9dc66e3111a40"
 dependencies = [
  "soroban-env-common",
  "static_assertions",
@@ -770,7 +769,7 @@ dependencies = [
 [[package]]
 name = "soroban-env-host"
 version = "0.0.3"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=21bc98a#21bc98a3735aa3bdacba0c4ed04baec2c6b8fce0"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=556c75f#556c75fa80e3b6e5ff3dc09443b9dc66e3111a40"
 dependencies = [
  "backtrace",
  "dyn-fmt",
@@ -783,6 +782,7 @@ dependencies = [
  "num-traits",
  "sha2 0.10.2",
  "soroban-env-common",
+ "soroban-native-sdk-macros",
  "static_assertions",
  "thiserror",
  "tinyvec",
@@ -791,12 +791,23 @@ dependencies = [
 [[package]]
 name = "soroban-env-macros"
 version = "0.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92e07a8cf5452fce96ce19df1ba6874e6f92b2dc64302c71aa8460349c08cedc"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=556c75f#556c75fa80e3b6e5ff3dc09443b9dc66e3111a40"
 dependencies = [
+ "itertools",
  "proc-macro2",
  "quote",
  "stellar-xdr",
+ "syn",
+]
+
+[[package]]
+name = "soroban-native-sdk-macros"
+version = "0.0.1"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=556c75f#556c75fa80e3b6e5ff3dc09443b9dc66e3111a40"
+dependencies = [
+ "itertools",
+ "proc-macro2",
+ "quote",
  "syn",
 ]
 
@@ -834,7 +845,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 [[package]]
 name = "stellar-xdr"
 version = "0.0.1"
-source = "git+https://github.com/stellar/rs-stellar-xdr?rev=28a28dc0#28a28dc04056027a8814872932e84a71261e389a"
+source = "git+https://github.com/stellar/rs-stellar-xdr?rev=3eca5ce#3eca5ce2c11091469602a1370c53c24cf989202f"
 
 [[package]]
 name = "strsim"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,9 +32,12 @@ exclude = ["soroban-sdk-macros"]
 [patch.crates-io]
 soroban-sdk = { path = "soroban-sdk" }
 soroban-sdk-macros = { path = "soroban-sdk-macros" }
-soroban-env-guest = { git = "https://github.com/stellar/rs-soroban-env", rev = "21bc98a" }
-soroban-env-host = { git = "https://github.com/stellar/rs-soroban-env", rev = "21bc98a" }
-stellar-xdr = { git = "https://github.com/stellar/rs-stellar-xdr", rev = "28a28dc0" }
+soroban-env-common = { git = "https://github.com/stellar/rs-soroban-env", rev = "556c75f" }
+soroban-env-guest = { git = "https://github.com/stellar/rs-soroban-env", rev = "556c75f" }
+soroban-env-host = { git = "https://github.com/stellar/rs-soroban-env", rev = "556c75f" }
+soroban-env-macros = { git = "https://github.com/stellar/rs-soroban-env", rev = "556c75f" }
+soroban-native-sdk-macros = { git = "https://github.com/stellar/rs-soroban-env", rev = "556c75f" }
+stellar-xdr = { git = "https://github.com/stellar/rs-stellar-xdr", rev = "3eca5ce" }
 
 [profile.dev]
 overflow-checks = true

--- a/soroban-sdk-macros/src/map_type.rs
+++ b/soroban-sdk-macros/src/map_type.rs
@@ -26,7 +26,7 @@ pub fn map_type(t: &Type) -> Result<ScSpecTypeDef, Error> {
                 "Symbol" => Ok(ScSpecTypeDef::Symbol),
                 "Bitset" => Ok(ScSpecTypeDef::Bitset),
                 "Status" => Ok(ScSpecTypeDef::Status),
-                "Bytes" => Ok(ScSpecTypeDef::Binary),
+                "Bytes" => Ok(ScSpecTypeDef::Bytes),
                 "BigInt" => Ok(ScSpecTypeDef::BigInt),
                 s => Ok(ScSpecTypeDef::Udt(ScSpecTypeUdt {
                     name: s.try_into().map_err(|e| {
@@ -93,7 +93,7 @@ pub fn map_type(t: &Type) -> Result<ScSpecTypeDef, Error> {
                         })))
                     }
                     // TODO: Add proper support for BytesN as a first class spec type.
-                    "BytesN" => Ok(ScSpecTypeDef::Binary),
+                    "BytesN" => Ok(ScSpecTypeDef::Bytes),
                     _ => Err(Error::new(
                         angle_bracketed.span(),
                         "generics unsupported on user-defined types in contract functions",

--- a/soroban-sdk/src/bytes.rs
+++ b/soroban-sdk/src/bytes.rs
@@ -110,7 +110,7 @@ impl TryFrom<EnvObj> for Bytes {
 
     #[inline(always)]
     fn try_from(obj: EnvObj) -> Result<Self, Self::Error> {
-        if obj.as_object().is_obj_type(ScObjectType::Binary) {
+        if obj.as_object().is_obj_type(ScObjectType::Bytes) {
             Ok(unsafe { Bytes::unchecked_new(obj) })
         } else {
             Err(ConversionError {})

--- a/soroban-sdk/src/env.rs
+++ b/soroban-sdk/src/env.rs
@@ -197,6 +197,13 @@ impl Env {
     }
 
     #[doc(hidden)]
+    pub fn create_token_from_contract(&self, salt: BytesN<32>) -> BytesN<32> {
+        let salt_obj: Object = RawVal::from(salt).try_into().unwrap();
+        let id_obj = internal::Env::create_token_from_contract(self, salt_obj);
+        id_obj.in_env(self).try_into().unwrap()
+    }
+
+    #[doc(hidden)]
     pub fn binary_new_from_linear_memory(&self, ptr: u32, len: u32) -> Bytes {
         let bin_obj = internal::Env::binary_new_from_linear_memory(self, ptr.into(), len.into());
         bin_obj.in_env(self).try_into().unwrap()


### PR DESCRIPTION
### What

Bump dependencies, add `create_token_from_contract`.

### Why

Needed to support the native token contract.

### Known limitations

We might want a better interface to contract creation if there are going to be a lot of these functions.