### PR TITLE
Fix BytesN<N> generated N type as usize

### DIFF
--- a/soroban-spec/src/gen/rust/types.rs
+++ b/soroban-spec/src/gen/rust/types.rs
@@ -76,7 +76,7 @@ pub fn generate_type_ident(spec: &ScSpecTypeDef) -> TokenStream {
             quote! { (#(#type_idents,)*) }
         }
         ScSpecTypeDef::BytesN(b) => {
-            let n = b.n;
+            let n: usize = b.n as usize;
             quote! { ::soroban_sdk::BytesN<#n> }
         }
         ScSpecTypeDef::Udt(u) => {

--- a/soroban-spec/src/gen/rust/types.rs
+++ b/soroban-spec/src/gen/rust/types.rs
@@ -76,7 +76,7 @@ pub fn generate_type_ident(spec: &ScSpecTypeDef) -> TokenStream {
             quote! { (#(#type_idents,)*) }
         }
         ScSpecTypeDef::BytesN(b) => {
-            let n = Literal::usize_unsuffixed(b.n as usize);
+            let n = Literal::u32_unsuffixed(b.n);
             quote! { ::soroban_sdk::BytesN<#n> }
         }
         ScSpecTypeDef::Udt(u) => {

--- a/soroban-spec/src/gen/rust/types.rs
+++ b/soroban-spec/src/gen/rust/types.rs
@@ -1,4 +1,4 @@
-use proc_macro2::TokenStream;
+use proc_macro2::{Literal, TokenStream};
 use quote::{format_ident, quote};
 use stellar_xdr::{ScSpecTypeDef, ScSpecUdtStructV0, ScSpecUdtUnionV0};
 
@@ -76,7 +76,7 @@ pub fn generate_type_ident(spec: &ScSpecTypeDef) -> TokenStream {
             quote! { (#(#type_idents,)*) }
         }
         ScSpecTypeDef::BytesN(b) => {
-            let n: usize = b.n as usize;
+            let n = Literal::usize_unsuffixed(b.n as usize);
             quote! { ::soroban_sdk::BytesN<#n> }
         }
         ScSpecTypeDef::Udt(u) => {


### PR DESCRIPTION
### What
Remove the u32 suffix from the N value in generated code using BytesN<N>.

### Why
BytesN<N> has N as usize, but we actually store the value as u32 because the maximum size is really u32. By default the generated value has a suffix like `u32` on the end and the compiler errors because u32 is not usize. Changing the value that gets generated to have no suffix will make it get interpreted as whatever the type is specified at the call site. Instead of `1u32` it will just render as `1`.

Note that we could change it to render explicitly as usize, but that's slightly uglier generated code with no benefit.