### PR TITLE
Convert unit enums to single element vector

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -831,7 +831,6 @@ dependencies = [
 [[package]]
 name = "soroban-env-common"
 version = "0.0.3"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=a9c1396a#a9c1396ac7936da22f447b1d1fb5b737a7ae1262"
 dependencies = [
  "soroban-env-macros",
  "soroban-wasmi",
@@ -842,7 +841,6 @@ dependencies = [
 [[package]]
 name = "soroban-env-guest"
 version = "0.0.3"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=a9c1396a#a9c1396ac7936da22f447b1d1fb5b737a7ae1262"
 dependencies = [
  "soroban-env-common",
  "static_assertions",
@@ -851,7 +849,6 @@ dependencies = [
 [[package]]
 name = "soroban-env-host"
 version = "0.0.3"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=a9c1396a#a9c1396ac7936da22f447b1d1fb5b737a7ae1262"
 dependencies = [
  "backtrace",
  "dyn-fmt",
@@ -875,7 +872,6 @@ dependencies = [
 [[package]]
 name = "soroban-env-macros"
 version = "0.0.3"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=a9c1396a#a9c1396ac7936da22f447b1d1fb5b737a7ae1262"
 dependencies = [
  "itertools",
  "proc-macro2",
@@ -983,7 +979,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 [[package]]
 name = "stellar-xdr"
 version = "0.0.1"
-source = "git+https://github.com/stellar/rs-stellar-xdr?rev=f4fe3091#f4fe309136070c3d932bfcb8019ded953b842e5c"
+source = "git+https://github.com/stellar/rs-stellar-xdr?rev=61de11d#61de11d0ce5eb8a6e722d903af2abfadb5f5bd0e"
 
 [[package]]
 name = "strsim"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -831,6 +831,7 @@ dependencies = [
 [[package]]
 name = "soroban-env-common"
 version = "0.0.3"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=4c288ce#4c288cec87229fd660e4a27fa233532c8cfed998"
 dependencies = [
  "soroban-env-macros",
  "soroban-wasmi",
@@ -841,6 +842,7 @@ dependencies = [
 [[package]]
 name = "soroban-env-guest"
 version = "0.0.3"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=4c288ce#4c288cec87229fd660e4a27fa233532c8cfed998"
 dependencies = [
  "soroban-env-common",
  "static_assertions",
@@ -849,6 +851,7 @@ dependencies = [
 [[package]]
 name = "soroban-env-host"
 version = "0.0.3"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=4c288ce#4c288cec87229fd660e4a27fa233532c8cfed998"
 dependencies = [
  "backtrace",
  "dyn-fmt",
@@ -872,6 +875,7 @@ dependencies = [
 [[package]]
 name = "soroban-env-macros"
 version = "0.0.3"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=4c288ce#4c288cec87229fd660e4a27fa233532c8cfed998"
 dependencies = [
  "itertools",
  "proc-macro2",
@@ -883,7 +887,7 @@ dependencies = [
 [[package]]
 name = "soroban-native-sdk-macros"
 version = "0.0.1"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=a9c1396a#a9c1396ac7936da22f447b1d1fb5b737a7ae1262"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=4c288ce#4c288cec87229fd660e4a27fa233532c8cfed998"
 dependencies = [
  "itertools",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,16 +42,16 @@ exclude = [
 [patch.crates-io]
 soroban-sdk = { path = "soroban-sdk" }
 soroban-sdk-macros = { path = "soroban-sdk-macros" }
-soroban-env-common = { git = "https://github.com/stellar/rs-soroban-env", rev = "a9c1396a" }
-# soroban-env-common = { path = "../rs-soroban-env/soroban-env-common"}
-soroban-env-guest = { git = "https://github.com/stellar/rs-soroban-env", rev = "a9c1396a" }
-# soroban-env-guest = { path = "../rs-soroban-env/soroban-env-guest"}
-soroban-env-host = { git = "https://github.com/stellar/rs-soroban-env", rev = "a9c1396a" }
-# soroban-env-host = { path = "../rs-soroban-env/soroban-env-host"}
-soroban-env-macros = { git = "https://github.com/stellar/rs-soroban-env", rev = "a9c1396a" }
-# soroban-env-macros = { path = "../rs-soroban-env/soroban-env-macros"}
+# soroban-env-common = { git = "https://github.com/stellar/rs-soroban-env", rev = "a9c1396a" }
+# soroban-env-guest = { git = "https://github.com/stellar/rs-soroban-env", rev = "a9c1396a" }
+# soroban-env-host = { git = "https://github.com/stellar/rs-soroban-env", rev = "a9c1396a" }
+# soroban-env-macros = { git = "https://github.com/stellar/rs-soroban-env", rev = "a9c1396a" }
+soroban-env-common = { path = "../rs-soroban-env/soroban-env-common" }
+soroban-env-guest = { path = "../rs-soroban-env/soroban-env-guest" }
+soroban-env-host = { path = "../rs-soroban-env/soroban-env-host" }
+soroban-env-macros = { path = "../rs-soroban-env/soroban-env-macros" }
 soroban-native-sdk-macros = { git = "https://github.com/stellar/rs-soroban-env", rev = "a9c1396a" }
-stellar-xdr = { git = "https://github.com/stellar/rs-stellar-xdr", rev = "f4fe3091" }
+stellar-xdr = { git = "https://github.com/stellar/rs-stellar-xdr", rev = "61de11d" }
 
 [profile.dev]
 overflow-checks = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,16 +42,17 @@ exclude = [
 [patch.crates-io]
 soroban-sdk = { path = "soroban-sdk" }
 soroban-sdk-macros = { path = "soroban-sdk-macros" }
-# soroban-env-common = { git = "https://github.com/stellar/rs-soroban-env", rev = "a9c1396a" }
-# soroban-env-guest = { git = "https://github.com/stellar/rs-soroban-env", rev = "a9c1396a" }
-# soroban-env-host = { git = "https://github.com/stellar/rs-soroban-env", rev = "a9c1396a" }
-# soroban-env-macros = { git = "https://github.com/stellar/rs-soroban-env", rev = "a9c1396a" }
-soroban-env-common = { path = "../rs-soroban-env/soroban-env-common" }
-soroban-env-guest = { path = "../rs-soroban-env/soroban-env-guest" }
-soroban-env-host = { path = "../rs-soroban-env/soroban-env-host" }
-soroban-env-macros = { path = "../rs-soroban-env/soroban-env-macros" }
-soroban-native-sdk-macros = { git = "https://github.com/stellar/rs-soroban-env", rev = "a9c1396a" }
+soroban-env-common = { git = "https://github.com/stellar/rs-soroban-env", rev = "4c288ce" }
+soroban-env-guest = { git = "https://github.com/stellar/rs-soroban-env", rev = "4c288ce" }
+soroban-env-host = { git = "https://github.com/stellar/rs-soroban-env", rev = "4c288ce" }
+soroban-env-macros = { git = "https://github.com/stellar/rs-soroban-env", rev = "4c288ce" }
+soroban-native-sdk-macros = { git = "https://github.com/stellar/rs-soroban-env", rev = "4c288ce" }
 stellar-xdr = { git = "https://github.com/stellar/rs-stellar-xdr", rev = "61de11d" }
+
+# soroban-env-common = { path = "../rs-soroban-env/soroban-env-common" }
+# soroban-env-guest = { path = "../rs-soroban-env/soroban-env-guest" }
+# soroban-env-host = { path = "../rs-soroban-env/soroban-env-host" }
+# soroban-env-macros = { path = "../rs-soroban-env/soroban-env-macros" }
 
 [profile.dev]
 overflow-checks = true

--- a/soroban-sdk/tests/contractfile_with_sha256.rs
+++ b/soroban-sdk/tests/contractfile_with_sha256.rs
@@ -1,6 +1,6 @@
 pub const WASM: &[u8] = soroban_sdk::contractfile!(
     file = "target/wasm32-unknown-unknown/release/example_add_i32.wasm",
-    sha256 = "082f8d7a70e88996451d2fa53844a95f8c6da4e9179f9ce133bd40489194b3ae"
+    sha256 = "4443da92909ba1b01564d65c74052cd5d39dceec7cc52e41bda38a13fdb6e160"
 );
 
 #[test]

--- a/soroban-sdk/tests/contractimport_with_sha256.rs
+++ b/soroban-sdk/tests/contractimport_with_sha256.rs
@@ -7,7 +7,7 @@ const ADD_CONTRACT_ID: [u8; 32] = [0; 32];
 mod addcontract {
     soroban_sdk::contractimport!(
         file = "target/wasm32-unknown-unknown/release/example_add_i32.wasm",
-        sha256 = "082f8d7a70e88996451d2fa53844a95f8c6da4e9179f9ce133bd40489194b3ae",
+        sha256 = "4443da92909ba1b01564d65c74052cd5d39dceec7cc52e41bda38a13fdb6e160",
     );
 }
 

--- a/soroban-sdk/tests/trybuild/contractfile_with_sha256_verify_fail.stderr
+++ b/soroban-sdk/tests/trybuild/contractfile_with_sha256_verify_fail.stderr
@@ -1,4 +1,4 @@
-error: sha256 does not match, expected: 082f8d7a70e88996451d2fa53844a95f8c6da4e9179f9ce133bd40489194b3ae
+error: sha256 does not match, expected: 4443da92909ba1b01564d65c74052cd5d39dceec7cc52e41bda38a13fdb6e160
  --> tests/trybuild/contractfile_with_sha256_verify_fail.rs:3:5
   |
 3 |     sha256 = "0000000000000000000000000000000000000000000000000000000000000000",

--- a/soroban-sdk/tests/trybuild/contractimport_with_sha256_verify_fail.stderr
+++ b/soroban-sdk/tests/trybuild/contractimport_with_sha256_verify_fail.stderr
@@ -1,4 +1,4 @@
-error: sha256 does not match, expected: 082f8d7a70e88996451d2fa53844a95f8c6da4e9179f9ce133bd40489194b3ae
+error: sha256 does not match, expected: 4443da92909ba1b01564d65c74052cd5d39dceec7cc52e41bda38a13fdb6e160
  --> tests/trybuild/contractimport_with_sha256_verify_fail.rs:3:5
   |
 3 |     sha256 = "0000000000000000000000000000000000000000000000000000000000000000",


### PR DESCRIPTION
### What

Convert unit enums to single element vectors and ignore extra fields when decoding.

### Why

For a number of reasons:
- Encode unit enums into their most efficient form.
- To make it easier to scale enum encoding to support tuple variants with more than a single value.
- To make it easier to make changes to enums by adding tuple values.

Close https://github.com/stellar/rs-soroban-sdk/issues/427

### Known limitations

N/A