### PR TITLE
Self invocations in tests use contractclient

### DIFF
--- a/soroban-sdk-macros/src/derive_client.rs
+++ b/soroban-sdk-macros/src/derive_client.rs
@@ -5,7 +5,7 @@ use syn::{
     punctuated::Punctuated,
     spanned::Spanned,
     token::Comma,
-    Error, FnArg, Ident, ItemImpl, ItemTrait, Pat, ReturnType, Token, Type, TypePath,
+    Attribute, Error, FnArg, Ident, ItemImpl, ItemTrait, Pat, ReturnType, Token, Type, TypePath,
 };
 
 use crate::syn_ext;
@@ -38,6 +38,7 @@ impl ClientItem {
 
 impl Parse for ClientItem {
     fn parse(input: ParseStream) -> syn::Result<Self> {
+        _ = input.call(Attribute::parse_outer);
         _ = input.parse::<Token![pub]>();
         let lookahead = input.lookahead1();
         if lookahead.peek(Token![trait]) {

--- a/soroban-sdk-macros/src/derive_client.rs
+++ b/soroban-sdk-macros/src/derive_client.rs
@@ -121,8 +121,11 @@ pub fn derive_client(name: &str, fns: &[ClientFn]) -> TokenStream {
             quote!{
                 pub fn #fn_ident(env: &::soroban_sdk::Env, contract_id: &::soroban_sdk::BytesN<32>, #(#fn_input_types),*) #fn_output {
                     use ::soroban_sdk::IntoVal;
-                    const FN_SYMBOL: ::soroban_sdk::Symbol = ::soroban_sdk::Symbol::from_str(#fn_name);
-                    env.invoke_contract(contract_id, &FN_SYMBOL, ::soroban_sdk::vec![env, #(#fn_input_names.into_env_val(&env)),*])
+                    env.invoke_contract(
+                        contract_id,
+                        &::soroban_sdk::symbol!(#fn_name),
+                        ::soroban_sdk::vec![env, #(#fn_input_names.into_env_val(&env)),*],
+                    )
                 }
 
                 #[cfg(feature = "testutils")]

--- a/soroban-sdk-macros/src/derive_fn.rs
+++ b/soroban-sdk-macros/src/derive_fn.rs
@@ -7,8 +7,8 @@ use stellar_xdr::{
 use syn::{
     punctuated::Punctuated,
     spanned::Spanned,
-    token::{And, Colon, Comma},
-    Error, FnArg, Ident, Pat, PatIdent, PatType, ReturnType, Type, TypePath, TypeReference,
+    token::{Colon, Comma},
+    Error, FnArg, Ident, Pat, PatIdent, PatType, ReturnType, Type, TypePath,
 };
 
 use crate::map_type::map_type;
@@ -48,7 +48,7 @@ pub fn derive_fn(
     });
 
     // Prepare the argument inputs.
-    let (spec_args, wrap_args, wrap_calls, invoke_args, invoke_idents): (Vec<_>, Vec<_>, Vec<_>, Vec<_>, Vec<_>) = inputs
+    let (spec_args, wrap_args, wrap_calls): (Vec<_>, Vec<_>, Vec<_>) = inputs
         .iter()
         .skip(if env_input.is_some() { 1 } else { 0 })
         .enumerate()
@@ -96,29 +96,11 @@ pub fn derive_fn(
                         #ident
                     ).unwrap()
                 };
-                let invoke_arg = FnArg::Typed(PatType {
-                    attrs: vec![],
-                    pat: Box::new(Pat::Ident(PatIdent {
-                        ident: ident.clone(),
-                        attrs: vec![],
-                        by_ref: None,
-                        mutability: None,
-                        subpat: None,
-                    })),
-                    colon_token: Colon::default(),
-                    ty: Box::new(Type::Reference(TypeReference {
-                        and_token: And::default(),
-                        lifetime: None,
-                        mutability: None,
-                        elem: pat_type.ty.clone(),
-                    })),
-                });
-                let invoke_call = quote! { #ident };
-                (spec, arg, call, invoke_arg, invoke_call)
+                (spec, arg, call)
             }
             FnArg::Receiver(_) => {
                 errors.push(Error::new(a.span(), "self argument not supported"));
-                (ScSpecFunctionInputV0{ name: "".try_into().unwrap(), type_: ScSpecTypeDef::I32 } , a.clone(), quote! {}, a.clone(), quote! {})
+                (ScSpecFunctionInputV0{ name: "".try_into().unwrap(), type_: ScSpecTypeDef::I32 } , a.clone(), quote! {})
             }
         })
         .multiunzip();
@@ -237,37 +219,6 @@ pub fn derive_fn(
             }
 
             use super::*;
-        }
-
-        pub mod #pub_mod_ident {
-            use super::*;
-
-            pub fn invoke(
-                e: &soroban_sdk::Env,
-                contract_id: &soroban_sdk::BytesN<32>,
-                #(#invoke_args),*
-            ) #output {
-                use soroban_sdk::{EnvVal, IntoVal, Symbol, Vec};
-                let mut args: Vec<EnvVal> = Vec::new(e);
-                #(args.push(#invoke_idents.clone().into_env_val(e));)*
-                e.invoke_contract(contract_id, &Symbol::from_str(#wrap_export_name), args)
-            }
-
-            #[cfg(feature = "testutils")]
-            #[cfg_attr(feature = "docs", doc(cfg(feature = "testutils")))]
-            pub fn invoke_xdr(
-                e: &soroban_sdk::Env,
-                contract_id: &soroban_sdk::BytesN<32>,
-                #(#invoke_args),*
-            ) #output {
-                use soroban_sdk::TryIntoVal;
-                e.invoke_contract_external_raw(
-                    soroban_sdk::xdr::HostFunction::Call,
-                    (contract_id, #wrap_export_name, #(#invoke_idents),*).try_into().unwrap()
-                )
-                .try_into_val(e)
-                .unwrap()
-            }
         }
     })
 }

--- a/soroban-sdk-macros/src/derive_fn.rs
+++ b/soroban-sdk-macros/src/derive_fn.rs
@@ -140,10 +140,8 @@ pub fn derive_fn(
     let wrap_export_name = format!("{}", ident);
     let pub_mod_ident = format_ident!("{}", ident);
     let hidden_mod_ident = format_ident!("__{}", ident);
-    let deprecated_note = format!(
-        "use `{}::{}` instead",
-        client_ident, &ident
-    );
+    let deprecated_note = format!("use `{}::{}` instead", client_ident, &ident);
+    let deprecated_note_xdr = format!("use `{}::{}_xdr` instead", client_ident, &ident);
     let env_call = if env_input.is_some() {
         quote! { env.clone(), }
     } else {
@@ -257,7 +255,7 @@ pub fn derive_fn(
 
             #[cfg(feature = "testutils")]
             #[cfg_attr(feature = "docs", doc(cfg(feature = "testutils")))]
-            #[deprecated(note = #deprecated_note)]
+            #[deprecated(note = #deprecated_note_xdr)]
             pub fn invoke_xdr(
                 e: &soroban_sdk::Env,
                 contract_id: &soroban_sdk::BytesN<32>,

--- a/soroban-sdk-macros/src/lib.rs
+++ b/soroban-sdk-macros/src/lib.rs
@@ -53,6 +53,7 @@ pub fn contractimpl(metadata: TokenStream, input: TokenStream) -> TokenStream {
         None
     }
     .unwrap_or_else(|| format!("Client"));
+
     let pub_methods: Vec<_> = syn_ext::impl_pub_methods(&imp).collect();
     let derived: Result<proc_macro2::TokenStream, proc_macro2::TokenStream> = pub_methods
         .iter()

--- a/soroban-sdk-macros/src/lib.rs
+++ b/soroban-sdk-macros/src/lib.rs
@@ -129,6 +129,7 @@ struct ContractFileArgs {
     sha256: darling::util::SpannedValue<String>,
 }
 
+#[doc(hidden)]
 #[proc_macro]
 pub fn contractfile(metadata: TokenStream) -> TokenStream {
     let args = parse_macro_input!(metadata as AttributeArgs);
@@ -169,6 +170,7 @@ struct ContractClientArgs {
     name: String,
 }
 
+#[doc(hidden)]
 #[proc_macro_attribute]
 pub fn contractclient(metadata: TokenStream, input: TokenStream) -> TokenStream {
     let args = parse_macro_input!(metadata as AttributeArgs);

--- a/soroban-sdk-macros/src/lib.rs
+++ b/soroban-sdk-macros/src/lib.rs
@@ -44,6 +44,8 @@ pub fn contractimpl(metadata: TokenStream, input: TokenStream) -> TokenStream {
     let imp = parse_macro_input!(input as ItemImpl);
     let ty = &imp.self_ty;
 
+    // TODO: Use imp.trait_ in generating the client ident, to create a unique
+    // client for each trait impl for a contract, to avoid conflicts.
     let client_ident = if let Type::Path(path) = &**ty {
         path.path
             .segments

--- a/soroban-sdk/src/vec.rs
+++ b/soroban-sdk/src/vec.rs
@@ -32,7 +32,7 @@ use crate::{Bytes, ContractData, Map};
 /// ```
 #[macro_export]
 macro_rules! vec {
-    ($env:expr) => {
+    ($env:expr $(,)?) => {
         $crate::Vec::new($env)
     };
     ($env:expr, $($x:expr),+ $(,)?) => {
@@ -619,6 +619,7 @@ mod test {
     fn test_vec_macro() {
         let env = Env::default();
         assert_eq!(vec![&env], Vec::<i32>::new(&env));
+        assert_eq!(vec![&env,], Vec::<i32>::new(&env));
         assert_eq!(vec![&env, 1], {
             let mut v = Vec::new(&env);
             v.push(1);

--- a/soroban-sdk/tests/contract_add_i32.rs
+++ b/soroban-sdk/tests/contract_add_i32.rs
@@ -2,12 +2,13 @@
 
 use std::io::Cursor;
 
-use soroban_sdk::{contractimpl, BytesN, Env};
+use soroban_sdk::{contractclient, contractimpl, BytesN, Env};
 use stellar_xdr::{ReadXdr, ScSpecEntry, ScSpecFunctionInputV0, ScSpecFunctionV0, ScSpecTypeDef};
 
 pub struct Contract;
 
 #[contractimpl]
+#[contractclient(name = "Client")]
 impl Contract {
     pub fn add(a: i32, b: i32) -> i32 {
         a + b
@@ -22,7 +23,7 @@ fn test_functional() {
 
     let a = 10i32;
     let b = 12i32;
-    let c = add::invoke(&e, &contract_id, &a, &b);
+    let c = Client::add(&e, &contract_id, a, b);
     assert_eq!(c, 22);
 }
 

--- a/soroban-sdk/tests/contract_add_i32.rs
+++ b/soroban-sdk/tests/contract_add_i32.rs
@@ -2,13 +2,12 @@
 
 use std::io::Cursor;
 
-use soroban_sdk::{contractclient, contractimpl, BytesN, Env};
+use soroban_sdk::{contractimpl, BytesN, Env};
 use stellar_xdr::{ReadXdr, ScSpecEntry, ScSpecFunctionInputV0, ScSpecFunctionV0, ScSpecTypeDef};
 
 pub struct Contract;
 
 #[contractimpl]
-#[contractclient(name = "Client")]
 impl Contract {
     pub fn add(a: i32, b: i32) -> i32 {
         a + b
@@ -23,7 +22,7 @@ fn test_functional() {
 
     let a = 10i32;
     let b = 12i32;
-    let c = Client::add(&e, &contract_id, a, b);
+    let c = ContractClient::add(&e, &contract_id, a, b);
     assert_eq!(c, 22);
 }
 

--- a/soroban-sdk/tests/contract_udt_enum.rs
+++ b/soroban-sdk/tests/contract_udt_enum.rs
@@ -1,7 +1,7 @@
 #![cfg(feature = "testutils")]
 
 use soroban_sdk::{
-    contractclient, contractimpl, contracttype, vec, BytesN, ConversionError, Env, IntoVal, Symbol,
+    contractclient, contractimpl, contracttype, symbol, vec, BytesN, ConversionError, Env, IntoVal,
     TryFromVal,
 };
 

--- a/soroban-sdk/tests/contract_udt_enum.rs
+++ b/soroban-sdk/tests/contract_udt_enum.rs
@@ -1,8 +1,7 @@
 #![cfg(feature = "testutils")]
 
 use soroban_sdk::{
-    contractclient, contractimpl, contracttype, symbol, vec, BytesN, ConversionError, Env, IntoVal,
-    TryFromVal,
+    contractimpl, contracttype, symbol, vec, BytesN, ConversionError, Env, IntoVal, TryFromVal,
 };
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
@@ -15,7 +14,6 @@ pub enum Udt {
 pub struct Contract;
 
 #[contractimpl]
-#[contractclient(name = "Client")]
 impl Contract {
     pub fn add(a: Udt, b: Udt) -> (Udt, Udt) {
         (a, b)
@@ -30,7 +28,7 @@ fn test_functional() {
 
     let a = Udt::Aaa;
     let b = Udt::Bbb(3);
-    let c = Client::add(&env, &contract_id, a, b);
+    let c = ContractClient::add(&env, &contract_id, a, b);
     assert_eq!(c, (a, b));
 }
 

--- a/soroban-sdk/tests/contract_udt_enum.rs
+++ b/soroban-sdk/tests/contract_udt_enum.rs
@@ -1,7 +1,8 @@
 #![cfg(feature = "testutils")]
 
 use soroban_sdk::{
-    contractimpl, contracttype, vec, BytesN, ConversionError, Env, IntoVal, Symbol, TryFromVal,
+    contractclient, contractimpl, contracttype, vec, BytesN, ConversionError, Env, IntoVal, Symbol,
+    TryFromVal,
 };
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
@@ -14,6 +15,7 @@ pub enum Udt {
 pub struct Contract;
 
 #[contractimpl]
+#[contractclient(name = "Client")]
 impl Contract {
     pub fn add(a: Udt, b: Udt) -> (Udt, Udt) {
         (a, b)
@@ -28,7 +30,7 @@ fn test_functional() {
 
     let a = Udt::Aaa;
     let b = Udt::Bbb(3);
-    let c = add::invoke(&env, &contract_id, &a, &b);
+    let c = Client::add(&env, &contract_id, a, b);
     assert_eq!(c, (a, b));
 }
 

--- a/soroban-sdk/tests/contract_udt_struct.rs
+++ b/soroban-sdk/tests/contract_udt_struct.rs
@@ -3,7 +3,8 @@
 use std::io::Cursor;
 
 use soroban_sdk::{
-    contractimpl, contracttype, map, BytesN, ConversionError, Env, Symbol, TryFromVal,
+    contractclient, contractimpl, contracttype, map, BytesN, ConversionError, Env, Symbol,
+    TryFromVal,
 };
 use stellar_xdr::{
     ReadXdr, ScSpecEntry, ScSpecFunctionInputV0, ScSpecFunctionV0, ScSpecTypeDef, ScSpecTypeTuple,
@@ -20,6 +21,7 @@ pub struct Udt {
 pub struct Contract;
 
 #[contractimpl]
+#[contractclient(name = "Client")]
 impl Contract {
     pub fn add(a: Udt, b: Udt) -> (Udt, Udt) {
         (a, b)
@@ -34,7 +36,7 @@ fn test_functional() {
 
     let a = Udt { a: 5, b: 7 };
     let b = Udt { a: 10, b: 14 };
-    let c = add::invoke(&env, &contract_id, &a, &b);
+    let c = Client::add(&env, &contract_id, a, b);
     assert_eq!(c, (a, b));
 }
 

--- a/soroban-sdk/tests/contract_udt_struct.rs
+++ b/soroban-sdk/tests/contract_udt_struct.rs
@@ -3,8 +3,7 @@
 use std::io::Cursor;
 
 use soroban_sdk::{
-    contractclient, contractimpl, contracttype, map, symbol, BytesN, ConversionError, Env,
-    TryFromVal,
+    contractimpl, contracttype, map, symbol, BytesN, ConversionError, Env, TryFromVal,
 };
 use stellar_xdr::{
     ReadXdr, ScSpecEntry, ScSpecFunctionInputV0, ScSpecFunctionV0, ScSpecTypeDef, ScSpecTypeTuple,
@@ -21,7 +20,6 @@ pub struct Udt {
 pub struct Contract;
 
 #[contractimpl]
-#[contractclient(name = "Client")]
 impl Contract {
     pub fn add(a: Udt, b: Udt) -> (Udt, Udt) {
         (a, b)
@@ -36,7 +34,7 @@ fn test_functional() {
 
     let a = Udt { a: 5, b: 7 };
     let b = Udt { a: 10, b: 14 };
-    let c = Client::add(&env, &contract_id, a, b);
+    let c = ContractClient::add(&env, &contract_id, a, b);
     assert_eq!(c, (a, b));
 }
 

--- a/soroban-sdk/tests/contract_udt_struct.rs
+++ b/soroban-sdk/tests/contract_udt_struct.rs
@@ -46,7 +46,7 @@ fn test_error_on_partial_decode() {
 
     // Success case, a map will decode to a Udt if the symbol keys match the
     // fields.
-    let map = map![&env, symbol!("a"), 5), symbol!("b"), 7)].to_raw();
+    let map = map![&env, (symbol!("a"), 5), (symbol!("b"), 7)].to_raw();
     let udt = Udt::try_from_val(&env, map);
     assert_eq!(udt, Ok(Udt { a: 5, b: 7 }));
 

--- a/soroban-sdk/tests/contract_udt_struct.rs
+++ b/soroban-sdk/tests/contract_udt_struct.rs
@@ -3,7 +3,7 @@
 use std::io::Cursor;
 
 use soroban_sdk::{
-    contractclient, contractimpl, contracttype, map, BytesN, ConversionError, Env, Symbol,
+    contractclient, contractimpl, contracttype, map, symbol, BytesN, ConversionError, Env,
     TryFromVal,
 };
 use stellar_xdr::{

--- a/soroban-sdk/tests/contractfile_with_sha256.rs
+++ b/soroban-sdk/tests/contractfile_with_sha256.rs
@@ -1,6 +1,6 @@
 pub const WASM: &[u8] = soroban_sdk::contractfile!(
     file = "target/wasm32-unknown-unknown/release/example_add_i32.wasm",
-    sha256 = "cce96634dca6b60232ee09d750c034804bb36aaadfb714fc0a6128ea4aea42d8"
+    sha256 = "58e28b943aeb95f3d0f9f8a87a2049d6f52a41f5dbaaa0b44e00a0e41d40cb68"
 );
 
 #[test]

--- a/soroban-sdk/tests/contractfile_with_sha256.rs
+++ b/soroban-sdk/tests/contractfile_with_sha256.rs
@@ -1,6 +1,6 @@
 pub const WASM: &[u8] = soroban_sdk::contractfile!(
     file = "target/wasm32-unknown-unknown/release/example_add_i32.wasm",
-    sha256 = "6c5a4fe67b30474ff71fe489ac7321d850b91cc2c7db3f36f377fad3d3087d6f"
+    sha256 = "cce96634dca6b60232ee09d750c034804bb36aaadfb714fc0a6128ea4aea42d8"
 );
 
 #[test]

--- a/soroban-sdk/tests/contractimport.rs
+++ b/soroban-sdk/tests/contractimport.rs
@@ -15,7 +15,7 @@ pub struct Contract;
 #[contractimpl]
 impl Contract {
     pub fn add_with(env: Env, x: i32, y: i32) -> i32 {
-        addcontract::Client::add(&env, &BytesN::from_array(&env, &ADD_CONTRACT_ID), x, y)
+        addcontract::ContractClient::add(&env, &BytesN::from_array(&env, &ADD_CONTRACT_ID), x, y)
     }
 }
 

--- a/soroban-sdk/tests/contractimport.rs
+++ b/soroban-sdk/tests/contractimport.rs
@@ -1,6 +1,6 @@
 #![cfg(feature = "testutils")]
 
-use soroban_sdk::{contractclient, contractimpl, BytesN, Env};
+use soroban_sdk::{contractimpl, BytesN, Env};
 use stellar_xdr::{ScSpecEntry, ScSpecFunctionInputV0, ScSpecFunctionV0, ScSpecTypeDef};
 
 const ADD_CONTRACT_ID: [u8; 32] = [0; 32];
@@ -13,7 +13,6 @@ mod addcontract {
 pub struct Contract;
 
 #[contractimpl]
-#[contractclient(name = "Client")]
 impl Contract {
     pub fn add_with(env: Env, x: i32, y: i32) -> i32 {
         addcontract::Client::add(&env, &BytesN::from_array(&env, &ADD_CONTRACT_ID), x, y)
@@ -32,7 +31,7 @@ fn test_functional() {
 
     let x = 10i32;
     let y = 12i32;
-    let z = Client::add_with(&e, &contract_id, x, y);
+    let z = ContractClient::add_with(&e, &contract_id, x, y);
     assert!(z == 22);
 }
 

--- a/soroban-sdk/tests/contractimport.rs
+++ b/soroban-sdk/tests/contractimport.rs
@@ -32,7 +32,7 @@ fn test_functional() {
 
     let x = 10i32;
     let y = 12i32;
-    let z = Client::add_with(&e, &contract_id, &x, &y);
+    let z = Client::add_with(&e, &contract_id, x, y);
     assert!(z == 22);
 }
 

--- a/soroban-sdk/tests/contractimport.rs
+++ b/soroban-sdk/tests/contractimport.rs
@@ -1,6 +1,6 @@
 #![cfg(feature = "testutils")]
 
-use soroban_sdk::{contractimpl, BytesN, Env};
+use soroban_sdk::{contractclient, contractimpl, BytesN, Env};
 use stellar_xdr::{ScSpecEntry, ScSpecFunctionInputV0, ScSpecFunctionV0, ScSpecTypeDef};
 
 const ADD_CONTRACT_ID: [u8; 32] = [0; 32];
@@ -13,6 +13,7 @@ mod addcontract {
 pub struct Contract;
 
 #[contractimpl]
+#[contractclient(name = "Client")]
 impl Contract {
     pub fn add_with(env: Env, x: i32, y: i32) -> i32 {
         addcontract::Client::add(&env, &BytesN::from_array(&env, &ADD_CONTRACT_ID), x, y)
@@ -31,7 +32,7 @@ fn test_functional() {
 
     let x = 10i32;
     let y = 12i32;
-    let z = add_with::invoke(&e, &contract_id, &x, &y);
+    let z = Client::add_with(&e, &contract_id, &x, &y);
     assert!(z == 22);
 }
 

--- a/soroban-sdk/tests/contractimport_with_sha256.rs
+++ b/soroban-sdk/tests/contractimport_with_sha256.rs
@@ -16,7 +16,7 @@ pub struct Contract;
 #[contractimpl]
 impl Contract {
     pub fn add_with(env: Env, x: i32, y: i32) -> i32 {
-        addcontract::Client::add(&env, &BytesN::from_array(&env, &ADD_CONTRACT_ID), x, y)
+        addcontract::ContractClient::add(&env, &BytesN::from_array(&env, &ADD_CONTRACT_ID), x, y)
     }
 }
 

--- a/soroban-sdk/tests/contractimport_with_sha256.rs
+++ b/soroban-sdk/tests/contractimport_with_sha256.rs
@@ -1,19 +1,20 @@
 #![cfg(feature = "testutils")]
 
-use soroban_sdk::{contractimpl, BytesN, Env};
+use soroban_sdk::{contractclient, contractimpl, BytesN, Env};
 use stellar_xdr::{ScSpecEntry, ScSpecFunctionInputV0, ScSpecFunctionV0, ScSpecTypeDef};
 
 const ADD_CONTRACT_ID: [u8; 32] = [0; 32];
 mod addcontract {
     soroban_sdk::contractimport!(
         file = "target/wasm32-unknown-unknown/release/example_add_i32.wasm",
-        sha256 = "6c5a4fe67b30474ff71fe489ac7321d850b91cc2c7db3f36f377fad3d3087d6f",
+        sha256 = "cce96634dca6b60232ee09d750c034804bb36aaadfb714fc0a6128ea4aea42d8",
     );
 }
 
 pub struct Contract;
 
 #[contractimpl]
+#[contractclient(name = "Client")]
 impl Contract {
     pub fn add_with(env: Env, x: i32, y: i32) -> i32 {
         addcontract::Client::add(&env, &BytesN::from_array(&env, &ADD_CONTRACT_ID), x, y)
@@ -32,7 +33,7 @@ fn test_functional() {
 
     let x = 10i32;
     let y = 12i32;
-    let z = add_with::invoke(&e, &contract_id, &x, &y);
+    let z = Client::add_with(&e, &contract_id, x, y);
     assert!(z == 22);
 }
 

--- a/soroban-sdk/tests/contractimport_with_sha256.rs
+++ b/soroban-sdk/tests/contractimport_with_sha256.rs
@@ -1,20 +1,19 @@
 #![cfg(feature = "testutils")]
 
-use soroban_sdk::{contractclient, contractimpl, BytesN, Env};
+use soroban_sdk::{contractimpl, BytesN, Env};
 use stellar_xdr::{ScSpecEntry, ScSpecFunctionInputV0, ScSpecFunctionV0, ScSpecTypeDef};
 
 const ADD_CONTRACT_ID: [u8; 32] = [0; 32];
 mod addcontract {
     soroban_sdk::contractimport!(
         file = "target/wasm32-unknown-unknown/release/example_add_i32.wasm",
-        sha256 = "cce96634dca6b60232ee09d750c034804bb36aaadfb714fc0a6128ea4aea42d8",
+        sha256 = "58e28b943aeb95f3d0f9f8a87a2049d6f52a41f5dbaaa0b44e00a0e41d40cb68",
     );
 }
 
 pub struct Contract;
 
 #[contractimpl]
-#[contractclient(name = "Client")]
 impl Contract {
     pub fn add_with(env: Env, x: i32, y: i32) -> i32 {
         addcontract::Client::add(&env, &BytesN::from_array(&env, &ADD_CONTRACT_ID), x, y)
@@ -33,7 +32,7 @@ fn test_functional() {
 
     let x = 10i32;
     let y = 12i32;
-    let z = Client::add_with(&e, &contract_id, x, y);
+    let z = ContractClient::add_with(&e, &contract_id, x, y);
     assert!(z == 22);
 }
 

--- a/soroban-sdk/tests/trybuild/contractfile_with_sha256_verify_fail.stderr
+++ b/soroban-sdk/tests/trybuild/contractfile_with_sha256_verify_fail.stderr
@@ -1,4 +1,4 @@
-error: sha256 does not match, expected: 6c5a4fe67b30474ff71fe489ac7321d850b91cc2c7db3f36f377fad3d3087d6f
+error: sha256 does not match, expected: cce96634dca6b60232ee09d750c034804bb36aaadfb714fc0a6128ea4aea42d8
  --> tests/trybuild/contractfile_with_sha256_verify_fail.rs:3:5
   |
 3 |     sha256 = "0000000000000000000000000000000000000000000000000000000000000000",

--- a/soroban-sdk/tests/trybuild/contractfile_with_sha256_verify_fail.stderr
+++ b/soroban-sdk/tests/trybuild/contractfile_with_sha256_verify_fail.stderr
@@ -1,4 +1,4 @@
-error: sha256 does not match, expected: cce96634dca6b60232ee09d750c034804bb36aaadfb714fc0a6128ea4aea42d8
+error: sha256 does not match, expected: 58e28b943aeb95f3d0f9f8a87a2049d6f52a41f5dbaaa0b44e00a0e41d40cb68
  --> tests/trybuild/contractfile_with_sha256_verify_fail.rs:3:5
   |
 3 |     sha256 = "0000000000000000000000000000000000000000000000000000000000000000",

--- a/soroban-sdk/tests/trybuild/contractimport_with_sha256_verify_fail.stderr
+++ b/soroban-sdk/tests/trybuild/contractimport_with_sha256_verify_fail.stderr
@@ -1,4 +1,4 @@
-error: sha256 does not match, expected: cce96634dca6b60232ee09d750c034804bb36aaadfb714fc0a6128ea4aea42d8
+error: sha256 does not match, expected: 58e28b943aeb95f3d0f9f8a87a2049d6f52a41f5dbaaa0b44e00a0e41d40cb68
  --> tests/trybuild/contractimport_with_sha256_verify_fail.rs:3:5
   |
 3 |     sha256 = "0000000000000000000000000000000000000000000000000000000000000000",

--- a/soroban-sdk/tests/trybuild/contractimport_with_sha256_verify_fail.stderr
+++ b/soroban-sdk/tests/trybuild/contractimport_with_sha256_verify_fail.stderr
@@ -1,4 +1,4 @@
-error: sha256 does not match, expected: 6c5a4fe67b30474ff71fe489ac7321d850b91cc2c7db3f36f377fad3d3087d6f
+error: sha256 does not match, expected: cce96634dca6b60232ee09d750c034804bb36aaadfb714fc0a6128ea4aea42d8
  --> tests/trybuild/contractimport_with_sha256_verify_fail.rs:3:5
   |
 3 |     sha256 = "0000000000000000000000000000000000000000000000000000000000000000",

--- a/soroban-spec/src/gen/rust.rs
+++ b/soroban-spec/src/gen/rust.rs
@@ -62,13 +62,18 @@ pub fn generate(specs: &[ScSpecEntry], file: &str, sha256: &str) -> TokenStream 
             ScSpecEntry::UdtUnionV0(u) => spec_unions.push(u),
         }
     }
-    let trait_ = r#trait::generate_trait("Contract", &spec_fns);
+
+    let trait_name = "Contract";
+    let client_name = format!("{}Client", trait_name);
+
+    let trait_ = r#trait::generate_trait(trait_name, &spec_fns);
     let structs = spec_structs.iter().map(|s| generate_struct(s));
     let unions = spec_unions.iter().map(|s| generate_union(s));
+
     quote! {
         pub const WASM: &[u8] = ::soroban_sdk::contractfile!(file = #file, sha256 = #sha256);
 
-        #[::soroban_sdk::contractclient(name = "Client")]
+        #[::soroban_sdk::contractclient(name = #client_name)]
         #trait_
 
         #(#structs)*

--- a/tests/add_i32/src/lib.rs
+++ b/tests/add_i32/src/lib.rs
@@ -1,10 +1,9 @@
 #![no_std]
-use soroban_sdk::{contractclient, contractimpl};
+use soroban_sdk::contractimpl;
 
 pub struct Contract;
 
 #[contractimpl]
-#[contractclient(name = "Client")]
 impl Contract {
     pub fn add(a: i32, b: i32) -> i32 {
         a + b
@@ -15,7 +14,7 @@ impl Contract {
 mod test {
     use soroban_sdk::{BytesN, Env};
 
-    use crate::{Client, Contract};
+    use crate::{Contract, ContractClient};
 
     #[test]
     fn test_add() {
@@ -25,7 +24,7 @@ mod test {
 
         let x = 10i32;
         let y = 12i32;
-        let z = Client::add(&e, &contract_id, x, y);
+        let z = ContractClient::add(&e, &contract_id, x, y);
         assert!(z == 22);
     }
 }

--- a/tests/add_i32/src/lib.rs
+++ b/tests/add_i32/src/lib.rs
@@ -1,9 +1,10 @@
 #![no_std]
-use soroban_sdk::contractimpl;
+use soroban_sdk::{contractclient, contractimpl};
 
 pub struct Contract;
 
 #[contractimpl]
+#[contractclient(name = "Client")]
 impl Contract {
     pub fn add(a: i32, b: i32) -> i32 {
         a + b
@@ -14,7 +15,7 @@ impl Contract {
 mod test {
     use soroban_sdk::{BytesN, Env};
 
-    use crate::{add, Contract};
+    use crate::{Client, Contract};
 
     #[test]
     fn test_add() {
@@ -24,7 +25,7 @@ mod test {
 
         let x = 10i32;
         let y = 12i32;
-        let z = add::invoke(&e, &contract_id, &x, &y);
+        let z = Client::add(&e, &contract_id, x, y);
         assert!(z == 22);
     }
 }

--- a/tests/add_i64/src/lib.rs
+++ b/tests/add_i64/src/lib.rs
@@ -1,5 +1,5 @@
 #![no_std]
-use soroban_sdk::{contractimpl, Env};
+use soroban_sdk::{contractclient, contractimpl, Env};
 
 // There are two ways to export contract fns:
 
@@ -8,6 +8,7 @@ use soroban_sdk::{contractimpl, Env};
 pub struct Add1;
 
 #[contractimpl]
+#[contractclient(name = "Add1Client")]
 impl Add1 {
     fn addimpl(a: i64, b: i64) -> i64 {
         a + b
@@ -26,6 +27,7 @@ pub trait Add2Trait {
 pub struct Add2;
 
 #[contractimpl]
+#[contractclient(name = "Add2Client")]
 impl Add2Trait for Add2 {
     fn add2(_e: Env, a: i64, b: i64) -> i64 {
         a + b
@@ -63,7 +65,7 @@ mod test_via_val {
 
         let x = 10i64;
         let y = 12i64;
-        let z = add1::invoke(&e, &contract_id, &x, &y);
+        let z = Add1Client::add1(&e, &contract_id, x, y);
         assert!(z == 22);
     }
 
@@ -75,7 +77,7 @@ mod test_via_val {
 
         let x = 10i64;
         let y = 12i64;
-        let z = add2::invoke(&e, &contract_id, &x, &y);
+        let z = Add2Client::add2(&e, &contract_id, x, y);
         assert!(z == 22);
     }
 }

--- a/tests/add_i64/src/lib.rs
+++ b/tests/add_i64/src/lib.rs
@@ -1,5 +1,5 @@
 #![no_std]
-use soroban_sdk::{contractclient, contractimpl, Env};
+use soroban_sdk::{contractimpl, Env};
 
 // There are two ways to export contract fns:
 
@@ -8,7 +8,6 @@ use soroban_sdk::{contractclient, contractimpl, Env};
 pub struct Add1;
 
 #[contractimpl]
-#[contractclient(name = "Add1Client")]
 impl Add1 {
     fn addimpl(a: i64, b: i64) -> i64 {
         a + b
@@ -27,7 +26,6 @@ pub trait Add2Trait {
 pub struct Add2;
 
 #[contractimpl]
-#[contractclient(name = "Add2Client")]
 impl Add2Trait for Add2 {
     fn add2(_e: Env, a: i64, b: i64) -> i64 {
         a + b

--- a/tests/empty/src/lib.rs
+++ b/tests/empty/src/lib.rs
@@ -1,9 +1,10 @@
 #![no_std]
-use soroban_sdk::contractimpl;
+use soroban_sdk::{contractclient, contractimpl};
 
 pub struct Contract;
 
 #[contractimpl]
+#[contractclient(name = "Client")]
 impl Contract {
     pub fn empty() {}
 }
@@ -12,7 +13,7 @@ impl Contract {
 mod test {
     use soroban_sdk::{BytesN, Env};
 
-    use crate::{empty, Contract};
+    use crate::{Client, Contract};
 
     #[test]
     fn test_hello() {
@@ -20,6 +21,6 @@ mod test {
         let contract_id = BytesN::from_array(&e, &[0; 32]);
         e.register_contract(&contract_id, Contract);
 
-        empty::invoke(&e, &contract_id);
+        Client::empty(&e, &contract_id);
     }
 }

--- a/tests/empty/src/lib.rs
+++ b/tests/empty/src/lib.rs
@@ -1,10 +1,9 @@
 #![no_std]
-use soroban_sdk::{contractclient, contractimpl};
+use soroban_sdk::contractimpl;
 
 pub struct Contract;
 
 #[contractimpl]
-#[contractclient(name = "Client")]
 impl Contract {
     pub fn empty() {}
 }
@@ -13,7 +12,7 @@ impl Contract {
 mod test {
     use soroban_sdk::{BytesN, Env};
 
-    use crate::{Client, Contract};
+    use crate::{Contract, ContractClient};
 
     #[test]
     fn test_hello() {
@@ -21,6 +20,6 @@ mod test {
         let contract_id = BytesN::from_array(&e, &[0; 32]);
         e.register_contract(&contract_id, Contract);
 
-        Client::empty(&e, &contract_id);
+        ContractClient::empty(&e, &contract_id);
     }
 }

--- a/tests/hello/src/lib.rs
+++ b/tests/hello/src/lib.rs
@@ -1,10 +1,9 @@
 #![no_std]
-use soroban_sdk::{contractclient, contractimpl, symbol, Symbol};
+use soroban_sdk::{contractimpl, symbol, Symbol};
 
 pub struct Contract;
 
 #[contractimpl]
-#[contractclient(name = "Client")]
 impl Contract {
     pub fn hello() -> Symbol {
         symbol!("hello")
@@ -15,7 +14,7 @@ impl Contract {
 mod test {
     use soroban_sdk::{symbol, BytesN, Env};
 
-    use crate::{Client, Contract};
+    use crate::{Contract, ContractClient};
 
     #[test]
     fn test_hello() {
@@ -23,7 +22,7 @@ mod test {
         let contract_id = BytesN::from_array(&e, &[0; 32]);
         e.register_contract(&contract_id, Contract);
 
-        let h = Client::hello(&e, &contract_id);
+        let h = ContractClient::hello(&e, &contract_id);
         assert!(h == symbol!("hello"));
     }
 }

--- a/tests/hello/src/lib.rs
+++ b/tests/hello/src/lib.rs
@@ -1,9 +1,5 @@
 #![no_std]
-<<<<<<< HEAD
-use soroban_sdk::{contractclient, contractimpl, Symbol};
-=======
-use soroban_sdk::{contractimpl, symbol, Symbol};
->>>>>>> main
+use soroban_sdk::{contractclient, contractimpl, symbol, Symbol};
 
 pub struct Contract;
 

--- a/tests/hello/src/lib.rs
+++ b/tests/hello/src/lib.rs
@@ -1,9 +1,10 @@
 #![no_std]
-use soroban_sdk::{contractimpl, Symbol};
+use soroban_sdk::{contractclient, contractimpl, Symbol};
 
 pub struct Contract;
 
 #[contractimpl]
+#[contractclient(name = "Client")]
 impl Contract {
     pub fn hello() -> Symbol {
         Symbol::from_str("hello")
@@ -14,7 +15,7 @@ impl Contract {
 mod test {
     use soroban_sdk::{BytesN, Env, Symbol};
 
-    use crate::{hello, Contract};
+    use crate::{Client, Contract};
 
     #[test]
     fn test_hello() {
@@ -22,7 +23,7 @@ mod test {
         let contract_id = BytesN::from_array(&e, &[0; 32]);
         e.register_contract(&contract_id, Contract);
 
-        let h = hello::invoke(&e, &contract_id);
+        let h = Client::hello(&e, &contract_id);
         assert!(h == Symbol::from_str("hello"));
     }
 }

--- a/tests/import_contract/src/lib.rs
+++ b/tests/import_contract/src/lib.rs
@@ -1,5 +1,5 @@
 #![no_std]
-use soroban_sdk::{contractimpl, BytesN, Env};
+use soroban_sdk::{contractclient, contractimpl, BytesN, Env};
 
 const ADD_CONTRACT_ID: [u8; 32] = [0; 32];
 mod addcontract {
@@ -11,6 +11,7 @@ mod addcontract {
 pub struct Contract;
 
 #[contractimpl]
+#[contractclient(name = "ContractClient")]
 impl Contract {
     pub fn add_with(env: Env, x: i32, y: i32) -> i32 {
         addcontract::Client::add(&env, &BytesN::from_array(&env, &ADD_CONTRACT_ID), x, y)
@@ -21,7 +22,7 @@ impl Contract {
 mod test {
     use soroban_sdk::{BytesN, Env};
 
-    use crate::{add_with, addcontract, Contract, ADD_CONTRACT_ID};
+    use crate::{addcontract, Contract, ContractClient, ADD_CONTRACT_ID};
 
     #[test]
     fn test_add() {
@@ -35,7 +36,7 @@ mod test {
 
         let x = 10i32;
         let y = 12i32;
-        let z = add_with::invoke(&e, &contract_id, &x, &y);
+        let z = ContractClient::add_with(&e, &contract_id, x, y);
         assert!(z == 22);
     }
 }

--- a/tests/import_contract/src/lib.rs
+++ b/tests/import_contract/src/lib.rs
@@ -1,5 +1,5 @@
 #![no_std]
-use soroban_sdk::{contractclient, contractimpl, BytesN, Env};
+use soroban_sdk::{contractimpl, BytesN, Env};
 
 const ADD_CONTRACT_ID: [u8; 32] = [0; 32];
 mod addcontract {
@@ -11,7 +11,6 @@ mod addcontract {
 pub struct Contract;
 
 #[contractimpl]
-#[contractclient(name = "ContractClient")]
 impl Contract {
     pub fn add_with(env: Env, x: i32, y: i32) -> i32 {
         addcontract::Client::add(&env, &BytesN::from_array(&env, &ADD_CONTRACT_ID), x, y)

--- a/tests/import_contract/src/lib.rs
+++ b/tests/import_contract/src/lib.rs
@@ -13,7 +13,7 @@ pub struct Contract;
 #[contractimpl]
 impl Contract {
     pub fn add_with(env: Env, x: i32, y: i32) -> i32 {
-        addcontract::Client::add(&env, &BytesN::from_array(&env, &ADD_CONTRACT_ID), x, y)
+        addcontract::ContractClient::add(&env, &BytesN::from_array(&env, &ADD_CONTRACT_ID), x, y)
     }
 }
 

--- a/tests/invoke_contract/src/lib.rs
+++ b/tests/invoke_contract/src/lib.rs
@@ -1,5 +1,5 @@
 #![no_std]
-use soroban_sdk::{contractclient, contractimpl, symbol, vec, BytesN, Env, IntoVal, Symbol};
+use soroban_sdk::{contractclient, contractimpl, symbol, vec, BytesN, Env, IntoVal};
 
 pub struct Contract;
 

--- a/tests/invoke_contract/src/lib.rs
+++ b/tests/invoke_contract/src/lib.rs
@@ -1,13 +1,15 @@
 #![no_std]
-use soroban_sdk::{contractimpl, vec, BytesN, Env, IntoVal, Symbol};
+use soroban_sdk::{contractclient, contractimpl, vec, BytesN, Env, IntoVal, Symbol};
 
 pub struct Contract;
 
 #[contractimpl]
+#[contractclient(name = "Client")]
 impl Contract {
-    pub fn add_with(env: Env, x: i32, y: i32, contract_id: BytesN<32>) -> i32 {
+    // TODO: Prevent arg overlap with generated args.
+    pub fn add_with(env: Env, x: i32, y: i32, _contract_id: BytesN<32>) -> i32 {
         env.invoke_contract(
-            &contract_id,
+            &_contract_id,
             &Symbol::from_str("add"),
             vec![&env, x.into_env_val(&env), y.into_env_val(&env)],
         )
@@ -27,7 +29,7 @@ impl AddContract {
 mod test {
     use soroban_sdk::{BytesN, Env};
 
-    use crate::{add_with, AddContract, Contract};
+    use crate::{AddContract, Client, Contract};
 
     #[test]
     fn test_add() {
@@ -39,7 +41,7 @@ mod test {
 
         let x = 10i32;
         let y = 12i32;
-        let z = add_with::invoke(&e, &contract_id, &x, &y, &add_contract_id);
+        let z = Client::add_with(&e, &contract_id, x, y, add_contract_id);
         assert!(z == 22);
     }
 }

--- a/tests/invoke_contract/src/lib.rs
+++ b/tests/invoke_contract/src/lib.rs
@@ -1,9 +1,5 @@
 #![no_std]
-<<<<<<< HEAD
-use soroban_sdk::{contractclient, contractimpl, vec, BytesN, Env, IntoVal, Symbol};
-=======
-use soroban_sdk::{contractimpl, symbol, vec, BytesN, Env, IntoVal};
->>>>>>> main
+use soroban_sdk::{contractclient, contractimpl, symbol, vec, BytesN, Env, IntoVal, Symbol};
 
 pub struct Contract;
 

--- a/tests/invoke_contract/src/lib.rs
+++ b/tests/invoke_contract/src/lib.rs
@@ -1,10 +1,9 @@
 #![no_std]
-use soroban_sdk::{contractclient, contractimpl, symbol, vec, BytesN, Env, IntoVal};
+use soroban_sdk::{contractimpl, symbol, vec, BytesN, Env, IntoVal};
 
 pub struct Contract;
 
 #[contractimpl]
-#[contractclient(name = "Client")]
 impl Contract {
     // TODO: Prevent arg overlap with generated args.
     pub fn add_with(env: Env, x: i32, y: i32, _contract_id: BytesN<32>) -> i32 {
@@ -29,7 +28,7 @@ impl AddContract {
 mod test {
     use soroban_sdk::{BytesN, Env};
 
-    use crate::{AddContract, Client, Contract};
+    use crate::{AddContract, Contract, ContractClient};
 
     #[test]
     fn test_add() {
@@ -41,7 +40,7 @@ mod test {
 
         let x = 10i32;
         let y = 12i32;
-        let z = Client::add_with(&e, &contract_id, x, y, add_contract_id);
+        let z = ContractClient::add_with(&e, &contract_id, x, y, add_contract_id);
         assert!(z == 22);
     }
 }

--- a/tests/udt/src/lib.rs
+++ b/tests/udt/src/lib.rs
@@ -1,5 +1,5 @@
 #![no_std]
-use soroban_sdk::{contractclient, contractimpl, contracttype, Vec};
+use soroban_sdk::{contractimpl, contracttype, Vec};
 
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -20,7 +20,6 @@ pub struct Contract;
 
 #[cfg_attr(feature = "export", contractimpl(export = true))]
 #[cfg_attr(not(feature = "export"), contractimpl(export = false))]
-#[contractclient(name = "Client")]
 impl Contract {
     pub fn add(a: UdtEnum, b: UdtEnum) -> i64 {
         let a = match a {
@@ -171,7 +170,7 @@ mod test {
             b: 12,
             c: vec![&e, 1],
         };
-        let z = Client::add(&e, &contract_id, UdtEnum::UdtA, UdtEnum::UdtB(udt));
+        let z = ContractClient::add(&e, &contract_id, UdtEnum::UdtA, UdtEnum::UdtB(udt));
         assert_eq!(z, 22);
     }
 

--- a/tests/udt/src/lib.rs
+++ b/tests/udt/src/lib.rs
@@ -1,5 +1,5 @@
 #![no_std]
-use soroban_sdk::{contractimpl, contracttype, Vec};
+use soroban_sdk::{contractclient, contractimpl, contracttype, Vec};
 
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -20,6 +20,7 @@ pub struct Contract;
 
 #[cfg_attr(feature = "export", contractimpl(export = true))]
 #[cfg_attr(not(feature = "export"), contractimpl(export = false))]
+#[contractclient(name = "Client")]
 impl Contract {
     pub fn add(a: UdtEnum, b: UdtEnum) -> i64 {
         let a = match a {
@@ -170,7 +171,7 @@ mod test {
             b: 12,
             c: vec![&e, 1],
         };
-        let z = add::invoke(&e, &contract_id, &UdtEnum::UdtA, &UdtEnum::UdtB(udt));
+        let z = Client::add(&e, &contract_id, UdtEnum::UdtA, UdtEnum::UdtB(udt));
         assert_eq!(z, 22);
     }
 


### PR DESCRIPTION
### What

Mark the `<fn>::invoke` functions as deprecated, and add as replacement with the developer calling their own contract using a generated client, the same client they'll use when calling other contracts.

#### Example
##### Before

```rust
const ADD_CONTRACT_ID: [u8; 32] = [0; 32];
mod addcontract {
    soroban_sdk::contractimport!(
        file = "target/wasm32-unknown-unknown/release/example_add_i32.wasm"
    );
}

pub struct Contract;

#[contractimpl]
impl Contract {
    pub fn add_with(env: Env, x: i32, y: i32) -> i32 {
        addcontract::ContractClient::add(&env, &BytesN::from_array(&env, &ADD_CONTRACT_ID), x, y)
    }
}

#[test]
fn test_functional() {
    let e = Env::default();

    let add_contract_id = BytesN::from_array(&e, &ADD_CONTRACT_ID);
    e.register_contract_wasm(&add_contract_id, addcontract::WASM);

    let contract_id = BytesN::from_array(&e, &[1; 32]);
    e.register_contract(&contract_id, Contract);

    let x = 10i32;
    let y = 12i32;
    let z = add_with::invoke(&e, &contract_id, &x, &y);
    assert!(z == 22);
}
```

##### After

```rust
const ADD_CONTRACT_ID: [u8; 32] = [0; 32];
mod addcontract {
    soroban_sdk::contractimport!(
        file = "target/wasm32-unknown-unknown/release/example_add_i32.wasm"
    );
}

pub struct Contract;

#[contractimpl]
impl Contract {
    pub fn add_with(env: Env, x: i32, y: i32) -> i32 {
        addcontract::ContractClient::add(&env, &BytesN::from_array(&env, &ADD_CONTRACT_ID), x, y)
    }
}

#[test]
fn test_functional() {
    let e = Env::default();

    let add_contract_id = BytesN::from_array(&e, &ADD_CONTRACT_ID);
    e.register_contract_wasm(&add_contract_id, addcontract::WASM);

    let contract_id = BytesN::from_array(&e, &[1; 32]);
    e.register_contract(&contract_id, Contract);

    let x = 10i32;
    let y = 12i32;
    let z = ContractClient::add_with(&e, &contract_id, x, y);
    assert!(z == 22);
}
```

##### Diff

```diff
@@ -31,7 +32,7 @@ fn test_functional() {
 
     let x = 10i32;
     let y = 12i32;
-    let z = add_with::invoke(&e, &contract_id, &x, &y);
+    let z = ContractClient::add_with(&e, &contract_id, x, y);
     assert!(z == 22);
 }
```

### Why

The `add_with::invoke` syntax is pretty odd and not intuitive. The client syntax is something we're surfacing for calling other contracts. It seems usable as a way to call a developers own contract in tests, and then it gives them one way to do something for all contracts.

Close #436

### Known limitations

N/A