### PR TITLE
Remove use of iterator from enum decoding

### DIFF
--- a/soroban-sdk-macros/src/derive_type.rs
+++ b/soroban-sdk-macros/src/derive_type.rs
@@ -335,7 +335,7 @@ pub fn derive_type_enum(enum_ident: &Ident, data: &DataEnum, spec: bool) -> Toke
                 let into = quote! { Self::#ident(value) => (#discriminant_const_sym_ident, value).into_val(env) };
                 let try_from_xdr = quote! {
                     #name => {
-                        if iter.len() > 2 {
+                        if vec.len() > 2 {
                             return Err(soroban_sdk::xdr::Error::Invalid);
                         }
                         let rv: soroban_sdk::RawVal = vec.get_unchecked(1).map_err(|_| soroban_sdk::xdr::Error::Invalid)?;


### PR DESCRIPTION
### What
Remove use of iterator from enum decoding

### Why
It adds additional WASM for little to no gain. The length of the vec is always known due to the length check which is required anyway. So there's no reason to add additional branches checking if the value is present or not, since we know it is.