### PR TITLE
Store contract ID inside client struct

### DIFF
--- a/soroban-sdk-macros/src/derive_fn.rs
+++ b/soroban-sdk-macros/src/derive_fn.rs
@@ -140,8 +140,8 @@ pub fn derive_fn(
     let wrap_export_name = format!("{}", ident);
     let pub_mod_ident = format_ident!("{}", ident);
     let hidden_mod_ident = format_ident!("__{}", ident);
-    let deprecated_note = format!("use `{}::{}` instead", client_ident, &ident);
-    let deprecated_note_xdr = format!("use `{}::{}_xdr` instead", client_ident, &ident);
+    let deprecated_note = format!("use `{}::new(&env, &contract_id).{}` instead", client_ident, &ident);
+    let deprecated_note_xdr = format!("use `{}::new(&env, &contract_id).{}_xdr` instead", client_ident, &ident);
     let env_call = if env_input.is_some() {
         quote! { env.clone(), }
     } else {

--- a/soroban-sdk/src/account.rs
+++ b/soroban-sdk/src/account.rs
@@ -3,7 +3,7 @@ use core::{borrow::Borrow, cmp::Ordering, fmt::Debug};
 use crate::{
     env::internal::{Env as _, RawVal, RawValConvertible},
     env::EnvObj,
-    Bytes, BytesN, ConversionError, Env, EnvType, EnvVal, IntoVal, Object, TryFromVal, TryIntoVal,
+    Bytes, BytesN, ConversionError, Env, EnvVal, IntoVal, Object, TryFromVal, TryIntoVal,
 };
 
 /// Account references a Stellar account and provides access to information
@@ -91,19 +91,9 @@ impl AsRef<BytesN<32>> for Account {
     }
 }
 
-impl From<EnvType<[u8; 32]>> for Account {
-    fn from(ev: EnvType<[u8; 32]>) -> Self {
-        Account(ev.into())
-    }
-}
-
 impl IntoVal<Env, Account> for [u8; 32] {
     fn into_val(self, env: &Env) -> Account {
-        EnvType {
-            env: env.clone(),
-            val: self,
-        }
-        .into()
+        Account(self.into_val(env))
     }
 }
 

--- a/soroban-sdk/src/bytes.rs
+++ b/soroban-sdk/src/bytes.rs
@@ -8,7 +8,7 @@ use core::{
 
 use super::{
     env::internal::{Env as _, EnvBase as _, RawValConvertible},
-    env::{EnvObj, EnvType, IntoVal},
+    env::{EnvObj, IntoVal},
     xdr::ScObjectType,
     ConversionError, Env, EnvVal, Object, RawVal, TryFromVal, TryIntoVal,
 };
@@ -213,12 +213,6 @@ impl TryIntoVal<Env, Bytes> for ScVal {
 impl IntoVal<Env, Bytes> for &str {
     fn into_val(self, env: &Env) -> Bytes {
         Bytes::from_slice(env, self.as_bytes())
-    }
-}
-
-impl From<EnvType<&str>> for Bytes {
-    fn from(ev: EnvType<&str>) -> Self {
-        Bytes::from_slice(&ev.env, ev.val.as_bytes())
     }
 }
 
@@ -656,24 +650,27 @@ impl<const N: usize> AsRef<Bytes> for BytesN<N> {
     }
 }
 
-impl<const N: usize> From<EnvType<[u8; N]>> for BytesN<N> {
-    #[inline(always)]
-    fn from(ev: EnvType<[u8; N]>) -> Self {
-        let mut bin = Bytes::new(&ev.env);
-        for b in ev.val {
-            bin.push(b);
-        }
-        BytesN(bin)
+impl<const N: usize> IntoVal<Env, BytesN<N>> for BytesN<N> {
+    fn into_val(self, _env: &Env) -> BytesN<N> {
+        self
+    }
+}
+
+impl<const N: usize> IntoVal<Env, BytesN<N>> for &BytesN<N> {
+    fn into_val(self, _env: &Env) -> BytesN<N> {
+        self.clone()
     }
 }
 
 impl<const N: usize> IntoVal<Env, BytesN<N>> for [u8; N] {
     fn into_val(self, env: &Env) -> BytesN<N> {
-        EnvType {
-            env: env.clone(),
-            val: self,
-        }
-        .into()
+        BytesN::from_array(env, &self)
+    }
+}
+
+impl<const N: usize> IntoVal<Env, BytesN<N>> for &[u8; N] {
+    fn into_val(self, env: &Env) -> BytesN<N> {
+        BytesN::from_array(env, self)
     }
 }
 

--- a/soroban-sdk/tests/contract_add_i32.rs
+++ b/soroban-sdk/tests/contract_add_i32.rs
@@ -22,7 +22,7 @@ fn test_functional() {
 
     let a = 10i32;
     let b = 12i32;
-    let c = ContractClient::add(&e, &contract_id, a, b);
+    let c = ContractClient::new(&e, &contract_id).add(&e, a, b);
     assert_eq!(c, 22);
 }
 

--- a/soroban-sdk/tests/contract_add_i32.rs
+++ b/soroban-sdk/tests/contract_add_i32.rs
@@ -22,7 +22,7 @@ fn test_functional() {
 
     let a = 10i32;
     let b = 12i32;
-    let c = ContractClient::new(&e, &contract_id).add(&e, a, b);
+    let c = ContractClient::new(&e, &contract_id).add(a, b);
     assert_eq!(c, 22);
 }
 

--- a/soroban-sdk/tests/contract_udt_enum.rs
+++ b/soroban-sdk/tests/contract_udt_enum.rs
@@ -25,10 +25,11 @@ fn test_functional() {
     let env = Env::default();
     let contract_id = BytesN::from_array(&env, &[0; 32]);
     env.register_contract(&contract_id, Contract);
+    let client = ContractClient::new(&env, &contract_id);
 
     let a = Udt::Aaa;
     let b = Udt::Bbb(3);
-    let c = ContractClient::add(&env, &contract_id, a, b);
+    let c = client.add(&env, a, b);
     assert_eq!(c, (a, b));
 }
 

--- a/soroban-sdk/tests/contract_udt_enum.rs
+++ b/soroban-sdk/tests/contract_udt_enum.rs
@@ -29,7 +29,7 @@ fn test_functional() {
 
     let a = Udt::Aaa;
     let b = Udt::Bbb(3);
-    let c = client.add(&env, a, b);
+    let c = client.add(a, b);
     assert_eq!(c, (a, b));
 }
 

--- a/soroban-sdk/tests/contract_udt_struct.rs
+++ b/soroban-sdk/tests/contract_udt_struct.rs
@@ -34,7 +34,7 @@ fn test_functional() {
 
     let a = Udt { a: 5, b: 7 };
     let b = Udt { a: 10, b: 14 };
-    let c = ContractClient::new(&env, &contract_id).add(&env, a, b);
+    let c = ContractClient::new(&env, &contract_id).add(a, b);
     assert_eq!(c, (a, b));
 }
 

--- a/soroban-sdk/tests/contract_udt_struct.rs
+++ b/soroban-sdk/tests/contract_udt_struct.rs
@@ -34,7 +34,7 @@ fn test_functional() {
 
     let a = Udt { a: 5, b: 7 };
     let b = Udt { a: 10, b: 14 };
-    let c = ContractClient::add(&env, &contract_id, a, b);
+    let c = ContractClient::new(&env, &contract_id).add(&env, a, b);
     assert_eq!(c, (a, b));
 }
 

--- a/soroban-sdk/tests/contractimport.rs
+++ b/soroban-sdk/tests/contractimport.rs
@@ -15,7 +15,7 @@ pub struct Contract;
 #[contractimpl]
 impl Contract {
     pub fn add_with(env: Env, x: i32, y: i32) -> i32 {
-        addcontract::ContractClient::new(&env, &ADD_CONTRACT_ID).add(&env, x, y)
+        addcontract::ContractClient::new(&env, &ADD_CONTRACT_ID).add(x, y)
     }
 }
 
@@ -32,7 +32,7 @@ fn test_functional() {
 
     let x = 10i32;
     let y = 12i32;
-    let z = client.add_with(&e, x, y);
+    let z = client.add_with(x, y);
     assert!(z == 22);
 }
 

--- a/soroban-sdk/tests/contractimport.rs
+++ b/soroban-sdk/tests/contractimport.rs
@@ -15,7 +15,7 @@ pub struct Contract;
 #[contractimpl]
 impl Contract {
     pub fn add_with(env: Env, x: i32, y: i32) -> i32 {
-        addcontract::ContractClient::add(&env, &BytesN::from_array(&env, &ADD_CONTRACT_ID), x, y)
+        addcontract::ContractClient::new(&env, &ADD_CONTRACT_ID).add(&env, x, y)
     }
 }
 
@@ -28,10 +28,11 @@ fn test_functional() {
 
     let contract_id = BytesN::from_array(&e, &[1; 32]);
     e.register_contract(&contract_id, Contract);
+    let client = ContractClient::new(&e, &contract_id);
 
     let x = 10i32;
     let y = 12i32;
-    let z = ContractClient::add_with(&e, &contract_id, x, y);
+    let z = client.add_with(&e, x, y);
     assert!(z == 22);
 }
 

--- a/soroban-sdk/tests/contractimport_with_sha256.rs
+++ b/soroban-sdk/tests/contractimport_with_sha256.rs
@@ -16,7 +16,7 @@ pub struct Contract;
 #[contractimpl]
 impl Contract {
     pub fn add_with(env: Env, x: i32, y: i32) -> i32 {
-        addcontract::ContractClient::new(&env, &ADD_CONTRACT_ID).add(&env, x, y)
+        addcontract::ContractClient::new(&env, &ADD_CONTRACT_ID).add(x, y)
     }
 }
 
@@ -33,7 +33,7 @@ fn test_functional() {
 
     let x = 10i32;
     let y = 12i32;
-    let z = client.add_with(&e, x, y);
+    let z = client.add_with(x, y);
     assert!(z == 22);
 }
 

--- a/soroban-sdk/tests/contractimport_with_sha256.rs
+++ b/soroban-sdk/tests/contractimport_with_sha256.rs
@@ -16,7 +16,7 @@ pub struct Contract;
 #[contractimpl]
 impl Contract {
     pub fn add_with(env: Env, x: i32, y: i32) -> i32 {
-        addcontract::ContractClient::add(&env, &BytesN::from_array(&env, &ADD_CONTRACT_ID), x, y)
+        addcontract::ContractClient::new(&env, &ADD_CONTRACT_ID).add(&env, x, y)
     }
 }
 
@@ -29,10 +29,11 @@ fn test_functional() {
 
     let contract_id = BytesN::from_array(&e, &[1; 32]);
     e.register_contract(&contract_id, Contract);
+    let client = ContractClient::new(&e, &contract_id);
 
     let x = 10i32;
     let y = 12i32;
-    let z = ContractClient::add_with(&e, &contract_id, x, y);
+    let z = client.add_with(&e, x, y);
     assert!(z == 22);
 }
 

--- a/tests/add_i32/src/lib.rs
+++ b/tests/add_i32/src/lib.rs
@@ -21,10 +21,11 @@ mod test {
         let e = Env::default();
         let contract_id = BytesN::from_array(&e, &[0; 32]);
         e.register_contract(&contract_id, Contract);
+        let client = ContractClient::new(&e, &contract_id);
 
         let x = 10i32;
         let y = 12i32;
-        let z = ContractClient::add(&e, &contract_id, x, y);
+        let z = client.add(&e, x, y);
         assert!(z == 22);
     }
 }

--- a/tests/add_i32/src/lib.rs
+++ b/tests/add_i32/src/lib.rs
@@ -25,7 +25,7 @@ mod test {
 
         let x = 10i32;
         let y = 12i32;
-        let z = client.add(&e, x, y);
+        let z = client.add(x, y);
         assert!(z == 22);
     }
 }

--- a/tests/add_i64/src/lib.rs
+++ b/tests/add_i64/src/lib.rs
@@ -64,7 +64,7 @@ mod test_via_val {
 
         let x = 10i64;
         let y = 12i64;
-        let z = client.add1(&e, x, y);
+        let z = client.add1(x, y);
         assert!(z == 22);
     }
 
@@ -77,7 +77,7 @@ mod test_via_val {
 
         let x = 10i64;
         let y = 12i64;
-        let z = client.add2(&e, x, y);
+        let z = client.add2(x, y);
         assert!(z == 22);
     }
 }

--- a/tests/add_i64/src/lib.rs
+++ b/tests/add_i64/src/lib.rs
@@ -60,10 +60,11 @@ mod test_via_val {
         let e = Env::default();
         let contract_id = BytesN::from_array(&e, &[0; 32]);
         e.register_contract(&contract_id, Add1);
+        let client = Add1Client::new(&e, &contract_id);
 
         let x = 10i64;
         let y = 12i64;
-        let z = Add1Client::add1(&e, &contract_id, x, y);
+        let z = client.add1(&e, x, y);
         assert!(z == 22);
     }
 
@@ -72,10 +73,11 @@ mod test_via_val {
         let e = Env::default();
         let contract_id = BytesN::from_array(&e, &[0; 32]);
         e.register_contract(&contract_id, Add2);
+        let client = Add2Client::new(&e, &contract_id);
 
         let x = 10i64;
         let y = 12i64;
-        let z = Add2Client::add2(&e, &contract_id, x, y);
+        let z = client.add2(&e, x, y);
         assert!(z == 22);
     }
 }

--- a/tests/empty/src/lib.rs
+++ b/tests/empty/src/lib.rs
@@ -19,7 +19,8 @@ mod test {
         let e = Env::default();
         let contract_id = BytesN::from_array(&e, &[0; 32]);
         e.register_contract(&contract_id, Contract);
+        let client = ContractClient::new(&e, &contract_id);
 
-        ContractClient::empty(&e, &contract_id);
+        client.empty(&e);
     }
 }

--- a/tests/empty/src/lib.rs
+++ b/tests/empty/src/lib.rs
@@ -21,6 +21,6 @@ mod test {
         e.register_contract(&contract_id, Contract);
         let client = ContractClient::new(&e, &contract_id);
 
-        client.empty(&e);
+        client.empty();
     }
 }

--- a/tests/hello/src/lib.rs
+++ b/tests/hello/src/lib.rs
@@ -23,7 +23,7 @@ mod test {
         e.register_contract(&contract_id, Contract);
         let client = ContractClient::new(&e, &contract_id);
 
-        let h = client.hello(&e);
+        let h = client.hello();
         assert!(h == symbol!("hello"));
     }
 }

--- a/tests/hello/src/lib.rs
+++ b/tests/hello/src/lib.rs
@@ -21,8 +21,9 @@ mod test {
         let e = Env::default();
         let contract_id = BytesN::from_array(&e, &[0; 32]);
         e.register_contract(&contract_id, Contract);
+        let client = ContractClient::new(&e, &contract_id);
 
-        let h = ContractClient::hello(&e, &contract_id);
+        let h = client.hello(&e);
         assert!(h == symbol!("hello"));
     }
 }

--- a/tests/import_contract/src/lib.rs
+++ b/tests/import_contract/src/lib.rs
@@ -1,5 +1,5 @@
 #![no_std]
-use soroban_sdk::{contractimpl, BytesN, Env};
+use soroban_sdk::{contractimpl, Env};
 
 const ADD_CONTRACT_ID: [u8; 32] = [0; 32];
 mod addcontract {
@@ -13,7 +13,7 @@ pub struct Contract;
 #[contractimpl]
 impl Contract {
     pub fn add_with(env: Env, x: i32, y: i32) -> i32 {
-        addcontract::ContractClient::add(&env, &BytesN::from_array(&env, &ADD_CONTRACT_ID), x, y)
+        addcontract::ContractClient::new(&env, &ADD_CONTRACT_ID).add(&env, x, y)
     }
 }
 
@@ -32,10 +32,11 @@ mod test {
 
         let contract_id = BytesN::from_array(&e, &[1; 32]);
         e.register_contract(&contract_id, Contract);
+        let client = ContractClient::new(&e, &contract_id);
 
         let x = 10i32;
         let y = 12i32;
-        let z = ContractClient::add_with(&e, &contract_id, x, y);
+        let z = client.add_with(&e, x, y);
         assert!(z == 22);
     }
 }

--- a/tests/import_contract/src/lib.rs
+++ b/tests/import_contract/src/lib.rs
@@ -13,7 +13,7 @@ pub struct Contract;
 #[contractimpl]
 impl Contract {
     pub fn add_with(env: Env, x: i32, y: i32) -> i32 {
-        addcontract::ContractClient::new(&env, &ADD_CONTRACT_ID).add(&env, x, y)
+        addcontract::ContractClient::new(&env, &ADD_CONTRACT_ID).add(x, y)
     }
 }
 
@@ -36,7 +36,7 @@ mod test {
 
         let x = 10i32;
         let y = 12i32;
-        let z = client.add_with(&e, x, y);
+        let z = client.add_with(x, y);
         assert!(z == 22);
     }
 }

--- a/tests/invoke_contract/src/lib.rs
+++ b/tests/invoke_contract/src/lib.rs
@@ -6,9 +6,9 @@ pub struct Contract;
 #[contractimpl]
 impl Contract {
     // TODO: Prevent arg overlap with generated args.
-    pub fn add_with(env: Env, x: i32, y: i32, _contract_id: BytesN<32>) -> i32 {
+    pub fn add_with(env: Env, x: i32, y: i32, contract_id: BytesN<32>) -> i32 {
         env.invoke_contract(
-            &_contract_id,
+            &contract_id,
             &symbol!("add"),
             vec![&env, x.into_env_val(&env), y.into_env_val(&env)],
         )
@@ -43,7 +43,7 @@ mod test {
 
         let x = 10i32;
         let y = 12i32;
-        let z = client.add_with(&e, x, y, add_contract_id);
+        let z = client.add_with(x, y, add_contract_id);
         assert!(z == 22);
     }
 }

--- a/tests/invoke_contract/src/lib.rs
+++ b/tests/invoke_contract/src/lib.rs
@@ -33,14 +33,17 @@ mod test {
     #[test]
     fn test_add() {
         let e = Env::default();
+
         let add_contract_id = BytesN::from_array(&e, &[0; 32]);
         e.register_contract(&add_contract_id, AddContract);
+
         let contract_id = BytesN::from_array(&e, &[1; 32]);
         e.register_contract(&contract_id, Contract);
+        let client = ContractClient::new(&e, &contract_id);
 
         let x = 10i32;
         let y = 12i32;
-        let z = ContractClient::add_with(&e, &contract_id, x, y, add_contract_id);
+        let z = client.add_with(&e, x, y, add_contract_id);
         assert!(z == 22);
     }
 }

--- a/tests/udt/src/lib.rs
+++ b/tests/udt/src/lib.rs
@@ -164,13 +164,14 @@ mod test {
         let e = Env::default();
         let contract_id = BytesN::from_array(&e, &[0; 32]);
         e.register_contract(&contract_id, Contract);
+        let client = ContractClient::new(&e, &contract_id);
 
         let udt = UdtStruct {
             a: 10,
             b: 12,
             c: vec![&e, 1],
         };
-        let z = ContractClient::add(&e, &contract_id, UdtEnum::UdtA, UdtEnum::UdtB(udt));
+        let z = client.add(&e, UdtEnum::UdtA, UdtEnum::UdtB(udt));
         assert_eq!(z, 22);
     }
 

--- a/tests/udt/src/lib.rs
+++ b/tests/udt/src/lib.rs
@@ -171,7 +171,7 @@ mod test {
             b: 12,
             c: vec![&e, 1],
         };
-        let z = client.add(&e, UdtEnum::UdtA, UdtEnum::UdtB(udt));
+        let z = client.add(UdtEnum::UdtA, UdtEnum::UdtB(udt));
         assert_eq!(z, 22);
     }
 


### PR DESCRIPTION
### What
Move the `env` and `contract_id` out of the client functions and into the client struct.

```diff
-     let c = ContractClient::add(&env, &contract_id, a, b);
+     let client = ContractClient::new(&env, &contract_id);
+     let c = client.add(a, b);
```

### Why
So that the env and contract ID does not need to be repeatedly passed to functions in cases where the ID is static. In cases where the ID is dynamic a new client can be constructed for each request.

This also reduces the chances of collissions with function parameters that are also named "contract_id".

Close https://github.com/stellar/rs-soroban-sdk/issues/463

### Fun Facts

This change has zero impact on the compiled artifact. The .wasm files are identical after this change as before this change. 🤯 