### PR TITLE
Use log_value in logging temporarily until Guest Env supports debug events

### DIFF
--- a/soroban-sdk/src/env.rs
+++ b/soroban-sdk/src/env.rs
@@ -269,11 +269,6 @@ impl Env {
         let stack = internal::Env::get_current_call_stack(self);
         stack.try_into_val(self).unwrap()
     }
-
-    #[doc(hidden)]
-    pub fn log_value<V: IntoVal<Env, RawVal>>(&self, v: V) {
-        internal::Env::log_value(self, v.into_val(self));
-    }
 }
 
 #[cfg(feature = "testutils")]

--- a/soroban-sdk/src/logging.rs
+++ b/soroban-sdk/src/logging.rs
@@ -3,7 +3,10 @@
 //! See [`log`][crate::log] for how to conveniently log debug events.
 use core::fmt::Debug;
 
-use crate::{env::internal::EnvBase, Env, RawVal};
+use crate::{
+    env::internal::{self},
+    vec, Env, IntoVal, RawVal, Vec,
+};
 
 /// Log a debug event.
 ///
@@ -110,7 +113,17 @@ impl Logger {
     pub fn log(&self, fmt: &'static str, args: &[RawVal]) {
         if cfg!(debug_assertions) {
             let env = self.env();
-            env.log_static_fmt_general(fmt, &args, &[]);
+
+            // Temporary logic using log_value.
+            let fmt: RawVal = fmt.into_val(env);
+            let mut values: Vec<RawVal> = vec![env, fmt];
+            values.extend_from_slice(args);
+            internal::Env::log_value(env, values.into_val(env));
+
+            // TODO: When debug events are supported in the Guest VM
+            // (https://github.com/stellar/rs-soroban-env/issues/447), use the
+            // better log static function.
+            // env.log_static_fmt_general(fmt, &args, &[]);
         }
     }
 }

--- a/soroban-sdk/src/logging.rs
+++ b/soroban-sdk/src/logging.rs
@@ -115,10 +115,10 @@ impl Logger {
             let env = self.env();
 
             // Temporary logic using log_value.
-            let fmt: RawVal = fmt.into_val(env);
-            let mut values: Vec<RawVal> = vec![env, fmt];
-            values.extend_from_slice(args);
-            internal::Env::log_value(env, values.into_val(env));
+            internal::Env::log_value(env, fmt.into_val(env));
+            for arg in args {
+                internal::Env::log_value(env, *arg);
+            }
 
             // TODO: When debug events are supported in the Guest VM
             // (https://github.com/stellar/rs-soroban-env/issues/447), use the


### PR DESCRIPTION
### What
Use log_value in logging temporarily until Guest Env supports debug events

### Why
Close #625