### PR TITLE
Fix trybuild tests

### DIFF
--- a/soroban-sdk/tests/trybuild.rs
+++ b/soroban-sdk/tests/trybuild.rs
@@ -1,5 +1,5 @@
 #[test]
 fn fails() {
     let t = trybuild::TestCases::new();
-    t.compile_fail("tests/macros_fails/*.rs");
+    t.compile_fail("tests/trybuild/*.rs");
 }

--- a/soroban-sdk/tests/trybuild/contractfile_with_sha256_verify_fail.stderr
+++ b/soroban-sdk/tests/trybuild/contractfile_with_sha256_verify_fail.stderr
@@ -1,11 +1,11 @@
 error: sha256 does not match, expected: 082f8d7a70e88996451d2fa53844a95f8c6da4e9179f9ce133bd40489194b3ae
- --> tests/macros_fails/contractfile_with_sha256_verify_fail.rs:3:5
+ --> tests/trybuild/contractfile_with_sha256_verify_fail.rs:3:5
   |
 3 |     sha256 = "0000000000000000000000000000000000000000000000000000000000000000",
   |     ^^^^^^
 
 error[E0601]: `main` function not found in crate `$CRATE`
- --> tests/macros_fails/contractfile_with_sha256_verify_fail.rs:4:3
+ --> tests/trybuild/contractfile_with_sha256_verify_fail.rs:4:3
   |
 4 | );
-  |   ^ consider adding a `main` function to `$DIR/tests/macros_fails/contractfile_with_sha256_verify_fail.rs`
+  |   ^ consider adding a `main` function to `$DIR/tests/trybuild/contractfile_with_sha256_verify_fail.rs`

--- a/soroban-sdk/tests/trybuild/contractimpl_fn_name_too_long.stderr
+++ b/soroban-sdk/tests/trybuild/contractimpl_fn_name_too_long.stderr
@@ -1,5 +1,5 @@
 error: contract function name too long, max length 10 characters
- --> tests/macros_fails/macros_spec_fn_name_too_long.rs:7:12
+ --> tests/trybuild/contractimpl_fn_name_too_long.rs:7:12
   |
 7 |     pub fn pay_to_destination() {
   |            ^^^^^^^^^^^^^^^^^^

--- a/soroban-sdk/tests/trybuild/contractimpl_fn_params_too_many.stderr
+++ b/soroban-sdk/tests/trybuild/contractimpl_fn_params_too_many.stderr
@@ -1,5 +1,5 @@
 error: contract function has too many parameters, max count 10 parameters
-  --> tests/macros_fails/macros_spec_fn_params_too_many.rs:18:9
+  --> tests/trybuild/contractimpl_fn_params_too_many.rs:18:9
    |
 18 |         p11: u32,
    |         ^^^

--- a/soroban-sdk/tests/trybuild/contractimpl_udt_generics.stderr
+++ b/soroban-sdk/tests/trybuild/contractimpl_udt_generics.stderr
@@ -1,11 +1,11 @@
 error: generics unsupported on user-defined types in contract functions
- --> tests/macros_fails/macros_spec_i32.rs:9:25
+ --> tests/trybuild/contractimpl_udt_generics.rs:9:25
   |
 9 |     pub fn add(a: MyType<i32>, b: MyType<i32>) -> i8 {
   |                         ^
 
 error: generics unsupported on user-defined types in contract functions
- --> tests/macros_fails/macros_spec_i32.rs:9:41
+ --> tests/trybuild/contractimpl_udt_generics.rs:9:41
   |
 9 |     pub fn add(a: MyType<i32>, b: MyType<i32>) -> i8 {
   |                                         ^

--- a/soroban-sdk/tests/trybuild/contractimport_with_sha256_verify_fail.stderr
+++ b/soroban-sdk/tests/trybuild/contractimport_with_sha256_verify_fail.stderr
@@ -1,5 +1,5 @@
 error: sha256 does not match, expected: 082f8d7a70e88996451d2fa53844a95f8c6da4e9179f9ce133bd40489194b3ae
- --> tests/macros_fails/contractimport_with_sha256_verify_fail.rs:3:5
+ --> tests/trybuild/contractimport_with_sha256_verify_fail.rs:3:5
   |
 3 |     sha256 = "0000000000000000000000000000000000000000000000000000000000000000",
   |     ^^^^^^


### PR DESCRIPTION
### What
Change the path of the trybuild test to match where the trybuild tests are found.

### Why
In #457 I renamed the folder where trybuild tests are found, but forgot to update the test that references them.