### PR TITLE
Use as_bytes instead of to_bytes

### DIFF
--- a/soroban-auth/src/testutils.rs
+++ b/soroban-auth/src/testutils.rs
@@ -21,7 +21,7 @@ pub mod ed25519 {
 
     impl Identifier for ed25519_dalek::Keypair {
         fn identifier(&self, env: &Env) -> IdentifierValue {
-            IdentifierValue::Ed25519(self.public.to_bytes().into_val(env))
+            IdentifierValue::Ed25519(self.public.as_bytes().into_val(env))
         }
     }
 


### PR DESCRIPTION
### What
Use as_bytes instead of to_bytes when converting a public key to a BytesN.

### Why
The conversion to BytesN does not need an owned byte slice.