### PR TITLE
Remove the old fn::invoke[_xdr] fns

### DIFF
--- a/soroban-sdk/src/contract_data.rs
+++ b/soroban-sdk/src/contract_data.rs
@@ -37,7 +37,7 @@ use crate::{
 /// #     let env = Env::default();
 /// #     let contract_id = BytesN::from_array(&env, &[0; 32]);
 /// #     env.register_contract(&contract_id, Contract);
-/// #     f::invoke(&env, &contract_id);
+/// #     ContractClient::new(&env, &contract_id).f();
 /// # }
 /// # #[cfg(not(feature = "testutils"))]
 /// # fn main() { }

--- a/soroban-sdk/src/deploy.rs
+++ b/soroban-sdk/src/deploy.rs
@@ -35,7 +35,7 @@
 //! #     let env = Env::default();
 //! #     let contract_id = BytesN::from_array(&env, &[0; 32]);
 //! #     env.register_contract(&contract_id, Contract);
-//! #     f::invoke(&env, &contract_id);
+//! #     ContractClient::new(&env, &contract_id).f();
 //! # }
 //! # #[cfg(not(feature = "testutils"))]
 //! # fn main() { }

--- a/soroban-sdk/src/events.rs
+++ b/soroban-sdk/src/events.rs
@@ -39,7 +39,7 @@ const TOPIC_BYTES_LENGTH_LIMIT: u32 = 32;
 /// #     let env = Env::default();
 /// #     let contract_id = BytesN::from_array(&env, &[0; 32]);
 /// #     env.register_contract(&contract_id, Contract);
-/// #     f::invoke(&env, &contract_id);
+/// #     ContractClient::new(&env, &contract_id).f();
 /// # }
 /// # #[cfg(not(feature = "testutils"))]
 /// # fn main() { }

--- a/soroban-sdk/src/ledger.rs
+++ b/soroban-sdk/src/ledger.rs
@@ -31,7 +31,7 @@ use crate::{
 /// #     let env = Env::default();
 /// #     let contract_id = BytesN::from_array(&env, &[0; 32]);
 /// #     env.register_contract(&contract_id, Contract);
-/// #     f::invoke(&env, &contract_id);
+/// #     ContractClient::new(&env, &contract_id).f();
 /// # }
 /// # #[cfg(not(feature = "testutils"))]
 /// # fn main() { }


### PR DESCRIPTION
### What
Remove the old `<fn>::invoke[_xdr]` functions that were generated for contract functions.

### Why
The functions are no longer in use. They were marked as deprecated in the last release and when we make the next release we should have them removed. We don't need to keep deprecated notices around for more than a single release at this point.

These functions were superseded in v0.0.4 by the generated contract client.