### PR TITLE
Only "export" fns on wasm target

### DIFF
--- a/soroban-sdk-macros/src/derive_fn.rs
+++ b/soroban-sdk-macros/src/derive_fn.rs
@@ -130,7 +130,9 @@ pub fn derive_fn(
     } else {
         quote! {}
     };
-    let export_name = export.then(|| quote! { #[export_name = #wrap_export_name] });
+    let export_name = export.then(|| {
+        quote! { #[cfg_attr(target_family = "wasm", export_name = #wrap_export_name)] }
+    });
     let slice_args: Vec<TokenStream2> = (0..wrap_args.len()).map(|n| quote! { args[#n] }).collect();
     let use_trait = if let Some(t) = trait_ident {
         quote! { use super::#t }


### PR DESCRIPTION
### What
Only "export" fns on wasm target.

### Why
People want to import contracts into other contracts so they can use test utility functionality in those crates. It's almost never someones intent when doing this to reexport the fns in that crate, which can create problems.

@jonjove and I discussed doing this a long time ago, but we decided not to at the time because the SDK was intended for use with built-in contracts, like the token contract. Now that it is no longer the case, we should do this.