### PR TITLE
Change tuple structs to be encoded as Vecs instead of Maps

### DIFF
--- a/soroban-sdk-macros/src/derive_struct_tuple.rs
+++ b/soroban-sdk-macros/src/derive_struct_tuple.rs
@@ -9,10 +9,6 @@ use stellar_xdr::{
 
 use crate::map_type::map_type;
 
-// TODO: Add field attribute for including/excluding fields in types.
-// TODO: Better handling of partial types and types without all their fields and
-// types with private fields.
-
 pub fn derive_type_struct_tuple(
     path: &Path,
     ident: &Ident,

--- a/soroban-sdk-macros/src/lib.rs
+++ b/soroban-sdk-macros/src/lib.rs
@@ -6,6 +6,7 @@ mod derive_enum_int;
 mod derive_error_enum_int;
 mod derive_fn;
 mod derive_struct;
+mod derive_struct_tuple;
 mod map_type;
 mod path;
 mod syn_ext;
@@ -16,6 +17,7 @@ use derive_enum_int::derive_type_enum_int;
 use derive_error_enum_int::derive_type_error_enum_int;
 use derive_fn::{derive_contract_function_set, derive_fn};
 use derive_struct::derive_type_struct;
+use derive_struct_tuple::derive_type_struct_tuple;
 
 use darling::FromMeta;
 use proc_macro::TokenStream;
@@ -24,8 +26,8 @@ use quote::quote;
 use sha2::{Digest, Sha256};
 use std::fs;
 use syn::{
-    parse_macro_input, parse_str, spanned::Spanned, AttributeArgs, DeriveInput, Error, ItemImpl,
-    LitStr, Path, Type, Visibility,
+    parse_macro_input, parse_str, spanned::Spanned, AttributeArgs, Data, DeriveInput, Error,
+    Fields, ItemImpl, LitStr, Path, Type, Visibility,
 };
 
 use self::derive_client::ClientItem;
@@ -155,8 +157,18 @@ pub fn contracttype(metadata: TokenStream, input: TokenStream) -> TokenStream {
         matches!(input.vis, Visibility::Public(_))
     };
     let derived = match &input.data {
-        syn::Data::Struct(s) => derive_type_struct(&args.crate_path, ident, s, gen_spec, &args.lib),
-        syn::Data::Enum(e) => {
+        Data::Struct(s) => match s.fields {
+            Fields::Named(_) => derive_type_struct(&args.crate_path, ident, s, gen_spec, &args.lib),
+            Fields::Unnamed(_) => {
+                derive_type_struct_tuple(&args.crate_path, ident, s, gen_spec, &args.lib)
+            }
+            Fields::Unit => Error::new(
+                s.fields.span(),
+                "unit structs are not supported as contract types",
+            )
+            .to_compile_error(),
+        },
+        Data::Enum(e) => {
             let count_of_variants = e.variants.len();
             let count_of_int_variants = e
                 .variants
@@ -172,7 +184,7 @@ pub fn contracttype(metadata: TokenStream, input: TokenStream) -> TokenStream {
                     .to_compile_error()
             }
         }
-        syn::Data::Union(u) => Error::new(
+        Data::Union(u) => Error::new(
             u.union_token.span(),
             "unions are unsupported as contract types",
         )
@@ -211,7 +223,7 @@ pub fn contracterror(metadata: TokenStream, input: TokenStream) -> TokenStream {
         matches!(input.vis, Visibility::Public(_))
     };
     let derived = match &input.data {
-        syn::Data::Enum(e) => {
+        Data::Enum(e) => {
             if e.variants.iter().all(|v| v.discriminant.is_some()) {
                 derive_type_error_enum_int(&args.crate_path, ident, e, gen_spec, &args.lib)
             } else {
@@ -219,12 +231,12 @@ pub fn contracterror(metadata: TokenStream, input: TokenStream) -> TokenStream {
                     .to_compile_error()
             }
         }
-        syn::Data::Struct(s) => Error::new(
+        Data::Struct(s) => Error::new(
             s.struct_token.span(),
             "structs are unsupported as contract errors",
         )
         .to_compile_error(),
-        syn::Data::Union(u) => Error::new(
+        Data::Union(u) => Error::new(
             u.union_token.span(),
             "unions are unsupported as contract errors",
         )

--- a/soroban-sdk/tests/contract_udt_struct_tuple.rs
+++ b/soroban-sdk/tests/contract_udt_struct_tuple.rs
@@ -1,0 +1,110 @@
+#![cfg(feature = "testutils")]
+
+use std::io::Cursor;
+
+use soroban_sdk::{
+    contractimpl, contracttype, vec, BytesN, ConversionError, Env, IntoVal, RawVal, TryFromVal,
+    TryIntoVal, Vec,
+};
+use stellar_xdr::{
+    ReadXdr, ScSpecEntry, ScSpecFunctionInputV0, ScSpecFunctionV0, ScSpecTypeDef, ScSpecTypeTuple,
+    ScSpecTypeUdt,
+};
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[contracttype]
+pub struct Udt(pub i32, pub i32);
+
+pub struct Contract;
+
+#[contractimpl]
+impl Contract {
+    pub fn add(a: Udt, b: Udt) -> (Udt, Udt) {
+        (a, b)
+    }
+}
+
+#[test]
+fn test_conversion() {
+    let env = Env::default();
+    let a = Udt(5, 7);
+    let r: RawVal = a.into_val(&env);
+    let v: Vec<i32> = r.try_into_val(&env).unwrap();
+    assert_eq!(v, vec![&env, 5, 7]);
+}
+
+#[test]
+fn test_functional() {
+    let env = Env::default();
+    let contract_id = BytesN::from_array(&env, &[0; 32]);
+    env.register_contract(&contract_id, Contract);
+
+    let a = Udt(5, 7);
+    let b = Udt(10, 14);
+    let c = ContractClient::new(&env, &contract_id).add(&a, &b);
+    assert_eq!(c, (a, b));
+}
+
+#[test]
+fn test_error_on_partial_decode() {
+    let env = Env::default();
+
+    // Success case, a vec will decode to a Udt.
+    let map = vec![&env, 5, 7].to_raw();
+    let udt = Udt::try_from_val(&env, map);
+    assert_eq!(udt, Ok(Udt(5, 7)));
+
+    // If a struct has 2 fields, and a vec is decoded into it where the vec has
+    // 2 elements, it is an error. It is an error because all fields must be
+    // assigned values.
+    let map = vec![&env, 5, 7, 9].to_raw();
+    let udt = Udt::try_from_val(&env, map);
+    assert_eq!(udt, Err(ConversionError));
+
+    // If a struct has 2 fields, and a vec is decoded into it where the vec has
+    // 3 elements, it is an error. It is an error because decoding and encoding
+    // will not round trip the data, and therefore partial decoding is
+    // relatively difficult to use safely.
+    let map = vec![&env, 5, 7, 9].to_raw();
+    let udt = Udt::try_from_val(&env, map);
+    assert_eq!(udt, Err(ConversionError));
+}
+
+#[test]
+fn test_spec() {
+    let entries = ScSpecEntry::read_xdr(&mut Cursor::new(&__SPEC_XDR_ADD)).unwrap();
+    let expect = ScSpecEntry::FunctionV0(ScSpecFunctionV0 {
+        name: "add".try_into().unwrap(),
+        inputs: std::vec![
+            ScSpecFunctionInputV0 {
+                name: "a".try_into().unwrap(),
+                type_: ScSpecTypeDef::Udt(ScSpecTypeUdt {
+                    name: "Udt".try_into().unwrap(),
+                }),
+            },
+            ScSpecFunctionInputV0 {
+                name: "b".try_into().unwrap(),
+                type_: ScSpecTypeDef::Udt(ScSpecTypeUdt {
+                    name: "Udt".try_into().unwrap(),
+                }),
+            },
+        ]
+        .try_into()
+        .unwrap(),
+        outputs: std::vec![ScSpecTypeDef::Tuple(Box::new(ScSpecTypeTuple {
+            value_types: std::vec![
+                ScSpecTypeDef::Udt(ScSpecTypeUdt {
+                    name: "Udt".try_into().unwrap(),
+                }),
+                ScSpecTypeDef::Udt(ScSpecTypeUdt {
+                    name: "Udt".try_into().unwrap(),
+                }),
+            ]
+            .try_into()
+            .unwrap(),
+        }))]
+        .try_into()
+        .unwrap(),
+    });
+    assert_eq!(entries, expect);
+}


### PR DESCRIPTION
### What
Change tuple structs to be encoded as Vecs instead of Maps.

### Why
Today tuple structs are encoded as maps where the keys are symbols containing the numeric number of the fields. I only recently implemented this (https://github.com/stellar/rs-soroban-sdk/pull/668) so no one should be depending on this behavior in any significant way.

There's a couple problems with the existing approach:
- It is very wasteful of space. The elements will be ordered, but we still include 12 bytes of additional data per key.
- Maps are much more complex data structures, so they're much harder for clients to produce. While this is unavoidable everywhere we need to use maps, for tuple structs there isn't a need to use maps, so we should avoid the complexity here.
- Tuple structs are very much like tuple values and tuple values are serialized as vecs, so it would be more consistent to also encode the tuple structs as vecs. A benefit of this is it makes tuples structs and tuple values interchangeable.

A run on benefit of doing this is we could use a tuple struct for the SignaturePayloadV0 in the soroban-auth package, and the fields would be ordered with network passphrase first.