### PR TITLE
Bump bytes-lit dependency to 0.0.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -109,12 +109,11 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes-lit"
-version = "0.0.1"
+version = "0.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b0f4f9f54e52a01d3195b9b9bc0f77b770e7a2f317fa6a2d3777b35e9c6c23a"
+checksum = "75651e281e98fa84907ea7704dde00b1970f611d803caeb0ee5619d4a1afc3cb"
 dependencies = [
  "num-bigint",
- "pretty_assertions",
  "proc-macro2",
  "quote",
  "syn",

--- a/soroban-sdk/Cargo.toml
+++ b/soroban-sdk/Cargo.toml
@@ -15,7 +15,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 soroban-sdk-macros = { version = "0.0.3" }
-bytes-lit = "0.0.1"
+bytes-lit = "0.0.2"
 ed25519-dalek = { version = "1.0.1", optional = true }
 
 [target.'cfg(target_family="wasm")'.dependencies]


### PR DESCRIPTION
### What
Bump bytes-lit dependency to 0.0.2.

### Why
To remove the pretty_assertions dependency from the dependencies list.