### PR TITLE
Fix conversions from guaranteed types

### DIFF
--- a/soroban-sdk/src/bigint.rs
+++ b/soroban-sdk/src/bigint.rs
@@ -1094,15 +1094,13 @@ impl BigInt {
     /// Returns true if the [BigInt] is zero.
     pub fn is_zero(&self) -> bool {
         let env = self.env();
-        let is_zero = env.bigint_is_zero(self.0.to_object());
-        bool::try_from(is_zero).unwrap()
+        env.bigint_is_zero(self.0.to_object()).is_true()
     }
 
     /// Returns the minimum number of bits required to store the [BigInt].
-    pub fn bits(&self) -> u32 {
+    pub fn bits(&self) -> u64 {
         let env = self.env();
-        let bits = env.bigint_bits(self.0.to_object());
-        u32::try_from(bits).unwrap()
+        env.bigint_bits(self.0.to_object())
     }
 }
 

--- a/soroban-sdk/src/bigint.rs
+++ b/soroban-sdk/src/bigint.rs
@@ -212,7 +212,7 @@ impl TryFrom<BigInt> for u64 {
     type Error = ();
 
     fn try_from(b: BigInt) -> Result<Self, Self::Error> {
-        if b.bits() <= u64::BITS {
+        if b.bits() <= u64::BITS.into() {
             Ok(b.to_u64())
         } else {
             Err(())
@@ -236,7 +236,7 @@ impl TryFrom<BigInt> for i64 {
     type Error = ();
 
     fn try_from(b: BigInt) -> Result<Self, Self::Error> {
-        if b.bits() <= i64::BITS {
+        if b.bits() <= i64::BITS.into() {
             Ok(b.to_i64())
         } else {
             Err(())
@@ -260,7 +260,7 @@ impl TryFrom<BigInt> for u32 {
     type Error = ();
 
     fn try_from(b: BigInt) -> Result<Self, Self::Error> {
-        if b.bits() <= u32::BITS {
+        if b.bits() <= u32::BITS.into() {
             Ok(b.to_u32())
         } else {
             Err(())
@@ -284,7 +284,7 @@ impl TryFrom<BigInt> for i32 {
     type Error = ();
 
     fn try_from(b: BigInt) -> Result<Self, Self::Error> {
-        if b.bits() <= i32::BITS {
+        if b.bits() <= i32::BITS.into() {
             Ok(b.to_i32())
         } else {
             Err(())

--- a/soroban-sdk/src/map.rs
+++ b/soroban-sdk/src/map.rs
@@ -3,8 +3,10 @@ use core::{cmp::Ordering, fmt::Debug, iter::FusedIterator, marker::PhantomData};
 use crate::iter::{UncheckedEnumerable, UncheckedIter};
 
 use super::{
-    env::internal::Env as _, env::EnvObj, xdr::ScObjectType, ConversionError, Env, EnvVal, IntoVal,
-    Object, RawVal, Status, TryFromVal, TryIntoVal, Vec,
+    env::internal::{Env as _, RawValConvertible},
+    env::EnvObj,
+    xdr::ScObjectType,
+    ConversionError, Env, EnvVal, IntoVal, Object, RawVal, Status, TryFromVal, TryIntoVal, Vec,
 };
 
 #[cfg(not(target_family = "wasm"))]
@@ -409,7 +411,7 @@ where
     pub fn len(&self) -> u32 {
         let env = self.env();
         let len = env.map_len(self.0.to_object());
-        u32::try_from_val(env, len).unwrap()
+        unsafe { <u32 as RawValConvertible>::unchecked_from_val(len) }
     }
 
     #[inline(always)]


### PR DESCRIPTION
### What
Change fallible conversions from guaranteed types to do an unsafe direct conversion. Also, in the process fixed bits to just return the raw u64 value.

### Why
The SDK can trust the host to always return the correct type for returned values that have types that are fixed. If the host says a return value from a function will always be a RawVal wrapping a u32, we can unsafe convert it to a u32 without adding a branch and panic on failure. This reduces some branches in the compiled WASM.

Also the bits function was converting a returned value to a u32 but the value was in fact just a raw u64 value.