### PR TITLE
Remove unnecessary ci build steps

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -56,7 +56,8 @@ jobs:
       run: rm -fr target
     - run: cargo install --locked --version 0.5.16 cargo-hack
     - run: cargo hack build --target wasm32-unknown-unknown --profile release
-    - run: cargo hack --feature-powerset --exclude-features docs build --target ${{ matrix.sys.target }} --lib --tests
+    - run: cargo hack --feature-powerset --exclude-features docs build --target ${{ matrix.sys.target }} --lib
+    - run: cargo hack --feature-powerset --exclude-features docs build --target ${{ matrix.sys.target }} --lib --tests -p soroban-sdk
     - run: cargo hack --feature-powerset --exclude-features docs test --target ${{ matrix.sys.target }}
 
   docs:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -56,7 +56,7 @@ jobs:
       run: rm -fr target
     - run: cargo install --locked --version 0.5.16 cargo-hack
     - run: cargo hack build --target wasm32-unknown-unknown --profile release
-    - run: cargo hack --feature-powerset --exclude-features docs check --target ${{ matrix.sys.target }} --lib --tests
+    - run: cargo hack --feature-powerset --exclude-features docs build --target ${{ matrix.sys.target }} --lib --tests
     - run: cargo hack --feature-powerset --exclude-features docs test --target ${{ matrix.sys.target }}
 
   docs:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -56,8 +56,7 @@ jobs:
       run: rm -fr target
     - run: cargo install --locked --version 0.5.16 cargo-hack
     - run: cargo hack build --target wasm32-unknown-unknown --profile release
-    - run: cargo hack --feature-powerset --exclude-features docs build --target ${{ matrix.sys.target }} --lib
-    - run: cargo hack --feature-powerset --exclude-features docs build --target ${{ matrix.sys.target }} --lib --tests -p soroban-sdk
+    - run: cargo hack --feature-powerset --exclude-features docs build --target ${{ matrix.sys.target }}
     - run: cargo hack --feature-powerset --exclude-features docs test --target ${{ matrix.sys.target }}
 
   docs:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -55,10 +55,8 @@ jobs:
     - if: github.ref_protected
       run: rm -fr target
     - run: cargo install --locked --version 0.5.16 cargo-hack
-    - run: cargo hack check --target wasm32-unknown-unknown --lib --profile release
     - run: cargo hack build --target wasm32-unknown-unknown --profile release
     - run: cargo hack --feature-powerset --exclude-features docs check --target ${{ matrix.sys.target }} --lib --tests
-    - run: cargo hack --feature-powerset --exclude-features docs build --target ${{ matrix.sys.target }}
     - run: cargo hack --feature-powerset --exclude-features docs test --target ${{ matrix.sys.target }}
 
   docs:


### PR DESCRIPTION
### What
Remove from ci the check step for wasm32 builds and the build step for native builds.

### Why
We don't need to check and build for both of these, just one or the other. Build is preferred for wasm32 because we use the resulting wasm32 outputs in our tests. Check is preferred for the local builds because we don't need the outputs.