### PR TITLE
Allow trailing comma in zero length vec!

### DIFF
--- a/soroban-sdk/src/vec.rs
+++ b/soroban-sdk/src/vec.rs
@@ -32,7 +32,7 @@ use crate::{Bytes, ContractData, Map};
 /// ```
 #[macro_export]
 macro_rules! vec {
-    ($env:expr) => {
+    ($env:expr $(,)?) => {
         $crate::Vec::new($env)
     };
     ($env:expr, $($x:expr),+ $(,)?) => {
@@ -619,6 +619,7 @@ mod test {
     fn test_vec_macro() {
         let env = Env::default();
         assert_eq!(vec![&env], Vec::<i32>::new(&env));
+        assert_eq!(vec![&env,], Vec::<i32>::new(&env));
         assert_eq!(vec![&env, 1], {
             let mut v = Vec::new(&env);
             v.push(1);


### PR DESCRIPTION
### What
Allow trailing comma in zero length vec!.

### Why
If a trailing comma is present at the end of the vec! macro when there are zero items in the vec, the macro rule won't match. The comma should be fine and ignorable as trailing commas can show up in generated code and in formatted code.