### PR TITLE
Simplify the import example a little

### DIFF
--- a/tests/import_contract/src/lib.rs
+++ b/tests/import_contract/src/lib.rs
@@ -1,13 +1,15 @@
 #![no_std]
 use soroban_sdk::{contractimpl, vec, BytesN, Env, IntoVal, Symbol};
 
+const ADD_CONTRACT_ID: [u8; 32] = [0; 32];
+
 pub struct Contract;
 
 #[contractimpl]
 impl Contract {
-    pub fn add_with(env: Env, x: i32, y: i32, contract_id: BytesN<32>) -> i32 {
+    pub fn add_with(env: Env, x: i32, y: i32) -> i32 {
         env.invoke_contract(
-            &contract_id,
+            &BytesN::from_array(&env, ADD_CONTRACT_ID),
             &Symbol::from_str("add"),
             vec![&env, x.into_env_val(&env), y.into_env_val(&env)],
         )
@@ -18,7 +20,7 @@ impl Contract {
 mod test {
     use soroban_sdk::{BytesN, Env};
 
-    use crate::{add_with, Contract};
+    use crate::{add_with, Contract, ADD_CONTRACT_ID};
 
     const ADD_CONTRACT_WASM: &[u8] =
         include_bytes!("../../../target/wasm32-unknown-unknown/release/example_add_i32.wasm");
@@ -27,7 +29,7 @@ mod test {
     fn test_add() {
         let e = Env::default();
 
-        let add_contract_id = BytesN::from_array(&e, [0; 32]);
+        let add_contract_id = BytesN::from_array(&e, ADD_CONTRACT_ID);
         e.register_contract_wasm(&add_contract_id, ADD_CONTRACT_WASM);
 
         let contract_id = BytesN::from_array(&e, [1; 32]);
@@ -35,7 +37,7 @@ mod test {
 
         let x = 10i32;
         let y = 12i32;
-        let z = add_with::invoke(&e, &contract_id, &x, &y, &add_contract_id);
+        let z = add_with::invoke(&e, &contract_id, &x, &y);
         assert!(z == 22);
     }
 }


### PR DESCRIPTION
### What
Remove contract ID as a parameter.

### Why
It is more likely that the contract ID would be stored as contract data during initialization. I don't want to introduce storage to this example because I want it to be as simple as possible. Storing the value in a constant feels more similar to the resulting contract without the initialization and using contract data.