### PR TITLE
Add link to CONTRIBUTING.md in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,7 @@ Docs: https://docs.rs/soroban-sdk
 **This repository contains code that is in early development, incomplete, not tested, and not recommended for use. The API is unstable, experimental, and is receiving breaking changes frequently.**
 
 [Soroban]: https://soroban.stellar.org
+
+## Contributing
+
+Contributing to the SDK? Read [CONTRIBUTING.md](CONTRIBUTING.md).


### PR DESCRIPTION
### What

Add link to CONTRIBUTING.md in README.

### Why

To make CONTRIBUTING.md discoverable.
