### PR TITLE
Disable publish of example_vec test

### DIFF
--- a/tests/vec/Cargo.toml
+++ b/tests/vec/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.0.4"
 authors = ["Stellar Development Foundation <info@stellar.org>"]
 license = "Apache-2.0"
 edition = "2021"
+publish = false
 rust-version = "1.63"
 
 [lib]


### PR DESCRIPTION
### What
Disable publish of example_vec test.

### Why
The crate is a test and shouldn't be published. All the other test crates are configured same.