### PR TITLE
Make the file path of contract imports stable relative to Cargo.toml

### DIFF
--- a/soroban-sdk-macros/src/path.rs
+++ b/soroban-sdk-macros/src/path.rs
@@ -1,0 +1,17 @@
+use std::{env, path::PathBuf};
+
+/// Return an absolute path when given a relative path that is relative to the
+/// Cargo manifest file.
+///
+/// If an absolute path is provided it is returned unaltered.
+pub fn abs_from_rel_to_manifest(path: impl Into<PathBuf>) -> PathBuf {
+    let path: PathBuf = path.into();
+    if path.is_relative() {
+        let root: PathBuf = env::var("CARGO_MANIFEST_DIR")
+            .expect("CARGO_MANIFEST_DIR environment variable is required to be set")
+            .into();
+        root.join(path)
+    } else {
+        path
+    }
+}

--- a/soroban-sdk/tests/contractfile_with_sha256.rs
+++ b/soroban-sdk/tests/contractfile_with_sha256.rs
@@ -1,5 +1,5 @@
 pub const WASM: &[u8] = soroban_sdk::contractfile!(
-    file = "target/wasm32-unknown-unknown/release/example_add_i32.wasm",
+    file = "../target/wasm32-unknown-unknown/release/example_add_i32.wasm",
     sha256 = "e353760a571abf2c69493af1f433593438b540a509cc19f4f56bd0d4b1e9c5db",
 );
 

--- a/soroban-sdk/tests/contractimport.rs
+++ b/soroban-sdk/tests/contractimport.rs
@@ -6,7 +6,7 @@ use stellar_xdr::{ScSpecEntry, ScSpecFunctionInputV0, ScSpecFunctionV0, ScSpecTy
 const ADD_CONTRACT_ID: [u8; 32] = [0; 32];
 mod addcontract {
     soroban_sdk::contractimport!(
-        file = "target/wasm32-unknown-unknown/release/example_add_i32.wasm"
+        file = "../target/wasm32-unknown-unknown/release/example_add_i32.wasm"
     );
 }
 

--- a/soroban-sdk/tests/contractimport_with_sha256.rs
+++ b/soroban-sdk/tests/contractimport_with_sha256.rs
@@ -6,7 +6,7 @@ use stellar_xdr::{ScSpecEntry, ScSpecFunctionInputV0, ScSpecFunctionV0, ScSpecTy
 const ADD_CONTRACT_ID: [u8; 32] = [0; 32];
 mod addcontract {
     soroban_sdk::contractimport!(
-        file = "target/wasm32-unknown-unknown/release/example_add_i32.wasm",
+        file = "../target/wasm32-unknown-unknown/release/example_add_i32.wasm",
         sha256 = "e353760a571abf2c69493af1f433593438b540a509cc19f4f56bd0d4b1e9c5db",
     );
 }

--- a/tests/import_contract/src/lib.rs
+++ b/tests/import_contract/src/lib.rs
@@ -4,7 +4,7 @@ use soroban_sdk::{contractimpl, Env};
 const ADD_CONTRACT_ID: [u8; 32] = [0; 32];
 mod addcontract {
     soroban_sdk::contractimport!(
-        file = "target/wasm32-unknown-unknown/release/example_add_i32.wasm"
+        file = "../../target/wasm32-unknown-unknown/release/example_add_i32.wasm"
     );
 }
 


### PR DESCRIPTION
### What
Make the file path of `contractimport!` stable relative to Cargo.toml.

### Why
Reading files inside proc-macros it turns out is rather difficult. The current working directory isn't consistent, especially in virutal workspaces. Doctests use the crate's directory. Builds and normal tests use the virtual workspace directory.

Reading around about this problem most other proc-macros appear to use and rely on the `CARGO_MANIFEST_DIR` to know where the root of the crate is. This isn't great, but it works.

This problem appeared when attempting to use `contractimport!` in the soroban-examples repo, where examples generate doctests.

C_lose https://github.com/stellar/soroban-examples/issues/87