### PR TITLE
Rename soroban-sdk-auth to soroban-auth

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -964,7 +964,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "soroban-sdk-auth"
+name = "soroban-auth"
 version = "0.0.0"
 dependencies = [
  "soroban-sdk",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 
 members = [
     "soroban-sdk",
-    "soroban-sdk-auth",
+    "soroban-auth",
     "soroban-sdk-macros",
     "soroban-spec",
     "tests/empty",
@@ -21,7 +21,7 @@ members = [
 
 [patch.crates-io]
 soroban-sdk = { path = "soroban-sdk" }
-soroban-sdk-auth = { path = "soroban-sdk-auth" }
+soroban-auth = { path = "soroban-auth" }
 soroban-sdk-macros = { path = "soroban-sdk-macros" }
 soroban-env-common = { git = "https://github.com/stellar/rs-soroban-env", rev = "b94bbb7" }
 soroban-env-guest = { git = "https://github.com/stellar/rs-soroban-env", rev = "b94bbb7" }

--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,8 @@ CARGO_TEST_SUBCOMMAND:=$(shell type -p cargo-nextest >/dev/null && echo nextest 
 CARGO_DOC_ARGS?=--open
 
 doc: fmt
-	cargo test --doc -p soroban-sdk -p soroban-sdk-macros -p soroban-sdk-auth --features testutils
-	cargo +nightly doc -p soroban-sdk -p soroban-sdk-auth --no-deps --features docs,testutils $(CARGO_DOC_ARGS)
+	cargo test --doc -p soroban-sdk -p soroban-sdk-macros -p soroban-auth --features testutils
+	cargo +nightly doc -p soroban-sdk -p soroban-auth --no-deps --features docs,testutils $(CARGO_DOC_ARGS)
 
 test: fmt build
 	cargo hack --feature-powerset --exclude-features docs $(CARGO_TEST_SUBCOMMAND)
@@ -21,7 +21,7 @@ build-optimized: fmt
 		--exclude soroban-spec \
 		--exclude soroban-sdk \
 		--exclude soroban-sdk-macros \
-		--exclude soroban-sdk-auth \
+		--exclude soroban-auth \
 		-Z build-std=std,panic_abort \
 		-Z build-std-features=panic_immediate_abort
 	cd target-tiny/wasm32-unknown-unknown/release/ && \

--- a/soroban-sdk-auth/Cargo.toml
+++ b/soroban-sdk-auth/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "soroban-sdk-auth"
+name = "soroban-auth"
 description = "Soroban authorization sdk"
 homepage = "https://github.com/stellar/rs-soroban-sdk"
 repository = "https://github.com/stellar/rs-soroban-sdk"


### PR DESCRIPTION
### What
Rename soroban-sdk-auth to soroban-auth

### Why
The crate name soroban-sdk-auth is not available.