### PR TITLE
Reorder cargo install options to match other repos

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -49,7 +49,7 @@ jobs:
     - run: rustup update
     - run: rustup target add ${{ matrix.sys.target }}
     - run: rustup target add wasm32-unknown-unknown
-    - run: cargo install --locked --version 0.5.16 cargo-hack --target-dir ~/.cargo/target
+    - run: cargo install --target-dir ~/.cargo/target --locked --version 0.5.16 cargo-hack
     - run: cargo hack build --target wasm32-unknown-unknown --profile release
     - run: cargo hack --feature-powerset --exclude-features docs build --target ${{ matrix.sys.target }}
     - run: cargo hack --feature-powerset --exclude-features docs test --target ${{ matrix.sys.target }}
@@ -70,7 +70,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: stellar/actions/rust-cache@main
     - run: rustup update
-    - run: cargo install --locked --version 0.2.35 cargo-workspaces --target-dir ~/.cargo/target
+    - run: cargo install --target-dir ~/.cargo/target --locked --version 0.2.35 cargo-workspaces
     - run: make publish
       env:
         CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}


### PR DESCRIPTION
### What
Reorder cargo install options to match other repos.

### Why
Consistency with other workflows in other repos that do the same thing.