### PR TITLE
Change how events are asserted to use ScVal types

### DIFF
--- a/soroban-sdk/src/testutils.rs
+++ b/soroban-sdk/src/testutils.rs
@@ -8,7 +8,7 @@ pub use test_sign::ed25519;
 
 pub use crate::env::testutils::*;
 
-use crate::{Env, RawVal, Symbol, Vec};
+use crate::{xdr::ScVal, Env, RawVal, Symbol};
 
 #[doc(hidden)]
 pub trait ContractFunctionSet {
@@ -23,7 +23,7 @@ pub trait Events {
     /// - Contract ID
     /// - Event Topics as a [`Vec<RawVal>`]
     /// - Event Data as a [`RawVal`]
-    fn all(&self) -> Vec<(crate::BytesN<32>, Vec<RawVal>, RawVal)>;
+    fn all(&self) -> std::vec::Vec<([u8; 32], std::vec::Vec<ScVal>, ScVal)>;
 }
 
 /// Test utilities for [`Logger`][crate::logging::Logger].

--- a/tests/events/src/lib.rs
+++ b/tests/events/src/lib.rs
@@ -15,8 +15,8 @@ impl Contract {
 
 #[cfg(test)]
 mod test {
-    extern crate alloc;
-    use soroban_sdk::{symbol, testutils::Events, vec, BytesN, Env, IntoVal};
+    extern crate std;
+    use soroban_sdk::{symbol, testutils::Events, xdr::ScVal, BytesN, Env, IntoVal};
 
     use crate::{Contract, ContractClient};
 
@@ -31,22 +31,27 @@ mod test {
 
         assert_eq!(
             env.events().all(),
-            vec![
-                &env,
+            std::vec![
                 // Expect 2 events.
                 (
-                    contract_id.clone(),
+                    &[0; 32],
                     // Expect these event topics.
-                    (symbol!("greetings"), symbol!("topic2")).into_val(&env),
+                    std::vec![
+                        ScVal::Symbol("greetings".try_into().unwrap()),
+                        ScVal::Symbol("topic2".try_into().unwrap()),
+                    ],
                     // Expect this event body.
-                    symbol!("hello").into_val(&env)
+                    ScVal::Symbol("hello".try_into().unwrap()),
                 ),
                 (
-                    contract_id.clone(),
+                    &[0; 32],
                     // Expect these event topics.
-                    (symbol!("farewells"), symbol!("topic2")).into_val(&env),
+                    std::vec![
+                        ScVal::Symbol("farewells".try_into().unwrap()),
+                        ScVal::Symbol("topic2".try_into().unwrap()),
+                    ],
                     // Expect this event body.
-                    symbol!("bye").into_val(&env)
+                    ScVal::Symbol("byte".try_into().unwrap()),
                 ),
             ],
         );


### PR DESCRIPTION
### What
Change how events are asserted to use ScVal types

### Why
A quick experiment in making the interface more similar to debug events. Opening a draft PR to capture that experiment, but not pursuing at this time.