### PR TITLE
Handle account does not exist

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -873,7 +873,7 @@ dependencies = [
 [[package]]
 name = "soroban-env-common"
 version = "0.0.3"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=335910a0#335910a0acb28e98c7dd84b1e4c8c007f10d13cf"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=fb125eae#fb125eae0621917d1f23badf91fb1bb9719427f4"
 dependencies = [
  "soroban-env-macros",
  "soroban-wasmi",
@@ -884,7 +884,7 @@ dependencies = [
 [[package]]
 name = "soroban-env-guest"
 version = "0.0.3"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=335910a0#335910a0acb28e98c7dd84b1e4c8c007f10d13cf"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=fb125eae#fb125eae0621917d1f23badf91fb1bb9719427f4"
 dependencies = [
  "soroban-env-common",
  "static_assertions",
@@ -893,7 +893,7 @@ dependencies = [
 [[package]]
 name = "soroban-env-host"
 version = "0.0.3"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=335910a0#335910a0acb28e98c7dd84b1e4c8c007f10d13cf"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=fb125eae#fb125eae0621917d1f23badf91fb1bb9719427f4"
 dependencies = [
  "backtrace",
  "dyn-fmt",
@@ -916,7 +916,7 @@ dependencies = [
 [[package]]
 name = "soroban-env-macros"
 version = "0.0.3"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=335910a0#335910a0acb28e98c7dd84b1e4c8c007f10d13cf"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=fb125eae#fb125eae0621917d1f23badf91fb1bb9719427f4"
 dependencies = [
  "itertools",
  "proc-macro2",
@@ -928,7 +928,7 @@ dependencies = [
 [[package]]
 name = "soroban-native-sdk-macros"
 version = "0.0.1"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=335910a0#335910a0acb28e98c7dd84b1e4c8c007f10d13cf"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=fb125eae#fb125eae0621917d1f23badf91fb1bb9719427f4"
 dependencies = [
  "itertools",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,11 +44,11 @@ exclude = [
 soroban-sdk = { path = "soroban-sdk" }
 soroban-sdk-auth = { path = "soroban-sdk-auth" }
 soroban-sdk-macros = { path = "soroban-sdk-macros" }
-soroban-env-common = { git = "https://github.com/stellar/rs-soroban-env", rev = "335910a0" }
-soroban-env-guest = { git = "https://github.com/stellar/rs-soroban-env", rev = "335910a0" }
-soroban-env-host = { git = "https://github.com/stellar/rs-soroban-env", rev = "335910a0" }
-soroban-env-macros = { git = "https://github.com/stellar/rs-soroban-env", rev = "335910a0" }
-soroban-native-sdk-macros = { git = "https://github.com/stellar/rs-soroban-env", rev = "335910a0" }
+soroban-env-common = { git = "https://github.com/stellar/rs-soroban-env", rev = "fb125eae" }
+soroban-env-guest = { git = "https://github.com/stellar/rs-soroban-env", rev = "fb125eae" }
+soroban-env-host = { git = "https://github.com/stellar/rs-soroban-env", rev = "fb125eae" }
+soroban-env-macros = { git = "https://github.com/stellar/rs-soroban-env", rev = "fb125eae" }
+soroban-native-sdk-macros = { git = "https://github.com/stellar/rs-soroban-env", rev = "fb125eae" }
 stellar-xdr = { git = "https://github.com/stellar/rs-stellar-xdr", rev = "5b129da0" }
 
 # soroban-env-common = { path = "../rs-soroban-env/soroban-env-common" }

--- a/soroban-sdk/src/account.rs
+++ b/soroban-sdk/src/account.rs
@@ -1,4 +1,8 @@
-use core::{borrow::Borrow, cmp::Ordering, fmt::Debug};
+use core::{
+    borrow::Borrow,
+    cmp::Ordering,
+    fmt::{Debug, Display},
+};
 
 use crate::{
     env::internal::{Env as _, RawVal, RawValConvertible},
@@ -10,6 +14,19 @@ use crate::{
 /// about the account, such as its thresholds and signers.
 #[derive(Clone)]
 pub struct Account(BytesN<32>);
+
+#[derive(Debug, Clone, PartialEq, PartialOrd)]
+pub enum AccountError {
+    DoesNotExist,
+}
+
+impl Display for AccountError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            AccountError::DoesNotExist => write!(f, "account does not exist"),
+        }
+    }
+}
 
 impl Debug for Account {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
@@ -153,15 +170,18 @@ impl Account {
     }
 
     /// Creates an account from a public key.
-    ///
-    /// TODO: Return a `Result` `Err` if the account does not exist. Currently panics if account does not exist.
-    pub fn from_public_key(public_key: &BytesN<32>) -> Result<Account, ()> {
-        let acc = Account(public_key.clone());
-        // TODO: Fail when account doesn't exist. In the meantime cause a trap
-        // at this point by trying to get some information about the account
-        // which will trap if the account doesn't exist.
-        _ = acc.low_threshold();
-        Ok(acc)
+    pub fn from_public_key(public_key: &BytesN<32>) -> Result<Account, AccountError> {
+        let env = public_key.env();
+        if env.account_exists(public_key.to_object()).is_false() {
+            return Err(AccountError::DoesNotExist);
+        }
+        Ok(Account(public_key.clone()))
+    }
+
+    /// Returns if the account exists.
+    pub fn exists(public_key: &BytesN<32>) -> bool {
+        let env = public_key.env();
+        env.account_exists(public_key.to_object()).is_true()
     }
 
     /// Returns the low threshold for the Stellar account.

--- a/soroban-sdk/tests/contractfile_with_sha256.rs
+++ b/soroban-sdk/tests/contractfile_with_sha256.rs
@@ -1,6 +1,6 @@
 pub const WASM: &[u8] = soroban_sdk::contractfile!(
     file = "target/wasm32-unknown-unknown/release/example_add_i32.wasm",
-    sha256 = "21503b60e37e5488d383c666c42b310191b15082e57c94d81dd0686c092f4750"
+    sha256 = "2e3b1bdaaf988ebfb44cfb811275b1605a08b7189e5f6b095cb5df8b20ecbaf4"
 );
 
 #[test]

--- a/soroban-sdk/tests/contractimport_with_sha256.rs
+++ b/soroban-sdk/tests/contractimport_with_sha256.rs
@@ -7,7 +7,7 @@ const ADD_CONTRACT_ID: [u8; 32] = [0; 32];
 mod addcontract {
     soroban_sdk::contractimport!(
         file = "target/wasm32-unknown-unknown/release/example_add_i32.wasm",
-        sha256 = "21503b60e37e5488d383c666c42b310191b15082e57c94d81dd0686c092f4750",
+        sha256 = "2e3b1bdaaf988ebfb44cfb811275b1605a08b7189e5f6b095cb5df8b20ecbaf4",
     );
 }
 

--- a/soroban-sdk/tests/trybuild/contractfile_with_sha256_verify_fail.stderr
+++ b/soroban-sdk/tests/trybuild/contractfile_with_sha256_verify_fail.stderr
@@ -1,4 +1,4 @@
-error: sha256 does not match, expected: 21503b60e37e5488d383c666c42b310191b15082e57c94d81dd0686c092f4750
+error: sha256 does not match, expected: 2e3b1bdaaf988ebfb44cfb811275b1605a08b7189e5f6b095cb5df8b20ecbaf4
  --> tests/trybuild/contractfile_with_sha256_verify_fail.rs:3:5
   |
 3 |     sha256 = "0000000000000000000000000000000000000000000000000000000000000000",

--- a/soroban-sdk/tests/trybuild/contractimport_with_sha256_verify_fail.stderr
+++ b/soroban-sdk/tests/trybuild/contractimport_with_sha256_verify_fail.stderr
@@ -1,4 +1,4 @@
-error: sha256 does not match, expected: 21503b60e37e5488d383c666c42b310191b15082e57c94d81dd0686c092f4750
+error: sha256 does not match, expected: 2e3b1bdaaf988ebfb44cfb811275b1605a08b7189e5f6b095cb5df8b20ecbaf4
  --> tests/trybuild/contractimport_with_sha256_verify_fail.rs:3:5
   |
 3 |     sha256 = "0000000000000000000000000000000000000000000000000000000000000000",


### PR DESCRIPTION
### What
Add `Account::exists` for checking if an account exists, and also check in `Account::from_public_key`.

### Why
A contract can rarely assume a Stellar account exists because Stellar accounts can be merged (deleted). Even if it performed some action with the account previously there's little to guarantee the account exists in a future ledger. This is because Soroban contracts have very little visibility into Stellar accounts having only access to their thresholds and signers.

For this reason a contract developer should be aware that accessing information about an Account can always fail.

(There is only one situation that a Soroban contract can guarantee an account exists, and it is when the account was checked to have exists previously, and the account had all its thresholds set to zero. This is one narrow edge case, so it has been ignored when assessing if contracts should be forced to check if an account exists.)

This introduces one host functions into every account that is accessed, but not into every access. If this is deemed in the future to be too high of a cost, we can introduce a companion `from_public_key_unchecked` function that skips the check.

Related to https://github.com/stellar/rs-soroban-env/pull/383

Close https://github.com/stellar/rs-soroban-env/issues/262