### PR TITLE
Add JSON representation for a soroban sc spec

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "ansi_term"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -130,6 +139,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctor"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdffe87e1d521a10f9696f833fe502293ea446d7f256c06128293a4119bdf4cb"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "curve25519-dalek"
 version = "3.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -176,6 +195,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "diff"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
 name = "digest"
@@ -555,6 +580,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
+name = "output_vt100"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "628223faebab4e3e40667ee0b2336d34a5b960ff60ea743ddfdbcf7770bcfb66"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "parity-wasm"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -565,6 +599,18 @@ name = "ppv-lite86"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
+
+[[package]]
+name = "pretty_assertions"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c89f989ac94207d048d92db058e4f6ec7342b0971fc58d1271ca148b799b3563"
+dependencies = [
+ "ansi_term",
+ "ctor",
+ "diff",
+ "output_vt100",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -933,6 +979,7 @@ dependencies = [
  "base64",
  "darling",
  "itertools",
+ "pretty_assertions",
  "proc-macro2",
  "quote",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -758,6 +758,9 @@ name = "serde"
 version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc855a42c7967b7c369eb5860f7164ef1f6f81c20c7cc1141f2a604e18723b03"
+dependencies = [
+ "serde_derive",
+]
 
 [[package]]
 name = "serde_derive"
@@ -932,7 +935,11 @@ dependencies = [
  "itertools",
  "proc-macro2",
  "quote",
+ "serde",
+ "serde_derive",
+ "serde_json",
  "sha2 0.10.2",
+ "soroban-env-host",
  "stellar-xdr",
  "syn",
  "thiserror",
@@ -983,6 +990,9 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 name = "stellar-xdr"
 version = "0.0.1"
 source = "git+https://github.com/stellar/rs-stellar-xdr?rev=61de11d#61de11d0ce5eb8a6e722d903af2abfadb5f5bd0e"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "strsim"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ resolver = "2"
 members = [
     "soroban-sdk",
     "soroban-sdk-auth",
+    "soroban-spec",
     "tests/empty",
     "tests/hello",
     "tests/add_i32",

--- a/soroban-spec/Cargo.toml
+++ b/soroban-spec/Cargo.toml
@@ -20,3 +20,7 @@ itertools = "0.10.3"
 darling = "0.14.1"
 sha2 = "0.10.2"
 wasmparser = "0.88.0"
+serde = "1.0.82"
+serde_derive = "1.0.82"
+serde_json = "1.0.82"
+soroban-env-host = { version = "0.0.3", features = ["vm", "serde"] }

--- a/soroban-spec/Cargo.toml
+++ b/soroban-spec/Cargo.toml
@@ -24,3 +24,6 @@ serde = "1.0.82"
 serde_derive = "1.0.82"
 serde_json = "1.0.82"
 soroban-env-host = { version = "0.0.3", features = ["vm", "serde"] }
+
+[dev_dependencies]
+pretty_assertions = "1.2.1"

--- a/soroban-spec/src/gen.rs
+++ b/soroban-spec/src/gen.rs
@@ -1,1 +1,2 @@
+pub mod json;
 pub mod rust;

--- a/soroban-spec/src/gen/json.rs
+++ b/soroban-spec/src/gen/json.rs
@@ -44,7 +44,7 @@ impl TryFrom<&ScSpecFunctionInputV0> for FunctionInput {
 #[serde(rename_all = "camelCase")]
 pub struct UnionCase {
     name: String,
-    value: Option<SpecType>,
+    values: Vec<SpecType>,
 }
 
 impl TryFrom<&ScSpecUdtUnionCaseV0> for UnionCase {
@@ -53,7 +53,13 @@ impl TryFrom<&ScSpecUdtUnionCaseV0> for UnionCase {
     fn try_from(c: &ScSpecUdtUnionCaseV0) -> Result<Self, Self::Error> {
         Ok(UnionCase {
             name: c.name.to_string()?,
-            value: c.type_.as_ref().map(SpecType::try_from).transpose()?,
+            values: c
+                .type_
+                .as_ref()
+                .map(SpecType::try_from)
+                .transpose()?
+                .into_iter()
+                .collect(),
         })
     }
 }
@@ -196,6 +202,8 @@ impl TryFrom<&ScSpecEntry> for SpecType {
 
 #[cfg(test)]
 mod test {
+    use pretty_assertions::assert_eq;
+
     use super::SpecType;
 
     const EXAMPLE_WASM: &[u8] =
@@ -217,14 +225,16 @@ mod test {
   "cases": [
     {
       "name": "UdtA",
-      "value": null
+      "values": []
     },
     {
       "name": "UdtB",
-      "value": {
-        "type": "userDefined",
-        "name": "UdtStruct"
-      }
+      "values": [
+        {
+          "type": "userDefined",
+          "name": "UdtStruct"
+        }
+      ]
     }
   ]
 }{
@@ -277,7 +287,7 @@ mod test {
       "type": "i64"
     }
   ]
-}"#
+}"#,
         );
     }
 }

--- a/soroban-spec/src/gen/json.rs
+++ b/soroban-spec/src/gen/json.rs
@@ -220,3 +220,91 @@ impl TryFrom<&ScSpecEntry> for SpecType {
         }
     }
 }
+
+#[cfg(test)]
+mod test {
+    use super::SpecType;
+
+    const EXAMPLE_WASM: &[u8] =
+        include_bytes!("../../../target/wasm32-unknown-unknown/release/example_udt.wasm");
+
+    #[test]
+    fn example() {
+        let entries = crate::read::from_wasm(EXAMPLE_WASM).unwrap();
+        let mut json = "".to_string();
+        for entry in &entries {
+            let json_entry: SpecType = entry.try_into().unwrap();
+            json.push_str(&serde_json::to_string_pretty(&json_entry).unwrap());
+        }
+        assert_eq!(
+            json,
+            r#"{
+  "type": "union",
+  "name": "UdtEnum",
+  "cases": [
+    {
+      "name": "UdtA",
+      "value": null
+    },
+    {
+      "name": "UdtB",
+      "value": {
+        "type": "userDefined",
+        "name": "UdtStruct"
+      }
+    }
+  ]
+}{
+  "type": "struct",
+  "name": "UdtStruct",
+  "fields": [
+    {
+      "name": "a",
+      "value": {
+        "type": "i64"
+      }
+    },
+    {
+      "name": "b",
+      "value": {
+        "type": "i64"
+      }
+    },
+    {
+      "name": "c",
+      "value": {
+        "type": "vec",
+        "element": {
+          "type": "i64"
+        }
+      }
+    }
+  ]
+}{
+  "type": "function",
+  "name": "add",
+  "inputs": [
+    {
+      "name": "a",
+      "value": {
+        "type": "userDefined",
+        "name": "UdtEnum"
+      }
+    },
+    {
+      "name": "b",
+      "value": {
+        "type": "userDefined",
+        "name": "UdtEnum"
+      }
+    }
+  ],
+  "outputs": [
+    {
+      "type": "i64"
+    }
+  ]
+}"#
+        );
+    }
+}

--- a/soroban-spec/src/gen/json.rs
+++ b/soroban-spec/src/gen/json.rs
@@ -1,0 +1,222 @@
+use serde::Serialize;
+use soroban_env_host::xdr::{
+    Error, ScSpecEntry, ScSpecFunctionInputV0, ScSpecTypeDef, ScSpecUdtStructFieldV0,
+    ScSpecUdtUnionCaseV0,
+};
+
+#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StructField {
+    name: String,
+    value: SpecType,
+}
+
+impl TryFrom<&ScSpecUdtStructFieldV0> for StructField {
+    type Error = Error;
+
+    fn try_from(f: &ScSpecUdtStructFieldV0) -> Result<Self, Self::Error> {
+        let name = f.name.to_string()?;
+        let value = SpecType::try_from(&f.type_)?;
+        Ok(StructField {
+            name: name,
+            value: value,
+        })
+    }
+}
+
+#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FunctionInput {
+    name: String,
+    value: SpecType,
+}
+
+impl TryFrom<&ScSpecFunctionInputV0> for FunctionInput {
+    type Error = Error;
+
+    fn try_from(f: &ScSpecFunctionInputV0) -> Result<Self, Self::Error> {
+        let name = f.name.to_string()?;
+        let value = SpecType::try_from(&f.type_)?;
+        Ok(FunctionInput {
+            name: name,
+            value: value,
+        })
+    }
+}
+
+#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UnionCase {
+    name: String,
+    value: Option<SpecType>,
+}
+
+impl TryFrom<&ScSpecUdtUnionCaseV0> for UnionCase {
+    type Error = Error;
+
+    fn try_from(c: &ScSpecUdtUnionCaseV0) -> Result<Self, Self::Error> {
+        let name = c.name.to_string()?;
+        let value = c.type_.as_ref().map(SpecType::try_from);
+        Ok(UnionCase {
+            name: name,
+            value: match value {
+                None => None,
+                Some(r) => Some(r?),
+            },
+        })
+    }
+}
+
+#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize)]
+#[serde(tag = "type")]
+#[serde(rename_all = "camelCase")]
+pub enum SpecType {
+    U64,
+    I64,
+    U32,
+    I32,
+    Bool,
+    Symbol,
+    Bitset,
+    Status,
+    Bytes,
+    BigInt,
+    Function {
+        name: String,
+        inputs: Vec<FunctionInput>,
+        outputs: Vec<SpecType>,
+    },
+    Map {
+        key: Box<SpecType>,
+        value: Box<SpecType>,
+    },
+    Option {
+        value: Box<SpecType>,
+    },
+    Result {
+        value: Box<SpecType>,
+        error: Box<SpecType>,
+    },
+    Set {
+        element: Box<SpecType>,
+    },
+    Vec {
+        element: Box<SpecType>,
+    },
+    Tuple {
+        elements: Vec<SpecType>,
+    },
+    UserDefined {
+        name: String,
+    },
+    Struct {
+        name: String,
+        fields: Vec<StructField>,
+    },
+    Union {
+        name: String,
+        cases: Vec<UnionCase>,
+    },
+}
+
+impl TryFrom<&ScSpecTypeDef> for SpecType {
+    type Error = Error;
+
+    fn try_from(spec: &ScSpecTypeDef) -> Result<Self, Self::Error> {
+        match spec {
+            ScSpecTypeDef::Map(inner) => {
+                let key = SpecType::try_from(inner.key_type.as_ref());
+                let value = SpecType::try_from(inner.value_type.as_ref());
+                Ok(SpecType::Map {
+                    key: Box::new(key?),
+                    value: Box::new(value?),
+                })
+            }
+            ScSpecTypeDef::Option(inner) => {
+                let value = SpecType::try_from(inner.value_type.as_ref());
+                Ok(SpecType::Option {
+                    value: Box::new(value?),
+                })
+            }
+            ScSpecTypeDef::Result(inner) => {
+                let value = SpecType::try_from(inner.ok_type.as_ref());
+                let error = SpecType::try_from(inner.error_type.as_ref());
+                Ok(SpecType::Result {
+                    value: Box::new(value?),
+                    error: Box::new(error?),
+                })
+            }
+            ScSpecTypeDef::Set(inner) => {
+                let element = SpecType::try_from(inner.element_type.as_ref());
+                Ok(SpecType::Set {
+                    element: Box::new(element?),
+                })
+            }
+            ScSpecTypeDef::Tuple(inner) => {
+                let elements: Result<Vec<SpecType>, Error> =
+                    inner.value_types.iter().map(SpecType::try_from).collect();
+                Ok(SpecType::Tuple {
+                    elements: elements?,
+                })
+            }
+            ScSpecTypeDef::Vec(inner) => {
+                let element = SpecType::try_from(inner.element_type.as_ref());
+                Ok(SpecType::Vec {
+                    element: Box::new(element?),
+                })
+            }
+            ScSpecTypeDef::Udt(inner) => Ok(SpecType::UserDefined {
+                name: inner.name.to_string()?,
+            }),
+            ScSpecTypeDef::U64 => Ok(SpecType::U64),
+            ScSpecTypeDef::I64 => Ok(SpecType::I64),
+            ScSpecTypeDef::U32 => Ok(SpecType::U32),
+            ScSpecTypeDef::I32 => Ok(SpecType::I32),
+            ScSpecTypeDef::Bool => Ok(SpecType::Bool),
+            ScSpecTypeDef::Symbol => Ok(SpecType::Symbol),
+            ScSpecTypeDef::Bitset => Ok(SpecType::Bitset),
+            ScSpecTypeDef::Status => Ok(SpecType::Status),
+            ScSpecTypeDef::Bytes => Ok(SpecType::Bytes),
+            ScSpecTypeDef::BigInt => Ok(SpecType::BigInt),
+        }
+    }
+}
+
+impl TryFrom<&ScSpecEntry> for SpecType {
+    type Error = Error;
+
+    fn try_from(spec: &ScSpecEntry) -> Result<Self, Self::Error> {
+        match spec {
+            ScSpecEntry::FunctionV0(f) => {
+                let name = f.name.to_string()?;
+                let inputs: Result<Vec<FunctionInput>, Error> =
+                    f.inputs.iter().map(FunctionInput::try_from).collect();
+                let outputs: Result<Vec<SpecType>, Error> =
+                    f.outputs.iter().map(SpecType::try_from).collect();
+                Ok(SpecType::Function {
+                    name: name,
+                    inputs: inputs?,
+                    outputs: outputs?,
+                })
+            }
+            ScSpecEntry::UdtStructV0(s) => {
+                let name = s.name.to_string()?;
+                let fields: Result<Vec<StructField>, Error> =
+                    s.fields.iter().map(StructField::try_from).collect();
+                Ok(SpecType::Struct {
+                    name: name,
+                    fields: fields?,
+                })
+            }
+            ScSpecEntry::UdtUnionV0(u) => {
+                let name = u.name.to_string()?;
+                let cases: Result<Vec<UnionCase>, Error> =
+                    u.cases.iter().map(UnionCase::try_from).collect();
+                Ok(SpecType::Union {
+                    name: name,
+                    cases: cases?,
+                })
+            }
+        }
+    }
+}

--- a/soroban-spec/src/gen/json.rs
+++ b/soroban-spec/src/gen/json.rs
@@ -8,7 +8,7 @@ use soroban_env_host::xdr::{
 #[serde(rename_all = "camelCase")]
 pub struct StructField {
     name: String,
-    value: SpecType,
+    value: Type,
 }
 
 impl TryFrom<&ScSpecUdtStructFieldV0> for StructField {
@@ -17,7 +17,7 @@ impl TryFrom<&ScSpecUdtStructFieldV0> for StructField {
     fn try_from(f: &ScSpecUdtStructFieldV0) -> Result<Self, Self::Error> {
         Ok(StructField {
             name: f.name.to_string()?,
-            value: SpecType::try_from(&f.type_)?,
+            value: Type::try_from(&f.type_)?,
         })
     }
 }
@@ -26,7 +26,7 @@ impl TryFrom<&ScSpecUdtStructFieldV0> for StructField {
 #[serde(rename_all = "camelCase")]
 pub struct FunctionInput {
     name: String,
-    value: SpecType,
+    value: Type,
 }
 
 impl TryFrom<&ScSpecFunctionInputV0> for FunctionInput {
@@ -35,7 +35,7 @@ impl TryFrom<&ScSpecFunctionInputV0> for FunctionInput {
     fn try_from(f: &ScSpecFunctionInputV0) -> Result<Self, Self::Error> {
         Ok(FunctionInput {
             name: f.name.to_string()?,
-            value: SpecType::try_from(&f.type_)?,
+            value: Type::try_from(&f.type_)?,
         })
     }
 }
@@ -44,7 +44,7 @@ impl TryFrom<&ScSpecFunctionInputV0> for FunctionInput {
 #[serde(rename_all = "camelCase")]
 pub struct UnionCase {
     name: String,
-    values: Vec<SpecType>,
+    values: Vec<Type>,
 }
 
 impl TryFrom<&ScSpecUdtUnionCaseV0> for UnionCase {
@@ -56,7 +56,7 @@ impl TryFrom<&ScSpecUdtUnionCaseV0> for UnionCase {
             values: c
                 .type_
                 .as_ref()
-                .map(SpecType::try_from)
+                .map(Type::try_from)
                 .transpose()?
                 .into_iter()
                 .collect(),
@@ -67,7 +67,7 @@ impl TryFrom<&ScSpecUdtUnionCaseV0> for UnionCase {
 #[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize)]
 #[serde(tag = "type")]
 #[serde(rename_all = "camelCase")]
-pub enum SpecType {
+pub enum Type {
     U64,
     I64,
     U32,
@@ -78,39 +78,23 @@ pub enum SpecType {
     Status,
     Bytes,
     BigInt,
-    Map {
-        key: Box<SpecType>,
-        value: Box<SpecType>,
-    },
-    Option {
-        value: Box<SpecType>,
-    },
-    Result {
-        value: Box<SpecType>,
-        error: Box<SpecType>,
-    },
-    Set {
-        element: Box<SpecType>,
-    },
-    Vec {
-        element: Box<SpecType>,
-    },
-    Tuple {
-        elements: Vec<SpecType>,
-    },
-    Custom {
-        name: String,
-    },
+    Map { key: Box<Type>, value: Box<Type> },
+    Option { value: Box<Type> },
+    Result { value: Box<Type>, error: Box<Type> },
+    Set { element: Box<Type> },
+    Vec { element: Box<Type> },
+    Tuple { elements: Vec<Type> },
+    Custom { name: String },
 }
 
 #[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize)]
 #[serde(tag = "type")]
 #[serde(rename_all = "camelCase")]
-pub enum EntryType {
+pub enum Entry {
     Function {
         name: String,
         inputs: Vec<FunctionInput>,
-        outputs: Vec<SpecType>,
+        outputs: Vec<Type>,
     },
     Struct {
         name: String,
@@ -122,58 +106,58 @@ pub enum EntryType {
     },
 }
 
-impl TryFrom<&ScSpecTypeDef> for SpecType {
+impl TryFrom<&ScSpecTypeDef> for Type {
     type Error = Error;
 
     fn try_from(spec: &ScSpecTypeDef) -> Result<Self, Self::Error> {
         match spec {
-            ScSpecTypeDef::Map(map) => Ok(SpecType::Map {
-                key: Box::new(SpecType::try_from(map.key_type.as_ref())?),
-                value: Box::new(SpecType::try_from(map.value_type.as_ref())?),
+            ScSpecTypeDef::Map(map) => Ok(Type::Map {
+                key: Box::new(Type::try_from(map.key_type.as_ref())?),
+                value: Box::new(Type::try_from(map.value_type.as_ref())?),
             }),
-            ScSpecTypeDef::Option(opt) => Ok(SpecType::Option {
-                value: Box::new(SpecType::try_from(opt.value_type.as_ref())?),
+            ScSpecTypeDef::Option(opt) => Ok(Type::Option {
+                value: Box::new(Type::try_from(opt.value_type.as_ref())?),
             }),
-            ScSpecTypeDef::Result(res) => Ok(SpecType::Result {
-                value: Box::new(SpecType::try_from(res.ok_type.as_ref())?),
-                error: Box::new(SpecType::try_from(res.error_type.as_ref())?),
+            ScSpecTypeDef::Result(res) => Ok(Type::Result {
+                value: Box::new(Type::try_from(res.ok_type.as_ref())?),
+                error: Box::new(Type::try_from(res.error_type.as_ref())?),
             }),
-            ScSpecTypeDef::Set(set) => Ok(SpecType::Set {
-                element: Box::new(SpecType::try_from(set.element_type.as_ref())?),
+            ScSpecTypeDef::Set(set) => Ok(Type::Set {
+                element: Box::new(Type::try_from(set.element_type.as_ref())?),
             }),
-            ScSpecTypeDef::Tuple(tuple) => Ok(SpecType::Tuple {
+            ScSpecTypeDef::Tuple(tuple) => Ok(Type::Tuple {
                 elements: tuple
                     .value_types
                     .iter()
-                    .map(SpecType::try_from)
+                    .map(Type::try_from)
                     .collect::<Result<Vec<_>, Error>>()?,
             }),
-            ScSpecTypeDef::Vec(vec) => Ok(SpecType::Vec {
-                element: Box::new(SpecType::try_from(vec.element_type.as_ref())?),
+            ScSpecTypeDef::Vec(vec) => Ok(Type::Vec {
+                element: Box::new(Type::try_from(vec.element_type.as_ref())?),
             }),
-            ScSpecTypeDef::Udt(udt) => Ok(SpecType::Custom {
+            ScSpecTypeDef::Udt(udt) => Ok(Type::Custom {
                 name: udt.name.to_string()?,
             }),
-            ScSpecTypeDef::U64 => Ok(SpecType::U64),
-            ScSpecTypeDef::I64 => Ok(SpecType::I64),
-            ScSpecTypeDef::U32 => Ok(SpecType::U32),
-            ScSpecTypeDef::I32 => Ok(SpecType::I32),
-            ScSpecTypeDef::Bool => Ok(SpecType::Bool),
-            ScSpecTypeDef::Symbol => Ok(SpecType::Symbol),
-            ScSpecTypeDef::Bitset => Ok(SpecType::Bitset),
-            ScSpecTypeDef::Status => Ok(SpecType::Status),
-            ScSpecTypeDef::Bytes => Ok(SpecType::Bytes),
-            ScSpecTypeDef::BigInt => Ok(SpecType::BigInt),
+            ScSpecTypeDef::U64 => Ok(Type::U64),
+            ScSpecTypeDef::I64 => Ok(Type::I64),
+            ScSpecTypeDef::U32 => Ok(Type::U32),
+            ScSpecTypeDef::I32 => Ok(Type::I32),
+            ScSpecTypeDef::Bool => Ok(Type::Bool),
+            ScSpecTypeDef::Symbol => Ok(Type::Symbol),
+            ScSpecTypeDef::Bitset => Ok(Type::Bitset),
+            ScSpecTypeDef::Status => Ok(Type::Status),
+            ScSpecTypeDef::Bytes => Ok(Type::Bytes),
+            ScSpecTypeDef::BigInt => Ok(Type::BigInt),
         }
     }
 }
 
-impl TryFrom<&ScSpecEntry> for EntryType {
+impl TryFrom<&ScSpecEntry> for Entry {
     type Error = Error;
 
     fn try_from(spec: &ScSpecEntry) -> Result<Self, Self::Error> {
         match spec {
-            ScSpecEntry::FunctionV0(f) => Ok(EntryType::Function {
+            ScSpecEntry::FunctionV0(f) => Ok(Entry::Function {
                 name: f.name.to_string()?,
                 inputs: f
                     .inputs
@@ -183,10 +167,10 @@ impl TryFrom<&ScSpecEntry> for EntryType {
                 outputs: f
                     .outputs
                     .iter()
-                    .map(SpecType::try_from)
+                    .map(Type::try_from)
                     .collect::<Result<Vec<_>, Error>>()?,
             }),
-            ScSpecEntry::UdtStructV0(s) => Ok(EntryType::Struct {
+            ScSpecEntry::UdtStructV0(s) => Ok(Entry::Struct {
                 name: s.name.to_string()?,
                 fields: s
                     .fields
@@ -194,7 +178,7 @@ impl TryFrom<&ScSpecEntry> for EntryType {
                     .map(StructField::try_from)
                     .collect::<Result<Vec<_>, Error>>()?,
             }),
-            ScSpecEntry::UdtUnionV0(u) => Ok(EntryType::Union {
+            ScSpecEntry::UdtUnionV0(u) => Ok(Entry::Union {
                 name: u.name.to_string()?,
                 cases: u
                     .cases
@@ -210,7 +194,7 @@ impl TryFrom<&ScSpecEntry> for EntryType {
 mod test {
     use pretty_assertions::assert_eq;
 
-    use super::EntryType;
+    use super::Entry;
 
     const EXAMPLE_WASM: &[u8] =
         include_bytes!("../../../target/wasm32-unknown-unknown/release/example_udt.wasm");
@@ -220,7 +204,7 @@ mod test {
         let entries = crate::read::from_wasm(EXAMPLE_WASM).unwrap();
         let mut json = "".to_string();
         for entry in &entries {
-            let json_entry: EntryType = entry.try_into().unwrap();
+            let json_entry: Entry = entry.try_into().unwrap();
             json.push_str(&serde_json::to_string_pretty(&json_entry).unwrap());
         }
         assert_eq!(


### PR DESCRIPTION
### What

Add JSON representation for a soroban smart contract spec. Checkout https://github.com/stellar/soroban-cli/pull/91/files for how `SpecType` is used to serialize the smart contract into JSON.

For the following function `pub fn add(a: BigInt, b: BigInt) -> BigInt` this is what the JSON output looks like:

```
{"type":"function","name":"add","inputs":[{"name":"a","value":{"type":"bigInt"}},{"name":"b","value":{"type":"bigInt"}}],"outputs":[{"type":"bigInt"}]}
```





### Why

This is necessary to implement https://github.com/stellar/soroban-cli/issues/56 .

### Known limitations

[N/A]
