### PR TITLE
Use AccountId instead of BytesN<32> for account ids

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -254,6 +254,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f107b87b6afc2a64fd13cac55fe06d6c8859f12d4b14cbcdd2c67d0976781be"
 
 [[package]]
+name = "example_account"
+version = "0.0.4"
+dependencies = [
+ "soroban-sdk",
+]
+
+[[package]]
 name = "example_add_bigint"
 version = "0.0.4"
 dependencies = [
@@ -784,7 +791,7 @@ dependencies = [
 [[package]]
 name = "soroban-env-common"
 version = "0.0.5"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=4e2f308b#4e2f308b00ef286630635e07b08726d0d7f24cd8"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=18c41a6c#18c41a6cbfb5461d2f34909c34a12a5dc7837ae0"
 dependencies = [
  "soroban-env-macros",
  "soroban-wasmi",
@@ -795,7 +802,7 @@ dependencies = [
 [[package]]
 name = "soroban-env-guest"
 version = "0.0.5"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=4e2f308b#4e2f308b00ef286630635e07b08726d0d7f24cd8"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=18c41a6c#18c41a6cbfb5461d2f34909c34a12a5dc7837ae0"
 dependencies = [
  "soroban-env-common",
  "static_assertions",
@@ -804,7 +811,7 @@ dependencies = [
 [[package]]
 name = "soroban-env-host"
 version = "0.0.5"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=4e2f308b#4e2f308b00ef286630635e07b08726d0d7f24cd8"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=18c41a6c#18c41a6cbfb5461d2f34909c34a12a5dc7837ae0"
 dependencies = [
  "backtrace",
  "dyn-fmt",
@@ -827,7 +834,7 @@ dependencies = [
 [[package]]
 name = "soroban-env-macros"
 version = "0.0.5"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=4e2f308b#4e2f308b00ef286630635e07b08726d0d7f24cd8"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=18c41a6c#18c41a6cbfb5461d2f34909c34a12a5dc7837ae0"
 dependencies = [
  "itertools",
  "proc-macro2",
@@ -839,7 +846,7 @@ dependencies = [
 [[package]]
 name = "soroban-native-sdk-macros"
 version = "0.0.5"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=4e2f308b#4e2f308b00ef286630635e07b08726d0d7f24cd8"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=18c41a6c#18c41a6cbfb5461d2f34909c34a12a5dc7837ae0"
 dependencies = [
  "itertools",
  "proc-macro2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -791,7 +791,7 @@ dependencies = [
 [[package]]
 name = "soroban-env-common"
 version = "0.0.5"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=18c41a6c#18c41a6cbfb5461d2f34909c34a12a5dc7837ae0"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=1173313f#1173313f6001757f8cdc7b7627f49e24a185339e"
 dependencies = [
  "soroban-env-macros",
  "soroban-wasmi",
@@ -802,7 +802,7 @@ dependencies = [
 [[package]]
 name = "soroban-env-guest"
 version = "0.0.5"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=18c41a6c#18c41a6cbfb5461d2f34909c34a12a5dc7837ae0"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=1173313f#1173313f6001757f8cdc7b7627f49e24a185339e"
 dependencies = [
  "soroban-env-common",
  "static_assertions",
@@ -811,7 +811,7 @@ dependencies = [
 [[package]]
 name = "soroban-env-host"
 version = "0.0.5"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=18c41a6c#18c41a6cbfb5461d2f34909c34a12a5dc7837ae0"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=1173313f#1173313f6001757f8cdc7b7627f49e24a185339e"
 dependencies = [
  "backtrace",
  "dyn-fmt",
@@ -834,7 +834,7 @@ dependencies = [
 [[package]]
 name = "soroban-env-macros"
 version = "0.0.5"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=18c41a6c#18c41a6cbfb5461d2f34909c34a12a5dc7837ae0"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=1173313f#1173313f6001757f8cdc7b7627f49e24a185339e"
 dependencies = [
  "itertools",
  "proc-macro2",
@@ -846,7 +846,7 @@ dependencies = [
 [[package]]
 name = "soroban-native-sdk-macros"
 version = "0.0.5"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=18c41a6c#18c41a6cbfb5461d2f34909c34a12a5dc7837ae0"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=1173313f#1173313f6001757f8cdc7b7627f49e24a185339e"
 dependencies = [
  "itertools",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,11 +30,11 @@ soroban-sdk = { path = "soroban-sdk" }
 soroban-auth = { path = "soroban-auth" }
 soroban-spec = { path = "soroban-spec" }
 soroban-sdk-macros = { path = "soroban-sdk-macros" }
-soroban-env-common = { git = "https://github.com/stellar/rs-soroban-env", rev = "18c41a6c" }
-soroban-env-guest = { git = "https://github.com/stellar/rs-soroban-env", rev = "18c41a6c" }
-soroban-env-host = { git = "https://github.com/stellar/rs-soroban-env", rev = "18c41a6c" }
-soroban-env-macros = { git = "https://github.com/stellar/rs-soroban-env", rev = "18c41a6c" }
-soroban-native-sdk-macros = { git = "https://github.com/stellar/rs-soroban-env", rev = "18c41a6c" }
+soroban-env-common = { git = "https://github.com/stellar/rs-soroban-env", rev = "1173313f" }
+soroban-env-guest = { git = "https://github.com/stellar/rs-soroban-env", rev = "1173313f" }
+soroban-env-host = { git = "https://github.com/stellar/rs-soroban-env", rev = "1173313f" }
+soroban-env-macros = { git = "https://github.com/stellar/rs-soroban-env", rev = "1173313f" }
+soroban-native-sdk-macros = { git = "https://github.com/stellar/rs-soroban-env", rev = "1173313f" }
 stellar-xdr = { git = "https://github.com/stellar/rs-stellar-xdr", rev = "91405076" }
 wasmi = { package = "soroban-wasmi", git = "https://github.com/stellar/wasmi", rev = "a61b6df" }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ members = [
     "tests/events",
     "tests/logging",
     "tests/errors",
+    "tests/account",
 ]
 
 [patch.crates-io]
@@ -29,11 +30,11 @@ soroban-sdk = { path = "soroban-sdk" }
 soroban-auth = { path = "soroban-auth" }
 soroban-spec = { path = "soroban-spec" }
 soroban-sdk-macros = { path = "soroban-sdk-macros" }
-soroban-env-common = { git = "https://github.com/stellar/rs-soroban-env", rev = "4e2f308b" }
-soroban-env-guest = { git = "https://github.com/stellar/rs-soroban-env", rev = "4e2f308b" }
-soroban-env-host = { git = "https://github.com/stellar/rs-soroban-env", rev = "4e2f308b" }
-soroban-env-macros = { git = "https://github.com/stellar/rs-soroban-env", rev = "4e2f308b" }
-soroban-native-sdk-macros = { git = "https://github.com/stellar/rs-soroban-env", rev = "4e2f308b" }
+soroban-env-common = { git = "https://github.com/stellar/rs-soroban-env", rev = "18c41a6c" }
+soroban-env-guest = { git = "https://github.com/stellar/rs-soroban-env", rev = "18c41a6c" }
+soroban-env-host = { git = "https://github.com/stellar/rs-soroban-env", rev = "18c41a6c" }
+soroban-env-macros = { git = "https://github.com/stellar/rs-soroban-env", rev = "18c41a6c" }
+soroban-native-sdk-macros = { git = "https://github.com/stellar/rs-soroban-env", rev = "18c41a6c" }
 stellar-xdr = { git = "https://github.com/stellar/rs-stellar-xdr", rev = "91405076" }
 wasmi = { package = "soroban-wasmi", git = "https://github.com/stellar/wasmi", rev = "a61b6df" }
 

--- a/soroban-auth/src/lib.rs
+++ b/soroban-auth/src/lib.rs
@@ -40,7 +40,7 @@ fn verify_ed25519_signature(env: &Env, auth: &Ed25519Signature, name: Symbol, ar
 }
 
 fn verify_account_signatures(env: &Env, auth: &AccountSignatures, name: Symbol, args: Vec<RawVal>) {
-    let acc = Account::from_public_key(&auth.account_id).unwrap();
+    let acc = Account::from_id(&auth.account_id).unwrap();
 
     let msg = SignaturePayloadV0 {
         name,

--- a/soroban-auth/src/public_types.rs
+++ b/soroban-auth/src/public_types.rs
@@ -1,4 +1,4 @@
-use soroban_sdk::{contracttype, Bytes, BytesN, Env, Invoker, RawVal, Symbol, Vec};
+use soroban_sdk::{contracttype, AccountId, Bytes, BytesN, Env, Invoker, RawVal, Symbol, Vec};
 
 /// An Ed25519 signature contains a single signature for the
 /// [`SignaturePayload`].
@@ -17,7 +17,7 @@ pub struct Ed25519Signature {
 #[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
 #[contracttype(lib = "soroban_auth")]
 pub struct AccountSignatures {
-    pub account_id: BytesN<32>,
+    pub account_id: AccountId,
     pub signatures: Vec<Ed25519Signature>,
 }
 
@@ -55,7 +55,7 @@ impl Signature {
 pub enum Identifier {
     Invoker(Invoker),
     Ed25519(BytesN<32>),
-    Account(BytesN<32>),
+    Account(AccountId),
 }
 
 /// Signature payload v0 contains the data that must be signed to authenticate

--- a/soroban-sdk/tests/contractfile_with_sha256.rs
+++ b/soroban-sdk/tests/contractfile_with_sha256.rs
@@ -1,6 +1,6 @@
 pub const WASM: &[u8] = soroban_sdk::contractfile!(
     file = "../target/wasm32-unknown-unknown/release/example_add_i32.wasm",
-    sha256 = "c0c5db07dd4db1ff9f38d69b6ef9b7a73acaa8af94eba17515874be9b22f2a48",
+    sha256 = "bd54d7acd68edca80653a4cebdf8204fdb678de773911eba73fdd96962efd9b5",
 );
 
 #[test]

--- a/soroban-sdk/tests/contractimport_with_sha256.rs
+++ b/soroban-sdk/tests/contractimport_with_sha256.rs
@@ -7,7 +7,7 @@ const ADD_CONTRACT_ID: [u8; 32] = [0; 32];
 mod addcontract {
     soroban_sdk::contractimport!(
         file = "../target/wasm32-unknown-unknown/release/example_add_i32.wasm",
-        sha256 = "c0c5db07dd4db1ff9f38d69b6ef9b7a73acaa8af94eba17515874be9b22f2a48",
+        sha256 = "bd54d7acd68edca80653a4cebdf8204fdb678de773911eba73fdd96962efd9b5",
     );
 }
 

--- a/soroban-sdk/tests/trybuild/contractfile_with_sha256_verify_fail.stderr
+++ b/soroban-sdk/tests/trybuild/contractfile_with_sha256_verify_fail.stderr
@@ -1,4 +1,4 @@
-error: sha256 does not match, expected: c0c5db07dd4db1ff9f38d69b6ef9b7a73acaa8af94eba17515874be9b22f2a48
+error: sha256 does not match, expected: bd54d7acd68edca80653a4cebdf8204fdb678de773911eba73fdd96962efd9b5
  --> tests/trybuild/contractfile_with_sha256_verify_fail.rs:3:5
   |
 3 |     sha256 = "0000000000000000000000000000000000000000000000000000000000000000",

--- a/soroban-sdk/tests/trybuild/contractimport_with_sha256_verify_fail.stderr
+++ b/soroban-sdk/tests/trybuild/contractimport_with_sha256_verify_fail.stderr
@@ -1,4 +1,4 @@
-error: sha256 does not match, expected: c0c5db07dd4db1ff9f38d69b6ef9b7a73acaa8af94eba17515874be9b22f2a48
+error: sha256 does not match, expected: bd54d7acd68edca80653a4cebdf8204fdb678de773911eba73fdd96962efd9b5
  --> tests/trybuild/contractimport_with_sha256_verify_fail.rs:3:5
   |
 3 |     sha256 = "0000000000000000000000000000000000000000000000000000000000000000",

--- a/tests/account/Cargo.toml
+++ b/tests/account/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "example_account"
+version = "0.0.4"
+authors = ["Stellar Development Foundation <info@stellar.org>"]
+license = "Apache-2.0"
+edition = "2021"
+publish = false
+rust-version = "1.64"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+doctest = false
+
+[dependencies]
+soroban-sdk = {path = "../../soroban-sdk"}
+
+[dev-dependencies]
+soroban-sdk = {path = "../../soroban-sdk", features = ["testutils"]}
+
+[features]
+testutils = ["soroban-sdk/testutils"]

--- a/tests/account/src/lib.rs
+++ b/tests/account/src/lib.rs
@@ -28,6 +28,11 @@ mod test {
         let client = ContractClient::new(&e, &contract_id);
 
         let exists = client.exists();
+
+        // TODO: This test is somewhat odd in that the account invoking the
+        // contract would always exist in the real world, but doesn't exist in
+        // tests. We should find a way to align the test behavior with real
+        // world behavior.
         assert!(!exists);
     }
 }

--- a/tests/account/src/lib.rs
+++ b/tests/account/src/lib.rs
@@ -1,0 +1,33 @@
+#![no_std]
+use soroban_sdk::{contractimpl, Account, Env};
+
+pub struct Contract;
+
+#[contractimpl]
+impl Contract {
+    pub fn exists(env: Env) -> bool {
+        let a = match env.invoker() {
+            soroban_sdk::Invoker::Account(a) => a,
+            _ => panic!("must be invoked by account"),
+        };
+        Account::exists(&a)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use soroban_sdk::{BytesN, Env};
+
+    use crate::{Contract, ContractClient};
+
+    #[test]
+    fn test_hello() {
+        let e = Env::default();
+        let contract_id = BytesN::from_array(&e, &[0; 32]);
+        e.register_contract(&contract_id, Contract);
+        let client = ContractClient::new(&e, &contract_id);
+
+        let exists = client.exists();
+        assert!(!exists);
+    }
+}


### PR DESCRIPTION
### What
Use AccountId instead of BytesN<32> for account ids.

### Why
The env is changing to use AccountId because that's what is used for the invoker.

Close https://github.com/stellar/rs-soroban-env/issues/477