### PR TITLE
Change Account::signer_weight from u32 to u8

### DIFF
--- a/soroban-auth/src/lib.rs
+++ b/soroban-auth/src/lib.rs
@@ -80,8 +80,9 @@ fn verify_account_signatures(env: &Env, auth: &AccountSignatures, name: Symbol, 
         if signer_weight == 0 {
             panic!("signature doesn't belong to account");
         }
-        // Signature weight can be at most 255, hence overflow isn't possible
-        // here as 255 * MAX_ACCOUNT_SIGNATURES is < u32::MAX.
+        // A signature's weight can be at most u8::MAX, hence overflow isn't
+        // possible here as u8::MAX * MAX_ACCOUNT_SIGNATURES is < u32::MAX.
+        let signer_weight: u32 = signer_weight.into();
         weight += signer_weight;
 
         prev_pk = Some(sig.public_key);

--- a/soroban-sdk/src/account.rs
+++ b/soroban-sdk/src/account.rs
@@ -285,9 +285,10 @@ impl Account {
 
     /// Returns the signer weight for the signer for this Stellar account. If
     /// the signer does not exist for the account, returns zero (`0`).
-    pub fn signer_weight(&self, signer: &BytesN<32>) -> u32 {
+    pub fn signer_weight(&self, signer: &BytesN<32>) -> u8 {
         let env = self.env();
         let val = env.account_get_signer_weight(self.to_object(), signer.to_object());
-        unsafe { <u32 as RawValConvertible>::unchecked_from_val(val) }
+        let weight_u32 = unsafe { <u32 as RawValConvertible>::unchecked_from_val(val) };
+        weight_u32 as u8
     }
 }


### PR DESCRIPTION
### What
Change Account::signer_weight from u32 to u8.

### Why
@dmkozh made several improvements to how we handle Stellar signers recently, one being that the signer weight the host provides is guaranteed to be a u8 (clamped to 0-255). We can have the SDK present the value as u8 for this reason, which mean people using the SDK can rely on the value being in that range.

Related https://github.com/stellar/rs-soroban-env/pull/493