### PR TITLE
Plumb through support for fallible contract invocations

### DIFF
--- a/soroban-sdk/src/env.rs
+++ b/soroban-sdk/src/env.rs
@@ -111,7 +111,7 @@ impl Env {
         let rv = internal::Env::try_call(self, contract_id.to_object(), *func, args.to_object());
         match Status::try_from_val(self, rv) {
             Ok(status) => Err(status),
-            Err(_) => Ok(T::try_from_val(self, rv)),
+            Err(ConversionError) => Ok(T::try_from_val(self, rv)),
         }
     }
 

--- a/soroban-sdk/tests/contract_invoke.rs
+++ b/soroban-sdk/tests/contract_invoke.rs
@@ -1,0 +1,42 @@
+#![cfg(feature = "testutils")]
+
+use soroban_sdk::{contractimpl, xdr::ScStatusType, BytesN, Env, Status};
+use stellar_xdr::ScVmErrorCode;
+
+pub struct Contract;
+
+#[contractimpl]
+impl Contract {
+    pub fn panic() -> i32 {
+        panic!("I panicked")
+    }
+}
+
+#[test]
+#[should_panic(expected = "I panicked")]
+fn test_invoke() {
+    let e = Env::default();
+    let contract_id = BytesN::from_array(&e, &[0; 32]);
+    e.register_contract(&contract_id, Contract);
+
+    ContractClient::new(&e, &contract_id).panic();
+}
+
+#[test]
+// TODO: Remove the should_panic when this issue is fixed:
+// https://github.com/stellar/rs-soroban-env/issues/430.
+#[should_panic(expected = "I panicked")]
+fn test_try_invoke() {
+    let e = Env::default();
+    let contract_id = BytesN::from_array(&e, &[0; 32]);
+    e.register_contract(&contract_id, Contract);
+
+    let res = ContractClient::new(&e, &contract_id).try_panic();
+    assert_eq!(
+        res,
+        Err(Status::from_type_and_code(
+            ScStatusType::VmError,
+            ScVmErrorCode::Function as u32,
+        ))
+    );
+}


### PR DESCRIPTION
### What
Plumb through support for fallible contract invocations.

### Why
It should be possible to invoke contracts that can fail, without having the caller also fail. This is possible in the environment, but not plumbed through the SDK yet.

### Todo

- [ ] Add tests.