### PR TITLE
Improve docs for panicerror!

### DIFF
--- a/soroban-sdk/src/lib.rs
+++ b/soroban-sdk/src/lib.rs
@@ -99,6 +99,8 @@ pub use soroban_sdk_macros::{
 ///
 /// Equivalent to `panic!`, but with an error value instead of a string. The
 /// error value will be given to any calling contract.
+///
+/// See [`contracterror`] for how to define an error type.
 #[macro_export]
 macro_rules! panic_error {
     ($env:expr, $error:expr) => {{


### PR DESCRIPTION
### What
Improve docs for panicerror!.

### Why
To direct the user to how to define an error.