### PR TITLE
Stop special casing the macro and spec crates in the members list

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ resolver = "2"
 members = [
     "soroban-sdk",
     "soroban-sdk-auth",
+    "soroban-sdk-macros",
     "soroban-spec",
     "tests/empty",
     "tests/hello",
@@ -16,28 +17,6 @@ members = [
     "tests/udt",
     "tests/contract_data",
     "tests/create_contract",
-]
-
-exclude = [
-    # Exclude proc-macro crates from the workspace so that when building the
-    # workspace their dependencies do not pollute the feature selection of other
-    # crates. Ordinarily when you build a proc-macro crate as a dependency of
-    # another crate, the proc-macro crate's dependencies are decoupled from the
-    # dependencies of other crates. This has an important side-effect of not
-    # unifiying the features selected in shared dependencies. When a proc-macro
-    # crate is part of a workspace and the workspace as a whole is built the
-    # proc-macro is seen as a first-class crate and its dependencies, including
-    # their feature selection, affects the overall dependency graph used to build
-    # all crates. This has an unfortunate side-effect for proc-macro crates, like
-    # 'macros', that depend on std features when other crates, like 'sdk',
-    # explicitly must not depend on std. Hopefully one day this will be fixed in:
-    # https://github.com/rust-lang/cargo/issues/10827
-    "soroban-sdk-macros",
-    # Exclude crates that are not intended for building on the wasm32 target, so
-    # that the majority of cargo-hack usage won't trigger builds on these crates
-    # in isolation, but these crates will still be built when the SDK gets built
-    # because they're named as a dependency.
-    "soroban-spec",
 ]
 
 [patch.crates-io]

--- a/soroban-sdk-macros/src/derive_fn.rs
+++ b/soroban-sdk-macros/src/derive_fn.rs
@@ -140,8 +140,14 @@ pub fn derive_fn(
     let wrap_export_name = format!("{}", ident);
     let pub_mod_ident = format_ident!("{}", ident);
     let hidden_mod_ident = format_ident!("__{}", ident);
-    let deprecated_note = format!("use `{}::new(&env, &contract_id).{}` instead", client_ident, &ident);
-    let deprecated_note_xdr = format!("use `{}::new(&env, &contract_id).{}_xdr` instead", client_ident, &ident);
+    let deprecated_note = format!(
+        "use `{}::new(&env, &contract_id).{}` instead",
+        client_ident, &ident
+    );
+    let deprecated_note_xdr = format!(
+        "use `{}::new(&env, &contract_id).{}_xdr` instead",
+        client_ident, &ident
+    );
     let env_call = if env_input.is_some() {
         quote! { env.clone(), }
     } else {

--- a/soroban-sdk-macros/src/syn_ext.rs
+++ b/soroban-sdk-macros/src/syn_ext.rs
@@ -1,4 +1,7 @@
-use syn::{ImplItem, ImplItemMethod, ItemImpl, ItemTrait, TraitItem, TraitItemMethod, Visibility, FnArg, Type, TypeReference, token::And, PatType, Pat, Error, spanned::Spanned, Ident};
+use syn::{
+    spanned::Spanned, token::And, Error, FnArg, Ident, ImplItem, ImplItemMethod, ItemImpl,
+    ItemTrait, Pat, PatType, TraitItem, TraitItemMethod, Type, TypeReference, Visibility,
+};
 
 /// Gets methods from the implementation that have public visibility. For
 /// methods that are inherently implemented this is methods that have a pub


### PR DESCRIPTION
### What
Stop special casing the macro and spec crates in the members list.

### Why
The crates were excluded because of dependency resolution unifying the features of dependencies. However, we now use cargo-hack to run builds and tests for each crate independently, and so this is no longer a concern.

There are disadvantages of not having the crates in the member list. For example, cargo fmt will not run on them. And it may affect publishing the workspace as well.