### PR TITLE
Use `u8` for account thresholds.

### DIFF
--- a/soroban-auth/src/lib.rs
+++ b/soroban-auth/src/lib.rs
@@ -88,7 +88,7 @@ fn verify_account_signatures(env: &Env, auth: &AccountSignatures, name: Symbol, 
         prev_pk = Some(sig.public_key);
     }
 
-    if weight < threshold {
+    if weight < threshold.into() {
         panic!("insufficient signing weight")
     }
 }

--- a/soroban-sdk/src/account.rs
+++ b/soroban-sdk/src/account.rs
@@ -263,24 +263,27 @@ impl Account {
     }
 
     /// Returns the low threshold for the Stellar account.
-    pub fn low_threshold(&self) -> u32 {
+    pub fn low_threshold(&self) -> u8 {
         let env = self.env();
         let val = env.account_get_low_threshold(self.to_object());
-        unsafe { <u32 as RawValConvertible>::unchecked_from_val(val) }
+        let threshold_u32 = unsafe { <u32 as RawValConvertible>::unchecked_from_val(val) };
+        threshold_u32 as u8
     }
 
     /// Returns the medium threshold for the Stellar account.
-    pub fn medium_threshold(&self) -> u32 {
+    pub fn medium_threshold(&self) -> u8 {
         let env = self.env();
         let val = env.account_get_medium_threshold(self.to_object());
-        unsafe { <u32 as RawValConvertible>::unchecked_from_val(val) }
+        let threshold_u32 = unsafe { <u32 as RawValConvertible>::unchecked_from_val(val) };
+        threshold_u32 as u8
     }
 
     /// Returns the high threshold for the Stellar account.
-    pub fn high_threshold(&self) -> u32 {
+    pub fn high_threshold(&self) -> u8 {
         let env = self.env();
         let val = env.account_get_high_threshold(self.to_object());
-        unsafe { <u32 as RawValConvertible>::unchecked_from_val(val) }
+        let threshold_u32 = unsafe { <u32 as RawValConvertible>::unchecked_from_val(val) };
+        threshold_u32 as u8
     }
 
     /// Returns the signer weight for the signer for this Stellar account. If


### PR DESCRIPTION
### What

Use `u8` for account thresholds.

### Why

This is their real type in ledger/host.

### Known limitations

N/A