### PR TITLE
Add names to input types in spec functions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -831,7 +831,7 @@ dependencies = [
 [[package]]
 name = "soroban-env-common"
 version = "0.0.3"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=fba7071c#fba7071c55df509f3702b5074f9249749dae9a9b"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=7395b810#7395b8108b7eae28a2a068a0f3b75a5f824ee515"
 dependencies = [
  "soroban-env-macros",
  "soroban-wasmi",
@@ -842,7 +842,7 @@ dependencies = [
 [[package]]
 name = "soroban-env-guest"
 version = "0.0.3"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=fba7071c#fba7071c55df509f3702b5074f9249749dae9a9b"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=7395b810#7395b8108b7eae28a2a068a0f3b75a5f824ee515"
 dependencies = [
  "soroban-env-common",
  "static_assertions",
@@ -851,7 +851,7 @@ dependencies = [
 [[package]]
 name = "soroban-env-host"
 version = "0.0.3"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=fba7071c#fba7071c55df509f3702b5074f9249749dae9a9b"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=7395b810#7395b8108b7eae28a2a068a0f3b75a5f824ee515"
 dependencies = [
  "backtrace",
  "dyn-fmt",
@@ -875,7 +875,7 @@ dependencies = [
 [[package]]
 name = "soroban-env-macros"
 version = "0.0.3"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=fba7071c#fba7071c55df509f3702b5074f9249749dae9a9b"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=7395b810#7395b8108b7eae28a2a068a0f3b75a5f824ee515"
 dependencies = [
  "itertools",
  "proc-macro2",
@@ -887,7 +887,7 @@ dependencies = [
 [[package]]
 name = "soroban-native-sdk-macros"
 version = "0.0.1"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=fba7071c#fba7071c55df509f3702b5074f9249749dae9a9b"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=7395b810#7395b8108b7eae28a2a068a0f3b75a5f824ee515"
 dependencies = [
  "itertools",
  "proc-macro2",
@@ -982,7 +982,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 [[package]]
 name = "stellar-xdr"
 version = "0.0.1"
-source = "git+https://github.com/stellar/rs-stellar-xdr?rev=66436840#66436840ec4adcb871dac634d78568854b30dddb"
+source = "git+https://github.com/stellar/rs-stellar-xdr?rev=f4fe3091#f4fe309136070c3d932bfcb8019ded953b842e5c"
 
 [[package]]
 name = "strsim"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,12 +42,12 @@ exclude = [
 [patch.crates-io]
 soroban-sdk = { path = "soroban-sdk" }
 soroban-sdk-macros = { path = "soroban-sdk-macros" }
-soroban-env-common = { git = "https://github.com/stellar/rs-soroban-env", rev = "fba7071c" }
-soroban-env-guest = { git = "https://github.com/stellar/rs-soroban-env", rev = "fba7071c" }
-soroban-env-host = { git = "https://github.com/stellar/rs-soroban-env", rev = "fba7071c" }
-soroban-env-macros = { git = "https://github.com/stellar/rs-soroban-env", rev = "fba7071c" }
-soroban-native-sdk-macros = { git = "https://github.com/stellar/rs-soroban-env", rev = "fba7071c" }
-stellar-xdr = { git = "https://github.com/stellar/rs-stellar-xdr", rev = "66436840" }
+soroban-env-common = { git = "https://github.com/stellar/rs-soroban-env", rev = "7395b810" }
+soroban-env-guest = { git = "https://github.com/stellar/rs-soroban-env", rev = "7395b810" }
+soroban-env-host = { git = "https://github.com/stellar/rs-soroban-env", rev = "7395b810" }
+soroban-env-macros = { git = "https://github.com/stellar/rs-soroban-env", rev = "7395b810" }
+soroban-native-sdk-macros = { git = "https://github.com/stellar/rs-soroban-env", rev = "7395b810" }
+stellar-xdr = { git = "https://github.com/stellar/rs-stellar-xdr", rev = "f4fe3091" }
 
 [profile.dev]
 overflow-checks = true

--- a/soroban-sdk-macros/src/derive_client.rs
+++ b/soroban-sdk-macros/src/derive_client.rs
@@ -35,24 +35,19 @@ pub fn derive_client(name: &str, methods: &[&TraitItemMethod]) -> TokenStream {
             let (fn_input_names, fn_input_types): (Vec<_>, Vec<_>) = m.sig.inputs
                 .iter()
                 .skip(if env_input.is_some() { 1 } else { 0 })
-                .enumerate().map(|(i, t)| {
+                .map(|t| {
                     match t {
                         FnArg::Typed(pat_type) => {
                             if let Pat::Ident(pat_ident) = *pat_type.pat.clone() {
-                                let ident = format_ident!("arg_{}", i);
-                                let mut pat_type = pat_type.clone();
-                                let mut pat_ident = pat_ident.clone();
-                                pat_ident.ident = ident.clone();
-                                pat_type.pat = Box::new(Pat::Ident(pat_ident));
-                                (ident, FnArg::Typed(pat_type))
+                                (pat_ident.ident, t)
                             } else {
                                 errors.push(Error::new(t.span(), "argument not supported"));
-                                (format_ident!(""), t.clone())
+                                (format_ident!(""), t)
                             }
                         }
                         _ => {
                             errors.push(Error::new(t.span(), "argument not supported"));
-                            (format_ident!(""), t.clone())
+                            (format_ident!(""), t)
                         }
                     }
                 })

--- a/soroban-sdk/tests/contractfile_with_sha256.rs
+++ b/soroban-sdk/tests/contractfile_with_sha256.rs
@@ -1,6 +1,6 @@
 pub const WASM: &[u8] = soroban_sdk::contractfile!(
     file = "target/wasm32-unknown-unknown/release/example_add_i32.wasm",
-    sha256 = "0ef130ce81f57cb03a9e20b0e8b5c9e47bf8c50cf0a811e4b25535ad95b92a7e"
+    sha256 = "082f8d7a70e88996451d2fa53844a95f8c6da4e9179f9ce133bd40489194b3ae"
 );
 
 #[test]

--- a/soroban-sdk/tests/contractimport.rs
+++ b/soroban-sdk/tests/contractimport.rs
@@ -1,7 +1,7 @@
 #![cfg(feature = "testutils")]
 
 use soroban_sdk::{contractimpl, BytesN, Env};
-use stellar_xdr::{ScSpecEntry, ScSpecFunctionV0, ScSpecTypeDef};
+use stellar_xdr::{ScSpecEntry, ScSpecFunctionInputV0, ScSpecFunctionV0, ScSpecTypeDef};
 
 const ADD_CONTRACT_ID: [u8; 32] = [0; 32];
 mod addcontract {
@@ -40,10 +40,19 @@ fn test_spec() {
     let entries = soroban_spec::read::parse_raw(&Contract::spec_xdr_add_with()).unwrap();
     let expect = vec![ScSpecEntry::FunctionV0(ScSpecFunctionV0 {
         name: "add_with".try_into().unwrap(),
-        input_types: vec![ScSpecTypeDef::I32, ScSpecTypeDef::I32]
-            .try_into()
-            .unwrap(),
-        output_types: vec![ScSpecTypeDef::I32].try_into().unwrap(),
+        inputs: vec![
+            ScSpecFunctionInputV0 {
+                name: "x".try_into().unwrap(),
+                type_: ScSpecTypeDef::I32,
+            },
+            ScSpecFunctionInputV0 {
+                name: "y".try_into().unwrap(),
+                type_: ScSpecTypeDef::I32,
+            },
+        ]
+        .try_into()
+        .unwrap(),
+        outputs: vec![ScSpecTypeDef::I32].try_into().unwrap(),
     })];
     assert_eq!(entries, expect);
 }

--- a/soroban-sdk/tests/contractimport_with_sha256.rs
+++ b/soroban-sdk/tests/contractimport_with_sha256.rs
@@ -1,13 +1,13 @@
 #![cfg(feature = "testutils")]
 
 use soroban_sdk::{contractimpl, BytesN, Env};
-use stellar_xdr::{ScSpecEntry, ScSpecFunctionV0, ScSpecTypeDef};
+use stellar_xdr::{ScSpecEntry, ScSpecFunctionInputV0, ScSpecFunctionV0, ScSpecTypeDef};
 
 const ADD_CONTRACT_ID: [u8; 32] = [0; 32];
 mod addcontract {
     soroban_sdk::contractimport!(
         file = "target/wasm32-unknown-unknown/release/example_add_i32.wasm",
-        sha256 = "0ef130ce81f57cb03a9e20b0e8b5c9e47bf8c50cf0a811e4b25535ad95b92a7e",
+        sha256 = "082f8d7a70e88996451d2fa53844a95f8c6da4e9179f9ce133bd40489194b3ae",
     );
 }
 
@@ -41,10 +41,19 @@ fn test_spec() {
     let entries = soroban_spec::read::parse_raw(&Contract::spec_xdr_add_with()).unwrap();
     let expect = vec![ScSpecEntry::FunctionV0(ScSpecFunctionV0 {
         name: "add_with".try_into().unwrap(),
-        input_types: vec![ScSpecTypeDef::I32, ScSpecTypeDef::I32]
-            .try_into()
-            .unwrap(),
-        output_types: vec![ScSpecTypeDef::I32].try_into().unwrap(),
+        inputs: vec![
+            ScSpecFunctionInputV0 {
+                name: "x".try_into().unwrap(),
+                type_: ScSpecTypeDef::I32,
+            },
+            ScSpecFunctionInputV0 {
+                name: "y".try_into().unwrap(),
+                type_: ScSpecTypeDef::I32,
+            },
+        ]
+        .try_into()
+        .unwrap(),
+        outputs: vec![ScSpecTypeDef::I32].try_into().unwrap(),
     })];
     assert_eq!(entries, expect);
 }

--- a/soroban-sdk/tests/macros_fails/contractfile_with_sha256_verify_fail.stderr
+++ b/soroban-sdk/tests/macros_fails/contractfile_with_sha256_verify_fail.stderr
@@ -1,4 +1,4 @@
-error: sha256 does not match, expected: 0ef130ce81f57cb03a9e20b0e8b5c9e47bf8c50cf0a811e4b25535ad95b92a7e
+error: sha256 does not match, expected: 082f8d7a70e88996451d2fa53844a95f8c6da4e9179f9ce133bd40489194b3ae
  --> tests/macros_fails/contractfile_with_sha256_verify_fail.rs:3:5
   |
 3 |     sha256 = "0000000000000000000000000000000000000000000000000000000000000000",

--- a/soroban-sdk/tests/macros_fails/contractimport_with_sha256_verify_fail.stderr
+++ b/soroban-sdk/tests/macros_fails/contractimport_with_sha256_verify_fail.stderr
@@ -1,4 +1,4 @@
-error: sha256 does not match, expected: 0ef130ce81f57cb03a9e20b0e8b5c9e47bf8c50cf0a811e4b25535ad95b92a7e
+error: sha256 does not match, expected: 082f8d7a70e88996451d2fa53844a95f8c6da4e9179f9ce133bd40489194b3ae
  --> tests/macros_fails/contractimport_with_sha256_verify_fail.rs:3:5
   |
 3 |     sha256 = "0000000000000000000000000000000000000000000000000000000000000000",

--- a/soroban-sdk/tests/macros_spec_i32.rs
+++ b/soroban-sdk/tests/macros_spec_i32.rs
@@ -3,7 +3,7 @@
 use std::io::Cursor;
 
 use soroban_sdk::{contractimpl, BytesN, Env};
-use stellar_xdr::{ReadXdr, ScSpecEntry, ScSpecFunctionV0, ScSpecTypeDef};
+use stellar_xdr::{ReadXdr, ScSpecEntry, ScSpecFunctionInputV0, ScSpecFunctionV0, ScSpecTypeDef};
 
 pub struct Contract;
 
@@ -31,10 +31,19 @@ fn test_spec() {
     let entries = ScSpecEntry::read_xdr(&mut Cursor::new(&__SPEC_XDR_ADD)).unwrap();
     let expect = ScSpecEntry::FunctionV0(ScSpecFunctionV0 {
         name: "add".try_into().unwrap(),
-        input_types: vec![ScSpecTypeDef::I32, ScSpecTypeDef::I32]
-            .try_into()
-            .unwrap(),
-        output_types: vec![ScSpecTypeDef::I32].try_into().unwrap(),
+        inputs: vec![
+            ScSpecFunctionInputV0 {
+                name: "a".try_into().unwrap(),
+                type_: ScSpecTypeDef::I32,
+            },
+            ScSpecFunctionInputV0 {
+                name: "b".try_into().unwrap(),
+                type_: ScSpecTypeDef::I32,
+            },
+        ]
+        .try_into()
+        .unwrap(),
+        outputs: vec![ScSpecTypeDef::I32].try_into().unwrap(),
     });
     assert_eq!(entries, expect);
 }

--- a/soroban-sdk/tests/macros_spec_udt.rs
+++ b/soroban-sdk/tests/macros_spec_udt.rs
@@ -4,7 +4,8 @@ use std::io::Cursor;
 
 use soroban_sdk::{contractimpl, contracttype, BytesN, Env};
 use stellar_xdr::{
-    ReadXdr, ScSpecEntry, ScSpecFunctionV0, ScSpecTypeDef, ScSpecTypeTuple, ScSpecTypeUdt,
+    ReadXdr, ScSpecEntry, ScSpecFunctionInputV0, ScSpecFunctionV0, ScSpecTypeDef, ScSpecTypeTuple,
+    ScSpecTypeUdt,
 };
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
@@ -40,17 +41,23 @@ fn test_spec() {
     let entries = ScSpecEntry::read_xdr(&mut Cursor::new(&__SPEC_XDR_ADD)).unwrap();
     let expect = ScSpecEntry::FunctionV0(ScSpecFunctionV0 {
         name: "add".try_into().unwrap(),
-        input_types: vec![
-            ScSpecTypeDef::Udt(ScSpecTypeUdt {
-                name: "Udt".try_into().unwrap(),
-            }),
-            ScSpecTypeDef::Udt(ScSpecTypeUdt {
-                name: "Udt".try_into().unwrap(),
-            }),
+        inputs: vec![
+            ScSpecFunctionInputV0 {
+                name: "a".try_into().unwrap(),
+                type_: ScSpecTypeDef::Udt(ScSpecTypeUdt {
+                    name: "Udt".try_into().unwrap(),
+                }),
+            },
+            ScSpecFunctionInputV0 {
+                name: "b".try_into().unwrap(),
+                type_: ScSpecTypeDef::Udt(ScSpecTypeUdt {
+                    name: "Udt".try_into().unwrap(),
+                }),
+            },
         ]
         .try_into()
         .unwrap(),
-        output_types: vec![ScSpecTypeDef::Tuple(Box::new(ScSpecTypeTuple {
+        outputs: vec![ScSpecTypeDef::Tuple(Box::new(ScSpecTypeTuple {
             value_types: vec![
                 ScSpecTypeDef::Udt(ScSpecTypeUdt {
                     name: "Udt".try_into().unwrap(),

--- a/soroban-spec/src/gen/rust/trait.rs
+++ b/soroban-spec/src/gen/rust/trait.rs
@@ -12,13 +12,13 @@ pub fn generate_trait(name: &str, specs: &[&ScSpecFunctionV0]) -> TokenStream {
         .iter()
         .map(|s| {
             let fn_ident = format_ident!("{}", s.name.to_string().unwrap());
-            let fn_inputs = s.input_types.iter().enumerate().map(|(i, t)| {
-                let name = format_ident!("a{}", i);
-                let type_ident = generate_type_ident(t);
+            let fn_inputs = s.inputs.iter().map(|input| {
+                let name = format_ident!("{}", input.name.to_string().unwrap());
+                let type_ident = generate_type_ident(&input.type_);
                 quote! { #name: #type_ident }
             });
             let fn_output = s
-                .output_types
+                .outputs
                 .to_option()
                 .map(|t| generate_type_ident(&t))
                 .map(|t| quote! { -> #t });


### PR DESCRIPTION
### What
Add names to input types in spec functions.

### Why
When defining an interface it is helpful to give names to the arguments of the functions so a user of the interface knows what to put in the arguments. This is especially helpful when multiple arguments have the same type, since a name is the only thing that distinguishes them.

Close stellar/rs-soroban-sdk#434