### PR TITLE
Add Bytes/BytesN conversions

### DIFF
--- a/soroban-sdk/src/bytes.rs
+++ b/soroban-sdk/src/bytes.rs
@@ -722,6 +722,18 @@ impl<const N: usize> IntoVal<Env, BytesN<N>> for &BytesN<N> {
     }
 }
 
+impl<const N: usize> IntoVal<Env, Bytes> for BytesN<N> {
+    fn into_val(self, _env: &Env) -> Bytes {
+        self.0
+    }
+}
+
+impl<const N: usize> IntoVal<Env, Bytes> for &BytesN<N> {
+    fn into_val(self, _env: &Env) -> Bytes {
+        self.0.clone()
+    }
+}
+
 impl<const N: usize> IntoVal<Env, BytesN<N>> for [u8; N] {
     fn into_val(self, env: &Env) -> BytesN<N> {
         BytesN::from_array(env, &self)


### PR DESCRIPTION
### What
Add Bytes/BytesN conversions.

### Why
To make it possible to pass `BytesN` into `IntoVal<_, Bytes>`.