### PR TITLE
Reexport the byteslit::bytes proc-macro for use in bigint!

### DIFF
--- a/soroban-sdk/src/bigint.rs
+++ b/soroban-sdk/src/bigint.rs
@@ -62,10 +62,10 @@ macro_rules! bigint {
         $crate::BigInt::from_slice($env, &[$($x),+])
     };
     ($env:expr, $x:tt $(,)?) => {
-        $crate::BigInt::from_slice($env, &::bytes_lit::bytes!($x))
+        $crate::BigInt::from_slice($env, &$crate::__bytes_lit_bytes!($x))
     };
     ($env:expr, -$x:tt $(,)?) => {
-        $crate::BigInt::from_sign_and_slice($env, &$crate::Sign::Minus, &::bytes_lit::bytes!($x))
+        $crate::BigInt::from_sign_and_slice($env, &$crate::Sign::Minus, &$crate::__bytes_lit_bytes!($x))
     };
 }
 

--- a/soroban-sdk/src/lib.rs
+++ b/soroban-sdk/src/lib.rs
@@ -74,6 +74,9 @@ fn __link_sections() {
     static __ENV_META_XDR: [u8; env::meta::XDR.len()] = env::meta::XDR;
 }
 
+#[doc(hidden)]
+pub use bytes_lit::bytes as __bytes_lit_bytes;
+
 pub use soroban_sdk_macros::{
     contractclient, contractfile, contractimpl, contractimport, contracttype,
 };


### PR DESCRIPTION
### What
Reexport the byteslit::bytes proc-macro.

### Why
The bigint! macro_rules macro uses the byteslit::bytes proc-macro. Contracts have to manually include the proc-macro to be able to use bigint!. This was an oversight, and creates a poor developer experience as the error is not particularly informative.