### PR TITLE
Update `binary_` function calls to `bytes_`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -885,7 +885,7 @@ dependencies = [
 [[package]]
 name = "soroban-env-common"
 version = "0.0.3"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=73a944a2#73a944a28051c99acb5e4b0ef549d22a75c35bf2"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=36b0efe#36b0efe5cbf500748bb3933d21fff490d1e093b2"
 dependencies = [
  "soroban-env-macros",
  "soroban-wasmi",
@@ -896,7 +896,7 @@ dependencies = [
 [[package]]
 name = "soroban-env-guest"
 version = "0.0.3"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=73a944a2#73a944a28051c99acb5e4b0ef549d22a75c35bf2"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=36b0efe#36b0efe5cbf500748bb3933d21fff490d1e093b2"
 dependencies = [
  "soroban-env-common",
  "static_assertions",
@@ -905,7 +905,7 @@ dependencies = [
 [[package]]
 name = "soroban-env-host"
 version = "0.0.3"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=73a944a2#73a944a28051c99acb5e4b0ef549d22a75c35bf2"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=36b0efe#36b0efe5cbf500748bb3933d21fff490d1e093b2"
 dependencies = [
  "backtrace",
  "dyn-fmt",
@@ -928,7 +928,7 @@ dependencies = [
 [[package]]
 name = "soroban-env-macros"
 version = "0.0.3"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=73a944a2#73a944a28051c99acb5e4b0ef549d22a75c35bf2"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=36b0efe#36b0efe5cbf500748bb3933d21fff490d1e093b2"
 dependencies = [
  "itertools",
  "proc-macro2",
@@ -940,7 +940,7 @@ dependencies = [
 [[package]]
 name = "soroban-native-sdk-macros"
 version = "0.0.1"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=73a944a2#73a944a28051c99acb5e4b0ef549d22a75c35bf2"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=36b0efe#36b0efe5cbf500748bb3933d21fff490d1e093b2"
 dependencies = [
  "itertools",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,11 +44,11 @@ exclude = [
 soroban-sdk = { path = "soroban-sdk" }
 soroban-sdk-auth = { path = "soroban-sdk-auth" }
 soroban-sdk-macros = { path = "soroban-sdk-macros" }
-soroban-env-common = { git = "https://github.com/stellar/rs-soroban-env", rev = "73a944a2" }
-soroban-env-guest = { git = "https://github.com/stellar/rs-soroban-env", rev = "73a944a2" }
-soroban-env-host = { git = "https://github.com/stellar/rs-soroban-env", rev = "73a944a2" }
-soroban-env-macros = { git = "https://github.com/stellar/rs-soroban-env", rev = "73a944a2" }
-soroban-native-sdk-macros = { git = "https://github.com/stellar/rs-soroban-env", rev = "73a944a2" }
+soroban-env-common = { git = "https://github.com/stellar/rs-soroban-env", rev = "36b0efe" }
+soroban-env-guest = { git = "https://github.com/stellar/rs-soroban-env", rev = "36b0efe" }
+soroban-env-host = { git = "https://github.com/stellar/rs-soroban-env", rev = "36b0efe" }
+soroban-env-macros = { git = "https://github.com/stellar/rs-soroban-env", rev = "36b0efe" }
+soroban-native-sdk-macros = { git = "https://github.com/stellar/rs-soroban-env", rev = "36b0efe" }
 stellar-xdr = { git = "https://github.com/stellar/rs-stellar-xdr", rev = "5b129da0" }
 
 # soroban-env-common = { path = "../rs-soroban-env/soroban-env-common" }

--- a/soroban-sdk/src/bytes.rs
+++ b/soroban-sdk/src/bytes.rs
@@ -306,7 +306,7 @@ impl Bytes {
     /// Create an empty Bytes.
     #[inline(always)]
     pub fn new(env: &Env) -> Bytes {
-        let obj = env.binary_new().in_env(env);
+        let obj = env.bytes_new().in_env(env);
         unsafe { Self::unchecked_new(obj) }
     }
 
@@ -318,7 +318,7 @@ impl Bytes {
 
     #[inline(always)]
     pub fn from_slice(env: &Env, items: &[u8]) -> Bytes {
-        Bytes(env.binary_new_from_slice(items).in_env(env))
+        Bytes(env.bytes_new_from_slice(items).in_env(env))
     }
 
     #[inline(always)]
@@ -326,7 +326,7 @@ impl Bytes {
         let v32: u32 = v.into();
         self.0 = self
             .env()
-            .binary_put(self.0.to_object(), i.into(), v32.into())
+            .bytes_put(self.0.to_object(), i.into(), v32.into())
             .in_env(self.env());
     }
 
@@ -343,7 +343,7 @@ impl Bytes {
     pub fn get_unchecked(&self, i: u32) -> u8 {
         let res32: u32 = self
             .env()
-            .binary_get(self.0.to_object(), i.into())
+            .bytes_get(self.0.to_object(), i.into())
             .try_into()
             .unwrap();
         res32.try_into().unwrap()
@@ -351,15 +351,12 @@ impl Bytes {
 
     #[inline(always)]
     pub fn is_empty(&self) -> bool {
-        self.env().binary_len(self.0.to_object()).is_u32_zero()
+        self.env().bytes_len(self.0.to_object()).is_u32_zero()
     }
 
     #[inline(always)]
     pub fn len(&self) -> u32 {
-        self.env()
-            .binary_len(self.0.to_object())
-            .try_into()
-            .unwrap()
+        self.env().bytes_len(self.0.to_object()).try_into().unwrap()
     }
 
     #[inline(always)]
@@ -375,7 +372,7 @@ impl Bytes {
     pub fn first_unchecked(&self) -> u8 {
         let res32: u32 = self
             .env()
-            .binary_front(self.0.to_object())
+            .bytes_front(self.0.to_object())
             .try_into()
             .unwrap();
         res32.try_into().unwrap()
@@ -394,7 +391,7 @@ impl Bytes {
     pub fn last_unchecked(&self) -> u8 {
         let res32: u32 = self
             .env()
-            .binary_back(self.0.to_object())
+            .bytes_back(self.0.to_object())
             .try_into()
             .unwrap();
         res32.try_into().unwrap()
@@ -413,7 +410,7 @@ impl Bytes {
     #[inline(always)]
     pub fn remove_unchecked(&mut self, i: u32) {
         let env = self.env();
-        let bin = env.binary_del(self.0.to_object(), i.into());
+        let bin = env.bytes_del(self.0.to_object(), i.into());
         self.0 = bin.in_env(env);
     }
 
@@ -421,7 +418,7 @@ impl Bytes {
     pub fn push(&mut self, x: u8) {
         let x32: u32 = x.into();
         let env = self.env();
-        let bin = env.binary_push(self.0.to_object(), x32.into());
+        let bin = env.bytes_push(self.0.to_object(), x32.into());
         self.0 = bin.in_env(env);
     }
 
@@ -429,7 +426,7 @@ impl Bytes {
     pub fn pop(&mut self) -> Option<u8> {
         let last = self.last()?;
         let env = self.env();
-        let bin = env.binary_pop(self.0.to_object());
+        let bin = env.bytes_pop(self.0.to_object());
         self.0 = bin.in_env(env);
         Some(last)
     }
@@ -438,7 +435,7 @@ impl Bytes {
     pub fn pop_unchecked(&mut self) -> u8 {
         let last = self.last_unchecked();
         let env = self.env();
-        self.0 = env.binary_pop(self.0.to_object()).in_env(env);
+        self.0 = env.bytes_pop(self.0.to_object()).in_env(env);
         last
     }
 
@@ -452,7 +449,7 @@ impl Bytes {
     pub fn insert(&mut self, i: u32, b: u8) {
         let env = self.env();
         let b32: u32 = b.into();
-        let bin = env.binary_insert(self.0.to_object(), i.into(), b32.into());
+        let bin = env.bytes_insert(self.0.to_object(), i.into(), b32.into());
         self.0 = bin.in_env(env);
     }
 
@@ -498,7 +495,7 @@ impl Bytes {
     #[inline(always)]
     pub fn append(&mut self, other: &Bytes) {
         let env = self.env();
-        let bin = env.binary_append(self.0.to_object(), other.0.to_object());
+        let bin = env.bytes_append(self.0.to_object(), other.0.to_object());
         self.0 = bin.in_env(env);
     }
 
@@ -511,7 +508,7 @@ impl Bytes {
     pub fn extend_from_slice(&mut self, slice: &[u8]) {
         let env = self.env();
         self.0 = env
-            .binary_copy_from_slice(self.to_object(), self.len().into(), &slice)
+            .bytes_copy_from_slice(self.to_object(), self.len().into(), &slice)
             .in_env(env);
     }
 
@@ -523,7 +520,7 @@ impl Bytes {
     pub fn copy_from_slice(&mut self, i: u32, slice: &[u8]) {
         let env = self.env();
         self.0 = env
-            .binary_copy_from_slice(self.to_object(), i.into(), slice)
+            .bytes_copy_from_slice(self.to_object(), i.into(), slice)
             .in_env(env);
     }
 
@@ -534,7 +531,7 @@ impl Bytes {
     #[inline(always)]
     pub fn copy_into_slice(&self, slice: &mut [u8]) {
         let env = self.env();
-        env.binary_copy_to_slice(self.to_object(), RawVal::U32_ZERO, slice);
+        env.bytes_copy_to_slice(self.to_object(), RawVal::U32_ZERO, slice);
     }
 
     #[must_use]
@@ -550,7 +547,7 @@ impl Bytes {
             Bound::Unbounded => self.len(),
         };
         let env = self.env();
-        let bin = env.binary_slice(self.0.to_object(), start_bound.into(), end_bound.into());
+        let bin = env.bytes_slice(self.0.to_object(), start_bound.into(), end_bound.into());
         unsafe { Self::unchecked_new(bin.in_env(env)) }
     }
 
@@ -584,7 +581,7 @@ impl Iterator for BinIter {
         if self.0.len() == 0 {
             None
         } else {
-            let val = self.0.env().binary_front(self.0 .0.to_object());
+            let val = self.0.env().bytes_front(self.0 .0.to_object());
             self.0 = self.0.slice(1..);
             let val = unsafe { <u32 as RawValConvertible>::unchecked_from_val(val) } as u8;
             Some(val)
@@ -603,7 +600,7 @@ impl DoubleEndedIterator for BinIter {
         if len == 0 {
             None
         } else {
-            let val = self.0.env().binary_back(self.0 .0.to_object());
+            let val = self.0.env().bytes_back(self.0 .0.to_object());
             self.0 = self.0.slice(..len - 1);
             let val = unsafe { <u32 as RawValConvertible>::unchecked_from_val(val) } as u8;
             Some(val)
@@ -951,7 +948,7 @@ impl<const N: usize> BytesN<N> {
     #[inline(always)]
     pub fn copy_into_slice(&self, slice: &mut [u8]) {
         let env = self.env();
-        env.binary_copy_to_slice(self.to_object(), RawVal::U32_ZERO, slice);
+        env.bytes_copy_to_slice(self.to_object(), RawVal::U32_ZERO, slice);
     }
 
     pub fn iter(&self) -> BinIter {

--- a/soroban-sdk/src/env.rs
+++ b/soroban-sdk/src/env.rs
@@ -447,16 +447,16 @@ impl internal::EnvBase for Env {
         }
     }
 
-    fn binary_copy_from_slice(&self, b: Object, b_pos: RawVal, mem: &[u8]) -> Object {
-        self.env_impl.binary_copy_from_slice(b, b_pos, mem)
+    fn bytes_copy_from_slice(&self, b: Object, b_pos: RawVal, mem: &[u8]) -> Object {
+        self.env_impl.bytes_copy_from_slice(b, b_pos, mem)
     }
 
-    fn binary_copy_to_slice(&self, b: Object, b_pos: RawVal, mem: &mut [u8]) {
-        self.env_impl.binary_copy_to_slice(b, b_pos, mem)
+    fn bytes_copy_to_slice(&self, b: Object, b_pos: RawVal, mem: &mut [u8]) {
+        self.env_impl.bytes_copy_to_slice(b, b_pos, mem)
     }
 
-    fn binary_new_from_slice(&self, mem: &[u8]) -> Object {
-        self.env_impl.binary_new_from_slice(mem)
+    fn bytes_new_from_slice(&self, mem: &[u8]) -> Object {
+        self.env_impl.bytes_new_from_slice(mem)
     }
 
     fn log_static_fmt_val(&self, _: &'static str, _: RawVal) {

--- a/soroban-sdk/src/serde.rs
+++ b/soroban-sdk/src/serde.rs
@@ -15,7 +15,7 @@ where
 {
     fn serialize(self, env: &Env) -> Bytes {
         let val: RawVal = self.into_val(env);
-        let bin = env.serialize_to_binary(val);
+        let bin = env.serialize_to_bytes(val);
         unsafe { Bytes::unchecked_new(bin.in_env(env)) }
     }
 }
@@ -27,7 +27,7 @@ where
     type Error = T::Error;
 
     fn deserialize(env: &Env, b: &Bytes) -> Result<Self, Self::Error> {
-        let t = env.deserialize_from_binary(b.into());
+        let t = env.deserialize_from_bytes(b.into());
         T::try_from_val(env, t)
     }
 }

--- a/soroban-sdk/tests/contractfile_with_sha256.rs
+++ b/soroban-sdk/tests/contractfile_with_sha256.rs
@@ -1,6 +1,6 @@
 pub const WASM: &[u8] = soroban_sdk::contractfile!(
     file = "target/wasm32-unknown-unknown/release/example_add_i32.wasm",
-    sha256 = "29c2ddba158eb180082be9137d7818271f99c366d623e248363b7b518159f523",
+    sha256 = "e353760a571abf2c69493af1f433593438b540a509cc19f4f56bd0d4b1e9c5db",
 );
 
 #[test]

--- a/soroban-sdk/tests/contractimport_with_sha256.rs
+++ b/soroban-sdk/tests/contractimport_with_sha256.rs
@@ -7,7 +7,7 @@ const ADD_CONTRACT_ID: [u8; 32] = [0; 32];
 mod addcontract {
     soroban_sdk::contractimport!(
         file = "target/wasm32-unknown-unknown/release/example_add_i32.wasm",
-        sha256 = "29c2ddba158eb180082be9137d7818271f99c366d623e248363b7b518159f523",
+        sha256 = "e353760a571abf2c69493af1f433593438b540a509cc19f4f56bd0d4b1e9c5db",
     );
 }
 

--- a/soroban-sdk/tests/trybuild/contractfile_with_sha256_verify_fail.stderr
+++ b/soroban-sdk/tests/trybuild/contractfile_with_sha256_verify_fail.stderr
@@ -1,4 +1,4 @@
-error: sha256 does not match, expected: 29c2ddba158eb180082be9137d7818271f99c366d623e248363b7b518159f523
+error: sha256 does not match, expected: e353760a571abf2c69493af1f433593438b540a509cc19f4f56bd0d4b1e9c5db
  --> tests/trybuild/contractfile_with_sha256_verify_fail.rs:3:5
   |
 3 |     sha256 = "0000000000000000000000000000000000000000000000000000000000000000",

--- a/soroban-sdk/tests/trybuild/contractimport_with_sha256_verify_fail.stderr
+++ b/soroban-sdk/tests/trybuild/contractimport_with_sha256_verify_fail.stderr
@@ -1,4 +1,4 @@
-error: sha256 does not match, expected: 29c2ddba158eb180082be9137d7818271f99c366d623e248363b7b518159f523
+error: sha256 does not match, expected: e353760a571abf2c69493af1f433593438b540a509cc19f4f56bd0d4b1e9c5db
  --> tests/trybuild/contractimport_with_sha256_verify_fail.rs:3:5
   |
 3 |     sha256 = "0000000000000000000000000000000000000000000000000000000000000000",


### PR DESCRIPTION
### What

Follow-up on https://github.com/stellar/rs-soroban-env/pull/389.
Update the `bytes` host function calls to be compatible with the latest interface version. 

### Why

[TODO: Why this change is being made. Include any context required to understand the why.]

### Known limitations

[TODO or N/A]
