### PR TITLE
Rename contract data to data

### DIFF
--- a/soroban-auth/src/tests/test_complex.rs
+++ b/soroban-auth/src/tests/test_complex.rs
@@ -9,7 +9,7 @@ pub enum DataKey {
 
 fn read_nonce(e: &Env, id: &Identifier) -> BigInt {
     let key = DataKey::Nonce(id.clone());
-    e.contract_data()
+    e.data()
         .get(key)
         .unwrap_or_else(|| Ok(BigInt::zero(e)))
         .unwrap()
@@ -32,7 +32,7 @@ fn verify_and_consume_nonce(e: &Env, id: &Identifier, expected_nonce: &BigInt) {
     if nonce != expected_nonce {
         panic!("incorrect nonce")
     }
-    e.contract_data().set(key, &nonce + 1);
+    e.data().set(key, &nonce + 1);
 }
 
 pub struct TestContract;

--- a/soroban-sdk/src/bytes.rs
+++ b/soroban-sdk/src/bytes.rs
@@ -14,7 +14,7 @@ use super::{
 };
 
 #[cfg(doc)]
-use crate::{contract_data::ContractData, Map, Vec};
+use crate::{data::Data, Map, Vec};
 
 #[cfg(not(target_family = "wasm"))]
 use super::xdr::ScVal;
@@ -103,8 +103,8 @@ macro_rules! bytesn {
 /// The array is stored in the Host and available to the Guest through the
 /// functions defined on Bytes.
 ///
-/// Bytes values can be stored as [ContractData], or in other
-/// types like [Vec], [Map], etc.
+/// Bytes values can be stored as [Data], or in other types like [Vec], [Map],
+/// etc.
 ///
 /// ### Examples
 ///
@@ -667,8 +667,8 @@ impl ExactSizeIterator for BinIter {
 /// The array is stored in the Host and available to the Guest through the
 /// functions defined on Bytes.
 ///
-/// Bytes values can be stored as [ContractData], or in other
-/// types like [Vec], [Map], etc.
+/// Bytes values can be stored as [Data], or in other types like [Vec], [Map],
+/// etc.
 ///
 /// ### Examples
 ///

--- a/soroban-sdk/src/data.rs
+++ b/soroban-sdk/src/data.rs
@@ -7,7 +7,7 @@ use crate::{
     Env, IntoVal, TryFromVal,
 };
 
-/// ContractData stores and retrieves data for the currently executing contract.
+/// Data stores and retrieves data for the currently executing contract.
 ///
 /// All data stored can only be queried and modified by the contract that stores
 /// it. Other contracts cannot query or modify data stored by other contracts.
@@ -45,23 +45,23 @@ use crate::{
 /// # fn main() { }
 /// ```
 #[derive(Clone)]
-pub struct ContractData(Env);
+pub struct Data(Env);
 
-impl Debug for ContractData {
+impl Debug for Data {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        write!(f, "ContractData")
+        write!(f, "Data")
     }
 }
 
-impl ContractData {
+impl Data {
     #[inline(always)]
     pub(crate) fn env(&self) -> &Env {
         &self.0
     }
 
     #[inline(always)]
-    pub(crate) fn new(env: &Env) -> ContractData {
-        ContractData(env.clone())
+    pub(crate) fn new(env: &Env) -> Data {
+        Data(env.clone())
     }
 
     // TODO: Use Borrow<K> for all key use in these functions.

--- a/soroban-sdk/src/data.rs
+++ b/soroban-sdk/src/data.rs
@@ -1,5 +1,4 @@
-//! Contract data contains types storing and retrieving data for the currently
-//! executing contract.
+//! Data contains types for storing data for the currently executing contract.
 use core::fmt::Debug;
 
 use crate::{
@@ -26,11 +25,11 @@ use crate::{
 /// # #[contractimpl]
 /// # impl Contract {
 /// #     pub fn f(env: Env) {
-/// let contract_data = env.contract_data();
+/// let data = env.data();
 /// let key = symbol!("key");
-/// env.contract_data().set(key, 1);
-/// assert_eq!(contract_data.has(key), true);
-/// assert_eq!(contract_data.get::<_, i32>(key), Some(Ok(1)));
+/// env.data().set(key, 1);
+/// assert_eq!(data.has(key), true);
+/// assert_eq!(data.get::<_, i32>(key), Some(Ok(1)));
 /// #     }
 /// # }
 /// #

--- a/soroban-sdk/src/env.rs
+++ b/soroban-sdk/src/env.rs
@@ -53,8 +53,8 @@ pub type EnvObj = internal::EnvVal<Env, Object>;
 use crate::invoker::Invoker;
 use crate::AccountId;
 use crate::{
-    contract_data::ContractData, deploy::Deployer, events::Events, ledger::Ledger, logging::Logger,
-    Bytes, BytesN, Vec,
+    data::Data, deploy::Deployer, events::Events, ledger::Ledger, logging::Logger, Bytes, BytesN,
+    Vec,
 };
 
 /// The [Env] type provides access to the environment the contract is executing
@@ -141,11 +141,11 @@ impl Env {
         }
     }
 
-    /// Get a [ContractData] for accessing and update contract data that has
-    /// been stored by the currently executing contract.
+    /// Get a [Data] for accessing and update contract data that has been stored
+    /// by the currently executing contract.
     #[inline(always)]
-    pub fn contract_data(&self) -> ContractData {
-        ContractData::new(self)
+    pub fn data(&self) -> Data {
+        Data::new(self)
     }
 
     /// Get a [Ledger] for accessing the current ledger.

--- a/soroban-sdk/src/lib.rs
+++ b/soroban-sdk/src/lib.rs
@@ -171,7 +171,7 @@ mod operators;
 mod account;
 mod bigint;
 mod bytes;
-pub mod contract_data;
+pub mod data;
 pub mod deploy;
 pub mod events;
 pub mod iter;

--- a/soroban-sdk/src/map.rs
+++ b/soroban-sdk/src/map.rs
@@ -13,7 +13,7 @@ use super::{
 use super::xdr::ScVal;
 
 #[cfg(doc)]
-use crate::contract_data::ContractData;
+use crate::data::Data;
 
 /// Create a [Map] with the given key-value pairs.
 ///
@@ -56,8 +56,8 @@ macro_rules! map {
 /// Maps have at most one entry per key. Setting a value for a key in the map
 /// that already has a value for that key replaces the value.
 ///
-/// Map values can be stored as [ContractData], or in other
-/// types like [Vec], [Map], etc.
+/// Map values can be stored as [Data], or in other types like [Vec], [Map],
+/// etc.
 ///
 /// ### Examples
 ///

--- a/soroban-sdk/src/vec.rs
+++ b/soroban-sdk/src/vec.rs
@@ -15,7 +15,7 @@ use super::{
 };
 
 #[cfg(doc)]
-use crate::{contract_data::ContractData, Bytes, BytesN, Map};
+use crate::{data::Data, Bytes, BytesN, Map};
 
 /// Create a [Vec] with the given items.
 ///
@@ -88,8 +88,8 @@ impl_into_vec_for_tuple! { T0 0 T1 1 T2 2 T3 3 T4 4 T5 5 T6 6 T7 7 T8 8 T9 9 T10
 ///
 /// To store `u8`s and binary data, use [Bytes]/[BytesN] instead.
 ///
-/// Vec values can be stored as [ContractData], or in other
-/// types like [Vec], [Map], etc.
+/// Vec values can be stored as [Data], or in other types like [Vec], [Map],
+/// etc.
 ///
 /// ### Examples
 ///

--- a/tests/contract_data/src/lib.rs
+++ b/tests/contract_data/src/lib.rs
@@ -6,10 +6,10 @@ pub struct Contract;
 #[contractimpl]
 impl Contract {
     pub fn put(e: Env, key: Symbol, val: Symbol) {
-        e.contract_data().set(key, val)
+        e.data().set(key, val)
     }
 
     pub fn del(e: Env, key: Symbol) {
-        e.contract_data().remove(key)
+        e.data().remove(key)
     }
 }

--- a/tests/errors/src/lib.rs
+++ b/tests/errors/src/lib.rs
@@ -12,7 +12,7 @@ pub enum Error {
 #[contractimpl]
 impl Contract {
     pub fn hello(env: Env, flag: u32) -> Result<Symbol, Error> {
-        env.contract_data().set(symbol!("persisted"), true);
+        env.data().set(symbol!("persisted"), true);
         if flag == 0 {
             Ok(symbol!("hello"))
         } else if flag == 1 {
@@ -28,7 +28,7 @@ impl Contract {
 
     #[cfg(test)]
     pub fn persisted(env: Env) -> bool {
-        env.contract_data()
+        env.data()
             .get(symbol!("persisted"))
             .unwrap_or_else(|| Ok(false))
             .unwrap()


### PR DESCRIPTION
### What
Rename contract data to data.

### Why
We had a few places that the term "contract" showed up as a prefix, even though everything relates to contracts. Contract Data was one thing we didn't get to clean up. Cleaning it up now.