### PR TITLE
Fix Ord::cmp impls of all types

### DIFF
--- a/soroban-sdk/src/account.rs
+++ b/soroban-sdk/src/account.rs
@@ -53,10 +53,7 @@ impl PartialOrd for Account {
 
 impl Ord for Account {
     fn cmp(&self, other: &Self) -> core::cmp::Ordering {
-        let env = self.env();
-        let v = env.obj_cmp(self.0.to_raw(), other.0.to_raw());
-        let i = i32::try_from(v).unwrap();
-        i.cmp(&0)
+        self.0.cmp(&other.0)
     }
 }
 

--- a/soroban-sdk/src/bigint.rs
+++ b/soroban-sdk/src/bigint.rs
@@ -894,9 +894,7 @@ impl Eq for BigInt {}
 
 impl Ord for BigInt {
     fn cmp(&self, other: &Self) -> Ordering {
-        let env = self.env();
-        let i = env.obj_cmp(self.0.to_raw(), other.0.to_raw());
-        i.cmp(&0)
+        self.0.cmp(&other.0)
     }
 }
 

--- a/soroban-sdk/src/bytes.rs
+++ b/soroban-sdk/src/bytes.rs
@@ -126,10 +126,7 @@ impl PartialOrd for Bytes {
 
 impl Ord for Bytes {
     fn cmp(&self, other: &Self) -> core::cmp::Ordering {
-        let env = self.env();
-        let v = env.obj_cmp(self.0.to_raw(), other.0.to_raw());
-        let i = i32::try_from(v).unwrap();
-        i.cmp(&0)
+        self.0.cmp(&other.0)
     }
 }
 

--- a/soroban-sdk/src/map.rs
+++ b/soroban-sdk/src/map.rs
@@ -119,10 +119,7 @@ where
     V: IntoVal<Env, RawVal> + TryFromVal<Env, RawVal>,
 {
     fn cmp(&self, other: &Self) -> core::cmp::Ordering {
-        let env = self.env();
-        let v = env.obj_cmp(self.0.to_raw(), other.0.to_raw());
-        let i = i32::try_from(v).unwrap();
-        i.cmp(&0)
+        self.0.cmp(&other.0)
     }
 }
 

--- a/soroban-sdk/src/vec.rs
+++ b/soroban-sdk/src/vec.rs
@@ -129,10 +129,7 @@ where
     T: IntoVal<Env, RawVal> + TryFromVal<Env, RawVal>,
 {
     fn cmp(&self, other: &Self) -> core::cmp::Ordering {
-        let env = self.env();
-        let v = env.obj_cmp(self.0.to_raw(), other.0.to_raw());
-        let i = i32::try_from(v).unwrap();
-        i.cmp(&0)
+        self.0.cmp(&other.0)
     }
 }
 


### PR DESCRIPTION
### What
Change Ord::cmp impls of all types to use the <EnvVal as Ord>::cmp impl.

### Why
The EnvVal type provides an optimized implementation of the Ord::cmp trait with a couple of fast paths that avoid a host function call. The EnvVal type was designed by @graydon to provide easy comparison between types without us having to reimplement the comparison everywhere ourselves. It looks like this was overlooked when implementing some, but not all, SDK types.

Also, @graydon pointed out that the implementation of these comparison functions in the SDK are incorrect because they consume the result as an i32 encoded in a RawVal when in-fact they are i64 values without any RawVal encoding.