### PR TITLE
Add Tuple to Vec<RawVal> ref conversion

### DIFF
--- a/soroban-sdk/src/vec.rs
+++ b/soroban-sdk/src/vec.rs
@@ -50,6 +50,15 @@ macro_rules! impl_into_vec_for_tuple {
                 vec![&env, $(self.$idx.into_val(env), )*]
             }
         }
+
+        impl<$($typ),*> IntoVal<Env, Vec<RawVal>> for &($($typ,)*)
+        where
+            $(for <'a> &'a $typ: IntoVal<Env, RawVal>),*
+        {
+            fn into_val(self, env: &Env) -> Vec<RawVal> {
+                vec![&env, $((&self.$idx).into_val(env), )*]
+            }
+        }
     };
 }
 impl_into_vec_for_tuple! { T0 0 }


### PR DESCRIPTION
### What
Add Tuple to Vec<RawVal> ref conversion.

### Why
Conversions to RawVal types can always be done with refs because the original values never needed to be owned by the destination type, RawVal. It's convenient if we can offer these since it reduces unnecessary clones in contract code.