### PR TITLE
Fix soroban-auth soroban-sdk dep version

### DIFF
--- a/soroban-auth/Cargo.toml
+++ b/soroban-auth/Cargo.toml
@@ -14,4 +14,4 @@ rust-version = "1.63"
 testutils = ["soroban-sdk/testutils"]
 
 [dependencies]
-soroban-sdk = { path = "../soroban-sdk" }
+soroban-sdk = "0.0.4"


### PR DESCRIPTION
### What
Fix soroban-auth soroban-sdk dep version.

### Why
It is blocking the release.