### PR TITLE
Small refactor to store spec_xdr on the type it relates.

### DIFF
--- a/soroban-sdk-macros/src/derive_type.rs
+++ b/soroban-sdk-macros/src/derive_type.rs
@@ -92,7 +92,13 @@ pub fn derive_type_struct(ident: &Ident, data: &DataStruct, spec: bool) -> Token
         let spec_ident = format_ident!("__SPEC_XDR_{}", ident.to_string().to_uppercase());
         Some(quote! {
             #[cfg_attr(target_family = "wasm", link_section = "contractspecv0")]
-            pub static #spec_ident: [u8; #spec_xdr_len] = *#spec_xdr_lit;
+            pub static #spec_ident: [u8; #spec_xdr_len] = #ident::spec_xdr();
+
+            impl #ident {
+                pub const fn spec_xdr() -> [u8; #spec_xdr_len] {
+                    *#spec_xdr_lit
+                }
+            }
         })
     } else {
         None
@@ -354,7 +360,13 @@ pub fn derive_type_enum(enum_ident: &Ident, data: &DataEnum, spec: bool) -> Toke
         let spec_ident = format_ident!("__SPEC_XDR_{}", enum_ident.to_string().to_uppercase());
         Some(quote! {
             #[cfg_attr(target_family = "wasm", link_section = "contractspecv0")]
-            pub static #spec_ident: [u8; #spec_xdr_len] = *#spec_xdr_lit;
+            pub static #spec_ident: [u8; #spec_xdr_len] = #enum_ident::spec_xdr();
+
+            impl #enum_ident {
+                pub const fn spec_xdr() -> [u8; #spec_xdr_len] {
+                    *#spec_xdr_lit
+                }
+            }
         })
     } else {
         None

--- a/soroban-sdk-macros/src/lib.rs
+++ b/soroban-sdk-macros/src/lib.rs
@@ -30,8 +30,7 @@ pub fn contractimpl(metadata: TokenStream, input: TokenStream) -> TokenStream {
     };
     let imp = parse_macro_input!(input as ItemImpl);
     let ty = &imp.self_ty;
-    let pub_methods: Vec<_> = syn_ext::impl_pub_methods(&imp)
-        .collect();
+    let pub_methods: Vec<_> = syn_ext::impl_pub_methods(&imp).collect();
     let derived: Result<proc_macro2::TokenStream, proc_macro2::TokenStream> = pub_methods
         .iter()
         .map(|m| {
@@ -40,6 +39,7 @@ pub fn contractimpl(metadata: TokenStream, input: TokenStream) -> TokenStream {
             let trait_ident = imp.trait_.as_ref().and_then(|x| x.1.get_ident());
             derive_fn(
                 &call,
+                ty,
                 ident,
                 &m.sig.inputs,
                 &m.sig.output,


### PR DESCRIPTION
### What

Move where the source of the spec_xdr is onto the type it relates.

### Why

I'm tried moving some existing generated things onto the types they relate in the lead up to moving invoke functions onto the type as well. There isn't a lot of benefit we'll see by doing this for the contracttype specs, but for contractimpl specs it will make it much more sane for the user since they'll be able to do `MyContract::invoke_add` as opposed to `add::invoke`. I wanted to see if it would work using something simpler, which is why I did the contracttype ones first. Consistency might be valued, so I'm going to commit this experiment. It has no material impact on the user, or on binary size.

Related to #436.

### Known limitations

N/A
