### PR TITLE
Add a compile error for testutils with wasm

### DIFF
--- a/soroban-sdk/src/lib.rs
+++ b/soroban-sdk/src/lib.rs
@@ -44,7 +44,7 @@
 #![allow(dead_code)]
 
 #[cfg(all(target_family = "wasm", feature = "testutils"))]
-compile_error!("'testutils' feature is not supported on 'wasm' targets");
+compile_error!("'testutils' feature is not supported on 'wasm' target");
 
 #[cfg(target_family = "wasm")]
 #[panic_handler]

--- a/soroban-sdk/src/lib.rs
+++ b/soroban-sdk/src/lib.rs
@@ -43,6 +43,9 @@
 #![cfg_attr(feature = "docs", feature(doc_cfg))]
 #![allow(dead_code)]
 
+#[cfg(all(target_family = "wasm", feature = "testutils"))]
+compile_error!("'testutils' feature is not supported on 'wasm' targets");
+
 #[cfg(target_family = "wasm")]
 #[panic_handler]
 fn handle_panic(_: &core::panic::PanicInfo) -> ! {


### PR DESCRIPTION
### What
Add a compile error for testutils with wasm.

### Why
Raise a compile error if the testutils feature is used with wasmi.

It is an easy mistake to make sometimes and it is more helpful to get an error that states this is intentionally not supported than it is to get errors about missing types and functions that do not exist.