### PR TITLE
Add a test to auth that also outputs its inputs/outputs

### DIFF
--- a/soroban-auth/src/lib.rs
+++ b/soroban-auth/src/lib.rs
@@ -15,6 +15,8 @@
 //! contract invocations to be replayable if it is important they are not.**
 #![no_std]
 
+mod test;
+
 use soroban_sdk::{serde::Serialize, Account, BytesN, Env, IntoVal, RawVal, Symbol, Vec};
 
 pub mod testutils;

--- a/soroban-auth/src/test.rs
+++ b/soroban-auth/src/test.rs
@@ -25,7 +25,7 @@ impl ExampleContract {
 }
 
 #[test]
-fn sig() {
+fn test() {
     let env = Env::default();
     let contract_id = BytesN::from_array(&env, &[0; 32]);
     env.register_contract(&contract_id, ExampleContract);

--- a/soroban-auth/src/test.rs
+++ b/soroban-auth/src/test.rs
@@ -1,0 +1,47 @@
+#![cfg(test)]
+#![cfg(feature = "testutils")]
+
+extern crate std;
+
+use soroban_sdk::{contractimpl, symbol, BytesN, Env};
+
+use crate::{
+    testutils::ed25519::{generate, sign},
+    verify, Signature,
+};
+
+pub struct ExampleContract;
+
+#[contractimpl]
+impl ExampleContract {
+    pub fn examplefn(env: Env, sig: Signature, arg1: i32, arg2: i32) {
+        verify(
+            &env,
+            &sig,
+            symbol!("examplefn"),
+            (&sig.identifier(&env), arg1, arg2),
+        );
+    }
+}
+
+#[test]
+fn sig() {
+    let env = Env::default();
+    let contract_id = BytesN::from_array(&env, &[0; 32]);
+    env.register_contract(&contract_id, ExampleContract);
+    let client = ExampleContractClient::new(&env, &contract_id);
+
+    let (id, signer) = generate(&env);
+    std::println!("signer: {:?}", signer);
+    std::println!("id: {:?}", id);
+    let sig = sign(
+        &env,
+        &signer,
+        &contract_id,
+        symbol!("examplefn"),
+        (&id, &1, &2),
+    );
+    std::println!("signature: {:?}", sig);
+
+    client.examplefn(&sig, &1, &2);
+}

--- a/soroban-auth/src/testutils.rs
+++ b/soroban-auth/src/testutils.rs
@@ -5,6 +5,7 @@
 //! [`soroban_auth`](crate).
 
 pub mod ed25519 {
+    use core::fmt::Debug;
     use core::panic;
 
     use soroban_sdk::{testutils::ed25519::Sign, BytesN, Env, IntoVal, RawVal, Symbol, Vec};
@@ -31,7 +32,7 @@ pub mod ed25519 {
         env: &Env,
     ) -> (
         IdentifierValue,
-        impl Identifier + Sign<SignaturePayload, Signature = [u8; 64]>,
+        impl Identifier + Sign<SignaturePayload, Signature = [u8; 64]> + Debug,
     ) {
         let signer = ed25519_dalek::Keypair::generate(&mut rand::thread_rng());
         (signer.identifier(env), signer)


### PR DESCRIPTION
### What
Add a test to auth that also outputs its inputs/outputs.

### Why
So that we have a test that shares its inputs and outputs that can be also used as test vectors in other applications for verifying consistency with this SDK.

Note that I had to add the Debug trait to the returned signer that the auth SDK testutils generates.