### PR TITLE
Separate the publish workflows and use new versions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,12 @@
+name: Publish
+
+on:
+  release:
+    types: [published]
+
+jobs:
+
+  publish:
+    uses: stellar/actions/.github/workflows/rust-publish.yml@main
+    secrets:
+      CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -72,4 +72,5 @@ jobs:
     uses: stellar/actions/.github/workflows/rust-publish-dry-run.yml@main
     with:
       runs-on: ${{ matrix.sys.os }}
-      cargo-package-options: --exclude-features docs --target ${{ matrix.sys.target }}
+      cargo-hack-feature-options: --exclude-features docs
+      cargo-package-options: --target ${{ matrix.sys.target }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -67,10 +67,12 @@ jobs:
         sys:
         - os: ubuntu-latest
           target: wasm32-unknown-unknown
+          cargo-hack-feature-options: ''
         - os: ubuntu-latest
           target: x86_64-unknown-linux-gnu
+          cargo-hack-feature-options: '--feature-powerset --exclude-features docs'
     uses: stellar/actions/.github/workflows/rust-publish-dry-run.yml@main
     with:
       runs-on: ${{ matrix.sys.os }}
-      cargo-hack-feature-options: --exclude-features docs
+      cargo-hack-feature-options: ${{ matrix.sys.cargo-hack-feature-options }}
       cargo-package-options: --target ${{ matrix.sys.target }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -72,4 +72,4 @@ jobs:
     uses: stellar/actions/.github/workflows/rust-publish-dry-run.yml@main
     with:
       runs-on: ${{ matrix.sys.os }}
-      cargo-package-options: --target ${{ matrix.sys.target }}
+      cargo-package-options: --exclude-features docs --target ${{ matrix.sys.target }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches: [main]
   pull_request:
-  release:
-    types: [published]
 
 env:
   RUSTFLAGS: -D warnings
@@ -14,7 +12,7 @@ jobs:
 
   complete:
     if: always()
-    needs: [fmt, rust-analyzer-compat, build-and-test, docs]
+    needs: [fmt, rust-analyzer-compat, build-and-test, docs, publish-dry-run]
     runs-on: ubuntu-latest
     steps:
     - if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
@@ -53,10 +51,6 @@ jobs:
     - run: cargo hack build --target wasm32-unknown-unknown --profile release
     - run: cargo hack --feature-powerset --exclude-features docs build --target ${{ matrix.sys.target }}
     - run: cargo hack --feature-powerset --exclude-features docs test --target ${{ matrix.sys.target }}
-    - if: startsWith(github.head_ref, 'release/')
-      uses: stellar/actions/rust-workspace-publish-dry-run@main
-      with:
-        cargo-package-options: --target ${{ matrix.sys.target }}
 
   docs:
     runs-on: ubuntu-latest
@@ -66,15 +60,16 @@ jobs:
     - run: rustup install nightly
     - run: make doc
 
-  publish:
-    if: github.event_name == 'release'
-    needs: [complete]
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v3
-    - uses: stellar/actions/rust-cache@main
-    - run: rustup update
-    - run: cargo install --target-dir ~/.cargo/target --locked --version 0.2.35 cargo-workspaces
-    - run: make publish
-      env:
-        CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+  publish-dry-run:
+    if: startsWith(github.head_ref, 'release/')
+    strategy:
+      matrix:
+        sys:
+        - os: ubuntu-latest
+          target: wasm32-unknown-unknown
+        - os: ubuntu-latest
+          target: x86_64-unknown-linux-gnu
+    uses: stellar/actions/.github/workflows/rust-publish-dry-run.yml@main
+    with:
+      runs-on: ${{ matrix.sys.os }}
+      cargo-package-options: --target ${{ matrix.sys.target }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -907,8 +907,8 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-common"
-version = "0.0.4"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=bd3dc8d2#bd3dc8d2efb042022c598eec0e63bd88deb9f65d"
+version = "0.0.5"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=b08a54a7#b08a54a764eaa7b931503dd1a46ad72c1bcf7a2e"
 dependencies = [
  "soroban-env-macros",
  "soroban-wasmi",
@@ -918,8 +918,8 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-guest"
-version = "0.0.4"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=bd3dc8d2#bd3dc8d2efb042022c598eec0e63bd88deb9f65d"
+version = "0.0.5"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=b08a54a7#b08a54a764eaa7b931503dd1a46ad72c1bcf7a2e"
 dependencies = [
  "soroban-env-common",
  "static_assertions",
@@ -927,8 +927,8 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-host"
-version = "0.0.4"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=bd3dc8d2#bd3dc8d2efb042022c598eec0e63bd88deb9f65d"
+version = "0.0.5"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=b08a54a7#b08a54a764eaa7b931503dd1a46ad72c1bcf7a2e"
 dependencies = [
  "backtrace",
  "dyn-fmt",
@@ -950,8 +950,8 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-macros"
-version = "0.0.4"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=bd3dc8d2#bd3dc8d2efb042022c598eec0e63bd88deb9f65d"
+version = "0.0.5"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=b08a54a7#b08a54a764eaa7b931503dd1a46ad72c1bcf7a2e"
 dependencies = [
  "itertools",
  "proc-macro2",
@@ -962,8 +962,8 @@ dependencies = [
 
 [[package]]
 name = "soroban-native-sdk-macros"
-version = "0.0.4"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=bd3dc8d2#bd3dc8d2efb042022c598eec0e63bd88deb9f65d"
+version = "0.0.5"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=b08a54a7#b08a54a764eaa7b931503dd1a46ad72c1bcf7a2e"
 dependencies = [
  "itertools",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,11 +26,11 @@ soroban-sdk = { path = "soroban-sdk" }
 soroban-auth = { path = "soroban-auth" }
 soroban-spec = { path = "soroban-spec" }
 soroban-sdk-macros = { path = "soroban-sdk-macros" }
-soroban-env-common = { git = "https://github.com/stellar/rs-soroban-env", rev = "bd3dc8d2" }
-soroban-env-guest = { git = "https://github.com/stellar/rs-soroban-env", rev = "bd3dc8d2" }
-soroban-env-host = { git = "https://github.com/stellar/rs-soroban-env", rev = "bd3dc8d2" }
-soroban-env-macros = { git = "https://github.com/stellar/rs-soroban-env", rev = "bd3dc8d2" }
-soroban-native-sdk-macros = { git = "https://github.com/stellar/rs-soroban-env", rev = "bd3dc8d2" }
+soroban-env-common = { git = "https://github.com/stellar/rs-soroban-env", rev = "b08a54a7" }
+soroban-env-guest = { git = "https://github.com/stellar/rs-soroban-env", rev = "b08a54a7" }
+soroban-env-host = { git = "https://github.com/stellar/rs-soroban-env", rev = "b08a54a7" }
+soroban-env-macros = { git = "https://github.com/stellar/rs-soroban-env", rev = "b08a54a7" }
+soroban-native-sdk-macros = { git = "https://github.com/stellar/rs-soroban-env", rev = "b08a54a7" }
 stellar-xdr = { git = "https://github.com/stellar/rs-stellar-xdr", rev = "fee9a43" }
 
 # soroban-env-common = { path = "../rs-soroban-env/soroban-env-common" }

--- a/soroban-sdk-macros/Cargo.toml
+++ b/soroban-sdk-macros/Cargo.toml
@@ -16,7 +16,7 @@ doctest = false
 
 [dependencies]
 soroban-spec = "0.0.4"
-soroban-env-common = "0.0.4"
+soroban-env-common = "0.0.5"
 stellar-xdr = { version = "0.0.2", features = ["next", "std"] }
 syn = {version="1.0",features=["full"]}
 quote = "1.0"

--- a/soroban-sdk/Cargo.toml
+++ b/soroban-sdk/Cargo.toml
@@ -19,10 +19,10 @@ bytes-lit = "0.0.3"
 ed25519-dalek = { version = "1.0.1", optional = true }
 
 [target.'cfg(target_family="wasm")'.dependencies]
-soroban-env-guest = { version = "0.0.4" }
+soroban-env-guest = { version = "0.0.5" }
 
 [target.'cfg(not(target_family="wasm"))'.dependencies]
-soroban-env-host = { version = "0.0.4", features = ["vm"] }
+soroban-env-host = { version = "0.0.5", features = ["vm"] }
 
 [dev-dependencies]
 stellar-xdr = { version = "0.0.2", features = ["next", "std"] }

--- a/soroban-spec/Cargo.toml
+++ b/soroban-spec/Cargo.toml
@@ -12,7 +12,7 @@ rust-version = "1.63"
 
 [dependencies]
 stellar-xdr = { version = "0.0.2", features = ["next", "std"] }
-soroban-env-host = { version = "0.0.4", features = ["vm", "serde"] }
+soroban-env-host = { version = "0.0.5", features = ["vm", "serde"] }
 base64 = "0.13.0"
 thiserror = "1.0.32"
 syn = {version="1.0",features=["full"]}


### PR DESCRIPTION
### What
Separate the publish workflows and use new versions.

### Why
Publish doesn't need to be part of the rust workflow as it has no dependence on the other jobs in that workflow. Also this now uses the newer workflows.

The updates of the env crate is so that the publish dry run passes and to test it out, since the SDK is dependent on features that aren't in the version of the crates it is depending on now, it needs updating.