### PR TITLE
Rename the client on imported contracts to Client

### DIFF
--- a/soroban-sdk/tests/contractimport.rs
+++ b/soroban-sdk/tests/contractimport.rs
@@ -15,7 +15,7 @@ pub struct Contract;
 #[contractimpl]
 impl Contract {
     pub fn add_with(env: Env, x: i32, y: i32) -> i32 {
-        addcontract::ContractClient::new(&env, &ADD_CONTRACT_ID).add(&x, &y)
+        addcontract::Client::new(&env, &ADD_CONTRACT_ID).add(&x, &y)
     }
 }
 

--- a/soroban-sdk/tests/contractimport_with_sha256.rs
+++ b/soroban-sdk/tests/contractimport_with_sha256.rs
@@ -16,7 +16,7 @@ pub struct Contract;
 #[contractimpl]
 impl Contract {
     pub fn add_with(env: Env, x: i32, y: i32) -> i32 {
-        addcontract::ContractClient::new(&env, &ADD_CONTRACT_ID).add(&x, &y)
+        addcontract::Client::new(&env, &ADD_CONTRACT_ID).add(&x, &y)
     }
 }
 

--- a/soroban-spec/src/gen/rust.rs
+++ b/soroban-spec/src/gen/rust.rs
@@ -71,7 +71,7 @@ pub fn generate(specs: &[ScSpecEntry], file: &str, sha256: &str) -> TokenStream 
     }
 
     let trait_name = "Contract";
-    let client_name = format!("{}Client", trait_name);
+    let client_name = "Client";
 
     let trait_ = r#trait::generate_trait(trait_name, &spec_fns);
     let structs = spec_structs.iter().map(|s| generate_struct(s));

--- a/soroban-spec/src/gen/rust.rs
+++ b/soroban-spec/src/gen/rust.rs
@@ -71,7 +71,6 @@ pub fn generate(specs: &[ScSpecEntry], file: &str, sha256: &str) -> TokenStream 
     }
 
     let trait_name = "Contract";
-    let client_name = "Client";
 
     let trait_ = r#trait::generate_trait(trait_name, &spec_fns);
     let structs = spec_structs.iter().map(|s| generate_struct(s));
@@ -82,8 +81,11 @@ pub fn generate(specs: &[ScSpecEntry], file: &str, sha256: &str) -> TokenStream 
     quote! {
         pub const WASM: &[u8] = ::soroban_sdk::contractfile!(file = #file, sha256 = #sha256);
 
-        #[::soroban_sdk::contractclient(name = #client_name)]
+        #[::soroban_sdk::contractclient(name = "Client")]
         #trait_
+
+        #[deprecated(note = "use Client instead of ContractClient")]
+        pub type ContractClient = Client;
 
         #(#structs)*
         #(#unions)*

--- a/soroban-spec/src/gen/rust.rs
+++ b/soroban-spec/src/gen/rust.rs
@@ -84,7 +84,7 @@ pub fn generate(specs: &[ScSpecEntry], file: &str, sha256: &str) -> TokenStream 
         #[::soroban_sdk::contractclient(name = "Client")]
         #trait_
 
-        #[deprecated(note = "use Client instead of ContractClient")]
+        #[deprecated(note = "use Client instead of ContractClient as it has been renamed")]
         pub type ContractClient = Client;
 
         #(#structs)*

--- a/tests/import_contract/src/lib.rs
+++ b/tests/import_contract/src/lib.rs
@@ -13,7 +13,7 @@ pub struct Contract;
 #[contractimpl]
 impl Contract {
     pub fn add_with(env: Env, x: i32, y: i32) -> i32 {
-        addcontract::ContractClient::new(&env, &ADD_CONTRACT_ID).add(&x, &y)
+        addcontract::Client::new(&env, &ADD_CONTRACT_ID).add(&x, &y)
     }
 }
 


### PR DESCRIPTION
### What
Rename the client on imported contracts to Client.

### Why
I've noticed multiple people, including myself, prefer to rename the type because it is quite long which is annoying.

A deprecated notice has been added to the old name so that people don't seem ambiguous compile errors and instead see a message informing them of what the new name is.