### PR TITLE
Use bytes-lit v0.0.4 and fix bytes!s with leading zeros

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -88,9 +88,9 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes-lit"
-version = "0.0.3"
+version = "0.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3a949b8abd1d84c29a91f4c8480dac1b426d53cebc9a31a8424a5cbe5be32f6"
+checksum = "1c181bca161a49348b90fa75f9a54fe11b7138098eed90d841a1055d574b4250"
 dependencies = [
  "num-bigint",
  "proc-macro2",

--- a/soroban-sdk/Cargo.toml
+++ b/soroban-sdk/Cargo.toml
@@ -15,7 +15,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 soroban-sdk-macros = { version = "0.0.4" }
-bytes-lit = "0.0.3"
+bytes-lit = "0.0.4"
 ed25519-dalek = { version = "1.0.1", optional = true }
 
 [target.'cfg(target_family="wasm")'.dependencies]

--- a/soroban-sdk/src/bigint.rs
+++ b/soroban-sdk/src/bigint.rs
@@ -62,10 +62,10 @@ macro_rules! bigint {
         $crate::BigInt::from_slice($env, &[$($x),+])
     };
     ($env:expr, $x:tt $(,)?) => {
-        $crate::BigInt::from_slice($env, &$crate::__bytes_lit_bytes!($x))
+        $crate::BigInt::from_slice($env, &$crate::__bytes_lit_bytesmin!($x))
     };
     ($env:expr, -$x:tt $(,)?) => {
-        $crate::BigInt::from_sign_and_slice($env, &$crate::Sign::Minus, &$crate::__bytes_lit_bytes!($x))
+        $crate::BigInt::from_sign_and_slice($env, &$crate::Sign::Minus, &$crate::__bytes_lit_bytesmin!($x))
     };
 }
 
@@ -1550,6 +1550,8 @@ mod test {
         assert_eq!(bigint!(&env, 1), BigInt::from_u64(&env, 1),);
 
         assert_eq!(bigint!(&env, 0x10), BigInt::from_u64(&env, 16),);
+
+        assert_eq!(bigint!(&env, 0x0010), BigInt::from_u64(&env, 16),);
 
         let big = bigint!(&env, 340_282_366_920_938_463_463_374_607_431_768_211_456);
         assert_eq!(big.bits(), 129);

--- a/soroban-sdk/src/bytes.rs
+++ b/soroban-sdk/src/bytes.rs
@@ -1107,6 +1107,9 @@ mod test {
             b.push(1);
             b
         });
+        assert_eq!(bytes!(&env, 0x0000030201), {
+            Bytes::from_array(&env, &[0, 0, 3, 2, 1])
+        });
     }
 
     #[test]
@@ -1124,6 +1127,9 @@ mod test {
         let env = Env::default();
         assert_eq!(bytesn!(&env, 0x030201), {
             BytesN::from_array(&env, &[3, 2, 1])
+        });
+        assert_eq!(bytesn!(&env, 0x0000030201), {
+            BytesN::from_array(&env, &[0, 0, 3, 2, 1])
         });
     }
 

--- a/soroban-sdk/src/lib.rs
+++ b/soroban-sdk/src/lib.rs
@@ -83,6 +83,8 @@ fn __link_sections() {
 
 #[doc(hidden)]
 pub use bytes_lit::bytes as __bytes_lit_bytes;
+#[doc(hidden)]
+pub use bytes_lit::bytesmin as __bytes_lit_bytesmin;
 
 pub use soroban_sdk_macros::{
     contractclient, contractfile, contractimpl, contractimport, contracttype,


### PR DESCRIPTION
### What
Use bytes-lit v0.0.4 and fix bytes!s with leading zeros.

### Why
https://github.com/stellar/bytes-lit/pull/28 that was released in `bytes-lit` v0.0.4 fixed the underlying issue of the SDK's `bytes!` macro, where leading zeros were not preserved.

The `bigint!` macro now uses the `bytes_lit::bytesmin!` macro because it does not need leading zeros preserved.

Close https://github.com/stellar/bytes-lit/issues/27