### PR TITLE
Use refs as fn inputs and make args input to auth more flexible

### DIFF
--- a/soroban-auth/tests/test.rs
+++ b/soroban-auth/tests/test.rs
@@ -50,12 +50,7 @@ impl TestContract {
 
         verify_and_consume_nonce(&e, &auth_id, &nonce);
 
-        check_auth(
-            &e,
-            &sig,
-            symbol!("verify_sig"),
-            (&auth_id, nonce).into_val(&e),
-        );
+        check_auth(&e, &sig, symbol!("verify_sig"), (&auth_id, nonce));
     }
 
     pub fn nonce(e: Env, id: Identifier) -> BigInt {

--- a/soroban-sdk/src/env.rs
+++ b/soroban-sdk/src/env.rs
@@ -221,7 +221,7 @@ impl Env {
     }
 
     /// Computes a SHA-256 hash.
-    pub fn compute_hash_sha256(&self, msg: Bytes) -> BytesN<32> {
+    pub fn compute_hash_sha256(&self, msg: &Bytes) -> BytesN<32> {
         let bin_obj = internal::Env::compute_hash_sha256(self, msg.into());
         bin_obj.try_into_val(self).unwrap()
     }
@@ -238,7 +238,7 @@ impl Env {
     /// ### TODO
     ///
     /// Return a [Result] instead of panicking.
-    pub fn verify_sig_ed25519(&self, pk: BytesN<32>, msg: Bytes, sig: BytesN<64>) {
+    pub fn verify_sig_ed25519(&self, pk: &BytesN<32>, msg: &Bytes, sig: &BytesN<64>) {
         internal::Env::verify_sig_ed25519(self, msg.to_object(), pk.to_object(), sig.to_object())
             .try_into()
             .unwrap()

--- a/soroban-sdk/src/vec.rs
+++ b/soroban-sdk/src/vec.rs
@@ -164,6 +164,18 @@ where
     }
 }
 
+impl<T> IntoVal<Env, Vec<RawVal>> for Vec<T> {
+    fn into_val(self, _env: &Env) -> Vec<RawVal> {
+        unsafe { Vec::unchecked_new(self.0) }
+    }
+}
+
+impl<T> IntoVal<Env, Vec<RawVal>> for &Vec<T> {
+    fn into_val(self, _env: &Env) -> Vec<RawVal> {
+        unsafe { Vec::unchecked_new(self.0.clone()) }
+    }
+}
+
 impl<T> TryFromVal<Env, Object> for Vec<T>
 where
     T: IntoVal<Env, RawVal> + TryFromVal<Env, RawVal>,


### PR DESCRIPTION
### What
Use refs as fn inputs and make args input to auth more flexible.

### Why
Functions that accept types to convert to RawVal's don't need to accept owned values. They only need refs because they won't be consuming the value at all. We can be a little more flexible with what inputs we can use as the args for the check_auth function because we already have conversions for tuples into Vec<RawVal> which can make using the function more convenient because we no longer need to call into_val a bunch of time ourselves, or build a Vec.