### PR TITLE
Use parent call stack to SignaturePayload

### DIFF
--- a/soroban-auth/src/lib.rs
+++ b/soroban-auth/src/lib.rs
@@ -11,6 +11,7 @@ pub use crate::public_types::{
 fn check_ed25519_auth(env: &Env, auth: &Ed25519Signature, function: Symbol, args: Vec<RawVal>) {
     let msg = SignaturePayloadV0 {
         function,
+        call_cntxt: env.get_parent_call_stack(),
         contract: env.get_current_contract(),
         network: env.ledger().network_passphrase(),
         args,
@@ -25,6 +26,7 @@ fn check_account_auth(env: &Env, auth: &AccountSignatures, function: Symbol, arg
 
     let msg = SignaturePayloadV0 {
         function,
+        call_cntxt: env.get_parent_call_stack(),
         contract: env.get_current_contract(),
         network: env.ledger().network_passphrase(),
         args,

--- a/soroban-auth/src/public_types.rs
+++ b/soroban-auth/src/public_types.rs
@@ -45,6 +45,7 @@ pub enum Identifier {
 pub struct SignaturePayloadV0 {
     pub function: Symbol,
     pub contract: BytesN<32>,
+    pub call_cntxt: Vec<(BytesN<32>, Symbol)>,
     pub network: Bytes,
     pub args: Vec<RawVal>,
 }

--- a/soroban-sdk/src/env.rs
+++ b/soroban-sdk/src/env.rs
@@ -259,6 +259,16 @@ impl Env {
         stack.try_into_val(self).unwrap()
     }
 
+    //TODO: Docs
+    // Returns call stack like get_current_call_stack, but removes the
+    // most recent frame
+    pub fn get_parent_call_stack(&self) -> Vec<(BytesN<32>, Symbol)> {
+        let stack = internal::Env::get_current_call_stack(self);
+        let mut res: Vec<(BytesN<32>, Symbol)> = stack.try_into_val(self).unwrap();
+        res.pop_back();
+        res
+    }
+
     #[doc(hidden)]
     pub fn log_value<V: IntoVal<Env, RawVal>>(&self, v: V) {
         internal::Env::log_value(self, v.into_val(self));


### PR DESCRIPTION
Resolves the first problem specified in https://github.com/stellar/stellar-protocol/issues/1289

> If I sign a message, I cannot guarantee that the message is used by a specific contract function.

I marked this as a draft because we haven't decided on how the call stack should be used (or even if it should), but I wanted to get something down for us to look at. I need to think about better names for `call_cntxt` and `get_parent_call_stack`, and  the `get_parent_call_stack` approach still needs some thought ([relevant discussion](https://github.com/stellar/rs-soroban-sdk/pull/574#issuecomment-1241192968)).