### PR TITLE
Add BigInt other ref for ParitalEq, PartialOrd

### DIFF
--- a/soroban-sdk/src/bigint.rs
+++ b/soroban-sdk/src/bigint.rs
@@ -1669,6 +1669,8 @@ mod test {
 
         assert_eq!(&mut bigint!(&env, 1) + &1, bigint!(&env, 2));
         assert_eq!(&bigint!(&env, 1) + &mut 1, bigint!(&env, 2));
+
+        assert_eq!(bigint!(&env, 1) + 1, &bigint!(&env, 2));
     }
 
     #[test]
@@ -1692,5 +1694,9 @@ mod test {
         let mut b = bigint!(&env, 1);
         b += &mut 1;
         assert_eq!(b, bigint!(&env, 2));
+
+        let mut b = bigint!(&env, 1);
+        b += &mut 1;
+        assert_eq!(b, &bigint!(&env, 2));
     }
 }

--- a/soroban-sdk/src/operators.rs
+++ b/soroban-sdk/src/operators.rs
@@ -28,6 +28,12 @@ macro_rules! impl_ref_op {
                 (*self).clone().eq(other)
             }
         }
+        impl<'a> PartialEq<&$rhs> for $ty {
+            #[inline(always)]
+            fn eq(&self, other: &&$rhs) -> bool {
+                (*self).clone().eq(*other)
+            }
+        }
     };
     // Special case: PartialOrd.
     ($ty:ident, PartialOrd<$rhs:ident> :: eq) => {
@@ -35,6 +41,12 @@ macro_rules! impl_ref_op {
             #[inline(always)]
             fn partial_cmp(&self, other: &$rhs) -> Option<Ordering> {
                 (*self).clone().partial_cmp(other)
+            }
+        }
+        impl<'a> PartialOrd<&$rhs> for &'a mut $ty {
+            #[inline(always)]
+            fn partial_cmp(&self, other: &&$rhs) -> Option<Ordering> {
+                (*self).clone().partial_cmp(*other)
             }
         }
     };


### PR DESCRIPTION
### What
Add BigInt other ref for ParitalEq, PartialOrd.

### Why
So that it is possible to equality check against &BigInt where the ref is on the right-hand-side.