### PR TITLE
Rename spec read fns

### DIFF
--- a/soroban-sdk/tests/contractimport.rs
+++ b/soroban-sdk/tests/contractimport.rs
@@ -37,7 +37,7 @@ fn test_functional() {
 
 #[test]
 fn test_spec() {
-    let entries = soroban_spec::read::parse_spec(&Contract::spec_xdr_add_with()).unwrap();
+    let entries = soroban_spec::read::parse_raw(&Contract::spec_xdr_add_with()).unwrap();
     let expect = vec![ScSpecEntry::FunctionV0(ScSpecFunctionV0 {
         name: "add_with".try_into().unwrap(),
         input_types: vec![ScSpecTypeDef::I32, ScSpecTypeDef::I32]

--- a/soroban-sdk/tests/contractimport_with_sha256.rs
+++ b/soroban-sdk/tests/contractimport_with_sha256.rs
@@ -38,7 +38,7 @@ fn test_functional() {
 
 #[test]
 fn test_spec() {
-    let entries = soroban_spec::read::parse_spec(&Contract::spec_xdr_add_with()).unwrap();
+    let entries = soroban_spec::read::parse_raw(&Contract::spec_xdr_add_with()).unwrap();
     let expect = vec![ScSpecEntry::FunctionV0(ScSpecFunctionV0 {
         name: "add_with".try_into().unwrap(),
         input_types: vec![ScSpecTypeDef::I32, ScSpecTypeDef::I32]

--- a/soroban-spec/src/codegen/rust.rs
+++ b/soroban-spec/src/codegen/rust.rs
@@ -8,7 +8,7 @@ use quote::quote;
 use sha2::{Digest, Sha256};
 use stellar_xdr::{self, ScSpecEntry};
 
-use crate::read::{read_spec, GetSpecError};
+use crate::read::{from_wasm, FromWasmError};
 
 use types::{generate_struct, generate_union};
 
@@ -21,7 +21,7 @@ pub enum GenerateFromFileError {
     #[error("parsing contract spec: {0}")]
     Parse(stellar_xdr::Error),
     #[error("getting contract spec: {0}")]
-    GetSpec(GetSpecError),
+    GetSpec(FromWasmError),
 }
 
 pub fn generate_from_file(
@@ -44,7 +44,7 @@ pub fn generate_from_file(
     }
 
     // Read spec from file.
-    let spec = read_spec(&wasm).map_err(GenerateFromFileError::GetSpec)?;
+    let spec = from_wasm(&wasm).map_err(GenerateFromFileError::GetSpec)?;
 
     // Generate code.
     let code = generate(&spec, file, &sha256);

--- a/soroban-spec/src/read.rs
+++ b/soroban-spec/src/read.rs
@@ -48,7 +48,7 @@ pub fn raw_from_wasm(wasm: &[u8]) -> Result<Vec<u8>, FromWasmError> {
 
 pub fn base64_from_wasm(wasm: &[u8]) -> Result<String, FromWasmError> {
     let raw = raw_from_wasm(wasm)?;
-    base64::encode(raw)
+    Ok(base64::encode(raw))
 }
 
 pub fn from_wasm(wasm: &[u8]) -> Result<Vec<ScSpecEntry>, FromWasmError> {

--- a/soroban-spec/src/read.rs
+++ b/soroban-spec/src/read.rs
@@ -13,19 +13,19 @@ pub enum ParseSpecBase64Error {
     ParseXdr(stellar_xdr::Error),
 }
 
-pub fn parse_spec_base64(spec: &[u8]) -> Result<Vec<ScSpecEntry>, ParseSpecBase64Error> {
+pub fn parse_base64(spec: &[u8]) -> Result<Vec<ScSpecEntry>, ParseSpecBase64Error> {
     let decoded = base64::decode(spec).map_err(ParseSpecBase64Error::ParseBase64)?;
-    parse_spec(&decoded).map_err(ParseSpecBase64Error::ParseXdr)
+    parse_raw(&decoded).map_err(ParseSpecBase64Error::ParseXdr)
 }
 
-pub fn parse_spec(spec: &[u8]) -> Result<Vec<ScSpecEntry>, stellar_xdr::Error> {
+pub fn parse_raw(spec: &[u8]) -> Result<Vec<ScSpecEntry>, stellar_xdr::Error> {
     let mut cursor = Cursor::new(spec);
     let entries = ScSpecEntry::read_xdr_iter(&mut cursor).collect::<Result<Vec<_>, _>>()?;
     Ok(entries)
 }
 
 #[derive(thiserror::Error, Debug)]
-pub enum GetSpecError {
+pub enum FromWasmError {
     #[error("reading wasm")]
     Read(BinaryReaderError),
     #[error("parsing contract spec")]
@@ -34,19 +34,24 @@ pub enum GetSpecError {
     NotFound,
 }
 
-pub fn read_spec_raw(wasm: &[u8]) -> Result<Vec<u8>, GetSpecError> {
+pub fn raw_from_wasm(wasm: &[u8]) -> Result<Vec<u8>, FromWasmError> {
     for payload in Parser::new(0).parse_all(wasm) {
-        let payload = payload.map_err(GetSpecError::Read)?;
+        let payload = payload.map_err(FromWasmError::Read)?;
         if let Payload::CustomSection(section) = payload {
             if section.name() == "contractspecv0" {
                 return Ok(section.data().to_vec());
             }
         };
     }
-    Err(GetSpecError::NotFound)
+    Err(FromWasmError::NotFound)
 }
 
-pub fn read_spec(wasm: &[u8]) -> Result<Vec<ScSpecEntry>, GetSpecError> {
-    let spec = read_spec_raw(wasm)?;
-    parse_spec(&spec).map_err(GetSpecError::Parse)
+pub fn base64_from_wasm(wasm: &[u8]) -> Result<String, FromWasmError> {
+    let raw = raw_from_wasm(wasm)?;
+    base64::encode(raw)
+}
+
+pub fn from_wasm(wasm: &[u8]) -> Result<Vec<ScSpecEntry>, FromWasmError> {
+    let spec = raw_from_wasm(wasm)?;
+    parse_raw(&spec).map_err(FromWasmError::Parse)
 }


### PR DESCRIPTION
### What
Rename spec read fns.

### Why
After moving the fns around in a recent change their names don't quite fit as well as they could.