### PR TITLE
Compile error when contracttype struct field name too long

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -831,7 +831,7 @@ dependencies = [
 [[package]]
 name = "soroban-env-common"
 version = "0.0.3"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=7395b810#7395b8108b7eae28a2a068a0f3b75a5f824ee515"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=a9c1396a#a9c1396ac7936da22f447b1d1fb5b737a7ae1262"
 dependencies = [
  "soroban-env-macros",
  "soroban-wasmi",
@@ -842,7 +842,7 @@ dependencies = [
 [[package]]
 name = "soroban-env-guest"
 version = "0.0.3"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=7395b810#7395b8108b7eae28a2a068a0f3b75a5f824ee515"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=a9c1396a#a9c1396ac7936da22f447b1d1fb5b737a7ae1262"
 dependencies = [
  "soroban-env-common",
  "static_assertions",
@@ -851,7 +851,7 @@ dependencies = [
 [[package]]
 name = "soroban-env-host"
 version = "0.0.3"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=7395b810#7395b8108b7eae28a2a068a0f3b75a5f824ee515"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=a9c1396a#a9c1396ac7936da22f447b1d1fb5b737a7ae1262"
 dependencies = [
  "backtrace",
  "dyn-fmt",
@@ -875,7 +875,7 @@ dependencies = [
 [[package]]
 name = "soroban-env-macros"
 version = "0.0.3"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=7395b810#7395b8108b7eae28a2a068a0f3b75a5f824ee515"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=a9c1396a#a9c1396ac7936da22f447b1d1fb5b737a7ae1262"
 dependencies = [
  "itertools",
  "proc-macro2",
@@ -887,7 +887,7 @@ dependencies = [
 [[package]]
 name = "soroban-native-sdk-macros"
 version = "0.0.1"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=7395b810#7395b8108b7eae28a2a068a0f3b75a5f824ee515"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=a9c1396a#a9c1396ac7936da22f447b1d1fb5b737a7ae1262"
 dependencies = [
  "itertools",
  "proc-macro2",
@@ -918,6 +918,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "sha2 0.10.2",
+ "soroban-env-common",
  "soroban-spec",
  "stellar-xdr",
  "syn",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,11 +42,15 @@ exclude = [
 [patch.crates-io]
 soroban-sdk = { path = "soroban-sdk" }
 soroban-sdk-macros = { path = "soroban-sdk-macros" }
-soroban-env-common = { git = "https://github.com/stellar/rs-soroban-env", rev = "7395b810" }
-soroban-env-guest = { git = "https://github.com/stellar/rs-soroban-env", rev = "7395b810" }
-soroban-env-host = { git = "https://github.com/stellar/rs-soroban-env", rev = "7395b810" }
-soroban-env-macros = { git = "https://github.com/stellar/rs-soroban-env", rev = "7395b810" }
-soroban-native-sdk-macros = { git = "https://github.com/stellar/rs-soroban-env", rev = "7395b810" }
+soroban-env-common = { git = "https://github.com/stellar/rs-soroban-env", rev = "a9c1396a" }
+# soroban-env-common = { path = "../rs-soroban-env/soroban-env-common"}
+soroban-env-guest = { git = "https://github.com/stellar/rs-soroban-env", rev = "a9c1396a" }
+# soroban-env-guest = { path = "../rs-soroban-env/soroban-env-guest"}
+soroban-env-host = { git = "https://github.com/stellar/rs-soroban-env", rev = "a9c1396a" }
+# soroban-env-host = { path = "../rs-soroban-env/soroban-env-host"}
+soroban-env-macros = { git = "https://github.com/stellar/rs-soroban-env", rev = "a9c1396a" }
+# soroban-env-macros = { path = "../rs-soroban-env/soroban-env-macros"}
+soroban-native-sdk-macros = { git = "https://github.com/stellar/rs-soroban-env", rev = "a9c1396a" }
 stellar-xdr = { git = "https://github.com/stellar/rs-stellar-xdr", rev = "f4fe3091" }
 
 [profile.dev]

--- a/soroban-sdk-macros/Cargo.toml
+++ b/soroban-sdk-macros/Cargo.toml
@@ -15,6 +15,7 @@ doctest = false
 
 [dependencies]
 soroban-spec = { path = "../soroban-spec" }
+soroban-env-common = { version = "0.0.3" }
 stellar-xdr = { version = "0.0.1", features = ["next", "std"] }
 syn = {version="1.0",features=["full"]}
 quote = "1.0"

--- a/soroban-sdk/tests/trybuild/contracttype_field_name_too_long.rs
+++ b/soroban-sdk/tests/trybuild/contracttype_field_name_too_long.rs
@@ -1,0 +1,9 @@
+use soroban_sdk::contracttype;
+
+#[contracttype]
+pub struct MyType {
+    pub f1: bool,
+    pub f2istoolong: bool,
+}
+
+pub fn main() {}

--- a/soroban-sdk/tests/trybuild/contracttype_field_name_too_long.stderr
+++ b/soroban-sdk/tests/trybuild/contracttype_field_name_too_long.stderr
@@ -1,0 +1,5 @@
+error: struct field name symbol too long: length 11, max 10
+ --> tests/trybuild/contracttype_field_name_too_long.rs:6:9
+  |
+6 |     pub f2istoolong: bool,
+  |         ^^^^^^^^^^^


### PR DESCRIPTION
### What
Add compile error when contracttype struct field name too long.

### Why
Compile errors will render in a user friendly way to the developer, and can highlight the area of the code that is the problem.