### PR TITLE
Add some helper fns for generating specs from files

### DIFF
--- a/soroban-spec/src/gen/json.rs
+++ b/soroban-spec/src/gen/json.rs
@@ -50,15 +50,11 @@ pub fn generate_from_wasm(wasm: &[u8]) -> Result<String, FromWasmError> {
 }
 
 pub fn generate(spec: &[ScSpecEntry]) -> String {
-    let mut json = "".to_string();
-    for entry in spec {
-        let json_entry: Entry = entry.try_into().unwrap();
-        json.push_str(
-            &serde_json::to_string_pretty(&json_entry)
-                .expect("serialization of the spec entries should not have any failure cases as all keys are strings and the serialize implementations are derived"),
-        );
-    }
-    json
+    spec.iter().map(|entry| {
+        let entry: Entry = entry.try_into().unwrap();
+        serde_json::to_string_pretty(&entry)
+            .expect("serialization of the spec entries should not have any failure cases as all keys are strings and the serialize implementations are derived")
+    }).collect()
 }
 
 #[cfg(test)]

--- a/soroban-spec/src/gen/json.rs
+++ b/soroban-spec/src/gen/json.rs
@@ -1,202 +1,71 @@
-use serde::Serialize;
-use soroban_env_host::xdr::{
-    Error, ScSpecEntry, ScSpecFunctionInputV0, ScSpecTypeDef, ScSpecUdtStructFieldV0,
-    ScSpecUdtUnionCaseV0,
-};
+use std::{fs, io};
 
-#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct StructField {
-    name: String,
-    value: Type,
+pub mod types;
+
+use sha2::{Digest, Sha256};
+use soroban_env_host::xdr::ScSpecEntry;
+
+use types::Entry;
+
+use crate::read::{from_wasm, FromWasmError};
+
+#[derive(thiserror::Error, Debug)]
+pub enum GenerateFromFileError {
+    #[error("reading file: {0}")]
+    Io(io::Error),
+    #[error("sha256 does not match, expected: {expected}")]
+    VerifySha256 { expected: String },
+    #[error("parsing contract spec: {0}")]
+    Parse(stellar_xdr::Error),
+    #[error("getting contract spec: {0}")]
+    GetSpec(FromWasmError),
 }
 
-impl TryFrom<&ScSpecUdtStructFieldV0> for StructField {
-    type Error = Error;
+pub fn generate_from_file(
+    file: &str,
+    verify_sha256: Option<&str>,
+) -> Result<String, GenerateFromFileError> {
+    // Read file.
+    let wasm = fs::read(file).map_err(GenerateFromFileError::Io)?;
 
-    fn try_from(f: &ScSpecUdtStructFieldV0) -> Result<Self, Self::Error> {
-        Ok(StructField {
-            name: f.name.to_string()?,
-            value: Type::try_from(&f.type_)?,
-        })
-    }
-}
+    // Produce hash for file.
+    let sha256 = Sha256::digest(&wasm);
+    let sha256 = format!("{:x}", sha256);
 
-#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct FunctionInput {
-    name: String,
-    value: Type,
-}
-
-impl TryFrom<&ScSpecFunctionInputV0> for FunctionInput {
-    type Error = Error;
-
-    fn try_from(f: &ScSpecFunctionInputV0) -> Result<Self, Self::Error> {
-        Ok(FunctionInput {
-            name: f.name.to_string()?,
-            value: Type::try_from(&f.type_)?,
-        })
-    }
-}
-
-#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct UnionCase {
-    name: String,
-    values: Vec<Type>,
-}
-
-impl TryFrom<&ScSpecUdtUnionCaseV0> for UnionCase {
-    type Error = Error;
-
-    fn try_from(c: &ScSpecUdtUnionCaseV0) -> Result<Self, Self::Error> {
-        Ok(UnionCase {
-            name: c.name.to_string()?,
-            values: c
-                .type_
-                .as_ref()
-                .map(Type::try_from)
-                .transpose()?
-                .into_iter()
-                .collect(),
-        })
-    }
-}
-
-#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize)]
-#[serde(tag = "type")]
-#[serde(rename_all = "camelCase")]
-pub enum Type {
-    U64,
-    I64,
-    U32,
-    I32,
-    Bool,
-    Symbol,
-    Bitset,
-    Status,
-    Bytes,
-    BigInt,
-    Map { key: Box<Type>, value: Box<Type> },
-    Option { value: Box<Type> },
-    Result { value: Box<Type>, error: Box<Type> },
-    Set { element: Box<Type> },
-    Vec { element: Box<Type> },
-    BytesN { n: u32 },
-    Tuple { elements: Vec<Type> },
-    Custom { name: String },
-}
-
-#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize)]
-#[serde(tag = "type")]
-#[serde(rename_all = "camelCase")]
-pub enum Entry {
-    Function {
-        name: String,
-        inputs: Vec<FunctionInput>,
-        outputs: Vec<Type>,
-    },
-    Struct {
-        name: String,
-        fields: Vec<StructField>,
-    },
-    Union {
-        name: String,
-        cases: Vec<UnionCase>,
-    },
-}
-
-impl TryFrom<&ScSpecTypeDef> for Type {
-    type Error = Error;
-
-    fn try_from(spec: &ScSpecTypeDef) -> Result<Self, Self::Error> {
-        match spec {
-            ScSpecTypeDef::Map(map) => Ok(Type::Map {
-                key: Box::new(Type::try_from(map.key_type.as_ref())?),
-                value: Box::new(Type::try_from(map.value_type.as_ref())?),
-            }),
-            ScSpecTypeDef::Option(opt) => Ok(Type::Option {
-                value: Box::new(Type::try_from(opt.value_type.as_ref())?),
-            }),
-            ScSpecTypeDef::Result(res) => Ok(Type::Result {
-                value: Box::new(Type::try_from(res.ok_type.as_ref())?),
-                error: Box::new(Type::try_from(res.error_type.as_ref())?),
-            }),
-            ScSpecTypeDef::Set(set) => Ok(Type::Set {
-                element: Box::new(Type::try_from(set.element_type.as_ref())?),
-            }),
-            ScSpecTypeDef::Tuple(tuple) => Ok(Type::Tuple {
-                elements: tuple
-                    .value_types
-                    .iter()
-                    .map(Type::try_from)
-                    .collect::<Result<Vec<_>, Error>>()?,
-            }),
-            ScSpecTypeDef::Vec(vec) => Ok(Type::Vec {
-                element: Box::new(Type::try_from(vec.element_type.as_ref())?),
-            }),
-            ScSpecTypeDef::Udt(udt) => Ok(Type::Custom {
-                name: udt.name.to_string()?,
-            }),
-            ScSpecTypeDef::BytesN(b) => Ok(Type::BytesN { n: b.n }),
-            ScSpecTypeDef::U64 => Ok(Type::U64),
-            ScSpecTypeDef::I64 => Ok(Type::I64),
-            ScSpecTypeDef::U32 => Ok(Type::U32),
-            ScSpecTypeDef::I32 => Ok(Type::I32),
-            ScSpecTypeDef::Bool => Ok(Type::Bool),
-            ScSpecTypeDef::Symbol => Ok(Type::Symbol),
-            ScSpecTypeDef::Bitset => Ok(Type::Bitset),
-            ScSpecTypeDef::Status => Ok(Type::Status),
-            ScSpecTypeDef::Bytes => Ok(Type::Bytes),
-            ScSpecTypeDef::BigInt => Ok(Type::BigInt),
+    if let Some(verify_sha256) = verify_sha256 {
+        if verify_sha256 != sha256 {
+            return Err(GenerateFromFileError::VerifySha256 { expected: sha256 });
         }
     }
+
+    // Generate code.
+    let json = generate_from_wasm(&wasm).map_err(GenerateFromFileError::GetSpec)?;
+    Ok(json)
 }
 
-impl TryFrom<&ScSpecEntry> for Entry {
-    type Error = Error;
+pub fn generate_from_wasm(wasm: &[u8]) -> Result<String, FromWasmError> {
+    let spec = from_wasm(wasm)?;
+    let json = generate(&spec);
+    Ok(json)
+}
 
-    fn try_from(spec: &ScSpecEntry) -> Result<Self, Self::Error> {
-        match spec {
-            ScSpecEntry::FunctionV0(f) => Ok(Entry::Function {
-                name: f.name.to_string()?,
-                inputs: f
-                    .inputs
-                    .iter()
-                    .map(FunctionInput::try_from)
-                    .collect::<Result<Vec<_>, Error>>()?,
-                outputs: f
-                    .outputs
-                    .iter()
-                    .map(Type::try_from)
-                    .collect::<Result<Vec<_>, Error>>()?,
-            }),
-            ScSpecEntry::UdtStructV0(s) => Ok(Entry::Struct {
-                name: s.name.to_string()?,
-                fields: s
-                    .fields
-                    .iter()
-                    .map(StructField::try_from)
-                    .collect::<Result<Vec<_>, Error>>()?,
-            }),
-            ScSpecEntry::UdtUnionV0(u) => Ok(Entry::Union {
-                name: u.name.to_string()?,
-                cases: u
-                    .cases
-                    .iter()
-                    .map(UnionCase::try_from)
-                    .collect::<Result<Vec<_>, Error>>()?,
-            }),
-        }
+pub fn generate(spec: &[ScSpecEntry]) -> String {
+    let mut json = "".to_string();
+    for entry in spec {
+        let json_entry: Entry = entry.try_into().unwrap();
+        json.push_str(
+            &serde_json::to_string_pretty(&json_entry)
+                .expect("serialization of the spec entries should not have any failure cases as all keys are strings and the serialize implementations are derived"),
+        );
     }
+    json
 }
 
 #[cfg(test)]
 mod test {
     use pretty_assertions::assert_eq;
 
-    use super::Entry;
+    use super::generate;
 
     const EXAMPLE_WASM: &[u8] =
         include_bytes!("../../../target/wasm32-unknown-unknown/release/example_udt.wasm");
@@ -204,11 +73,7 @@ mod test {
     #[test]
     fn example() {
         let entries = crate::read::from_wasm(EXAMPLE_WASM).unwrap();
-        let mut json = "".to_string();
-        for entry in &entries {
-            let json_entry: Entry = entry.try_into().unwrap();
-            json.push_str(&serde_json::to_string_pretty(&json_entry).unwrap());
-        }
+        let json = generate(&entries);
         assert_eq!(
             json,
             r#"{

--- a/soroban-spec/src/gen/json/types.rs
+++ b/soroban-spec/src/gen/json/types.rs
@@ -1,0 +1,193 @@
+use serde::Serialize;
+use soroban_env_host::xdr::{
+    Error, ScSpecEntry, ScSpecFunctionInputV0, ScSpecTypeDef, ScSpecUdtStructFieldV0,
+    ScSpecUdtUnionCaseV0,
+};
+
+#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StructField {
+    name: String,
+    value: Type,
+}
+
+impl TryFrom<&ScSpecUdtStructFieldV0> for StructField {
+    type Error = Error;
+
+    fn try_from(f: &ScSpecUdtStructFieldV0) -> Result<Self, Self::Error> {
+        Ok(StructField {
+            name: f.name.to_string()?,
+            value: Type::try_from(&f.type_)?,
+        })
+    }
+}
+
+#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FunctionInput {
+    name: String,
+    value: Type,
+}
+
+impl TryFrom<&ScSpecFunctionInputV0> for FunctionInput {
+    type Error = Error;
+
+    fn try_from(f: &ScSpecFunctionInputV0) -> Result<Self, Self::Error> {
+        Ok(FunctionInput {
+            name: f.name.to_string()?,
+            value: Type::try_from(&f.type_)?,
+        })
+    }
+}
+
+#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UnionCase {
+    name: String,
+    values: Vec<Type>,
+}
+
+impl TryFrom<&ScSpecUdtUnionCaseV0> for UnionCase {
+    type Error = Error;
+
+    fn try_from(c: &ScSpecUdtUnionCaseV0) -> Result<Self, Self::Error> {
+        Ok(UnionCase {
+            name: c.name.to_string()?,
+            values: c
+                .type_
+                .as_ref()
+                .map(Type::try_from)
+                .transpose()?
+                .into_iter()
+                .collect(),
+        })
+    }
+}
+
+#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize)]
+#[serde(tag = "type")]
+#[serde(rename_all = "camelCase")]
+pub enum Type {
+    U64,
+    I64,
+    U32,
+    I32,
+    Bool,
+    Symbol,
+    Bitset,
+    Status,
+    Bytes,
+    BigInt,
+    Map { key: Box<Type>, value: Box<Type> },
+    Option { value: Box<Type> },
+    Result { value: Box<Type>, error: Box<Type> },
+    Set { element: Box<Type> },
+    Vec { element: Box<Type> },
+    BytesN { n: u32 },
+    Tuple { elements: Vec<Type> },
+    Custom { name: String },
+}
+
+#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize)]
+#[serde(tag = "type")]
+#[serde(rename_all = "camelCase")]
+pub enum Entry {
+    Function {
+        name: String,
+        inputs: Vec<FunctionInput>,
+        outputs: Vec<Type>,
+    },
+    Struct {
+        name: String,
+        fields: Vec<StructField>,
+    },
+    Union {
+        name: String,
+        cases: Vec<UnionCase>,
+    },
+}
+
+impl TryFrom<&ScSpecTypeDef> for Type {
+    type Error = Error;
+
+    fn try_from(spec: &ScSpecTypeDef) -> Result<Self, Self::Error> {
+        match spec {
+            ScSpecTypeDef::Map(map) => Ok(Type::Map {
+                key: Box::new(Type::try_from(map.key_type.as_ref())?),
+                value: Box::new(Type::try_from(map.value_type.as_ref())?),
+            }),
+            ScSpecTypeDef::Option(opt) => Ok(Type::Option {
+                value: Box::new(Type::try_from(opt.value_type.as_ref())?),
+            }),
+            ScSpecTypeDef::Result(res) => Ok(Type::Result {
+                value: Box::new(Type::try_from(res.ok_type.as_ref())?),
+                error: Box::new(Type::try_from(res.error_type.as_ref())?),
+            }),
+            ScSpecTypeDef::Set(set) => Ok(Type::Set {
+                element: Box::new(Type::try_from(set.element_type.as_ref())?),
+            }),
+            ScSpecTypeDef::Tuple(tuple) => Ok(Type::Tuple {
+                elements: tuple
+                    .value_types
+                    .iter()
+                    .map(Type::try_from)
+                    .collect::<Result<Vec<_>, Error>>()?,
+            }),
+            ScSpecTypeDef::Vec(vec) => Ok(Type::Vec {
+                element: Box::new(Type::try_from(vec.element_type.as_ref())?),
+            }),
+            ScSpecTypeDef::Udt(udt) => Ok(Type::Custom {
+                name: udt.name.to_string()?,
+            }),
+            ScSpecTypeDef::BytesN(b) => Ok(Type::BytesN { n: b.n }),
+            ScSpecTypeDef::U64 => Ok(Type::U64),
+            ScSpecTypeDef::I64 => Ok(Type::I64),
+            ScSpecTypeDef::U32 => Ok(Type::U32),
+            ScSpecTypeDef::I32 => Ok(Type::I32),
+            ScSpecTypeDef::Bool => Ok(Type::Bool),
+            ScSpecTypeDef::Symbol => Ok(Type::Symbol),
+            ScSpecTypeDef::Bitset => Ok(Type::Bitset),
+            ScSpecTypeDef::Status => Ok(Type::Status),
+            ScSpecTypeDef::Bytes => Ok(Type::Bytes),
+            ScSpecTypeDef::BigInt => Ok(Type::BigInt),
+        }
+    }
+}
+
+impl TryFrom<&ScSpecEntry> for Entry {
+    type Error = Error;
+
+    fn try_from(spec: &ScSpecEntry) -> Result<Self, Self::Error> {
+        match spec {
+            ScSpecEntry::FunctionV0(f) => Ok(Entry::Function {
+                name: f.name.to_string()?,
+                inputs: f
+                    .inputs
+                    .iter()
+                    .map(FunctionInput::try_from)
+                    .collect::<Result<Vec<_>, Error>>()?,
+                outputs: f
+                    .outputs
+                    .iter()
+                    .map(Type::try_from)
+                    .collect::<Result<Vec<_>, Error>>()?,
+            }),
+            ScSpecEntry::UdtStructV0(s) => Ok(Entry::Struct {
+                name: s.name.to_string()?,
+                fields: s
+                    .fields
+                    .iter()
+                    .map(StructField::try_from)
+                    .collect::<Result<Vec<_>, Error>>()?,
+            }),
+            ScSpecEntry::UdtUnionV0(u) => Ok(Entry::Union {
+                name: u.name.to_string()?,
+                cases: u
+                    .cases
+                    .iter()
+                    .map(UnionCase::try_from)
+                    .collect::<Result<Vec<_>, Error>>()?,
+            }),
+        }
+    }
+}

--- a/soroban-spec/src/gen/rust.rs
+++ b/soroban-spec/src/gen/rust.rs
@@ -37,17 +37,22 @@ pub fn generate_from_file(
 
     if let Some(verify_sha256) = verify_sha256 {
         if verify_sha256 != sha256 {
-            return Err(GenerateFromFileError::VerifySha256 {
-                expected: sha256.to_string(),
-            });
+            return Err(GenerateFromFileError::VerifySha256 { expected: sha256 });
         }
     }
 
-    // Read spec from file.
-    let spec = from_wasm(&wasm).map_err(GenerateFromFileError::GetSpec)?;
-
     // Generate code.
-    let code = generate(&spec, file, &sha256);
+    let code = generate_from_wasm(&wasm, file, &sha256).map_err(GenerateFromFileError::GetSpec)?;
+    Ok(code)
+}
+
+pub fn generate_from_wasm(
+    wasm: &[u8],
+    file: &str,
+    sha256: &str,
+) -> Result<TokenStream, FromWasmError> {
+    let spec = from_wasm(wasm)?;
+    let code = generate(&spec, file, sha256);
     Ok(code)
 }
 


### PR DESCRIPTION
### What
Add some helper fns for generating specs from files

### Why
So that the way to use the soroban-spec JSON generation is the same as the Rust generation.