### PR TITLE
Add publish dry run to build on release branches

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -54,7 +54,7 @@ jobs:
     - run: cargo hack --feature-powerset --exclude-features docs build --target ${{ matrix.sys.target }}
     - run: cargo hack --feature-powerset --exclude-features docs test --target ${{ matrix.sys.target }}
     - if: startsWith(github.head_ref, 'release/')
-      uses: stellar/actions/rust-workspace-publish-dry-run@dryrun
+      uses: stellar/actions/rust-workspace-publish-dry-run@main
       with:
         cargo-package-options: --target ${{ matrix.sys.target }}
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -53,6 +53,10 @@ jobs:
     - run: cargo hack build --target wasm32-unknown-unknown --profile release
     - run: cargo hack --feature-powerset --exclude-features docs build --target ${{ matrix.sys.target }}
     - run: cargo hack --feature-powerset --exclude-features docs test --target ${{ matrix.sys.target }}
+    - if: startsWith(github.head_ref, 'release/')
+      uses: stellar/actions/rust-workspace-publish-dry-run@dryrun
+      with:
+        cargo-package-options: --target ${{ matrix.sys.target }}
 
   docs:
     runs-on: ubuntu-latest

--- a/tests/contract_data/Cargo.toml
+++ b/tests/contract_data/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Stellar Development Foundation <info@stellar.org>"]
 license = "Apache-2.0"
 edition = "2021"
 rust-version = "1.63"
+publish = false
 
 [lib]
 crate-type = ["cdylib", "rlib"]


### PR DESCRIPTION
### What
Add publish dry run to build on release branches.

### Why
So that release branches created by the bump version workflow are fully tested before going to the publish step after merge.