### PR TITLE
Remove EnvType that is not really needed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -884,7 +884,7 @@ dependencies = [
 [[package]]
 name = "soroban-env-common"
 version = "0.0.3"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=0d49a1bb#0d49a1bb5065b6b434566456ee6041d286a3e04e"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=2c084e9d#2c084e9d90c213414a66c5433dc0d4fcc05f5ebb"
 dependencies = [
  "soroban-env-macros",
  "soroban-wasmi",
@@ -895,7 +895,7 @@ dependencies = [
 [[package]]
 name = "soroban-env-guest"
 version = "0.0.3"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=0d49a1bb#0d49a1bb5065b6b434566456ee6041d286a3e04e"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=2c084e9d#2c084e9d90c213414a66c5433dc0d4fcc05f5ebb"
 dependencies = [
  "soroban-env-common",
  "static_assertions",
@@ -904,7 +904,7 @@ dependencies = [
 [[package]]
 name = "soroban-env-host"
 version = "0.0.3"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=0d49a1bb#0d49a1bb5065b6b434566456ee6041d286a3e04e"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=2c084e9d#2c084e9d90c213414a66c5433dc0d4fcc05f5ebb"
 dependencies = [
  "backtrace",
  "dyn-fmt",
@@ -927,7 +927,7 @@ dependencies = [
 [[package]]
 name = "soroban-env-macros"
 version = "0.0.3"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=0d49a1bb#0d49a1bb5065b6b434566456ee6041d286a3e04e"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=2c084e9d#2c084e9d90c213414a66c5433dc0d4fcc05f5ebb"
 dependencies = [
  "itertools",
  "proc-macro2",
@@ -939,7 +939,7 @@ dependencies = [
 [[package]]
 name = "soroban-native-sdk-macros"
 version = "0.0.1"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=0d49a1bb#0d49a1bb5065b6b434566456ee6041d286a3e04e"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=2c084e9d#2c084e9d90c213414a66c5433dc0d4fcc05f5ebb"
 dependencies = [
  "itertools",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,11 +45,11 @@ exclude = [
 soroban-sdk = { path = "soroban-sdk" }
 soroban-sdk-auth = { path = "soroban-sdk-auth" }
 soroban-sdk-macros = { path = "soroban-sdk-macros" }
-soroban-env-common = { git = "https://github.com/stellar/rs-soroban-env", rev = "0d49a1bb" }
-soroban-env-guest = { git = "https://github.com/stellar/rs-soroban-env", rev = "0d49a1bb" }
-soroban-env-host = { git = "https://github.com/stellar/rs-soroban-env", rev = "0d49a1bb" }
-soroban-env-macros = { git = "https://github.com/stellar/rs-soroban-env", rev = "0d49a1bb" }
-soroban-native-sdk-macros = { git = "https://github.com/stellar/rs-soroban-env", rev = "0d49a1bb" }
+soroban-env-common = { git = "https://github.com/stellar/rs-soroban-env", rev = "2c084e9d" }
+soroban-env-guest = { git = "https://github.com/stellar/rs-soroban-env", rev = "2c084e9d" }
+soroban-env-host = { git = "https://github.com/stellar/rs-soroban-env", rev = "2c084e9d" }
+soroban-env-macros = { git = "https://github.com/stellar/rs-soroban-env", rev = "2c084e9d" }
+soroban-native-sdk-macros = { git = "https://github.com/stellar/rs-soroban-env", rev = "2c084e9d" }
 stellar-xdr = { git = "https://github.com/stellar/rs-stellar-xdr", rev = "5b129da0" }
 
 # soroban-env-common = { path = "../rs-soroban-env/soroban-env-common" }

--- a/soroban-sdk-macros/src/derive_type.rs
+++ b/soroban-sdk-macros/src/derive_type.rs
@@ -159,7 +159,6 @@ pub fn derive_type_struct(ident: &Ident, data: &DataStruct, spec: bool) -> Token
             #[inline(always)]
             fn try_from_val(env: &soroban_sdk::Env, val: soroban_sdk::xdr::ScMap) -> Result<Self, Self::Error> {
                 use soroban_sdk::xdr::Validate;
-                // use soroban_sdk::EnvType;
                 use soroban_sdk::TryIntoVal;
                 let map = val;
                 if map.len() != #field_count_usize {
@@ -465,7 +464,6 @@ pub fn derive_type_enum(enum_ident: &Ident, data: &DataEnum, spec: bool) -> Toke
             #[inline(always)]
             fn try_from_val(env: &soroban_sdk::Env, val: soroban_sdk::xdr::ScVec) -> Result<Self, Self::Error> {
                 use soroban_sdk::xdr::Validate;
-                // use soroban_sdk::EnvType;
                 use soroban_sdk::TryIntoVal;
 
                 let vec = val;

--- a/soroban-sdk/src/bigint.rs
+++ b/soroban-sdk/src/bigint.rs
@@ -6,9 +6,9 @@ use core::{
 
 use super::{
     env::internal::{Env as _, EnvBase, RawValConvertible},
-    env::{EnvObj, EnvType},
+    env::EnvObj,
     xdr::ScObjectType,
-    Bytes, ConversionError, Env, EnvVal, IntoVal, Object, RawVal, TryFromVal, TryIntoVal,
+    Bytes, ConversionError, Env, EnvVal, FromVal, IntoVal, Object, RawVal, TryFromVal, TryIntoVal,
 };
 
 /// Create a [BigInt] with an integer literal, or an array.
@@ -222,9 +222,9 @@ impl TryFrom<BigInt> for u64 {
     }
 }
 
-impl From<EnvType<u64>> for BigInt {
-    fn from(ev: EnvType<u64>) -> Self {
-        BigInt::from_u64(&ev.env, ev.val)
+impl FromVal<Env, u64> for BigInt {
+    fn from_val(env: &Env, val: u64) -> Self {
+        BigInt::from_u64(env, val)
     }
 }
 
@@ -246,9 +246,9 @@ impl TryFrom<BigInt> for i64 {
     }
 }
 
-impl From<EnvType<i64>> for BigInt {
-    fn from(ev: EnvType<i64>) -> Self {
-        BigInt::from_i64(&ev.env, ev.val)
+impl FromVal<Env, i64> for BigInt {
+    fn from_val(env: &Env, val: i64) -> Self {
+        BigInt::from_i64(env, val)
     }
 }
 
@@ -270,9 +270,9 @@ impl TryFrom<BigInt> for u32 {
     }
 }
 
-impl From<EnvType<u32>> for BigInt {
-    fn from(ev: EnvType<u32>) -> Self {
-        BigInt::from_u32(&ev.env, ev.val)
+impl FromVal<Env, u32> for BigInt {
+    fn from_val(env: &Env, val: u32) -> Self {
+        BigInt::from_u32(env, val)
     }
 }
 
@@ -294,9 +294,9 @@ impl TryFrom<BigInt> for i32 {
     }
 }
 
-impl From<EnvType<i32>> for BigInt {
-    fn from(ev: EnvType<i32>) -> Self {
-        BigInt::from_i32(&ev.env, ev.val)
+impl FromVal<Env, i32> for BigInt {
+    fn from_val(env: &Env, val: i32) -> Self {
+        BigInt::from_i32(env, val)
     }
 }
 

--- a/soroban-sdk/src/env.rs
+++ b/soroban-sdk/src/env.rs
@@ -33,6 +33,7 @@ pub use internal::xdr;
 pub use internal::BitSet;
 pub use internal::ConversionError;
 pub use internal::EnvBase;
+pub use internal::FromVal;
 pub use internal::IntoVal;
 pub use internal::Object;
 pub use internal::RawVal;
@@ -43,7 +44,6 @@ pub use internal::TryFromVal;
 pub use internal::TryIntoVal;
 pub use internal::Val;
 
-pub type EnvType<V> = internal::EnvVal<Env, V>;
 pub type EnvVal = internal::EnvVal<Env, RawVal>;
 pub type EnvObj = internal::EnvVal<Env, Object>;
 

--- a/soroban-sdk/src/lib.rs
+++ b/soroban-sdk/src/lib.rs
@@ -48,13 +48,13 @@ pub use env::EnvVal;
 pub use env::RawVal;
 
 pub use env::IntoVal;
+pub use env::FromVal;
 pub use env::TryFromVal;
 pub use env::TryIntoVal;
 
 pub use env::Symbol;
 
 mod envhidden {
-    pub use super::env::EnvType;
     pub use super::env::Object;
     pub use super::env::Status;
 }

--- a/soroban-sdk/src/lib.rs
+++ b/soroban-sdk/src/lib.rs
@@ -47,8 +47,8 @@ pub use env::Env;
 pub use env::EnvVal;
 pub use env::RawVal;
 
-pub use env::IntoVal;
 pub use env::FromVal;
+pub use env::IntoVal;
 pub use env::TryFromVal;
 pub use env::TryIntoVal;
 


### PR DESCRIPTION
### What
Remove EnvType that is not really needed.

### Why
The EnvType was a poor work around added only to facilitate TryFromVal conversions from EnvVal<E, V>. However, we don't define these conversions this way anymore and his is a hold over from then.