### PR TITLE
Move soroban-auth tests together

### DIFF
--- a/soroban-auth/src/lib.rs
+++ b/soroban-auth/src/lib.rs
@@ -15,7 +15,7 @@
 //! contract invocations to be replayable if it is important they are not.**
 #![no_std]
 
-mod test;
+mod tests;
 
 use soroban_sdk::{serde::Serialize, Account, BytesN, Env, IntoVal, RawVal, Symbol, Vec};
 

--- a/soroban-auth/src/tests.rs
+++ b/soroban-auth/src/tests.rs
@@ -1,0 +1,4 @@
+#![cfg(test)]
+
+mod test_complex;
+mod test_simple;

--- a/soroban-auth/src/tests/test_complex.rs
+++ b/soroban-auth/src/tests/test_complex.rs
@@ -1,5 +1,5 @@
-use soroban_auth::testutils::ed25519::{generate, sign};
-use soroban_auth::{verify, Identifier, Signature};
+use crate::testutils::ed25519::{generate, sign};
+use crate::{verify, Identifier, Signature};
 use soroban_sdk::{contractimpl, contracttype, symbol, BigInt, BytesN, Env};
 
 #[contracttype]

--- a/soroban-auth/src/tests/test_simple.rs
+++ b/soroban-auth/src/tests/test_simple.rs
@@ -1,5 +1,3 @@
-#![cfg(test)]
-
 extern crate std;
 
 use soroban_sdk::{contractimpl, symbol, testutils::LedgerInfo, BytesN, Env};


### PR DESCRIPTION
### What
Move soroban-auth tests together

### Why
The tests in soroban-auth have been written in two different ways. Consolidating them so that it is clearer where new tests should go. The pattern in use is same as the env host repo is using.