### PR TITLE
Heap of small fixes

### DIFF
--- a/soroban-auth/src/lib.rs
+++ b/soroban-auth/src/lib.rs
@@ -65,11 +65,7 @@ fn check_ed25519_auth(env: &Env, auth: &Ed25519Signature, function: Symbol, args
     };
     let msg_bin = SignaturePayload::V0(msg).serialize(env);
 
-    env.verify_sig_ed25519(
-        auth.public_key.clone().into(),
-        msg_bin,
-        auth.signature.clone().into(),
-    );
+    env.verify_sig_ed25519(auth.public_key.clone(), msg_bin, auth.signature.clone());
 }
 
 fn check_account_auth(env: &Env, auth: &AccountSignatures, function: Symbol, args: Vec<RawVal>) {
@@ -99,11 +95,7 @@ fn check_account_auth(env: &Env, auth: &AccountSignatures, function: Symbol, arg
             }
         }
 
-        env.verify_sig_ed25519(
-            sig.public_key.clone().into(),
-            msg_bytes.clone(),
-            sig.signature.into(),
-        );
+        env.verify_sig_ed25519(sig.public_key.clone(), msg_bytes.clone(), sig.signature);
 
         weight = weight
             .checked_add(acc.signer_weight(&sig.public_key))
@@ -136,7 +128,7 @@ where
             if nonce != stored_nonce {
                 panic!("incorrect nonce")
             }
-            check_ed25519_auth(env, &kea, function, args)
+            check_ed25519_auth(env, kea, function, args)
         }
         Signature::Account(kaa) => {
             let stored_nonce =
@@ -144,7 +136,7 @@ where
             if nonce != stored_nonce {
                 panic!("incorrect nonce")
             }
-            check_account_auth(env, &kaa, function, args)
+            check_account_auth(env, kaa, function, args)
         }
     }
 }

--- a/soroban-auth/src/public_types.rs
+++ b/soroban-auth/src/public_types.rs
@@ -32,7 +32,7 @@ impl Signature {
     }
 }
 
-#[derive(Clone, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 #[contracttype(lib = "soroban_auth")]
 pub enum Identifier {
     Contract(BytesN<32>),

--- a/soroban-sdk-macros/src/derive_client.rs
+++ b/soroban-sdk-macros/src/derive_client.rs
@@ -140,7 +140,7 @@ pub fn derive_client(name: &str, fns: &[ClientFn]) -> TokenStream {
     // If errors have occurred, render them instead.
     if !errors.is_empty() {
         let compile_errors = errors.iter().map(Error::to_compile_error);
-        return quote! { #(#compile_errors)* }.into();
+        return quote! { #(#compile_errors)* };
     }
 
     // Render the Client.

--- a/soroban-sdk-macros/src/derive_fn.rs
+++ b/soroban-sdk-macros/src/derive_fn.rs
@@ -13,15 +13,15 @@ use syn::{
 
 use crate::map_type::map_type;
 
-#[allow(clippy::too_many_lines)]
+#[allow(clippy::too_many_arguments)]
 pub fn derive_fn(
     call: &TokenStream2,
-    ty: &Box<Type>,
+    ty: &Type,
     ident: &Ident,
     inputs: &Punctuated<FnArg, Comma>,
     output: &ReturnType,
     export: bool,
-    trait_ident: &Option<&Ident>,
+    trait_ident: Option<&Ident>,
     client_ident: &str,
 ) -> Result<TokenStream2, TokenStream2> {
     // Collect errors as they are encountered and emit them at the end.
@@ -281,7 +281,7 @@ pub fn derive_fn(
 
 #[allow(clippy::too_many_lines)]
 pub fn derive_contract_function_set<'a>(
-    ty: &Box<Type>,
+    ty: &Type,
     methods: impl Iterator<Item = &'a syn::ImplItemMethod>,
 ) -> TokenStream2 {
     let (idents, wrap_idents): (Vec<_>, Vec<_>) = methods

--- a/soroban-sdk-macros/src/derive_type.rs
+++ b/soroban-sdk-macros/src/derive_type.rs
@@ -313,7 +313,7 @@ pub fn derive_type_enum(
             // TODO: Handle field names longer than a symbol. Hash the name? Truncate the name?
             let ident = &v.ident;
             let name = &ident.to_string();
-            if let Err(e) = Symbol::try_from_str(&name) {
+            if let Err(e) = Symbol::try_from_str(name) {
                 errors.push(Error::new(ident.span(), format!("enum variant name {}", e)));
             }
             if v.fields.len() > 1 {

--- a/soroban-sdk-macros/src/lib.rs
+++ b/soroban-sdk-macros/src/lib.rs
@@ -59,7 +59,7 @@ pub fn contractimpl(metadata: TokenStream, input: TokenStream) -> TokenStream {
     } else {
         None
     }
-    .unwrap_or_else(|| format!("Client"));
+    .unwrap_or_else(|| "Client".to_string());
 
     let pub_methods: Vec<_> = syn_ext::impl_pub_methods(&imp).collect();
     let derived: Result<proc_macro2::TokenStream, proc_macro2::TokenStream> = pub_methods
@@ -75,7 +75,7 @@ pub fn contractimpl(metadata: TokenStream, input: TokenStream) -> TokenStream {
                 &m.sig.inputs,
                 &m.sig.output,
                 args.export,
-                &trait_ident,
+                trait_ident,
                 &client_ident,
             )
         })

--- a/soroban-sdk-macros/src/map_type.rs
+++ b/soroban-sdk-macros/src/map_type.rs
@@ -102,7 +102,7 @@ pub fn map_type(t: &Type) -> Result<ScSpecTypeDef, Error> {
                                 "incorrect number of generic arguments, expect one for BytesN<N>",
                             ))?,
                         };
-                            Ok(ScSpecTypeDef::BytesN(ScSpecTypeBytesN { n: n }))
+                            Ok(ScSpecTypeDef::BytesN(ScSpecTypeBytesN { n }))
                         }
                         _ => Err(Error::new(
                             angle_bracketed.span(),

--- a/soroban-sdk/src/account.rs
+++ b/soroban-sdk/src/account.rs
@@ -15,7 +15,7 @@ use crate::{
 #[derive(Clone)]
 pub struct Account(BytesN<32>);
 
-#[derive(Debug, Clone, PartialEq, PartialOrd)]
+#[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd)]
 pub enum AccountError {
     DoesNotExist,
 }

--- a/soroban-sdk/src/bigint.rs
+++ b/soroban-sdk/src/bigint.rs
@@ -105,7 +105,7 @@ pub enum Sign {
 }
 
 impl Sign {
-    pub(crate) const fn to_raw(&self) -> RawVal {
+    pub(crate) const fn to_raw(self) -> RawVal {
         match self {
             Sign::Minus => RawVal::I32_NEGATIVE_ONE,
             Sign::NoSign => RawVal::I32_ZERO,
@@ -128,7 +128,7 @@ impl Display for BigInt {
         let env = self.env();
         let bi = self.0.to_object();
         let obj: Object = env.bigint_to_radix_be(bi, 10u32.into());
-        if let Ok(bin) = TryIntoVal::<_, Bytes>::try_into_val(obj, &env) {
+        if let Ok(bin) = TryIntoVal::<_, Bytes>::try_into_val(obj, env) {
             if self.sign() == Sign::Minus {
                 write!(f, "-")?;
             }

--- a/soroban-sdk/src/bytes.rs
+++ b/soroban-sdk/src/bytes.rs
@@ -523,7 +523,7 @@ impl Bytes {
     pub fn extend_from_slice(&mut self, slice: &[u8]) {
         let env = self.env();
         self.0 = env
-            .bytes_copy_from_slice(self.to_object(), self.len().into(), &slice)
+            .bytes_copy_from_slice(self.to_object(), self.len().into(), slice)
             .in_env(env);
     }
 
@@ -593,7 +593,7 @@ impl Iterator for BinIter {
     type Item = u8;
 
     fn next(&mut self) -> Option<Self::Item> {
-        if self.0.len() == 0 {
+        if self.0.is_empty() {
             None
         } else {
             let val = self.0.env().bytes_front(self.0 .0.to_object());

--- a/soroban-sdk/src/env.rs
+++ b/soroban-sdk/src/env.rs
@@ -96,10 +96,10 @@ impl Env {
         &self,
         contract_id: &BytesN<32>,
         func: &Symbol,
-        args: crate::vec::Vec<EnvVal>,
+        args: Vec<EnvVal>,
     ) -> T {
         let rv = internal::Env::call(self, contract_id.to_object(), *func, args.to_object());
-        T::try_from_val(&self, rv).map_err(|_| ()).unwrap()
+        T::try_from_val(self, rv).map_err(|_| ()).unwrap()
     }
 
     /// Get a [ContractData] for accessing and update contract data that has


### PR DESCRIPTION
### What
Heap of small fixes that have no functional impact.

### Why
Clippy warns about all these things. Mostly unnecessary `.into()`s, and unnecesary `&`s.