### PR TITLE
Only export the meta sections function in wasm builds

### DIFF
--- a/soroban-sdk/src/lib.rs
+++ b/soroban-sdk/src/lib.rs
@@ -71,9 +71,10 @@ fn handle_panic(_: &core::panic::PanicInfo) -> ! {
 /// size.
 ///
 /// See https://github.com/stellar/rs-soroban-sdk/issues/383 for more details.
+#[cfg(target_family = "wasm")]
 #[export_name = "_"]
 fn __link_sections() {
-    #[cfg_attr(target_family = "wasm", link_section = "contractenvmetav0")]
+    #[link_section = "contractenvmetav0"]
     static __ENV_META_XDR: [u8; env::meta::XDR.len()] = env::meta::XDR;
 }
 


### PR DESCRIPTION
### What
Only export the meta sections function in wasm builds.

### Why
The `_` export was only intended for wasm builds and has no utility in non-wasm builds.