### PR TITLE
Remove the generated client _xdr fn and supporting infra

### DIFF
--- a/soroban-sdk-macros/src/derive_client.rs
+++ b/soroban-sdk-macros/src/derive_client.rs
@@ -82,7 +82,6 @@ pub fn derive_client(name: &str, fns: &[ClientFn]) -> TokenStream {
         .map(|f| {
             let fn_ident = &f.ident;
             let fn_try_ident = format_ident!("try_{}", &f.ident);
-            let fn_ident_xdr = format_ident!("{}_xdr", &f.ident);
             let fn_name = fn_ident.to_string();
 
             // Check for the Env argument.
@@ -140,18 +139,6 @@ pub fn derive_client(name: &str, fns: &[ClientFn]) -> TokenStream {
                         &::soroban_sdk::symbol!(#fn_name),
                         ::soroban_sdk::vec![&self.env, #(#fn_input_names.into_env_val(&self.env)),*],
                     )
-                }
-
-                #[cfg(feature = "testutils")]
-                #[cfg_attr(feature = "docs", doc(cfg(feature = "testutils")))]
-                pub fn #fn_ident_xdr(&self, #(#fn_input_types),*) #fn_output {
-                    use ::soroban_sdk::TryIntoVal;
-                    self.env.invoke_contract_external_raw(
-                        ::soroban_sdk::xdr::HostFunction::Call,
-                        (&self.contract_id, #fn_name, #(#fn_input_names),*).try_into().unwrap()
-                    )
-                    .try_into_val(&self.env)
-                    .unwrap()
                 }
             }
         })

--- a/soroban-sdk/src/env.rs
+++ b/soroban-sdk/src/env.rs
@@ -395,16 +395,6 @@ impl Env {
             .unwrap();
     }
 
-    #[doc(hidden)]
-    pub fn invoke_contract_external_raw(&self, hf: xdr::HostFunction, args: xdr::ScVec) -> RawVal {
-        self.env_impl.invoke_function_raw(hf, args).unwrap()
-    }
-
-    #[doc(hidden)]
-    pub fn invoke_contract_external(&self, hf: xdr::HostFunction, args: xdr::ScVec) -> xdr::ScVal {
-        self.env_impl.invoke_function(hf, args).unwrap()
-    }
-
     #[cfg(not(target_family = "wasm"))]
     fn clone_self_and_catch_panic<F, T>(&self, f: F) -> (Env, std::thread::Result<T>)
     where


### PR DESCRIPTION
### What
Remove the generated client `_xdr` functions and the supporting `Env::invoke_contract[_raw]` functions

### Why
The generated `_xdr` functions were added to make it possible for someone to invoke contracts using XDR types, but it looks like for some reason we made it accept `RawVal`s, not `ScVal`s. Internally it converts those `RawVal`s into `ScVal`s. In the end it is just a lot of conversions, and we don't seem to be using it anywhere.

I think there's value in us offering an `_xdr` version of the contract client functions that allows invoking the contract with the actual `ScVal` XDR types, but given that we aren't using this today, and given that we'd need to add a not-insignificant amount of code to fix it, I think we should drop this logic which will reduce the code we have to maintain.

We can bring this back if we need it.

cc @jonjove