### PR TITLE
Add note to log! macro about not currently supported on wasm

### DIFF
--- a/soroban-sdk/src/logging.rs
+++ b/soroban-sdk/src/logging.rs
@@ -14,6 +14,10 @@ use crate::{env::internal::EnvBase, Env, RawVal};
 /// `log!` statements are only enabled in non optimized builds that have
 /// `debug-assertions` enabled.
 ///
+/// <p style="padding:0.75em;background:var(--code-block-background-color);">
+/// <b>Note</b>: Log support in WASM builds is pending on <a href="https://github.com/stellar/rs-soroban-env/issues/447">soroban-env#447</a>.
+/// </p>
+///
 /// ### Examples
 ///
 /// Log a string:


### PR DESCRIPTION
### What
Add note to log! macro about not currently supported on wasm.

### Why
We plan to add support next iteration, but if something happens we don't get to it we'll leave this note.