### PR TITLE
Add sym! macro for const compile time Symbol creation

### DIFF
--- a/soroban-sdk-macros/src/derive_fn.rs
+++ b/soroban-sdk-macros/src/derive_fn.rs
@@ -250,7 +250,7 @@ pub fn derive_fn(
                 use soroban_sdk::{EnvVal, IntoVal, Symbol, Vec};
                 let mut args: Vec<EnvVal> = Vec::new(e);
                 #(args.push(#invoke_idents.clone().into_env_val(e));)*
-                e.invoke_contract(contract_id, &::soroban_sdk::sym!(#wrap_export_name), args)
+                e.invoke_contract(contract_id, &::soroban_sdk::symbol!(#wrap_export_name), args)
             }
 
             #[cfg(feature = "testutils")]

--- a/soroban-sdk-macros/src/derive_fn.rs
+++ b/soroban-sdk-macros/src/derive_fn.rs
@@ -247,10 +247,10 @@ pub fn derive_fn(
                 contract_id: &soroban_sdk::BytesN<32>,
                 #(#invoke_args),*
             ) #output {
-                use soroban_sdk::{EnvVal, IntoVal, Symbol, Vec, sym};
+                use soroban_sdk::{EnvVal, IntoVal, Symbol, Vec};
                 let mut args: Vec<EnvVal> = Vec::new(e);
                 #(args.push(#invoke_idents.clone().into_env_val(e));)*
-                e.invoke_contract(contract_id, &sym!(#wrap_export_name), args)
+                e.invoke_contract(contract_id, &::soroban_sdk::sym!(#wrap_export_name), args)
             }
 
             #[cfg(feature = "testutils")]

--- a/soroban-sdk-macros/src/derive_fn.rs
+++ b/soroban-sdk-macros/src/derive_fn.rs
@@ -247,10 +247,10 @@ pub fn derive_fn(
                 contract_id: &soroban_sdk::BytesN<32>,
                 #(#invoke_args),*
             ) #output {
-                use soroban_sdk::{EnvVal, IntoVal, Symbol, Vec};
+                use soroban_sdk::{EnvVal, IntoVal, Symbol, Vec, sym};
                 let mut args: Vec<EnvVal> = Vec::new(e);
                 #(args.push(#invoke_idents.clone().into_env_val(e));)*
-                e.invoke_contract(contract_id, &Symbol::from_str(#wrap_export_name), args)
+                e.invoke_contract(contract_id, &sym!(#wrap_export_name), args)
             }
 
             #[cfg(feature = "testutils")]

--- a/soroban-sdk-macros/src/derive_type.rs
+++ b/soroban-sdk-macros/src/derive_type.rs
@@ -51,7 +51,7 @@ pub fn derive_type_struct(ident: &Ident, data: &DataStruct, spec: bool) -> Token
                     }
                 },
             };
-            let map_key = quote! { ::soroban_sdk::sym!(#name) };
+            let map_key = quote! { ::soroban_sdk::symbol!(#name) };
             let try_from = quote! {
                 #ident: if let Some(Ok(val)) = map.get(#map_key) {
                     val.try_into_val(env)?
@@ -304,7 +304,7 @@ pub fn derive_type_enum(enum_ident: &Ident, data: &DataEnum, spec: bool) -> Toke
             let discriminant_const_sym_ident = format_ident!("DISCRIMINANT_SYM_{}", name.to_uppercase());
             let discriminant_const_u64_ident = format_ident!("DISCRIMINANT_U64_{}", name.to_uppercase());
             let discriminant_const_sym = quote! {
-                const #discriminant_const_sym_ident: soroban_sdk::Symbol = soroban_sdk::sym!(#name);
+                const #discriminant_const_sym_ident: soroban_sdk::Symbol = soroban_sdk::symbol!(#name);
             };
             let discriminant_const_u64 = quote! {
                 const #discriminant_const_u64_ident: u64 = #discriminant_const_sym_ident.to_raw().get_payload();

--- a/soroban-sdk-macros/src/derive_type.rs
+++ b/soroban-sdk-macros/src/derive_type.rs
@@ -52,7 +52,7 @@ pub fn derive_type_struct(ident: &Ident, data: &DataStruct, spec: bool) -> Token
                 },
             };
             let map_key = quote! { // TODO: Handle field names longer than a symbol. Hash the name? Truncate the name?
-                { const k: soroban_sdk::Symbol = soroban_sdk::Symbol::from_str(#name); k }
+                ::soroban_sdk::sym!(#name)
             };
             let try_from = quote! {
                 #ident: if let Some(Ok(val)) = map.get(#map_key) {
@@ -306,7 +306,7 @@ pub fn derive_type_enum(enum_ident: &Ident, data: &DataEnum, spec: bool) -> Toke
             let discriminant_const_sym_ident = format_ident!("DISCRIMINANT_SYM_{}", name.to_uppercase());
             let discriminant_const_u64_ident = format_ident!("DISCRIMINANT_U64_{}", name.to_uppercase());
             let discriminant_const_sym = quote! {
-                const #discriminant_const_sym_ident: soroban_sdk::Symbol = soroban_sdk::Symbol::from_str(#name);
+                const #discriminant_const_sym_ident: soroban_sdk::Symbol = soroban_sdk::sym!(#name);
             };
             let discriminant_const_u64 = quote! {
                 const #discriminant_const_u64_ident: u64 = #discriminant_const_sym_ident.to_raw().get_payload();

--- a/soroban-sdk-macros/src/derive_type.rs
+++ b/soroban-sdk-macros/src/derive_type.rs
@@ -51,9 +51,7 @@ pub fn derive_type_struct(ident: &Ident, data: &DataStruct, spec: bool) -> Token
                     }
                 },
             };
-            let map_key = quote! { // TODO: Handle field names longer than a symbol. Hash the name? Truncate the name?
-                ::soroban_sdk::sym!(#name)
-            };
+            let map_key = quote! { ::soroban_sdk::sym!(#name) };
             let try_from = quote! {
                 #ident: if let Some(Ok(val)) = map.get(#map_key) {
                     val.try_into_val(env)?

--- a/soroban-sdk/src/contract_data.rs
+++ b/soroban-sdk/src/contract_data.rs
@@ -17,7 +17,7 @@ use crate::{
 /// ```
 /// use soroban_sdk::{Env, Symbol};
 ///
-/// # use soroban_sdk::{contractimpl, BytesN};
+/// # use soroban_sdk::{contractimpl, sym, BytesN};
 /// #
 /// # pub struct Contract;
 /// #

--- a/soroban-sdk/src/contract_data.rs
+++ b/soroban-sdk/src/contract_data.rs
@@ -25,7 +25,7 @@ use crate::{
 /// # impl Contract {
 /// #     pub fn f(env: Env) {
 /// let contract_data = env.contract_data();
-/// let key = sym!("key");
+/// let key = symbol!("key");
 /// env.contract_data().set(key, 1);
 /// assert_eq!(contract_data.has(key), true);
 /// assert_eq!(contract_data.get::<_, i32>(key), Some(Ok(1)));

--- a/soroban-sdk/src/contract_data.rs
+++ b/soroban-sdk/src/contract_data.rs
@@ -25,7 +25,7 @@ use crate::{
 /// # impl Contract {
 /// #     pub fn f(env: Env) {
 /// let contract_data = env.contract_data();
-/// let key = Symbol::from_str("key");
+/// let key = sym!("key");
 /// env.contract_data().set(key, 1);
 /// assert_eq!(contract_data.has(key), true);
 /// assert_eq!(contract_data.get::<_, i32>(key), Some(Ok(1)));

--- a/soroban-sdk/src/contract_data.rs
+++ b/soroban-sdk/src/contract_data.rs
@@ -17,7 +17,7 @@ use crate::{
 /// ```
 /// use soroban_sdk::{Env, Symbol};
 ///
-/// # use soroban_sdk::{contractimpl, sym, BytesN};
+/// # use soroban_sdk::{contractimpl, symbol, BytesN};
 /// #
 /// # pub struct Contract;
 /// #

--- a/soroban-sdk/src/lib.rs
+++ b/soroban-sdk/src/lib.rs
@@ -70,6 +70,7 @@ pub mod iter;
 mod ledger;
 mod map;
 mod set;
+mod symbol;
 mod vec;
 pub use account::Account;
 pub use bigint::BigInt;

--- a/soroban-sdk/src/symbol.rs
+++ b/soroban-sdk/src/symbol.rs
@@ -8,20 +8,20 @@ use crate::Symbol;
 /// ### Examples
 ///
 /// ```
-/// use soroban_sdk::{sym, Symbol};
+/// use soroban_sdk::{symbol, Symbol};
 ///
 /// let symbol = symbol!("a_str");
 /// assert_eq!(symbol, Symbol::from_str("a_str"));
 /// ```
 ///
 /// ```
-/// use soroban_sdk::{sym, Symbol};
+/// use soroban_sdk::{symbol, Symbol};
 ///
 /// const symbol: Symbol = symbol!("a_str");
 /// assert_eq!(symbol, Symbol::from_str("a_str"));
 /// ```
 #[macro_export]
-macro_rules! sym {
+macro_rules! symbol {
     ($str:literal) => {{
         const symbol: $crate::Symbol = $crate::Symbol::from_str($str);
         symbol

--- a/soroban-sdk/src/symbol.rs
+++ b/soroban-sdk/src/symbol.rs
@@ -1,0 +1,29 @@
+#[cfg(doc)]
+use crate::Symbol;
+
+/// Create a [Symbol] with the given string.
+///
+/// The [Symbol] is generated at compile time and returned as a const.
+///
+/// ### Examples
+///
+/// ```
+/// use soroban_sdk::{sym, Symbol};
+///
+/// let symbol = sym!("a_str");
+/// assert_eq!(symbol, Symbol::from_str("a_str"));
+/// ```
+///
+/// ```
+/// use soroban_sdk::{sym, Symbol};
+///
+/// const symbol: Symbol = sym!("a_str");
+/// assert_eq!(symbol, Symbol::from_str("a_str"));
+/// ```
+#[macro_export]
+macro_rules! sym {
+    ($str:literal) => {{
+        const symbol: $crate::Symbol = $crate::Symbol::from_str($str);
+        symbol
+    }};
+}

--- a/soroban-sdk/src/symbol.rs
+++ b/soroban-sdk/src/symbol.rs
@@ -10,14 +10,14 @@ use crate::Symbol;
 /// ```
 /// use soroban_sdk::{sym, Symbol};
 ///
-/// let symbol = sym!("a_str");
+/// let symbol = symbol!("a_str");
 /// assert_eq!(symbol, Symbol::from_str("a_str"));
 /// ```
 ///
 /// ```
 /// use soroban_sdk::{sym, Symbol};
 ///
-/// const symbol: Symbol = sym!("a_str");
+/// const symbol: Symbol = symbol!("a_str");
 /// assert_eq!(symbol, Symbol::from_str("a_str"));
 /// ```
 #[macro_export]

--- a/soroban-sdk/src/vec.rs
+++ b/soroban-sdk/src/vec.rs
@@ -14,7 +14,7 @@ use super::{
 };
 
 #[cfg(doc)]
-use crate::{Bytes, ContractData, Map};
+use crate::{Bytes, BytesN, ContractData, Map};
 
 /// Create a [Vec] with the given items.
 ///

--- a/soroban-sdk/tests/contract_udt_enum.rs
+++ b/soroban-sdk/tests/contract_udt_enum.rs
@@ -1,7 +1,7 @@
 #![cfg(feature = "testutils")]
 
 use soroban_sdk::{
-    contractimpl, contracttype, sym, vec, BytesN, ConversionError, Env, IntoVal, TryFromVal,
+    contractimpl, contracttype, symbol, vec, BytesN, ConversionError, Env, IntoVal, TryFromVal,
 };
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]

--- a/soroban-sdk/tests/contract_udt_enum.rs
+++ b/soroban-sdk/tests/contract_udt_enum.rs
@@ -1,7 +1,7 @@
 #![cfg(feature = "testutils")]
 
 use soroban_sdk::{
-    contractimpl, contracttype, vec, BytesN, ConversionError, Env, IntoVal, Symbol, TryFromVal,
+    contractimpl, contracttype, sym, vec, BytesN, ConversionError, Env, IntoVal, TryFromVal,
 };
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
@@ -39,10 +39,10 @@ fn test_error_on_partial_decode() {
     // Success case, a vec will decode to a Udt if the first element is the
     // variant name as a Symbol, and following elements are tuple-like values
     // for the variant.
-    let vec = vec![&env, Symbol::from_str("Aaa").into_val(&env)].to_raw();
+    let vec = vec![&env, sym!("Aaa").into_val(&env)].to_raw();
     let udt = Udt::try_from_val(&env, vec);
     assert_eq!(udt, Ok(Udt::Aaa));
-    let vec = vec![&env, Symbol::from_str("Bbb").into_val(&env), 8.into()].to_raw();
+    let vec = vec![&env, sym!("Bbb").into_val(&env), 8.into()].to_raw();
     let udt = Udt::try_from_val(&env, vec);
     assert_eq!(udt, Ok(Udt::Bbb(8)));
 
@@ -50,16 +50,10 @@ fn test_error_on_partial_decode() {
     // multiple values, it is an error. It is an error because decoding and
     // encoding will not round trip the data, and therefore partial decoding is
     // relatively difficult to use safely.
-    let vec = vec![&env, Symbol::from_str("Aaa").into_val(&env), 8.into()].to_raw();
+    let vec = vec![&env, sym!("Aaa").into_val(&env), 8.into()].to_raw();
     let udt = Udt::try_from_val(&env, vec);
     assert_eq!(udt, Err(ConversionError));
-    let vec = vec![
-        &env,
-        Symbol::from_str("Bbb").into_val(&env),
-        8.into(),
-        9.into(),
-    ]
-    .to_raw();
+    let vec = vec![&env, sym!("Bbb").into_val(&env), 8.into(), 9.into()].to_raw();
     let udt = Udt::try_from_val(&env, vec);
     assert_eq!(udt, Err(ConversionError));
 }

--- a/soroban-sdk/tests/contract_udt_enum.rs
+++ b/soroban-sdk/tests/contract_udt_enum.rs
@@ -39,10 +39,10 @@ fn test_error_on_partial_decode() {
     // Success case, a vec will decode to a Udt if the first element is the
     // variant name as a Symbol, and following elements are tuple-like values
     // for the variant.
-    let vec = vec![&env, sym!("Aaa").into_val(&env)].to_raw();
+    let vec = vec![&env, symbol!("Aaa").into_val(&env)].to_raw();
     let udt = Udt::try_from_val(&env, vec);
     assert_eq!(udt, Ok(Udt::Aaa));
-    let vec = vec![&env, sym!("Bbb").into_val(&env), 8.into()].to_raw();
+    let vec = vec![&env, symbol!("Bbb").into_val(&env), 8.into()].to_raw();
     let udt = Udt::try_from_val(&env, vec);
     assert_eq!(udt, Ok(Udt::Bbb(8)));
 
@@ -50,10 +50,10 @@ fn test_error_on_partial_decode() {
     // multiple values, it is an error. It is an error because decoding and
     // encoding will not round trip the data, and therefore partial decoding is
     // relatively difficult to use safely.
-    let vec = vec![&env, sym!("Aaa").into_val(&env), 8.into()].to_raw();
+    let vec = vec![&env, symbol!("Aaa").into_val(&env), 8.into()].to_raw();
     let udt = Udt::try_from_val(&env, vec);
     assert_eq!(udt, Err(ConversionError));
-    let vec = vec![&env, sym!("Bbb").into_val(&env), 8.into(), 9.into()].to_raw();
+    let vec = vec![&env, symbol!("Bbb").into_val(&env), 8.into(), 9.into()].to_raw();
     let udt = Udt::try_from_val(&env, vec);
     assert_eq!(udt, Err(ConversionError));
 }

--- a/soroban-sdk/tests/contract_udt_struct.rs
+++ b/soroban-sdk/tests/contract_udt_struct.rs
@@ -42,7 +42,7 @@ fn test_error_on_partial_decode() {
 
     // Success case, a map will decode to a Udt if the symbol keys match the
     // fields.
-    let map = map![&env, (sym!("a"), 5), (sym!("b"), 7)].to_raw();
+    let map = map![&env, (symbol!("a"), 5), (symbol!("b"), 7)].to_raw();
     let udt = Udt::try_from_val(&env, map);
     assert_eq!(udt, Ok(Udt { a: 5, b: 7 }));
 
@@ -50,7 +50,13 @@ fn test_error_on_partial_decode() {
     // has fields a, b, and c, it is an error. It is an error because decoding
     // and encoding will not round trip the data, and therefore partial decoding
     // is relatively difficult to use safely.
-    let map = map![&env, (sym!("a"), 5), (sym!("b"), 7), (sym!("c"), 9)].to_raw();
+    let map = map![
+        &env,
+        (symbol!("a"), 5),
+        (symbol!("b"), 7),
+        (symbol!("c"), 9)
+    ]
+    .to_raw();
     let udt = Udt::try_from_val(&env, map);
     assert_eq!(udt, Err(ConversionError));
 }

--- a/soroban-sdk/tests/contract_udt_struct.rs
+++ b/soroban-sdk/tests/contract_udt_struct.rs
@@ -2,9 +2,7 @@
 
 use std::io::Cursor;
 
-use soroban_sdk::{
-    contractimpl, contracttype, map, BytesN, ConversionError, Env, Symbol, TryFromVal,
-};
+use soroban_sdk::{contractimpl, contracttype, map, sym, BytesN, ConversionError, Env, TryFromVal};
 use stellar_xdr::{
     ReadXdr, ScSpecEntry, ScSpecFunctionInputV0, ScSpecFunctionV0, ScSpecTypeDef, ScSpecTypeTuple,
     ScSpecTypeUdt,
@@ -44,7 +42,7 @@ fn test_error_on_partial_decode() {
 
     // Success case, a map will decode to a Udt if the symbol keys match the
     // fields.
-    let map = map![&env, (Symbol::from_str("a"), 5), (Symbol::from_str("b"), 7)].to_raw();
+    let map = map![&env, (sym!("a"), 5), (sym!("b"), 7)].to_raw();
     let udt = Udt::try_from_val(&env, map);
     assert_eq!(udt, Ok(Udt { a: 5, b: 7 }));
 
@@ -52,13 +50,7 @@ fn test_error_on_partial_decode() {
     // has fields a, b, and c, it is an error. It is an error because decoding
     // and encoding will not round trip the data, and therefore partial decoding
     // is relatively difficult to use safely.
-    let map = map![
-        &env,
-        (Symbol::from_str("a"), 5),
-        (Symbol::from_str("b"), 7),
-        (Symbol::from_str("c"), 9)
-    ]
-    .to_raw();
+    let map = map![&env, (sym!("a"), 5), (sym!("b"), 7), (sym!("c"), 9)].to_raw();
     let udt = Udt::try_from_val(&env, map);
     assert_eq!(udt, Err(ConversionError));
 }

--- a/soroban-sdk/tests/contract_udt_struct.rs
+++ b/soroban-sdk/tests/contract_udt_struct.rs
@@ -2,7 +2,9 @@
 
 use std::io::Cursor;
 
-use soroban_sdk::{contractimpl, contracttype, map, sym, BytesN, ConversionError, Env, TryFromVal};
+use soroban_sdk::{
+    contractimpl, contracttype, map, symbol, BytesN, ConversionError, Env, TryFromVal,
+};
 use stellar_xdr::{
     ReadXdr, ScSpecEntry, ScSpecFunctionInputV0, ScSpecFunctionV0, ScSpecTypeDef, ScSpecTypeTuple,
     ScSpecTypeUdt,

--- a/tests/hello/src/lib.rs
+++ b/tests/hello/src/lib.rs
@@ -1,5 +1,5 @@
 #![no_std]
-use soroban_sdk::{contractimpl, sym, Symbol};
+use soroban_sdk::{contractimpl, symbol, Symbol};
 
 pub struct Contract;
 
@@ -12,7 +12,7 @@ impl Contract {
 
 #[cfg(test)]
 mod test {
-    use soroban_sdk::{sym, BytesN, Env};
+    use soroban_sdk::{symbol, BytesN, Env};
 
     use crate::{hello, Contract};
 

--- a/tests/hello/src/lib.rs
+++ b/tests/hello/src/lib.rs
@@ -6,7 +6,7 @@ pub struct Contract;
 #[contractimpl]
 impl Contract {
     pub fn hello() -> Symbol {
-        sym!("hello")
+        symbol!("hello")
     }
 }
 
@@ -23,6 +23,6 @@ mod test {
         e.register_contract(&contract_id, Contract);
 
         let h = hello::invoke(&e, &contract_id);
-        assert!(h == sym!("hello"));
+        assert!(h == symbol!("hello"));
     }
 }

--- a/tests/hello/src/lib.rs
+++ b/tests/hello/src/lib.rs
@@ -1,18 +1,18 @@
 #![no_std]
-use soroban_sdk::{contractimpl, Symbol};
+use soroban_sdk::{contractimpl, sym, Symbol};
 
 pub struct Contract;
 
 #[contractimpl]
 impl Contract {
     pub fn hello() -> Symbol {
-        Symbol::from_str("hello")
+        sym!("hello")
     }
 }
 
 #[cfg(test)]
 mod test {
-    use soroban_sdk::{BytesN, Env, Symbol};
+    use soroban_sdk::{sym, BytesN, Env};
 
     use crate::{hello, Contract};
 
@@ -23,6 +23,6 @@ mod test {
         e.register_contract(&contract_id, Contract);
 
         let h = hello::invoke(&e, &contract_id);
-        assert!(h == Symbol::from_str("hello"));
+        assert!(h == sym!("hello"));
     }
 }

--- a/tests/invoke_contract/src/lib.rs
+++ b/tests/invoke_contract/src/lib.rs
@@ -8,7 +8,7 @@ impl Contract {
     pub fn add_with(env: Env, x: i32, y: i32, contract_id: BytesN<32>) -> i32 {
         env.invoke_contract(
             &contract_id,
-            &sym!("add"),
+            &symbol!("add"),
             vec![&env, x.into_env_val(&env), y.into_env_val(&env)],
         )
     }

--- a/tests/invoke_contract/src/lib.rs
+++ b/tests/invoke_contract/src/lib.rs
@@ -1,5 +1,5 @@
 #![no_std]
-use soroban_sdk::{contractimpl, sym, vec, BytesN, Env, IntoVal};
+use soroban_sdk::{contractimpl, symbol, vec, BytesN, Env, IntoVal};
 
 pub struct Contract;
 

--- a/tests/invoke_contract/src/lib.rs
+++ b/tests/invoke_contract/src/lib.rs
@@ -1,5 +1,5 @@
 #![no_std]
-use soroban_sdk::{contractimpl, vec, BytesN, Env, IntoVal, Symbol};
+use soroban_sdk::{contractimpl, sym, vec, BytesN, Env, IntoVal};
 
 pub struct Contract;
 
@@ -8,7 +8,7 @@ impl Contract {
     pub fn add_with(env: Env, x: i32, y: i32, contract_id: BytesN<32>) -> i32 {
         env.invoke_contract(
             &contract_id,
-            &Symbol::from_str("add"),
+            &sym!("add"),
             vec![&env, x.into_env_val(&env), y.into_env_val(&env)],
         )
     }


### PR DESCRIPTION
### What
Add sym! macro that creates a Symbol that is generated at compile time.

### Why
Symbol::from_str is a const fn and it can be used in a const context to generate the Symbol at compile time. However in Rust const fns are only evaluated at compile time if they are used explicitly in a const context. This means if someone uses Symbol::from_str in a non-const context inside a contract, they're introducing a couple hundred bytes of WASM instructions for the conversion logic.