### PR TITLE
Add .soroban/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ target/
 target-tiny/
 lcov.info
 *.profraw
+.soroban/


### PR DESCRIPTION
### What
Add .soroban/ to .gitignore.

### Why
When running the soroban-cli in the SDK directory the `.soroban/` directory gets created. Adding it to the `.gitignore` to make it more convenient as to not accidentally commit it.