### PR TITLE
Add Env::register_contract_wasm and import_contract example

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -55,8 +55,8 @@ jobs:
     - if: github.ref_protected
       run: rm -fr target
     - run: cargo install --locked --version 0.5.16 cargo-hack
-    - run: cargo hack --feature-powerset --exclude-features docs check --target wasm32-unknown --lib --profile release
-    - run: cargo hack --feature-powerset --exclude-features docs build --target wasm32-unknown --profile release
+    - run: cargo hack --feature-powerset --exclude-features docs check --target wasm32-unknown-unknown --lib --profile release
+    - run: cargo hack --feature-powerset --exclude-features docs build --target wasm32-unknown-unknown --profile release
     - run: cargo hack --feature-powerset --exclude-features docs check --target ${{ matrix.sys.target }} --lib --tests
     - run: cargo hack --feature-powerset --exclude-features docs build --target ${{ matrix.sys.target }}
     - run: cargo hack --feature-powerset --exclude-features docs test --target ${{ matrix.sys.target }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -55,8 +55,8 @@ jobs:
     - if: github.ref_protected
       run: rm -fr target
     - run: cargo install --locked --version 0.5.16 cargo-hack
-    - run: cargo hack docs check --target wasm32-unknown-unknown --lib --profile release
-    - run: cargo hack docs build --target wasm32-unknown-unknown --profile release
+    - run: cargo hack check --target wasm32-unknown-unknown --lib --profile release
+    - run: cargo hack build --target wasm32-unknown-unknown --profile release
     - run: cargo hack --feature-powerset --exclude-features docs check --target ${{ matrix.sys.target }} --lib --tests
     - run: cargo hack --feature-powerset --exclude-features docs build --target ${{ matrix.sys.target }}
     - run: cargo hack --feature-powerset --exclude-features docs test --target ${{ matrix.sys.target }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -55,8 +55,8 @@ jobs:
     - if: github.ref_protected
       run: rm -fr target
     - run: cargo install --locked --version 0.5.16 cargo-hack
-    - run: cargo hack --feature-powerset --exclude-features docs check --target wasm32-unknown-unknown --lib --profile release
-    - run: cargo hack --feature-powerset --exclude-features docs build --target wasm32-unknown-unknown --profile release
+    - run: cargo hack docs check --target wasm32-unknown-unknown --lib --profile release
+    - run: cargo hack docs build --target wasm32-unknown-unknown --profile release
     - run: cargo hack --feature-powerset --exclude-features docs check --target ${{ matrix.sys.target }} --lib --tests
     - run: cargo hack --feature-powerset --exclude-features docs build --target ${{ matrix.sys.target }}
     - run: cargo hack --feature-powerset --exclude-features docs test --target ${{ matrix.sys.target }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -55,10 +55,10 @@ jobs:
     - if: github.ref_protected
       run: rm -fr target
     - run: cargo install --locked --version 0.5.16 cargo-hack
-    - run: cargo hack --feature-powerset --excludes-features docs check --target wasm32-unknown --lib --profile release
-    - run: cargo hack --feature-powerset --excludes-features docs build --target wasm32-unknown --profile release
-    - run: cargo hack --feature-powerset --excludes-features docs check --target ${{ matrix.sys.target }} --lib --tests
-    - run: cargo hack --feature-powerset --excludes-features docs build --target ${{ matrix.sys.target }}
+    - run: cargo hack --feature-powerset --exclude-features docs check --target wasm32-unknown --lib --profile release
+    - run: cargo hack --feature-powerset --exclude-features docs build --target wasm32-unknown --profile release
+    - run: cargo hack --feature-powerset --exclude-features docs check --target ${{ matrix.sys.target }} --lib --tests
+    - run: cargo hack --feature-powerset --exclude-features docs build --target ${{ matrix.sys.target }}
     - run: cargo hack --feature-powerset --exclude-features docs test --target ${{ matrix.sys.target }}
 
   docs:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -30,31 +30,13 @@ jobs:
       matrix:
         sys:
         - os: ubuntu-latest
-          target: wasm32-unknown-unknown
-          profile: release
-          test: false
-        - os: ubuntu-latest
           target: x86_64-unknown-linux-gnu
-          profile: test
-          test: true
-        # TODO: Re-enable if we see value in doing so.
-        # - os: macos-latest
-        #   target: x86_64-apple-darwin
-        #   profile: test
-        #   test: true
-        # - os: macos-latest
-        #   target: aarch64-apple-darwin
-        #   profile: test
-        #   test: false
-        # - os: windows-latest
-        #   target: x86_64-pc-windows-msvc
-        #   profile: test
-        #   test: true
     runs-on: ${{ matrix.sys.os }}
     steps:
     - uses: actions/checkout@v3
     - run: rustup update
     - run: rustup target add ${{ matrix.sys.target }}
+    - run: rustup target add wasm32-unknown-unknown
     - uses: actions/cache@v3
       with:
         path: |
@@ -73,12 +55,11 @@ jobs:
     - if: github.ref_protected
       run: rm -fr target
     - run: cargo install --locked --version 0.5.16 cargo-hack
-    - run: cargo check --profile ${{ matrix.sys.profile }} --target ${{ matrix.sys.target }} --lib
-    - if: matrix.sys.test
-      run: cargo hack --feature-powerset check --exclude-features docs --profile ${{ matrix.sys.profile }} --target ${{ matrix.sys.target }} --bins --tests --examples --benches
-    - run: cargo build --profile ${{ matrix.sys.profile }} --target ${{ matrix.sys.target }}
-    - if: matrix.sys.test
-      run: cargo hack --feature-powerset test --exclude-features docs --profile ${{ matrix.sys.profile }} --target ${{ matrix.sys.target }}
+    - run: cargo hack --feature-powerset --excludes-features docs check --target wasm32-unknown --lib --profile release
+    - run: cargo hack --feature-powerset --excludes-features docs build --target wasm32-unknown --profile release
+    - run: cargo hack --feature-powerset --excludes-features docs check --target ${{ matrix.sys.target }} --lib --tests
+    - run: cargo hack --feature-powerset --excludes-features docs build --target ${{ matrix.sys.target }}
+    - run: cargo hack --feature-powerset --exclude-features docs test --target ${{ matrix.sys.target }}
 
   docs:
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -191,6 +191,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "downcast-rs"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
+
+[[package]]
 name = "dyn-fmt"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -257,6 +263,13 @@ dependencies = [
 
 [[package]]
 name = "example_create_contract"
+version = "0.0.0"
+dependencies = [
+ "soroban-sdk",
+]
+
+[[package]]
+name = "example_import_contract"
 version = "0.0.0"
 dependencies = [
  "soroban-sdk",
@@ -412,6 +425,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
 
 [[package]]
+name = "libm"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "292a948cd991e376cf75541fe5b97a1081d713c618b4f1b9500f8844e49eb565"
+
+[[package]]
 name = "log"
 version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -425,6 +444,12 @@ name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+
+[[package]]
+name = "memory_units"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8452105ba047068f40ff7093dd1d9da90898e63dd61736462e9cdda6a90ad3c3"
 
 [[package]]
 name = "miniz_oxide"
@@ -457,6 +482,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-rational"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0638a1c9d0a3c0914158145bc76cff373a75a627e6ecbfb71cbe6f453a5a19b0"
+dependencies = [
+ "autocfg",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -485,6 +522,12 @@ name = "opaque-debug"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
+
+[[package]]
+name = "parity-wasm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be5e13c266502aadf83426d87d81a0f5d1ef45b8027f5a471c360abfe4bfae92"
 
 [[package]]
 name = "ppv-lite86"
@@ -753,6 +796,7 @@ version = "0.0.3"
 source = "git+https://github.com/stellar/rs-soroban-env?rev=8861a4b5#8861a4b581a247b2799173859d7c9d04565e2046"
 dependencies = [
  "soroban-env-macros",
+ "soroban-wasmi",
  "static_assertions",
  "stellar-xdr",
 ]
@@ -769,7 +813,6 @@ dependencies = [
 [[package]]
 name = "soroban-env-host"
 version = "0.0.3"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=8861a4b5#8861a4b581a247b2799173859d7c9d04565e2046"
 dependencies = [
  "backtrace",
  "dyn-fmt",
@@ -780,9 +823,11 @@ dependencies = [
  "num-bigint",
  "num-integer",
  "num-traits",
+ "parity-wasm",
  "sha2 0.10.2",
  "soroban-env-common",
  "soroban-native-sdk-macros",
+ "soroban-wasmi",
  "static_assertions",
  "thiserror",
  "tinyvec",
@@ -834,6 +879,40 @@ dependencies = [
  "quote",
  "stellar-xdr",
  "syn",
+]
+
+[[package]]
+name = "soroban-wasmi"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ba96c441aa5a924f5d59114b43b2f8eab4ebbf7041dbf1c38fbae04620cb518"
+dependencies = [
+ "parity-wasm",
+ "soroban-wasmi-validation",
+ "soroban-wasmi_core",
+]
+
+[[package]]
+name = "soroban-wasmi-validation"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8983fe9f704b4f4c171ac02de77fcc85cba9fd65ad951e381525a8d6b58c374b"
+dependencies = [
+ "parity-wasm",
+]
+
+[[package]]
+name = "soroban-wasmi_core"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0db272b8e5d09022d701f74b58994710587cd7d5d7c4b1f00376a141edfbded"
+dependencies = [
+ "downcast-rs",
+ "libm",
+ "memory_units",
+ "num-rational",
+ "num-traits",
+ "parity-wasm",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "tests/add_i64",
     "tests/add_bigint",
     "tests/vec",
+    "tests/import_contract",
     "tests/invoke_contract",
     "tests/udt",
     "tests/contract_data",
@@ -34,7 +35,8 @@ soroban-sdk = { path = "soroban-sdk" }
 soroban-sdk-macros = { path = "soroban-sdk-macros" }
 soroban-env-common = { git = "https://github.com/stellar/rs-soroban-env", rev = "8861a4b5" }
 soroban-env-guest = { git = "https://github.com/stellar/rs-soroban-env", rev = "8861a4b5" }
-soroban-env-host = { git = "https://github.com/stellar/rs-soroban-env", rev = "8861a4b5" }
+# soroban-env-host = { git = "https://github.com/stellar/rs-soroban-env", rev = "8861a4b5" }
+soroban-env-host = { path = "../rs-soroban-env/soroban-env-host" }
 soroban-env-macros = { git = "https://github.com/stellar/rs-soroban-env", rev = "8861a4b5" }
 soroban-native-sdk-macros = { git = "https://github.com/stellar/rs-soroban-env", rev = "8861a4b5" }
 stellar-xdr = { git = "https://github.com/stellar/rs-stellar-xdr", rev = "3eca5ce" }

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ test: fmt
 	cargo hack --feature-powerset --exclude-features docs $(CARGO_TEST_SUBCOMMAND)
 
 build: fmt
-	cargo build --target wasm32-unknown-unknown --release
+	cargo hack build --target wasm32-unknown-unknown --release
 	CARGO_TARGET_DIR=target-tiny cargo +nightly build --target wasm32-unknown-unknown --release \
 		-Z build-std=std,panic_abort \
 		-Z build-std-features=panic_immediate_abort
@@ -34,7 +34,7 @@ build: fmt
 
 check: fmt
 	cargo hack --feature-powerset --exclude-features docs check --all-targets
-	cargo check --release --target wasm32-unknown-unknown
+	cargo hack check --release --target wasm32-unknown-unknown
 
 watch:
 	cargo watch --clear --watch-when-idle --shell '$(MAKE)'

--- a/soroban-sdk/Cargo.toml
+++ b/soroban-sdk/Cargo.toml
@@ -21,7 +21,7 @@ ed25519-dalek = { version = "1.0.1", optional = true }
 soroban-env-guest = { version = "0.0.3" }
 
 [target.'cfg(not(target_family="wasm"))'.dependencies]
-soroban-env-host = { version = "0.0.3" }
+soroban-env-host = { version = "0.0.3", features = ["vm"] }
 
 [dev-dependencies]
 stellar-xdr = { version = "0.0.1", features = ["next", "std"] }

--- a/soroban-sdk/doctest_fixtures/README.md
+++ b/soroban-sdk/doctest_fixtures/README.md
@@ -1,0 +1,4 @@
+# doctest_fixtures
+
+Files contained in this directory are used within examples inside docs, i.e.
+doctests.

--- a/soroban-sdk/src/env.rs
+++ b/soroban-sdk/src/env.rs
@@ -331,7 +331,7 @@ impl Env {
     /// ```
     /// use soroban_sdk::{BytesN, Env};
     ///
-    /// const WASM: &[u8] = include_bytes!("contract.wasm");
+    /// const WASM: &[u8] = include_bytes!("../doctest_fixtures/contract.wasm");
     ///
     /// # fn main() {
     /// let env = Env::default();

--- a/soroban-sdk/src/env.rs
+++ b/soroban-sdk/src/env.rs
@@ -325,6 +325,26 @@ impl Env {
             .unwrap();
     }
 
+    /// Register a contract in a WASM file with the [Env] for testing.
+    ///
+    /// ### Examples
+    /// ```
+    /// use soroban_sdk::{BytesN, Env};
+    ///
+    /// const WASM: &[u8] = include_bytes!("contract.wasm");
+    ///
+    /// # fn main() {
+    /// let env = Env::default();
+    /// let contract_id = BytesN::from_array(&env, [0; 32]);
+    /// env.register_contract_wasm(&contract_id, WASM);
+    /// # }
+    /// ```
+    pub fn register_contract_wasm(&self, contract_id: &BytesN<32>, contract_wasm: &[u8]) {
+        self.env_impl
+            .register_test_contract_wasm(contract_id.to_object(), contract_wasm)
+            .unwrap();
+    }
+
     #[doc(hidden)]
     pub fn invoke_contract_external_raw(&self, hf: xdr::HostFunction, args: xdr::ScVec) -> RawVal {
         self.env_impl.invoke_function_raw(hf, args).unwrap()

--- a/tests/import_contract/Cargo.toml
+++ b/tests/import_contract/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "example_import_contract"
+version = "0.0.0"
+authors = ["Stellar Development Foundation <info@stellar.org>"]
+license = "Apache-2.0"
+edition = "2021"
+publish = false
+rust-version = "1.63"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+doctest = false
+
+[dependencies]
+soroban-sdk = {path = "../../soroban-sdk"}
+
+[dev-dependencies]
+soroban-sdk = {path = "../../soroban-sdk", features = ["testutils"]}
+
+[features]
+testutils = ["soroban-sdk/testutils"]

--- a/tests/import_contract/src/lib.rs
+++ b/tests/import_contract/src/lib.rs
@@ -1,0 +1,41 @@
+#![no_std]
+use soroban_sdk::{contractimpl, vec, BytesN, Env, IntoVal, Symbol};
+
+pub struct Contract;
+
+#[contractimpl]
+impl Contract {
+    pub fn add_with(env: Env, x: i32, y: i32, contract_id: BytesN<32>) -> i32 {
+        env.invoke_contract(
+            &contract_id,
+            &Symbol::from_str("add"),
+            vec![&env, x.into_env_val(&env), y.into_env_val(&env)],
+        )
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use soroban_sdk::{BytesN, Env};
+
+    use crate::{add_with, Contract};
+
+    const ADD_CONTRACT_WASM: &[u8] =
+        include_bytes!("../../../target/wasm32-unknown-unknown/release/example_add_i32.wasm");
+
+    #[test]
+    fn test_add() {
+        let e = Env::default();
+
+        let add_contract_id = BytesN::from_array(&e, [0; 32]);
+        e.register_contract_wasm(&add_contract_id, ADD_CONTRACT_WASM);
+
+        let contract_id = BytesN::from_array(&e, [1; 32]);
+        e.register_contract(&contract_id, Contract);
+
+        let x = 10i32;
+        let y = 12i32;
+        let z = add_with::invoke(&e, &contract_id, &x, &y, &add_contract_id);
+        assert!(z == 22);
+    }
+}


### PR DESCRIPTION
### What
Add Env::register_contract_wasm and import_contract example.

### Why
Plumbing through the ability to register a contract WASM file directly against a contract ID as being added to the soroban-env-host::Host in https://github.com/stellar/rs-soroban-env/pull/332.

The import_contract example being added demonstrates the use.

The import_contract example being added will also serve as a good contract for the work being done in https://github.com/stellar/rs-soroban-sdk/pull/411 for https://github.com/stellar/rs-soroban-sdk/issues/118.