### PR TITLE
Add u64 test vector

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -298,6 +298,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "example_add_u64"
+version = "0.0.4"
+dependencies = [
+ "soroban-sdk",
+]
+
+[[package]]
 name = "example_contract_data"
 version = "0.0.4"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ members = [
     "tests/hello",
     "tests/add_i32",
     "tests/add_i64",
+    "tests/add_u64",
     "tests/add_bigint",
     "tests/vec",
     "tests/import_contract",

--- a/tests/add_u64/Cargo.toml
+++ b/tests/add_u64/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "example_add_u64"
+version = "0.0.4"
+authors = ["Stellar Development Foundation <info@stellar.org>"]
+license = "Apache-2.0"
+edition = "2021"
+publish = false
+rust-version = "1.63"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+doctest = false
+
+[dependencies]
+soroban-sdk = {path = "../../soroban-sdk"}
+
+[dev-dependencies]
+soroban-sdk = {path = "../../soroban-sdk", features = ["testutils"]}
+
+[features]
+testutils = ["soroban-sdk/testutils"]

--- a/tests/add_u64/src/lib.rs
+++ b/tests/add_u64/src/lib.rs
@@ -1,0 +1,31 @@
+#![no_std]
+use soroban_sdk::contractimpl;
+
+pub struct Contract;
+
+#[contractimpl]
+impl Contract {
+    pub fn add(a: u64, b: u64) -> u64 {
+        a + b
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use soroban_sdk::{BytesN, Env};
+
+    use crate::{Contract, ContractClient};
+
+    #[test]
+    fn test_add() {
+        let e = Env::default();
+        let contract_id = BytesN::from_array(&e, &[0; 32]);
+        e.register_contract(&contract_id, Contract);
+        let client = ContractClient::new(&e, &contract_id);
+
+        let x = 10u64;
+        let y = 12u64;
+        let z = client.add(&x, &y);
+        assert!(z == 22);
+    }
+}


### PR DESCRIPTION
### What
Add u64 test vector.

### Why
It is useful to have a test vector that is simple and uses an object type.