### PR TITLE
Replace EnvVal with RawVal in places that do not need it

### DIFF
--- a/soroban-sdk-macros/src/derive_client.rs
+++ b/soroban-sdk-macros/src/derive_client.rs
@@ -128,7 +128,7 @@ pub fn derive_client(name: &str, fns: &[ClientFn]) -> TokenStream {
                     self.env.invoke_contract(
                         &self.contract_id,
                         &::soroban_sdk::symbol!(#fn_name),
-                        ::soroban_sdk::vec![&self.env, #(#fn_input_names.into_env_val(&self.env)),*],
+                        ::soroban_sdk::vec![&self.env, #(#fn_input_names.into_val(&self.env)),*],
                     )
                 }
 
@@ -137,7 +137,7 @@ pub fn derive_client(name: &str, fns: &[ClientFn]) -> TokenStream {
                     self.env.try_invoke_contract(
                         &self.contract_id,
                         &::soroban_sdk::symbol!(#fn_name),
-                        ::soroban_sdk::vec![&self.env, #(#fn_input_names.into_env_val(&self.env)),*],
+                        ::soroban_sdk::vec![&self.env, #(#fn_input_names.into_val(&self.env)),*],
                     )
                 }
             }

--- a/soroban-sdk/src/env.rs
+++ b/soroban-sdk/src/env.rs
@@ -94,7 +94,7 @@ impl Env {
         &self,
         contract_id: &BytesN<32>,
         func: &Symbol,
-        args: Vec<EnvVal>,
+        args: Vec<RawVal>,
     ) -> T {
         let rv = internal::Env::call(self, contract_id.to_object(), *func, args.to_object());
         T::try_from_val(self, rv).map_err(|_| ()).unwrap()
@@ -106,7 +106,7 @@ impl Env {
         &self,
         contract_id: &BytesN<32>,
         func: &Symbol,
-        args: Vec<EnvVal>,
+        args: Vec<RawVal>,
     ) -> Result<Result<T, T::Error>, Status> {
         let rv = internal::Env::try_call(self, contract_id.to_object(), *func, args.to_object());
         match Status::try_from_val(self, rv) {

--- a/tests/invoke_contract/src/lib.rs
+++ b/tests/invoke_contract/src/lib.rs
@@ -10,7 +10,7 @@ impl Contract {
         env.invoke_contract(
             &contract_id,
             &symbol!("add"),
-            vec![&env, x.into_env_val(&env), y.into_env_val(&env)],
+            vec![&env, x.into_val(&env), y.into_val(&env)],
         )
     }
 }


### PR DESCRIPTION
### What
Replace EnvVal with RawVal in places that do not need it.

### Why
Most things in the SDK do not need an EnvVal. Having both an EnvVal and RawVal in the public interface of the SDK means two things for everyone to learn. We use RawVal most of the time, and EnvVal seems unnecessary in the public interface. EnvVal is used internally for managing objects attached to an Env.

Close https://github.com/stellar/rs-soroban-sdk/issues/311