### PR TITLE
Allow non-pub fields in contracttype structs

### DIFF
--- a/soroban-sdk-macros/src/derive_struct.rs
+++ b/soroban-sdk-macros/src/derive_struct.rs
@@ -2,7 +2,7 @@ use itertools::MultiUnzip;
 use proc_macro2::{Literal, TokenStream as TokenStream2};
 use quote::{format_ident, quote};
 use soroban_env_common::Symbol;
-use syn::{spanned::Spanned, DataStruct, Error, Ident, Visibility};
+use syn::{spanned::Spanned, DataStruct, Error, Ident};
 
 use stellar_xdr::{
     ScSpecEntry, ScSpecTypeDef, ScSpecUdtStructFieldV0, ScSpecUdtStructV0, VecM, WriteXdr,
@@ -34,7 +34,6 @@ pub fn derive_type_struct(
     });
     let (spec_fields, try_froms, intos, try_from_xdrs, into_xdrs): (Vec<_>, Vec<_>, Vec<_>, Vec<_>, Vec<_>) = fields
         .iter()
-        .filter(|f| matches!(f.vis, Visibility::Public(_)))
         .enumerate()
         .map(|(i, f)| {
             // For named fields use the ident as is. For unnamed fields like

--- a/tests/udt/src/lib.rs
+++ b/tests/udt/src/lib.rs
@@ -24,8 +24,8 @@ pub struct UdtTuple(pub i64, pub Vec<i64>);
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct UdtStruct {
-    pub a: i64,
-    pub b: i64,
+    a: i64,
+    b: i64,
     pub c: Vec<i64>,
 }
 


### PR DESCRIPTION
### What
Allow non-pub fields in contracttype structs.

### Why
There really isn't a good reason to disallow them. I think the fact they were disallowed was largely in error, probably a result of copy-paste from the code that derives functions where pub-or-not actually has some meaning.