### PR TITLE
Put the test utilities for events behind a trait

### DIFF
--- a/soroban-sdk/src/events.rs
+++ b/soroban-sdk/src/events.rs
@@ -117,18 +117,12 @@ impl Events {
 }
 
 #[cfg(feature = "testutils")]
-use crate::{xdr, TryIntoVal};
+use crate::{testutils, xdr, TryIntoVal};
 
 #[cfg(feature = "testutils")]
 #[cfg_attr(feature = "docs", doc(cfg(feature = "testutils")))]
-impl Events {
-    /// Returns all events that have been published by contracts.
-    ///
-    /// Returns a [`Vec`] of three element tuples containing:
-    /// - Contract ID
-    /// - Event Topics as a [`Vec<RawVal>`]
-    /// - Event Data as a [`RawVal`]
-    pub fn all(&self) -> Vec<(crate::BytesN<32>, Vec<RawVal>, RawVal)> {
+impl testutils::Events for Events {
+    fn all(&self) -> Vec<(crate::BytesN<32>, Vec<RawVal>, RawVal)> {
         let env = self.env();
         let mut vec = Vec::new(env);
         self.env()

--- a/soroban-sdk/src/testutils.rs
+++ b/soroban-sdk/src/testutils.rs
@@ -8,9 +8,20 @@ pub use test_sign::ed25519;
 
 pub use crate::env::testutils::*;
 
-use crate::{Env, RawVal, Symbol};
+use crate::{Env, RawVal, Symbol, Vec};
 
 #[doc(hidden)]
 pub trait ContractFunctionSet {
     fn call(&self, func: &Symbol, env: Env, args: &[RawVal]) -> Option<RawVal>;
+}
+
+/// Test utilities for [`Events`][crate::Events].
+pub trait Events {
+    /// Returns all events that have been published by contracts.
+    ///
+    /// Returns a [`Vec`] of three element tuples containing:
+    /// - Contract ID
+    /// - Event Topics as a [`Vec<RawVal>`]
+    /// - Event Data as a [`RawVal`]
+    fn all(&self) -> Vec<(crate::BytesN<32>, Vec<RawVal>, RawVal)>;
 }

--- a/tests/events/src/lib.rs
+++ b/tests/events/src/lib.rs
@@ -16,7 +16,7 @@ impl Contract {
 #[cfg(test)]
 mod test {
     extern crate alloc;
-    use soroban_sdk::{symbol, vec, BytesN, Env, IntoVal};
+    use soroban_sdk::{symbol, testutils::Events, vec, BytesN, Env, IntoVal};
 
     use crate::{Contract, ContractClient};
 


### PR DESCRIPTION
### What
Put the test utilities for events behind a trait.

### Why
So that it is harder to accidentally use the utilities inside contracts and so it is really clear that the functions belong to another purpose.