### PR TITLE
Remove deprecated functions

### DIFF
--- a/soroban-sdk/src/env.rs
+++ b/soroban-sdk/src/env.rs
@@ -1,5 +1,4 @@
 use core::convert::TryInto;
-use core::fmt::Debug;
 
 #[cfg(target_family = "wasm")]
 pub mod internal {

--- a/soroban-sdk/src/env.rs
+++ b/soroban-sdk/src/env.rs
@@ -248,7 +248,7 @@ impl Env {
 
 #[cfg(feature = "testutils")]
 use crate::testutils::ContractFunctionSet;
-#[cfg(feature = "doc")]
+#[cfg(feature = "testutils")]
 use core::fmt::Debug;
 #[cfg(feature = "testutils")]
 use std::rc::Rc;

--- a/soroban-sdk/src/env.rs
+++ b/soroban-sdk/src/env.rs
@@ -248,6 +248,8 @@ impl Env {
 
 #[cfg(feature = "testutils")]
 use crate::testutils::ContractFunctionSet;
+#[cfg(feature = "doc")]
+use core::fmt::Debug;
 #[cfg(feature = "testutils")]
 use std::rc::Rc;
 #[cfg(feature = "testutils")]

--- a/soroban-sdk/src/env.rs
+++ b/soroban-sdk/src/env.rs
@@ -181,45 +181,6 @@ impl Env {
         bin.try_into().unwrap()
     }
 
-    #[doc(hidden)]
-    #[deprecated(note = "use contract_data().has(key)")]
-    pub fn has_contract_data<K>(&self, key: K) -> bool
-    where
-        K: IntoVal<Env, RawVal>,
-    {
-        self.contract_data().has(key)
-    }
-
-    #[doc(hidden)]
-    #[deprecated(note = "use contract_data().get(key)")]
-    pub fn get_contract_data<K, V>(&self, key: K) -> V
-    where
-        V::Error: Debug,
-        K: IntoVal<Env, RawVal>,
-        V: TryFromVal<Env, RawVal>,
-    {
-        self.contract_data().get_unchecked(key).unwrap()
-    }
-
-    #[doc(hidden)]
-    #[deprecated(note = "use contract_data().set(key)")]
-    pub fn put_contract_data<K, V>(&self, key: K, val: V)
-    where
-        K: IntoVal<Env, RawVal>,
-        V: IntoVal<Env, RawVal>,
-    {
-        self.contract_data().set(key, val);
-    }
-
-    #[doc(hidden)]
-    #[deprecated(note = "use contract_data().remove(key)")]
-    pub fn del_contract_data<K>(&self, key: K)
-    where
-        K: IntoVal<Env, RawVal>,
-    {
-        self.contract_data().remove(key);
-    }
-
     /// Computes a SHA-256 hash.
     pub fn compute_hash_sha256(&self, msg: &Bytes) -> BytesN<32> {
         let bin_obj = internal::Env::compute_hash_sha256(self, msg.into());


### PR DESCRIPTION
### What
Remove deprecated functions.

### Why
They were marked as deprecated sometime ago and do not need to be in the next release.