### PR TITLE
Support generating contracts containing tuple structs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -606,6 +606,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettyplease"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a49e86d2c26a24059894a3afa13fd17d063419b05dfb83f06d9c3566060c3f5a"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -875,6 +885,7 @@ dependencies = [
  "darling",
  "itertools",
  "pretty_assertions",
+ "prettyplease",
  "proc-macro2",
  "quote",
  "serde",

--- a/soroban-spec/Cargo.toml
+++ b/soroban-spec/Cargo.toml
@@ -25,6 +25,7 @@ wasmparser = "0.88.0"
 serde = "1.0.82"
 serde_derive = "1.0.82"
 serde_json = "1.0.82"
+prettyplease = "0.1.18"
 
 [dev_dependencies]
 pretty_assertions = "1.2.1"

--- a/soroban-spec/src/gen/rust/types.rs
+++ b/soroban-spec/src/gen/rust/types.rs
@@ -5,6 +5,9 @@ use stellar_xdr::{
 };
 
 // TODO: Replace the unwrap()s in this code with returning Result.
+// TODO: Create Idents in a way that we can get a Result back and return it too
+// because at the moment the format_ident! calls can panic if the inputs do not
+// result in a valid ident.
 
 /// Constructs a token stream containing a single struct that mirrors the struct
 /// spec.

--- a/soroban-spec/src/gen/rust/types.rs
+++ b/soroban-spec/src/gen/rust/types.rs
@@ -4,6 +4,8 @@ use stellar_xdr::{
     ScSpecTypeDef, ScSpecUdtEnumV0, ScSpecUdtErrorEnumV0, ScSpecUdtStructV0, ScSpecUdtUnionV0,
 };
 
+// TODO: Replace the unwrap()s in this code with returning Result.
+
 /// Constructs a token stream containing a single struct that mirrors the struct
 /// spec.
 pub fn generate_struct(spec: &ScSpecUdtStructV0) -> TokenStream {


### PR DESCRIPTION
### What
Map numeric struct field names to unnamed fields on tuple structs.

### Why
We support tuple structs that have unnamed fields by simply naming the fields after their indexes, but when generating contract types for those contract specs we don't generate a tuple but instead attempt to generate a regular struct with field names.

Close #667