### PR TITLE
Add BytesN support to spec

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -873,7 +873,7 @@ dependencies = [
 [[package]]
 name = "soroban-env-common"
 version = "0.0.3"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=52ed59a#52ed59a8ec1113f888422a8d538bbe93567d63a0"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=823711e4#823711e40b48b5d211ee17c63d886ecefe936c48"
 dependencies = [
  "soroban-env-macros",
  "soroban-wasmi",
@@ -884,7 +884,7 @@ dependencies = [
 [[package]]
 name = "soroban-env-guest"
 version = "0.0.3"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=52ed59a#52ed59a8ec1113f888422a8d538bbe93567d63a0"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=823711e4#823711e40b48b5d211ee17c63d886ecefe936c48"
 dependencies = [
  "soroban-env-common",
  "static_assertions",
@@ -893,7 +893,7 @@ dependencies = [
 [[package]]
 name = "soroban-env-host"
 version = "0.0.3"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=52ed59a#52ed59a8ec1113f888422a8d538bbe93567d63a0"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=823711e4#823711e40b48b5d211ee17c63d886ecefe936c48"
 dependencies = [
  "backtrace",
  "dyn-fmt",
@@ -916,7 +916,7 @@ dependencies = [
 [[package]]
 name = "soroban-env-macros"
 version = "0.0.3"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=52ed59a#52ed59a8ec1113f888422a8d538bbe93567d63a0"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=823711e4#823711e40b48b5d211ee17c63d886ecefe936c48"
 dependencies = [
  "itertools",
  "proc-macro2",
@@ -928,7 +928,7 @@ dependencies = [
 [[package]]
 name = "soroban-native-sdk-macros"
 version = "0.0.1"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=09dbeaaa#09dbeaaaf3b87e0fdea48315c53bf28ea04b6817"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=823711e4#823711e40b48b5d211ee17c63d886ecefe936c48"
 dependencies = [
  "itertools",
  "proc-macro2",
@@ -1036,8 +1036,9 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 [[package]]
 name = "stellar-xdr"
 version = "0.0.1"
-source = "git+https://github.com/stellar/rs-stellar-xdr?rev=61de11d#61de11d0ce5eb8a6e722d903af2abfadb5f5bd0e"
+source = "git+https://github.com/stellar/rs-stellar-xdr?rev=4cb9c591#4cb9c5910a075386a440e57f26710bd6c0a4b3aa"
 dependencies = [
+ "base64",
  "serde",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,12 +44,12 @@ exclude = [
 soroban-sdk = { path = "soroban-sdk" }
 soroban-sdk-auth = { path = "soroban-sdk-auth" }
 soroban-sdk-macros = { path = "soroban-sdk-macros" }
-soroban-env-common = { git = "https://github.com/stellar/rs-soroban-env", rev = "52ed59a" }
-soroban-env-guest = { git = "https://github.com/stellar/rs-soroban-env", rev = "52ed59a" }
-soroban-env-host = { git = "https://github.com/stellar/rs-soroban-env", rev = "52ed59a" }
-soroban-env-macros = { git = "https://github.com/stellar/rs-soroban-env", rev = "52ed59a" }
-soroban-native-sdk-macros = { git = "https://github.com/stellar/rs-soroban-env", rev = "09dbeaaa" }
-stellar-xdr = { git = "https://github.com/stellar/rs-stellar-xdr", rev = "61de11d" }
+soroban-env-common = { git = "https://github.com/stellar/rs-soroban-env", rev = "823711e4" }
+soroban-env-guest = { git = "https://github.com/stellar/rs-soroban-env", rev = "823711e4" }
+soroban-env-host = { git = "https://github.com/stellar/rs-soroban-env", rev = "823711e4" }
+soroban-env-macros = { git = "https://github.com/stellar/rs-soroban-env", rev = "823711e4" }
+soroban-native-sdk-macros = { git = "https://github.com/stellar/rs-soroban-env", rev = "823711e4" }
+stellar-xdr = { git = "https://github.com/stellar/rs-stellar-xdr", rev = "4cb9c591" }
 
 # soroban-env-common = { path = "../rs-soroban-env/soroban-env-common" }
 # soroban-env-guest = { path = "../rs-soroban-env/soroban-env-guest" }

--- a/soroban-sdk-macros/src/map_type.rs
+++ b/soroban-sdk-macros/src/map_type.rs
@@ -105,7 +105,7 @@ pub fn map_type(t: &Type) -> Result<ScSpecTypeDef, Error> {
                     }
                     _ => Err(Error::new(
                         angle_bracketed.span(),
-                        "generics unsupported on user-defined custom types in contract functions",
+                        "generics unsupported on user-defined types in contract functions",
                     ))?,
                 }
                 }

--- a/soroban-spec/src/gen/json.rs
+++ b/soroban-spec/src/gen/json.rs
@@ -83,6 +83,7 @@ pub enum Type {
     Result { value: Box<Type>, error: Box<Type> },
     Set { element: Box<Type> },
     Vec { element: Box<Type> },
+    BytesN { n: u32 },
     Tuple { elements: Vec<Type> },
     Custom { name: String },
 }
@@ -138,6 +139,7 @@ impl TryFrom<&ScSpecTypeDef> for Type {
             ScSpecTypeDef::Udt(udt) => Ok(Type::Custom {
                 name: udt.name.to_string()?,
             }),
+            ScSpecTypeDef::BytesN(b) => Ok(Type::BytesN { n: b.n }),
             ScSpecTypeDef::U64 => Ok(Type::U64),
             ScSpecTypeDef::I64 => Ok(Type::I64),
             ScSpecTypeDef::U32 => Ok(Type::U32),

--- a/soroban-spec/src/gen/rust/types.rs
+++ b/soroban-spec/src/gen/rust/types.rs
@@ -74,6 +74,10 @@ pub fn generate_type_ident(spec: &ScSpecTypeDef) -> TokenStream {
             let type_idents = t.value_types.iter().map(generate_type_ident);
             quote! { (#(#type_idents,)*) }
         }
+        ScSpecTypeDef::BytesN(b) => {
+            let n = b.n;
+            quote! { ::soroban_sdk::BytesN<#n> }
+        }
         ScSpecTypeDef::Udt(u) => {
             let ident = format_ident!("{}", u.name.to_string().unwrap());
             quote! { #ident }


### PR DESCRIPTION
### What
Add BytesN support to spec

### Why
So that functions that accept BytesN can be generated as such.

Close https://github.com/stellar/stellar-xdr-next/issues/15