### PR TITLE
Add Vec::keys,values tests

### DIFF
--- a/soroban-sdk/src/map.rs
+++ b/soroban-sdk/src/map.rs
@@ -548,6 +548,7 @@ where
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::vec;
 
     #[test]
     fn test_map_macro() {
@@ -639,5 +640,29 @@ mod test {
         assert_eq!(iter.next(), None);
         assert_eq!(iter.next_back(), None);
         assert_eq!(iter.next_back(), None);
+    }
+
+    #[test]
+    // TODO: Remove this should_panic when
+    // https://github.com/stellar/rs-soroban-env/issues/405 is fixed.
+    #[should_panic = "already borrowed: BorrowMutError"]
+    fn test_keys() {
+        let env = Env::default();
+
+        let map = map![&env, (0, 0), (1, 10), (2, 20), (3, 30), (4, 40)];
+        let keys = map.keys();
+        assert_eq!(keys, vec![&env, 0, 1, 2, 3, 4]);
+    }
+
+    #[test]
+    // TODO: Remove this should_panic when
+    // https://github.com/stellar/rs-soroban-env/issues/405 is fixed.
+    #[should_panic = "already borrowed: BorrowMutError"]
+    fn test_values() {
+        let env = Env::default();
+
+        let map = map![&env, (0, 0), (1, 10), (2, 20), (3, 30), (4, 40)];
+        let values = map.values();
+        assert_eq!(values, vec![&env, 0, 10, 20, 30, 40]);
     }
 }


### PR DESCRIPTION
### What
Add Vec::keys,values tests that currently fail but expect to pass once https://github.com/stellar/rs-soroban-env/issues/405 is fixed.

### Why
We should have tests for the keys and values functionality of maps. While we can't add passing tests right now due to the bug captured in https://github.com/stellar/rs-soroban-env/issues/405, we can write tests and mark them as failing and update them to pass in the future.

cc @accordeiro – Thanks for identifying this test gap and the bug.