### PR TITLE
Make auth types top-level in crate

### DIFF
--- a/soroban-sdk-auth/src/lib.rs
+++ b/soroban-sdk-auth/src/lib.rs
@@ -15,10 +15,7 @@ pub use crate::public_types::{
 /// ### Examples
 /// ```
 /// use soroban_sdk::{BigInt, Env, contracttype};
-/// use soroban_sdk_auth::{check_auth,
-///     public_types::{Identifier, Signature},
-///     NonceAuth,
-/// };
+/// use soroban_sdk_auth::{check_auth, Identifier, Signature, NonceAuth};
 ///
 /// #[contracttype]
 /// pub enum DataKey {

--- a/soroban-sdk-auth/src/lib.rs
+++ b/soroban-sdk-auth/src/lib.rs
@@ -2,8 +2,8 @@
 
 use soroban_sdk::{serde::Serialize, Account, BigInt, BytesN, Env, RawVal, Symbol, Vec};
 
-pub mod public_types;
-use crate::public_types::{
+mod public_types;
+pub use crate::public_types::{
     AccountSignatures, Ed25519Signature, Identifier, Signature, SignaturePayload,
     SignaturePayloadV0,
 };


### PR DESCRIPTION
### What
Make auth types top-level in crate.

### Why
The auth crate has a small number of types and it is simpler to look at the docs if they are all presented at the root.

This also simplifies the contracttype macro somewhat because when it references the type across crates it can do so using a simple identifier instead of needing to use a well formed path.