### PR TITLE
Use VecM::to_string_lossy to simplify error handling in soroban-spec::json

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -873,7 +873,7 @@ dependencies = [
 [[package]]
 name = "soroban-env-common"
 version = "0.0.3"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=823711e4#823711e40b48b5d211ee17c63d886ecefe936c48"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=c88d6b61#c88d6b616323124607b4aa0393690c9c5374e355"
 dependencies = [
  "soroban-env-macros",
  "soroban-wasmi",
@@ -884,7 +884,7 @@ dependencies = [
 [[package]]
 name = "soroban-env-guest"
 version = "0.0.3"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=823711e4#823711e40b48b5d211ee17c63d886ecefe936c48"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=c88d6b61#c88d6b616323124607b4aa0393690c9c5374e355"
 dependencies = [
  "soroban-env-common",
  "static_assertions",
@@ -893,7 +893,7 @@ dependencies = [
 [[package]]
 name = "soroban-env-host"
 version = "0.0.3"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=823711e4#823711e40b48b5d211ee17c63d886ecefe936c48"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=c88d6b61#c88d6b616323124607b4aa0393690c9c5374e355"
 dependencies = [
  "backtrace",
  "dyn-fmt",
@@ -916,7 +916,7 @@ dependencies = [
 [[package]]
 name = "soroban-env-macros"
 version = "0.0.3"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=823711e4#823711e40b48b5d211ee17c63d886ecefe936c48"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=c88d6b61#c88d6b616323124607b4aa0393690c9c5374e355"
 dependencies = [
  "itertools",
  "proc-macro2",
@@ -928,7 +928,7 @@ dependencies = [
 [[package]]
 name = "soroban-native-sdk-macros"
 version = "0.0.1"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=823711e4#823711e40b48b5d211ee17c63d886ecefe936c48"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=c88d6b61#c88d6b616323124607b4aa0393690c9c5374e355"
 dependencies = [
  "itertools",
  "proc-macro2",
@@ -1036,7 +1036,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 [[package]]
 name = "stellar-xdr"
 version = "0.0.1"
-source = "git+https://github.com/stellar/rs-stellar-xdr?rev=4cb9c591#4cb9c5910a075386a440e57f26710bd6c0a4b3aa"
+source = "git+https://github.com/stellar/rs-stellar-xdr?rev=5b129da0#5b129da05a4b0ad6b1a9e0ce0b7d80f2cc1b0e70"
 dependencies = [
  "base64",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,12 +44,12 @@ exclude = [
 soroban-sdk = { path = "soroban-sdk" }
 soroban-sdk-auth = { path = "soroban-sdk-auth" }
 soroban-sdk-macros = { path = "soroban-sdk-macros" }
-soroban-env-common = { git = "https://github.com/stellar/rs-soroban-env", rev = "823711e4" }
-soroban-env-guest = { git = "https://github.com/stellar/rs-soroban-env", rev = "823711e4" }
-soroban-env-host = { git = "https://github.com/stellar/rs-soroban-env", rev = "823711e4" }
-soroban-env-macros = { git = "https://github.com/stellar/rs-soroban-env", rev = "823711e4" }
-soroban-native-sdk-macros = { git = "https://github.com/stellar/rs-soroban-env", rev = "823711e4" }
-stellar-xdr = { git = "https://github.com/stellar/rs-stellar-xdr", rev = "4cb9c591" }
+soroban-env-common = { git = "https://github.com/stellar/rs-soroban-env", rev = "c88d6b61" }
+soroban-env-guest = { git = "https://github.com/stellar/rs-soroban-env", rev = "c88d6b61" }
+soroban-env-host = { git = "https://github.com/stellar/rs-soroban-env", rev = "c88d6b61" }
+soroban-env-macros = { git = "https://github.com/stellar/rs-soroban-env", rev = "c88d6b61" }
+soroban-native-sdk-macros = { git = "https://github.com/stellar/rs-soroban-env", rev = "c88d6b61" }
+stellar-xdr = { git = "https://github.com/stellar/rs-stellar-xdr", rev = "5b129da0" }
 
 # soroban-env-common = { path = "../rs-soroban-env/soroban-env-common" }
 # soroban-env-guest = { path = "../rs-soroban-env/soroban-env-guest" }

--- a/soroban-sdk/tests/contractfile_with_sha256.rs
+++ b/soroban-sdk/tests/contractfile_with_sha256.rs
@@ -1,6 +1,6 @@
 pub const WASM: &[u8] = soroban_sdk::contractfile!(
     file = "target/wasm32-unknown-unknown/release/example_add_i32.wasm",
-    sha256 = "58e28b943aeb95f3d0f9f8a87a2049d6f52a41f5dbaaa0b44e00a0e41d40cb68"
+    sha256 = "21503b60e37e5488d383c666c42b310191b15082e57c94d81dd0686c092f4750"
 );
 
 #[test]

--- a/soroban-sdk/tests/contractimport_with_sha256.rs
+++ b/soroban-sdk/tests/contractimport_with_sha256.rs
@@ -7,7 +7,7 @@ const ADD_CONTRACT_ID: [u8; 32] = [0; 32];
 mod addcontract {
     soroban_sdk::contractimport!(
         file = "target/wasm32-unknown-unknown/release/example_add_i32.wasm",
-        sha256 = "58e28b943aeb95f3d0f9f8a87a2049d6f52a41f5dbaaa0b44e00a0e41d40cb68",
+        sha256 = "21503b60e37e5488d383c666c42b310191b15082e57c94d81dd0686c092f4750",
     );
 }
 

--- a/soroban-sdk/tests/trybuild/contractfile_with_sha256_verify_fail.stderr
+++ b/soroban-sdk/tests/trybuild/contractfile_with_sha256_verify_fail.stderr
@@ -1,4 +1,4 @@
-error: sha256 does not match, expected: 58e28b943aeb95f3d0f9f8a87a2049d6f52a41f5dbaaa0b44e00a0e41d40cb68
+error: sha256 does not match, expected: 21503b60e37e5488d383c666c42b310191b15082e57c94d81dd0686c092f4750
  --> tests/trybuild/contractfile_with_sha256_verify_fail.rs:3:5
   |
 3 |     sha256 = "0000000000000000000000000000000000000000000000000000000000000000",

--- a/soroban-sdk/tests/trybuild/contractimport_with_sha256_verify_fail.stderr
+++ b/soroban-sdk/tests/trybuild/contractimport_with_sha256_verify_fail.stderr
@@ -1,4 +1,4 @@
-error: sha256 does not match, expected: 58e28b943aeb95f3d0f9f8a87a2049d6f52a41f5dbaaa0b44e00a0e41d40cb68
+error: sha256 does not match, expected: 21503b60e37e5488d383c666c42b310191b15082e57c94d81dd0686c092f4750
  --> tests/trybuild/contractimport_with_sha256_verify_fail.rs:3:5
   |
 3 |     sha256 = "0000000000000000000000000000000000000000000000000000000000000000",

--- a/soroban-spec/src/gen/json.rs
+++ b/soroban-spec/src/gen/json.rs
@@ -50,11 +50,10 @@ pub fn generate_from_wasm(wasm: &[u8]) -> Result<String, FromWasmError> {
 }
 
 pub fn generate(spec: &[ScSpecEntry]) -> String {
-    spec.iter().map(|entry| {
-        let entry: Entry = entry.try_into().unwrap();
-        serde_json::to_string_pretty(&entry)
-            .expect("serialization of the spec entries should not have any failure cases as all keys are strings and the serialize implementations are derived")
-    }).collect()
+    spec.iter()
+        .map(Entry::from)
+        .map(|e| serde_json::to_string_pretty(&e).expect("serialization of the spec entries should not have any failure cases as all keys are strings and the serialize implementations are derived"))
+        .collect()
 }
 
 #[cfg(test)]


### PR DESCRIPTION
### What
Replace use of VecM::to_string with VecM::to_string_lossy in soroban_spec::json, and remove any error handling no longer required.

### Why
The soroban_spec::json functionality generates JSON for Soroban contract specs. We know that all string-like fields in Soroban contract specs will be valid UTF8 because of the restrictions on which characters are allowed to be in Symbols.

For this reason we can simplify the logic for generating the JSON significantly by doing a lossy conversion of the contract spec values to Strings.

Note that to_string_lossy didn't exist when we wrote this code.