### PR TITLE
Make SignaturePayloadV0 a tuple struct which is a Vec

### DIFF
--- a/soroban-auth/src/lib.rs
+++ b/soroban-auth/src/lib.rs
@@ -28,12 +28,12 @@ pub use crate::public_types::{
 };
 
 fn verify_ed25519_signature(env: &Env, auth: &Ed25519Signature, name: Symbol, args: Vec<RawVal>) {
-    let msg = SignaturePayloadV0 {
+    let msg = SignaturePayloadV0::new(
+        env.ledger().network_passphrase(),
+        env.get_current_contract(),
         name,
-        contract: env.get_current_contract(),
-        network: env.ledger().network_passphrase(),
         args,
-    };
+    );
     let msg_bin = SignaturePayload::V0(msg).serialize(env);
 
     env.verify_sig_ed25519(&auth.public_key, &msg_bin, &auth.signature);
@@ -42,12 +42,12 @@ fn verify_ed25519_signature(env: &Env, auth: &Ed25519Signature, name: Symbol, ar
 fn verify_account_signatures(env: &Env, auth: &AccountSignatures, name: Symbol, args: Vec<RawVal>) {
     let acc = Account::from_id(&auth.account_id).unwrap();
 
-    let msg = SignaturePayloadV0 {
+    let msg = SignaturePayloadV0::new(
+        env.ledger().network_passphrase(),
+        env.get_current_contract(),
         name,
-        contract: env.get_current_contract(),
-        network: env.ledger().network_passphrase(),
         args,
-    };
+    );
     let msg_bytes = SignaturePayload::V0(msg).serialize(env);
 
     let threshold = acc.medium_threshold();

--- a/soroban-auth/src/public_types.rs
+++ b/soroban-auth/src/public_types.rs
@@ -115,22 +115,6 @@ impl SignaturePayloadV0 {
     pub fn new(network: Bytes, contract: BytesN<32>, name: Symbol, args: Vec<RawVal>) -> Self {
         Self(network, contract, name, args)
     }
-
-    pub fn network(&self) -> &Bytes {
-        &self.0
-    }
-
-    pub fn contract(&self) -> &BytesN<32> {
-        &self.1
-    }
-
-    pub fn symbol(&self) -> &Symbol {
-        &self.2
-    }
-
-    pub fn args(&self) -> &Vec<RawVal> {
-        &self.3
-    }
 }
 
 /// Signature payload contains the data that must be signed to authenticate the

--- a/soroban-auth/src/public_types.rs
+++ b/soroban-auth/src/public_types.rs
@@ -92,13 +92,45 @@ pub enum Identifier {
 /// and signing the whole payload only. Applications should never trust a
 /// signature payload without either inspecting its entire contents, or building
 /// it themselves.
+///
+/// To produce this structure in XDR, produce an `ScVec` containing for elements:
+/// - Network: `ScVal::Object(Some(ScObject::Bytes(_)))`
+/// - Contract: `ScVal::Object(Some(ScObject::Bytes(_)))`
+/// - Name: `ScVal::Symbol(_)`
+/// - Args: `ScVal::Object(Some(ScObject::Vec(_)))`
 #[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
 #[contracttype(lib = "soroban_auth")]
-pub struct SignaturePayloadV0 {
-    pub network: Bytes,
-    pub contract: BytesN<32>,
-    pub name: Symbol,
-    pub args: Vec<RawVal>,
+pub struct SignaturePayloadV0(
+    // Network Passphrase
+    Bytes,
+    // Contract ID
+    BytesN<32>,
+    // Name
+    Symbol,
+    // Args
+    Vec<RawVal>,
+);
+
+impl SignaturePayloadV0 {
+    pub fn new(network: Bytes, contract: BytesN<32>, name: Symbol, args: Vec<RawVal>) -> Self {
+        Self(network, contract, name, args)
+    }
+
+    pub fn network(&self) -> &Bytes {
+        &self.0
+    }
+
+    pub fn contract(&self) -> &BytesN<32> {
+        &self.1
+    }
+
+    pub fn symbol(&self) -> &Symbol {
+        &self.2
+    }
+
+    pub fn args(&self) -> &Vec<RawVal> {
+        &self.3
+    }
 }
 
 /// Signature payload contains the data that must be signed to authenticate the

--- a/soroban-auth/src/testutils.rs
+++ b/soroban-auth/src/testutils.rs
@@ -55,12 +55,12 @@ pub mod ed25519 {
         } else {
             panic!("identifier must be ed25519")
         };
-        let payload = SignaturePayload::V0(SignaturePayloadV0 {
-            network: env.ledger().network_passphrase(),
-            contract: contract.clone(),
+        let payload = SignaturePayload::V0(SignaturePayloadV0::new(
+            env.ledger().network_passphrase(),
+            contract.clone(),
             name,
-            args: args.into_val(env),
-        });
+            args.into_val(env),
+        ));
         let signature = match signer.sign(payload) {
             Ok(signature) => signature,
             Err(_) => panic!("error signing signature payload"),


### PR DESCRIPTION
### What
Make SignaturePayloadV0 a tuple struct which is a Vec under the hood.

### Why
So that the domain separator is encoded in order-of scope.