### PR TITLE
Rename Env::create_contract_from_contract to Env::deploy_contract

### DIFF
--- a/soroban-sdk/src/env.rs
+++ b/soroban-sdk/src/env.rs
@@ -188,16 +188,26 @@ impl Env {
             .unwrap()
     }
 
-    #[doc(hidden)]
-    pub fn create_contract_from_contract(&self, contract: Bytes, salt: BytesN<32>) -> BytesN<32> {
+    /// Deploy contract takes the given contract bytes and stores it on ledger
+    /// with a new contract ID that is generated using a combination of the
+    /// currently executing contract ID and the provided salt.
+    ///
+    /// The given contract bytes must be a valid WASM Soroban contract.
+    ///
+    /// Returns the contract ID of the deployed contract.
+    pub fn deploy_contract(&self, contract: Bytes, salt: BytesN<32>) -> BytesN<32> {
         let contract_obj: Object = RawVal::from(contract).try_into().unwrap();
         let salt_obj: Object = RawVal::from(salt).try_into().unwrap();
         let id_obj = internal::Env::create_contract_from_contract(self, contract_obj, salt_obj);
         id_obj.in_env(self).try_into().unwrap()
     }
 
-    #[doc(hidden)]
-    pub fn create_token_from_contract(&self, salt: BytesN<32>) -> BytesN<32> {
+    /// Deploy token deploys a new instance of the built-in token contract with
+    /// a new contract ID that is generated using a combination of the currently
+    /// executing contract ID and the provided salt.
+    ///
+    /// Returns the contract ID of the deployed token contract.
+    pub fn deploy_token(&self, salt: BytesN<32>) -> BytesN<32> {
         let salt_obj: Object = RawVal::from(salt).try_into().unwrap();
         let id_obj = internal::Env::create_token_from_contract(self, salt_obj);
         id_obj.in_env(self).try_into().unwrap()

--- a/soroban-sdk/src/env.rs
+++ b/soroban-sdk/src/env.rs
@@ -202,12 +202,12 @@ impl Env {
         id_obj.in_env(self).try_into().unwrap()
     }
 
-    /// Deploy token deploys a new instance of the built-in token contract with
-    /// a new contract ID that is generated using a combination of the currently
-    /// executing contract ID and the provided salt.
+    /// Deploy token contract deploys a new instance of the built-in token
+    /// contract with a new contract ID that is generated using a combination of
+    /// the currently executing contract ID and the provided salt.
     ///
     /// Returns the contract ID of the deployed token contract.
-    pub fn deploy_token(&self, salt: BytesN<32>) -> BytesN<32> {
+    pub fn deploy_token_contract(&self, salt: BytesN<32>) -> BytesN<32> {
         let salt_obj: Object = RawVal::from(salt).try_into().unwrap();
         let id_obj = internal::Env::create_token_from_contract(self, salt_obj);
         id_obj.in_env(self).try_into().unwrap()

--- a/tests/create_contract/src/lib.rs
+++ b/tests/create_contract/src/lib.rs
@@ -8,6 +8,6 @@ impl Contract {
     // Note that anyone can create a contract here with any salt, so a users call to
     // this could be frontrun and the same salt taken.
     pub fn create(e: Env, c: Bytes, s: BytesN<32>) {
-        e.create_contract_from_contract(c, s);
+        e.deploy_contract(c, s);
     }
 }


### PR DESCRIPTION
### What
Rename `Env::create_contract_from_contract` to `Env::deploy_contract`.

Rename `Env::create_token_from_contract` to `Env::deploy_token_contract`.

### Why
The distinction between creating a contract from an ed25519 or a contract is not particularly relevant within the SDK. Contracts can only create contracts from contracts. To put it in the developers words, a contract can deploy contracts. We use the term deploy in other places that the developer sees, like the CLI. We can use that term here.

There could be an argument that we also need a function for creating from ed25519 for tests, but I think that is unclear. And, if we do add that later, I think that is still doable and these function names still stand well with a change like that.