### PR TITLE
Remove need for testutils in soroban-auth tests

### DIFF
--- a/soroban-auth/src/test.rs
+++ b/soroban-auth/src/test.rs
@@ -1,5 +1,4 @@
 #![cfg(test)]
-#![cfg(feature = "testutils")]
 
 extern crate std;
 

--- a/soroban-auth/src/testutils.rs
+++ b/soroban-auth/src/testutils.rs
@@ -1,4 +1,4 @@
-#![cfg(feature = "testutils")]
+#![cfg(any(test, feature = "testutils"))]
 #![cfg_attr(feature = "docs", doc(cfg(feature = "testutils")))]
 
 //! Utilities intended for use when testing contracts that use

--- a/soroban-auth/tests/test.rs
+++ b/soroban-auth/tests/test.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "testutils")]
+
 use soroban_auth::testutils::ed25519::{generate, sign};
 use soroban_auth::{verify, Identifier, Signature};
 use soroban_sdk::{contractimpl, contracttype, symbol, BigInt, BytesN, Env};

--- a/soroban-auth/tests/test.rs
+++ b/soroban-auth/tests/test.rs
@@ -1,5 +1,3 @@
-#![cfg(feature = "testutils")]
-
 use soroban_auth::testutils::ed25519::{generate, sign};
 use soroban_auth::{verify, Identifier, Signature};
 use soroban_sdk::{contractimpl, contracttype, symbol, BigInt, BytesN, Env};


### PR DESCRIPTION
### What
Remove need for testutils in soroban-auth tests.

### Why
Putting testutils requirement on all the soroban-auth tests causes none of the tests to run when the feature flag isn't provided. We don't need to require the testutils feature if the testutils functionality is available in tests, so we can simply export the testutils functionality whenever tests are running. We use this pattern in the SDK and in other places.

I'm changing this now because I'm working in the soroban-auth crate, and just discovered I wasn't running any of the tests because I wasn't using the feature.