### PR TITLE
Fix first time build missing wasm file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ doc: fmt
 		--features docs,testutils \
 		$(CARGO_DOC_ARGS)
 
-test: fmt
+test: fmt build
 	cargo hack --feature-powerset --exclude-features docs $(CARGO_TEST_SUBCOMMAND)
 
 build: fmt


### PR DESCRIPTION
### What
Run builds before tests in Makefile.

### Why
The tests rely on the existence of .wasm files for cross-contract calls.

Note that this comes at a small cost of compile time, but that tradeoff reduces the maintenance burden of setting up fixtures in the tests, and Rust/Cargo's caching system should make rebuilds fast.