### PR TITLE
Add BigInt mutable ref operators

### DIFF
--- a/soroban-sdk/src/bigint.rs
+++ b/soroban-sdk/src/bigint.rs
@@ -1648,9 +1648,17 @@ mod test {
         let env = Env::default();
 
         assert_eq!(bigint!(&env, 1) + 1, bigint!(&env, 2));
+
         assert_eq!(bigint!(&env, 1) + &1, bigint!(&env, 2));
         assert_eq!(&bigint!(&env, 1) + 1, bigint!(&env, 2));
         assert_eq!(&bigint!(&env, 1) + &1, bigint!(&env, 2));
+
+        assert_eq!(bigint!(&env, 1) + &mut 1, bigint!(&env, 2));
+        assert_eq!(&mut bigint!(&env, 1) + 1, bigint!(&env, 2));
+        assert_eq!(&mut bigint!(&env, 1) + &mut 1, bigint!(&env, 2));
+
+        assert_eq!(&mut bigint!(&env, 1) + &1, bigint!(&env, 2));
+        assert_eq!(&bigint!(&env, 1) + &mut 1, bigint!(&env, 2));
     }
 
     #[test]
@@ -1660,6 +1668,7 @@ mod test {
         let mut b = bigint!(&env, 1);
         b += 1;
         assert_eq!(b, bigint!(&env, 2));
+
         let mut b = bigint!(&env, 1);
         b += &1;
         assert_eq!(b.clone(), bigint!(&env, 2));
@@ -1668,6 +1677,10 @@ mod test {
         assert_eq!(b.clone(), bigint!(&env, 2));
         let mut b = &mut bigint!(&env, 1);
         b += &1;
+        assert_eq!(b.clone(), bigint!(&env, 2));
+
+        let mut b = bigint!(&env, 1);
+        b += &mut 1;
         assert_eq!(b.clone(), bigint!(&env, 2));
     }
 }

--- a/soroban-sdk/src/bigint.rs
+++ b/soroban-sdk/src/bigint.rs
@@ -1642,4 +1642,32 @@ mod test {
         let b = BigInt::from_i64(&env, -2);
         assert_eq!(b.sign(), Sign::Minus);
     }
+
+    #[test]
+    fn operators() {
+        let env = Env::default();
+
+        assert_eq!(bigint!(&env, 1) + 1, bigint!(&env, 2));
+        assert_eq!(bigint!(&env, 1) + &1, bigint!(&env, 2));
+        assert_eq!(&bigint!(&env, 1) + 1, bigint!(&env, 2));
+        assert_eq!(&bigint!(&env, 1) + &1, bigint!(&env, 2));
+    }
+
+    #[test]
+    fn assignment_operators() {
+        let env = Env::default();
+
+        let mut b = bigint!(&env, 1);
+        b += 1;
+        assert_eq!(b, bigint!(&env, 2));
+        let mut b = bigint!(&env, 1);
+        b += &1;
+        assert_eq!(b.clone(), bigint!(&env, 2));
+        let mut b = &mut bigint!(&env, 1);
+        b += 1;
+        assert_eq!(b.clone(), bigint!(&env, 2));
+        let mut b = &mut bigint!(&env, 1);
+        b += &1;
+        assert_eq!(b.clone(), bigint!(&env, 2));
+    }
 }

--- a/soroban-sdk/src/bigint.rs
+++ b/soroban-sdk/src/bigint.rs
@@ -1,7 +1,11 @@
 use core::{
     cmp::Ordering,
     fmt::{Debug, Display},
-    ops::{Add, BitAnd, BitOr, BitXor, Div, Mul, Neg, Not, Rem, Shl, Shr, Sub},
+    ops::{
+        Add, AddAssign, BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign, Div,
+        DivAssign, Mul, MulAssign, Neg, Not, Rem, RemAssign, Shl, ShlAssign, Shr, ShrAssign, Sub,
+        SubAssign,
+    },
 };
 
 use super::{
@@ -389,6 +393,48 @@ impl Add<i32> for BigInt {
 }
 crate::operators::impl_ref_op!(BigInt, Add<i32>::add);
 
+impl AddAssign for BigInt {
+    fn add_assign(&mut self, rhs: Self) {
+        let env = self.env();
+        env.check_same_env(rhs.env());
+        let b = env.bigint_add(self.0.to_object(), rhs.0.to_object());
+        *self = Self::try_from_val(env, b).unwrap()
+    }
+}
+crate::operators::impl_ref_assign_op!(BigInt, AddAssign<BigInt>::add_assign);
+
+impl AddAssign<u64> for BigInt {
+    fn add_assign(&mut self, rhs: u64) {
+        let rhs = BigInt::from_u64(self.env(), rhs);
+        self.add_assign(rhs)
+    }
+}
+crate::operators::impl_ref_assign_op!(BigInt, AddAssign<u64>::add_assign);
+
+impl AddAssign<i64> for BigInt {
+    fn add_assign(&mut self, rhs: i64) {
+        let rhs = BigInt::from_i64(self.env(), rhs);
+        self.add_assign(rhs)
+    }
+}
+crate::operators::impl_ref_assign_op!(BigInt, AddAssign<i64>::add_assign);
+
+impl AddAssign<u32> for BigInt {
+    fn add_assign(&mut self, rhs: u32) {
+        let rhs = BigInt::from_u32(self.env(), rhs);
+        self.add_assign(rhs)
+    }
+}
+crate::operators::impl_ref_assign_op!(BigInt, AddAssign<u32>::add_assign);
+
+impl AddAssign<i32> for BigInt {
+    fn add_assign(&mut self, rhs: i32) {
+        let rhs = BigInt::from_i32(self.env(), rhs);
+        self.add_assign(rhs)
+    }
+}
+crate::operators::impl_ref_assign_op!(BigInt, AddAssign<i32>::add_assign);
+
 impl Sub for BigInt {
     type Output = BigInt;
     fn sub(self, rhs: Self) -> Self::Output {
@@ -435,6 +481,48 @@ impl Sub<i32> for BigInt {
     }
 }
 crate::operators::impl_ref_op!(BigInt, Sub<i32>::sub);
+
+impl SubAssign for BigInt {
+    fn sub_assign(&mut self, rhs: Self) {
+        let env = self.env();
+        env.check_same_env(rhs.env());
+        let b = env.bigint_sub(self.0.to_object(), rhs.0.to_object());
+        *self = Self::try_from_val(env, b).unwrap()
+    }
+}
+crate::operators::impl_ref_assign_op!(BigInt, SubAssign<BigInt>::sub_assign);
+
+impl SubAssign<u64> for BigInt {
+    fn sub_assign(&mut self, rhs: u64) {
+        let rhs = BigInt::from_u64(self.env(), rhs);
+        self.sub_assign(rhs)
+    }
+}
+crate::operators::impl_ref_assign_op!(BigInt, SubAssign<u64>::sub_assign);
+
+impl SubAssign<i64> for BigInt {
+    fn sub_assign(&mut self, rhs: i64) {
+        let rhs = BigInt::from_i64(self.env(), rhs);
+        self.sub_assign(rhs)
+    }
+}
+crate::operators::impl_ref_assign_op!(BigInt, SubAssign<i64>::sub_assign);
+
+impl SubAssign<u32> for BigInt {
+    fn sub_assign(&mut self, rhs: u32) {
+        let rhs = BigInt::from_u32(self.env(), rhs);
+        self.sub_assign(rhs)
+    }
+}
+crate::operators::impl_ref_assign_op!(BigInt, SubAssign<u32>::sub_assign);
+
+impl SubAssign<i32> for BigInt {
+    fn sub_assign(&mut self, rhs: i32) {
+        let rhs = BigInt::from_i32(self.env(), rhs);
+        self.sub_assign(rhs)
+    }
+}
+crate::operators::impl_ref_assign_op!(BigInt, SubAssign<i32>::sub_assign);
 
 impl Mul for BigInt {
     type Output = BigInt;
@@ -483,6 +571,48 @@ impl Mul<i32> for BigInt {
 }
 crate::operators::impl_ref_op!(BigInt, Mul<i32>::mul);
 
+impl MulAssign for BigInt {
+    fn mul_assign(&mut self, rhs: Self) {
+        let env = self.env();
+        env.check_same_env(rhs.env());
+        let b = env.bigint_mul(self.0.to_object(), rhs.0.to_object());
+        *self = Self::try_from_val(env, b).unwrap()
+    }
+}
+crate::operators::impl_ref_assign_op!(BigInt, MulAssign<BigInt>::mul_assign);
+
+impl MulAssign<u64> for BigInt {
+    fn mul_assign(&mut self, rhs: u64) {
+        let rhs = BigInt::from_u64(self.env(), rhs);
+        self.mul_assign(rhs)
+    }
+}
+crate::operators::impl_ref_assign_op!(BigInt, MulAssign<u64>::mul_assign);
+
+impl MulAssign<i64> for BigInt {
+    fn mul_assign(&mut self, rhs: i64) {
+        let rhs = BigInt::from_i64(self.env(), rhs);
+        self.mul_assign(rhs)
+    }
+}
+crate::operators::impl_ref_assign_op!(BigInt, MulAssign<i64>::mul_assign);
+
+impl MulAssign<u32> for BigInt {
+    fn mul_assign(&mut self, rhs: u32) {
+        let rhs = BigInt::from_u32(self.env(), rhs);
+        self.mul_assign(rhs)
+    }
+}
+crate::operators::impl_ref_assign_op!(BigInt, MulAssign<u32>::mul_assign);
+
+impl MulAssign<i32> for BigInt {
+    fn mul_assign(&mut self, rhs: i32) {
+        let rhs = BigInt::from_i32(self.env(), rhs);
+        self.mul_assign(rhs)
+    }
+}
+crate::operators::impl_ref_assign_op!(BigInt, MulAssign<i32>::mul_assign);
+
 impl Div for BigInt {
     type Output = BigInt;
     fn div(self, rhs: Self) -> Self::Output {
@@ -529,6 +659,48 @@ impl Div<i32> for BigInt {
     }
 }
 crate::operators::impl_ref_op!(BigInt, Div<i32>::div);
+
+impl DivAssign for BigInt {
+    fn div_assign(&mut self, rhs: Self) {
+        let env = self.env();
+        env.check_same_env(rhs.env());
+        let b = env.bigint_div(self.0.to_object(), rhs.0.to_object());
+        *self = Self::try_from_val(env, b).unwrap()
+    }
+}
+crate::operators::impl_ref_assign_op!(BigInt, DivAssign<BigInt>::div_assign);
+
+impl DivAssign<u64> for BigInt {
+    fn div_assign(&mut self, rhs: u64) {
+        let rhs = BigInt::from_u64(self.env(), rhs);
+        self.div_assign(rhs)
+    }
+}
+crate::operators::impl_ref_assign_op!(BigInt, DivAssign<u64>::div_assign);
+
+impl DivAssign<i64> for BigInt {
+    fn div_assign(&mut self, rhs: i64) {
+        let rhs = BigInt::from_i64(self.env(), rhs);
+        self.div_assign(rhs)
+    }
+}
+crate::operators::impl_ref_assign_op!(BigInt, DivAssign<i64>::div_assign);
+
+impl DivAssign<u32> for BigInt {
+    fn div_assign(&mut self, rhs: u32) {
+        let rhs = BigInt::from_u32(self.env(), rhs);
+        self.div_assign(rhs)
+    }
+}
+crate::operators::impl_ref_assign_op!(BigInt, DivAssign<u32>::div_assign);
+
+impl DivAssign<i32> for BigInt {
+    fn div_assign(&mut self, rhs: i32) {
+        let rhs = BigInt::from_i32(self.env(), rhs);
+        self.div_assign(rhs)
+    }
+}
+crate::operators::impl_ref_assign_op!(BigInt, DivAssign<i32>::div_assign);
 
 impl Rem for BigInt {
     type Output = BigInt;
@@ -577,6 +749,48 @@ impl Rem<i32> for BigInt {
 }
 crate::operators::impl_ref_op!(BigInt, Rem<i32>::rem);
 
+impl RemAssign for BigInt {
+    fn rem_assign(&mut self, rhs: Self) {
+        let env = self.env();
+        env.check_same_env(rhs.env());
+        let b = env.bigint_rem(self.0.to_object(), rhs.0.to_object());
+        *self = Self::try_from_val(env, b).unwrap()
+    }
+}
+crate::operators::impl_ref_assign_op!(BigInt, RemAssign<BigInt>::rem_assign);
+
+impl RemAssign<u64> for BigInt {
+    fn rem_assign(&mut self, rhs: u64) {
+        let rhs = BigInt::from_u64(self.env(), rhs);
+        self.rem_assign(rhs)
+    }
+}
+crate::operators::impl_ref_assign_op!(BigInt, RemAssign<u64>::rem_assign);
+
+impl RemAssign<i64> for BigInt {
+    fn rem_assign(&mut self, rhs: i64) {
+        let rhs = BigInt::from_i64(self.env(), rhs);
+        self.rem_assign(rhs)
+    }
+}
+crate::operators::impl_ref_assign_op!(BigInt, RemAssign<i64>::rem_assign);
+
+impl RemAssign<u32> for BigInt {
+    fn rem_assign(&mut self, rhs: u32) {
+        let rhs = BigInt::from_u32(self.env(), rhs);
+        self.rem_assign(rhs)
+    }
+}
+crate::operators::impl_ref_assign_op!(BigInt, RemAssign<u32>::rem_assign);
+
+impl RemAssign<i32> for BigInt {
+    fn rem_assign(&mut self, rhs: i32) {
+        let rhs = BigInt::from_i32(self.env(), rhs);
+        self.rem_assign(rhs)
+    }
+}
+crate::operators::impl_ref_assign_op!(BigInt, RemAssign<i32>::rem_assign);
+
 impl BitAnd for BigInt {
     type Output = BigInt;
     fn bitand(self, rhs: Self) -> Self::Output {
@@ -623,6 +837,48 @@ impl BitAnd<i32> for BigInt {
     }
 }
 crate::operators::impl_ref_op!(BigInt, BitAnd<i32>::bitand);
+
+impl BitAndAssign for BigInt {
+    fn bitand_assign(&mut self, rhs: Self) {
+        let env = self.env();
+        env.check_same_env(rhs.env());
+        let b = env.bigint_and(self.0.to_object(), rhs.0.to_object());
+        *self = Self::try_from_val(env, b).unwrap()
+    }
+}
+crate::operators::impl_ref_assign_op!(BigInt, BitAndAssign<BigInt>::bitand_assign);
+
+impl BitAndAssign<u64> for BigInt {
+    fn bitand_assign(&mut self, rhs: u64) {
+        let rhs = BigInt::from_u64(self.env(), rhs);
+        self.bitand_assign(rhs)
+    }
+}
+crate::operators::impl_ref_assign_op!(BigInt, BitAndAssign<u64>::bitand_assign);
+
+impl BitAndAssign<i64> for BigInt {
+    fn bitand_assign(&mut self, rhs: i64) {
+        let rhs = BigInt::from_i64(self.env(), rhs);
+        self.bitand_assign(rhs)
+    }
+}
+crate::operators::impl_ref_assign_op!(BigInt, BitAndAssign<i64>::bitand_assign);
+
+impl BitAndAssign<u32> for BigInt {
+    fn bitand_assign(&mut self, rhs: u32) {
+        let rhs = BigInt::from_u32(self.env(), rhs);
+        self.bitand_assign(rhs)
+    }
+}
+crate::operators::impl_ref_assign_op!(BigInt, BitAndAssign<u32>::bitand_assign);
+
+impl BitAndAssign<i32> for BigInt {
+    fn bitand_assign(&mut self, rhs: i32) {
+        let rhs = BigInt::from_i32(self.env(), rhs);
+        self.bitand_assign(rhs)
+    }
+}
+crate::operators::impl_ref_assign_op!(BigInt, BitAndAssign<i32>::bitand_assign);
 
 impl BitOr for BigInt {
     type Output = BigInt;
@@ -671,6 +927,48 @@ impl BitOr<i32> for BigInt {
 }
 crate::operators::impl_ref_op!(BigInt, BitOr<i32>::bitor);
 
+impl BitOrAssign for BigInt {
+    fn bitor_assign(&mut self, rhs: Self) {
+        let env = self.env();
+        env.check_same_env(rhs.env());
+        let b = env.bigint_or(self.0.to_object(), rhs.0.to_object());
+        *self = Self::try_from_val(env, b).unwrap()
+    }
+}
+crate::operators::impl_ref_assign_op!(BigInt, BitOrAssign<BigInt>::bitor_assign);
+
+impl BitOrAssign<u64> for BigInt {
+    fn bitor_assign(&mut self, rhs: u64) {
+        let rhs = BigInt::from_u64(self.env(), rhs);
+        self.bitor_assign(rhs)
+    }
+}
+crate::operators::impl_ref_assign_op!(BigInt, BitOrAssign<u64>::bitor_assign);
+
+impl BitOrAssign<i64> for BigInt {
+    fn bitor_assign(&mut self, rhs: i64) {
+        let rhs = BigInt::from_i64(self.env(), rhs);
+        self.bitor_assign(rhs)
+    }
+}
+crate::operators::impl_ref_assign_op!(BigInt, BitOrAssign<i64>::bitor_assign);
+
+impl BitOrAssign<u32> for BigInt {
+    fn bitor_assign(&mut self, rhs: u32) {
+        let rhs = BigInt::from_u32(self.env(), rhs);
+        self.bitor_assign(rhs)
+    }
+}
+crate::operators::impl_ref_assign_op!(BigInt, BitOrAssign<u32>::bitor_assign);
+
+impl BitOrAssign<i32> for BigInt {
+    fn bitor_assign(&mut self, rhs: i32) {
+        let rhs = BigInt::from_i32(self.env(), rhs);
+        self.bitor_assign(rhs)
+    }
+}
+crate::operators::impl_ref_assign_op!(BigInt, BitOrAssign<i32>::bitor_assign);
+
 impl BitXor for BigInt {
     type Output = BigInt;
     fn bitxor(self, rhs: Self) -> Self::Output {
@@ -717,6 +1015,48 @@ impl BitXor<i32> for BigInt {
     }
 }
 crate::operators::impl_ref_op!(BigInt, BitXor<i32>::bitxor);
+
+impl BitXorAssign for BigInt {
+    fn bitxor_assign(&mut self, rhs: Self) {
+        let env = self.env();
+        env.check_same_env(rhs.env());
+        let b = env.bigint_xor(self.0.to_object(), rhs.0.to_object());
+        *self = Self::try_from_val(env, b).unwrap()
+    }
+}
+crate::operators::impl_ref_assign_op!(BigInt, BitXorAssign<BigInt>::bitxor_assign);
+
+impl BitXorAssign<u64> for BigInt {
+    fn bitxor_assign(&mut self, rhs: u64) {
+        let rhs = BigInt::from_u64(self.env(), rhs);
+        self.bitxor_assign(rhs)
+    }
+}
+crate::operators::impl_ref_assign_op!(BigInt, BitXorAssign<u64>::bitxor_assign);
+
+impl BitXorAssign<i64> for BigInt {
+    fn bitxor_assign(&mut self, rhs: i64) {
+        let rhs = BigInt::from_i64(self.env(), rhs);
+        self.bitxor_assign(rhs)
+    }
+}
+crate::operators::impl_ref_assign_op!(BigInt, BitXorAssign<i64>::bitxor_assign);
+
+impl BitXorAssign<u32> for BigInt {
+    fn bitxor_assign(&mut self, rhs: u32) {
+        let rhs = BigInt::from_u32(self.env(), rhs);
+        self.bitxor_assign(rhs)
+    }
+}
+crate::operators::impl_ref_assign_op!(BigInt, BitXorAssign<u32>::bitxor_assign);
+
+impl BitXorAssign<i32> for BigInt {
+    fn bitxor_assign(&mut self, rhs: i32) {
+        let rhs = BigInt::from_i32(self.env(), rhs);
+        self.bitxor_assign(rhs)
+    }
+}
+crate::operators::impl_ref_assign_op!(BigInt, BitXorAssign<i32>::bitxor_assign);
 
 impl Neg for BigInt {
     type Output = BigInt;
@@ -784,6 +1124,48 @@ impl Shl<i32> for BigInt {
 }
 crate::operators::impl_ref_op!(BigInt, Shl<i32>::shl);
 
+impl ShlAssign<BigInt> for BigInt {
+    fn shl_assign(&mut self, rhs: BigInt) {
+        let env = self.env();
+        let b = env.bigint_shl(self.0.to_object(), rhs.0.to_object());
+        *self = Self::try_from_val(env, b).unwrap()
+    }
+}
+crate::operators::impl_ref_assign_op!(BigInt, ShlAssign<BigInt>::shl_assign);
+
+impl ShlAssign<u64> for BigInt {
+    fn shl_assign(&mut self, rhs: u64) {
+        let rhs = BigInt::from_u64(self.env(), rhs);
+        self.shl_assign(rhs)
+    }
+}
+crate::operators::impl_ref_assign_op!(BigInt, ShlAssign<u64>::shl_assign);
+
+impl ShlAssign<i64> for BigInt {
+    fn shl_assign(&mut self, rhs: i64) {
+        let rhs = BigInt::from_i64(self.env(), rhs);
+        self.shl_assign(rhs)
+    }
+}
+crate::operators::impl_ref_assign_op!(BigInt, ShlAssign<i64>::shl_assign);
+
+impl ShlAssign<u32> for BigInt {
+    fn shl_assign(&mut self, rhs: u32) {
+        let rhs = BigInt::from_u32(self.env(), rhs);
+        self.shl_assign(rhs)
+    }
+}
+crate::operators::impl_ref_assign_op!(BigInt, ShlAssign<u32>::shl_assign);
+
+impl ShlAssign<i32> for BigInt {
+    fn shl_assign(&mut self, rhs: i32) {
+        let rhs = BigInt::from_i32(self.env(), rhs);
+        self.shl_assign(rhs)
+    }
+}
+
+crate::operators::impl_ref_assign_op!(BigInt, ShlAssign<i32>::shl_assign);
+
 impl Shr<BigInt> for BigInt {
     type Output = BigInt;
     fn shr(self, rhs: BigInt) -> Self::Output {
@@ -829,6 +1211,47 @@ impl Shr<i32> for BigInt {
     }
 }
 crate::operators::impl_ref_op!(BigInt, Shr<i32>::shr);
+
+impl ShrAssign<BigInt> for BigInt {
+    fn shr_assign(&mut self, rhs: BigInt) {
+        let env = self.env();
+        let b = env.bigint_shl(self.0.to_object(), rhs.0.to_object());
+        *self = Self::try_from_val(env, b).unwrap()
+    }
+}
+crate::operators::impl_ref_assign_op!(BigInt, ShrAssign<BigInt>::shr_assign);
+
+impl ShrAssign<u64> for BigInt {
+    fn shr_assign(&mut self, rhs: u64) {
+        let rhs = BigInt::from_u64(self.env(), rhs);
+        self.shr_assign(rhs)
+    }
+}
+crate::operators::impl_ref_assign_op!(BigInt, ShrAssign<u64>::shr_assign);
+
+impl ShrAssign<i64> for BigInt {
+    fn shr_assign(&mut self, rhs: i64) {
+        let rhs = BigInt::from_i64(self.env(), rhs);
+        self.shr_assign(rhs)
+    }
+}
+crate::operators::impl_ref_assign_op!(BigInt, ShrAssign<i64>::shr_assign);
+
+impl ShrAssign<u32> for BigInt {
+    fn shr_assign(&mut self, rhs: u32) {
+        let rhs = BigInt::from_u32(self.env(), rhs);
+        self.shr_assign(rhs)
+    }
+}
+crate::operators::impl_ref_assign_op!(BigInt, ShrAssign<u32>::shr_assign);
+
+impl ShrAssign<i32> for BigInt {
+    fn shr_assign(&mut self, rhs: i32) {
+        let rhs = BigInt::from_i32(self.env(), rhs);
+        self.shr_assign(rhs)
+    }
+}
+crate::operators::impl_ref_assign_op!(BigInt, ShrAssign<i32>::shr_assign);
 
 impl PartialEq for BigInt {
     fn eq(&self, other: &Self) -> bool {

--- a/soroban-sdk/src/bigint.rs
+++ b/soroban-sdk/src/bigint.rs
@@ -352,7 +352,7 @@ impl Add for BigInt {
         let env = self.env();
         env.check_same_env(rhs.env());
         let b = env.bigint_add(self.0.to_object(), rhs.0.to_object());
-        Self::try_from_val(env, b).unwrap()
+        unsafe { Self::unchecked_new(b.in_env(env)) }
     }
 }
 crate::operators::impl_ref_op!(BigInt, Add<BigInt>::add);
@@ -398,7 +398,7 @@ impl AddAssign for BigInt {
         let env = self.env();
         env.check_same_env(rhs.env());
         let b = env.bigint_add(self.0.to_object(), rhs.0.to_object());
-        *self = Self::try_from_val(env, b).unwrap()
+        *self = unsafe { Self::unchecked_new(b.in_env(env)) }
     }
 }
 crate::operators::impl_ref_assign_op!(BigInt, AddAssign<BigInt>::add_assign);
@@ -441,7 +441,7 @@ impl Sub for BigInt {
         let env = self.env();
         env.check_same_env(rhs.env());
         let b = env.bigint_sub(self.0.to_object(), rhs.0.to_object());
-        Self::try_from_val(env, b).unwrap()
+        unsafe { Self::unchecked_new(b.in_env(env)) }
     }
 }
 crate::operators::impl_ref_op!(BigInt, Sub<BigInt>::sub);
@@ -487,7 +487,7 @@ impl SubAssign for BigInt {
         let env = self.env();
         env.check_same_env(rhs.env());
         let b = env.bigint_sub(self.0.to_object(), rhs.0.to_object());
-        *self = Self::try_from_val(env, b).unwrap()
+        *self = unsafe { Self::unchecked_new(b.in_env(env)) }
     }
 }
 crate::operators::impl_ref_assign_op!(BigInt, SubAssign<BigInt>::sub_assign);
@@ -530,7 +530,7 @@ impl Mul for BigInt {
         let env = self.env();
         env.check_same_env(rhs.env());
         let b = env.bigint_mul(self.0.to_object(), rhs.0.to_object());
-        Self::try_from_val(env, b).unwrap()
+        unsafe { Self::unchecked_new(b.in_env(env)) }
     }
 }
 crate::operators::impl_ref_op!(BigInt, Mul<BigInt>::mul);
@@ -576,7 +576,7 @@ impl MulAssign for BigInt {
         let env = self.env();
         env.check_same_env(rhs.env());
         let b = env.bigint_mul(self.0.to_object(), rhs.0.to_object());
-        *self = Self::try_from_val(env, b).unwrap()
+        *self = unsafe { Self::unchecked_new(b.in_env(env)) }
     }
 }
 crate::operators::impl_ref_assign_op!(BigInt, MulAssign<BigInt>::mul_assign);
@@ -619,7 +619,7 @@ impl Div for BigInt {
         let env = self.env();
         env.check_same_env(rhs.env());
         let b = env.bigint_div(self.0.to_object(), rhs.0.to_object());
-        Self::try_from_val(env, b).unwrap()
+        unsafe { Self::unchecked_new(b.in_env(env)) }
     }
 }
 crate::operators::impl_ref_op!(BigInt, Div<BigInt>::div);
@@ -665,7 +665,7 @@ impl DivAssign for BigInt {
         let env = self.env();
         env.check_same_env(rhs.env());
         let b = env.bigint_div(self.0.to_object(), rhs.0.to_object());
-        *self = Self::try_from_val(env, b).unwrap()
+        *self = unsafe { Self::unchecked_new(b.in_env(env)) }
     }
 }
 crate::operators::impl_ref_assign_op!(BigInt, DivAssign<BigInt>::div_assign);
@@ -708,7 +708,7 @@ impl Rem for BigInt {
         let env = self.env();
         env.check_same_env(rhs.env());
         let b = env.bigint_rem(self.0.to_object(), rhs.0.to_object());
-        Self::try_from_val(env, b).unwrap()
+        unsafe { Self::unchecked_new(b.in_env(env)) }
     }
 }
 crate::operators::impl_ref_op!(BigInt, Rem<BigInt>::rem);
@@ -754,7 +754,7 @@ impl RemAssign for BigInt {
         let env = self.env();
         env.check_same_env(rhs.env());
         let b = env.bigint_rem(self.0.to_object(), rhs.0.to_object());
-        *self = Self::try_from_val(env, b).unwrap()
+        *self = unsafe { Self::unchecked_new(b.in_env(env)) }
     }
 }
 crate::operators::impl_ref_assign_op!(BigInt, RemAssign<BigInt>::rem_assign);
@@ -797,7 +797,7 @@ impl BitAnd for BigInt {
         let env = self.env();
         env.check_same_env(rhs.env());
         let b = env.bigint_and(self.0.to_object(), rhs.0.to_object());
-        Self::try_from_val(env, b).unwrap()
+        unsafe { Self::unchecked_new(b.in_env(env)) }
     }
 }
 crate::operators::impl_ref_op!(BigInt, BitAnd<BigInt>::bitand);
@@ -843,7 +843,7 @@ impl BitAndAssign for BigInt {
         let env = self.env();
         env.check_same_env(rhs.env());
         let b = env.bigint_and(self.0.to_object(), rhs.0.to_object());
-        *self = Self::try_from_val(env, b).unwrap()
+        *self = unsafe { Self::unchecked_new(b.in_env(env)) }
     }
 }
 crate::operators::impl_ref_assign_op!(BigInt, BitAndAssign<BigInt>::bitand_assign);
@@ -886,7 +886,7 @@ impl BitOr for BigInt {
         let env = self.env();
         env.check_same_env(rhs.env());
         let b = env.bigint_or(self.0.to_object(), rhs.0.to_object());
-        Self::try_from_val(env, b).unwrap()
+        unsafe { Self::unchecked_new(b.in_env(env)) }
     }
 }
 crate::operators::impl_ref_op!(BigInt, BitOr<BigInt>::bitor);
@@ -932,7 +932,7 @@ impl BitOrAssign for BigInt {
         let env = self.env();
         env.check_same_env(rhs.env());
         let b = env.bigint_or(self.0.to_object(), rhs.0.to_object());
-        *self = Self::try_from_val(env, b).unwrap()
+        *self = unsafe { Self::unchecked_new(b.in_env(env)) }
     }
 }
 crate::operators::impl_ref_assign_op!(BigInt, BitOrAssign<BigInt>::bitor_assign);
@@ -975,7 +975,7 @@ impl BitXor for BigInt {
         let env = self.env();
         env.check_same_env(rhs.env());
         let b = env.bigint_xor(self.0.to_object(), rhs.0.to_object());
-        Self::try_from_val(env, b).unwrap()
+        unsafe { Self::unchecked_new(b.in_env(env)) }
     }
 }
 crate::operators::impl_ref_op!(BigInt, BitXor<BigInt>::bitxor);
@@ -1021,7 +1021,7 @@ impl BitXorAssign for BigInt {
         let env = self.env();
         env.check_same_env(rhs.env());
         let b = env.bigint_xor(self.0.to_object(), rhs.0.to_object());
-        *self = Self::try_from_val(env, b).unwrap()
+        *self = unsafe { Self::unchecked_new(b.in_env(env)) }
     }
 }
 crate::operators::impl_ref_assign_op!(BigInt, BitXorAssign<BigInt>::bitxor_assign);
@@ -1063,7 +1063,7 @@ impl Neg for BigInt {
     fn neg(self) -> Self::Output {
         let env = self.env();
         let b = env.bigint_neg(self.0.to_object());
-        Self::try_from_val(env, b).unwrap()
+        unsafe { Self::unchecked_new(b.in_env(env)) }
     }
 }
 crate::operators::impl_ref_op!(BigInt, Neg::neg);
@@ -1073,7 +1073,7 @@ impl Not for BigInt {
     fn not(self) -> Self::Output {
         let env = self.env();
         let b = env.bigint_not(self.0.to_object());
-        Self::try_from_val(env, b).unwrap()
+        unsafe { Self::unchecked_new(b.in_env(env)) }
     }
 }
 crate::operators::impl_ref_op!(BigInt, Not::not);
@@ -1083,7 +1083,7 @@ impl Shl<BigInt> for BigInt {
     fn shl(self, rhs: BigInt) -> Self::Output {
         let env = self.env();
         let b = env.bigint_shl(self.0.to_object(), rhs.0.to_object());
-        Self::try_from_val(env, b).unwrap()
+        unsafe { Self::unchecked_new(b.in_env(env)) }
     }
 }
 crate::operators::impl_ref_op!(BigInt, Shl<BigInt>::shl);
@@ -1128,7 +1128,7 @@ impl ShlAssign<BigInt> for BigInt {
     fn shl_assign(&mut self, rhs: BigInt) {
         let env = self.env();
         let b = env.bigint_shl(self.0.to_object(), rhs.0.to_object());
-        *self = Self::try_from_val(env, b).unwrap()
+        *self = unsafe { Self::unchecked_new(b.in_env(env)) }
     }
 }
 crate::operators::impl_ref_assign_op!(BigInt, ShlAssign<BigInt>::shl_assign);
@@ -1171,7 +1171,7 @@ impl Shr<BigInt> for BigInt {
     fn shr(self, rhs: BigInt) -> Self::Output {
         let env = self.env();
         let b = env.bigint_shl(self.0.to_object(), rhs.0.to_object());
-        Self::try_from_val(env, b).unwrap()
+        unsafe { Self::unchecked_new(b.in_env(env)) }
     }
 }
 crate::operators::impl_ref_op!(BigInt, Shr<BigInt>::shr);
@@ -1216,7 +1216,7 @@ impl ShrAssign<BigInt> for BigInt {
     fn shr_assign(&mut self, rhs: BigInt) {
         let env = self.env();
         let b = env.bigint_shl(self.0.to_object(), rhs.0.to_object());
-        *self = Self::try_from_val(env, b).unwrap()
+        *self = unsafe { Self::unchecked_new(b.in_env(env)) }
     }
 }
 crate::operators::impl_ref_assign_op!(BigInt, ShrAssign<BigInt>::shr_assign);
@@ -1479,21 +1479,21 @@ impl BigInt {
     pub fn gcd(&self, other: BigInt) -> BigInt {
         let env = self.env();
         let b = env.bigint_gcd(self.0.to_object(), other.0.to_object());
-        Self::try_from_val(env, b).unwrap()
+        unsafe { Self::unchecked_new(b.in_env(env)) }
     }
 
     /// Returns the lowest common multiple of the [BigInt] and other.
     pub fn lcm(&self, other: BigInt) -> BigInt {
         let env = self.env();
         let b = env.bigint_lcm(self.0.to_object(), other.0.to_object());
-        Self::try_from_val(env, b).unwrap()
+        unsafe { Self::unchecked_new(b.in_env(env)) }
     }
 
     /// Returns the [BigInt] raised to the power specified.
     pub fn pow(&self, power: BigInt) -> BigInt {
         let env = self.env();
         let b = env.bigint_pow(self.0.to_object(), power.0.to_object());
-        Self::try_from_val(env, b).unwrap()
+        unsafe { Self::unchecked_new(b.in_env(env)) }
     }
 
     /// Returns `p.pow(q) mod m`.
@@ -1504,14 +1504,14 @@ impl BigInt {
     pub fn pow_mod(&self, q: BigInt, m: BigInt) -> BigInt {
         let env = self.env();
         let b = env.bigint_pow_mod(self.0.to_object(), q.0.to_object(), m.0.to_object());
-        Self::try_from_val(env, b).unwrap()
+        unsafe { Self::unchecked_new(b.in_env(env)) }
     }
 
     /// Returns the square root of the [BigInt].
     pub fn sqrt(&self) -> BigInt {
         let env = self.env();
         let b = env.bigint_sqrt(self.0.to_object());
-        Self::try_from_val(env, b).unwrap()
+        unsafe { Self::unchecked_new(b.in_env(env)) }
     }
 
     /// Returns true if the [BigInt] is zero.

--- a/soroban-sdk/src/operators.rs
+++ b/soroban-sdk/src/operators.rs
@@ -4,9 +4,15 @@
 ///  - ref-op-ref
 ///  - val-op-ref
 ///  - ref-op-val
+///  - ref-op-mut ref
+///  - val-op-mut ref
+///  - mut ref-op-ref
+///  - mut ref-op-val
+///  - mut ref-op-mut ref
 ///
 /// For operators without a RHS, implements:
 ///  - ref-op
+///  - mut ref-op
 ///
 /// Only operators with an Output are supported.
 ///
@@ -39,10 +45,58 @@ macro_rules! impl_ref_op {
                 self.$op_fn(rhs.clone())
             }
         }
+
+        impl<'a> $op<&'a $rhs> for &'a mut $ty {
+            type Output = $ty;
+            #[inline(always)]
+            fn $op_fn(self, rhs: &'a $rhs) -> Self::Output {
+                self.clone().$op_fn(rhs.clone())
+            }
+        }
+
+        impl<'a> $op<$rhs> for &'a mut $ty {
+            type Output = $ty;
+            #[inline(always)]
+            fn $op_fn(self, rhs: $rhs) -> Self::Output {
+                self.clone().$op_fn(rhs)
+            }
+        }
+
+        impl<'a> $op<&'a mut $rhs> for &'a $ty {
+            type Output = $ty;
+            #[inline(always)]
+            fn $op_fn(self, rhs: &'a mut $rhs) -> Self::Output {
+                self.clone().$op_fn(rhs.clone())
+            }
+        }
+
+        impl<'a> $op<&'a mut $rhs> for $ty {
+            type Output = $ty;
+            #[inline(always)]
+            fn $op_fn(self, rhs: &'a mut $rhs) -> Self::Output {
+                self.$op_fn(rhs.clone())
+            }
+        }
+
+        impl<'a> $op<&'a mut $rhs> for &'a mut $ty {
+            type Output = $ty;
+            #[inline(always)]
+            fn $op_fn(self, rhs: &'a mut $rhs) -> Self::Output {
+                self.clone().$op_fn(rhs.clone())
+            }
+        }
     };
     // Operators without a RHS.
     ($ty:ident, $op:ident :: $op_fn:ident) => {
         impl<'a> $op for &'a $ty {
+            type Output = $ty;
+            #[inline(always)]
+            fn $op_fn(self) -> Self::Output {
+                self.clone().$op_fn()
+            }
+        }
+
+        impl<'a> $op for &'a mut $ty {
             type Output = $ty;
             #[inline(always)]
             fn $op_fn(self) -> Self::Output {
@@ -57,9 +111,11 @@ pub(crate) use impl_ref_op;
 /// Implement an assign operator for a type for all the ref variations.
 ///
 /// Implements:
-///  - ref-op-ref
-///  - val-op-ref
+///  - ref-op-mut ref
+///  - val-op-mut ref
 ///  - ref-op-val
+///  - mut ref-op-mut ref
+///  - mut ref-op-val
 ///
 /// Only operators with a RHS, &mut self and no Output are supported.
 ///
@@ -85,6 +141,13 @@ macro_rules! impl_ref_assign_op {
         impl<'a> $op<&'a $rhs> for $ty {
             #[inline(always)]
             fn $op_fn(&mut self, rhs: &'a $rhs) {
+                (*self).$op_fn(rhs.clone());
+            }
+        }
+
+        impl<'a> $op<&'a mut $rhs> for $ty {
+            #[inline(always)]
+            fn $op_fn(&mut self, rhs: &'a mut $rhs) {
                 (*self).$op_fn(rhs.clone());
             }
         }

--- a/soroban-sdk/src/operators.rs
+++ b/soroban-sdk/src/operators.rs
@@ -53,3 +53,42 @@ macro_rules! impl_ref_op {
 }
 
 pub(crate) use impl_ref_op;
+
+/// Implement an assign operator for a type for all the ref variations.
+///
+/// Implements:
+///  - ref-op-ref
+///  - val-op-ref
+///  - ref-op-val
+///
+/// Only operators with a RHS, &mut self and no Output are supported.
+///
+/// Assumes that a val-op-val variaton already exists and calls it.
+///
+/// See [crate::BigInt] for example usage.
+macro_rules! impl_ref_assign_op {
+    ($ty:ident, $op:ident<$rhs:ident> :: $op_fn:ident) => {
+        impl<'a> $op<&'a $rhs> for &'a mut $ty {
+            #[inline(always)]
+            fn $op_fn(&mut self, rhs: &'a $rhs) {
+                (*self).$op_fn(rhs.clone());
+            }
+        }
+
+        impl<'a> $op<$rhs> for &'a mut $ty {
+            #[inline(always)]
+            fn $op_fn(&mut self, rhs: $rhs) {
+                (*self).$op_fn(rhs);
+            }
+        }
+
+        impl<'a> $op<&'a $rhs> for $ty {
+            #[inline(always)]
+            fn $op_fn(&mut self, rhs: &'a $rhs) {
+                (*self).$op_fn(rhs.clone());
+            }
+        }
+    };
+}
+
+pub(crate) use impl_ref_assign_op;


### PR DESCRIPTION
### What
Add BigInt mutable ref operators.

### Why
Without implementing all the mut ref combinations there are situations where the compiler cannot infer the appropriate implementation to map a &mut to. Adding these ref operators makes it so that the compiler doesn't have to guess.