### PR TITLE
Replace `Vec<RawVal>` with tuples of variable sizes in events publishing.

### DIFF
--- a/soroban-sdk/src/contract_event.rs
+++ b/soroban-sdk/src/contract_event.rs
@@ -1,13 +1,21 @@
 use core::fmt::Debug;
 
-use crate::{env::internal, Env, IntoVal, RawVal, Vec};
+use super::xdr::ScObjectType;
+
+// TODO: consolidate with host::events::TOPIC_BYTES_LENGTH_LIMIT
+const TOPIC_BYTES_LENGTH_LIMIT: u32 = 32;
+
+use crate::{
+    env::{internal, EnvObj},
+    Bytes, Env, IntoVal, Object, RawVal, Vec,
+};
 
 /// ### Examples
 ///
 /// ```
 /// use soroban_sdk::Env;
 ///
-/// # use soroban_sdk::{contractimpl, vec, map, RawVal, FixedBinary};
+/// # use soroban_sdk::{contractimpl, vec, map, RawVal, BytesN};
 /// #
 /// # pub struct Contract;
 /// #
@@ -15,7 +23,7 @@ use crate::{env::internal, Env, IntoVal, RawVal, Vec};
 /// # impl Contract {
 /// #     pub fn f(env: Env) {
 /// let event = env.contract_event();
-/// let topics = vec![&env, 0u32, 1u32];
+/// let topics = (0u32, 1u32);
 /// let data = map![&env, (1u32, 2u32)];
 /// event.publish(topics, data)
 /// #     }
@@ -24,7 +32,7 @@ use crate::{env::internal, Env, IntoVal, RawVal, Vec};
 /// # #[cfg(feature = "testutils")]
 /// # fn main() {
 /// #     let env = Env::default();
-/// #     let contract_id = FixedBinary::from_array(&env, [0; 32]);
+/// #     let contract_id = BytesN::from_array(&env, [0; 32]);
 /// #     env.register_contract(&contract_id, Contract);
 /// #     f::invoke(&env, &contract_id);
 /// # }
@@ -32,35 +40,83 @@ use crate::{env::internal, Env, IntoVal, RawVal, Vec};
 /// # fn main() { }
 /// ```
 #[derive(Clone)]
-pub struct ContractEvent(Env);
+pub struct Events(Env);
 
-impl Debug for ContractEvent {
+impl Debug for Events {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        write!(f, "ContractEvent")
+        write!(f, "Events")
     }
 }
 
-impl ContractEvent {
+pub trait IntoTopics {
+    fn into_topics(self, env: &Env) -> Object;
+}
+
+// 0 topics
+impl IntoTopics for () {
+    fn into_topics(self, env: &Env) -> Object {
+        Vec::<RawVal>::new(env).to_object()
+    }
+}
+
+macro_rules! impl_for_tuple {
+    ( $($typ:ident $idx:tt)* ) => {
+        impl<$($typ),*> IntoTopics for ($($typ,)*)
+        where
+            $($typ: IntoVal<Env, RawVal> + Clone),*
+        {
+            fn into_topics(self, env: &Env) -> Object {
+                $({
+                    let ev = self.$idx.clone().into_env_val(env);
+                    match TryInto::<EnvObj>::try_into(ev) {
+                        Ok(obj) => {
+                            if obj.as_object().is_obj_type(ScObjectType::Vec) {
+                                panic!("topic cannot be a vec")
+                            } else if obj.as_object().is_obj_type(ScObjectType::Map) {
+                                panic!("topic cannot be a map")
+                            } else if obj.as_object().is_obj_type(ScObjectType::Bytes) {
+                                let bytes = unsafe { Bytes::unchecked_new(obj.clone()) };
+                                if bytes.len() > TOPIC_BYTES_LENGTH_LIMIT {
+                                    panic!("topic exceeds bytes length limit")
+                                }
+                            }
+                        }
+                        Err(_) => (),
+                    }
+                })*
+                self.into_val(env)
+            }
+        }
+    };
+}
+
+// 1-4 topics
+impl_for_tuple! { T0 0 }
+impl_for_tuple! { T0 0 T1 1 }
+impl_for_tuple! { T0 0 T1 1 T2 2 }
+impl_for_tuple! { T0 0 T1 1 T2 2 T3 3 }
+
+impl Events {
     #[inline(always)]
     pub(crate) fn env(&self) -> &Env {
         &self.0
     }
 
     #[inline(always)]
-    pub(crate) fn new(env: &Env) -> ContractEvent {
-        ContractEvent(env.clone())
+    pub(crate) fn new(env: &Env) -> Events {
+        Events(env.clone())
     }
 
     /// Publishes `topics` and `data` into a contract event.
     /// `topics` is expected to have length <= 4 and cannot contain Vecs, Maps,
     /// or Binaries > 32 bytes
     #[inline(always)]
-    pub fn publish<T, D>(&self, topics: Vec<T>, data: D)
+    pub fn publish<T, D>(&self, topics: T, data: D)
     where
-        T: IntoVal<Env, RawVal>,
+        T: IntoTopics,
         D: IntoVal<Env, RawVal>,
     {
         let env = self.env();
-        internal::Env::contract_event(env, topics.to_object(), data.into_val(env));
+        internal::Env::contract_event(env, topics.into_topics(env), data.into_val(env));
     }
 }

--- a/soroban-sdk/src/env.rs
+++ b/soroban-sdk/src/env.rs
@@ -45,7 +45,7 @@ pub type EnvType<V> = internal::EnvVal<Env, V>;
 pub type EnvVal = internal::EnvVal<Env, RawVal>;
 pub type EnvObj = internal::EnvVal<Env, Object>;
 
-use crate::ContractEvent;
+use crate::Events;
 use crate::{Bytes, BytesN, ContractData, Ledger};
 
 /// The [Env] type provides access to the environment the contract is executing
@@ -114,11 +114,11 @@ impl Env {
         Ledger::new(self)
     }
 
-    /// Get a [ContractEvent] for publishing events associated with the
+    /// Get a [Events] for publishing events associated with the
     /// currently executing contract.
     #[inline(always)]
-    pub fn contract_event(&self) -> ContractEvent {
-        ContractEvent::new(self)
+    pub fn contract_event(&self) -> Events {
+        Events::new(self)
     }
 
     /// Get the 32-byte hash identifier of the current executing contract.

--- a/soroban-sdk/src/lib.rs
+++ b/soroban-sdk/src/lib.rs
@@ -77,7 +77,7 @@ pub use bigint::BigInt;
 pub use bytes::{Binary, FixedBinary};
 pub use bytes::{Bytes, BytesN};
 pub use contract_data::ContractData;
-pub use contract_event::ContractEvent;
+pub use contract_event::Events;
 pub use ledger::Ledger;
 pub use map::Map;
 pub use set::Set;


### PR DESCRIPTION
### What
Follows up to https://github.com/stellar/rs-soroban-sdk/pull/464 which resolves https://github.com/stellar/rs-soroban-sdk/issues/451
- Replace `Vec<RawVal>` with tuples of 0-4 sizes. 
- Address a couple comments in the previous PR. 

Note: this is duplicate work with https://github.com/stellar/rs-soroban-sdk/pull/467 with slightly different approach. Only one needs to be merged.  

### Why

[TODO: Why this change is being made. Include any context required to understand the why.]

### Known limitations

[TODO or N/A]
