### PR TITLE
Move ledger test utilities into Ledger

### DIFF
--- a/soroban-auth/src/tests/test_ed25519.rs
+++ b/soroban-auth/src/tests/test_ed25519.rs
@@ -1,6 +1,10 @@
 extern crate std;
 
-use soroban_sdk::{contractimpl, symbol, testutils::LedgerInfo, BytesN, Env};
+use soroban_sdk::{
+    contractimpl, symbol,
+    testutils::{Ledger, LedgerInfo},
+    BytesN, Env,
+};
 
 use crate::{
     testutils::ed25519::{generate, sign},
@@ -28,7 +32,7 @@ fn test() {
     env.register_contract(&contract_id, ExampleContract);
     let client = ExampleContractClient::new(&env, &contract_id);
 
-    env.set_ledger(LedgerInfo {
+    env.ledger().set_info(LedgerInfo {
         base_reserve: 0,
         network_passphrase: "soroban-auth test".as_bytes().to_vec(),
         protocol_version: 0,

--- a/soroban-auth/src/tests/test_ed25519.rs
+++ b/soroban-auth/src/tests/test_ed25519.rs
@@ -32,7 +32,7 @@ fn test() {
     env.register_contract(&contract_id, ExampleContract);
     let client = ExampleContractClient::new(&env, &contract_id);
 
-    env.ledger().set_info(LedgerInfo {
+    env.ledger().set(LedgerInfo {
         base_reserve: 0,
         network_passphrase: "soroban-auth test".as_bytes().to_vec(),
         protocol_version: 0,

--- a/soroban-sdk/src/env.rs
+++ b/soroban-sdk/src/env.rs
@@ -314,7 +314,7 @@ impl Env {
             xdr::Uint256([0; 32]),
         )));
 
-        env.ledger().set_info(internal::LedgerInfo {
+        env.ledger().set(internal::LedgerInfo {
             protocol_version: 0,
             sequence_number: 0,
             timestamp: 0,

--- a/soroban-sdk/src/env.rs
+++ b/soroban-sdk/src/env.rs
@@ -270,7 +270,7 @@ impl Env {
 }
 
 #[cfg(any(test, feature = "testutils"))]
-use crate::testutils::ContractFunctionSet;
+use crate::testutils::{ContractFunctionSet, Ledger as _};
 #[cfg(any(test, feature = "testutils"))]
 use core::fmt::Debug;
 #[cfg(any(test, feature = "testutils"))]
@@ -314,7 +314,7 @@ impl Env {
             xdr::Uint256([0; 32]),
         )));
 
-        env.set_ledger(internal::LedgerInfo {
+        env.ledger().set_info(internal::LedgerInfo {
             protocol_version: 0,
             sequence_number: 0,
             timestamp: 0,
@@ -353,19 +353,6 @@ impl Env {
                 storage.put(&k, &v)
             })
             .unwrap();
-    }
-
-    /// Sets ledger information in the [Env], which will be accessible via
-    /// [Env::ledger].
-    pub fn set_ledger(&self, li: internal::LedgerInfo) {
-        self.env_impl.set_ledger_info(li)
-    }
-
-    pub fn with_mut_ledger_info<F>(&self, f: F)
-    where
-        F: FnMut(&mut internal::LedgerInfo),
-    {
-        self.env_impl.with_mut_ledger_info(f).unwrap();
     }
 
     /// Register a contract with the [Env] for testing.

--- a/soroban-sdk/src/ledger.rs
+++ b/soroban-sdk/src/ledger.rs
@@ -104,7 +104,7 @@ impl testutils::Ledger for Ledger {
         env.host().set_ledger_info(li);
     }
 
-    fn with_mut_info<F>(&self, f: F)
+    fn with_mut<F>(&self, f: F)
     where
         F: FnMut(&mut internal::LedgerInfo),
     {

--- a/soroban-sdk/src/ledger.rs
+++ b/soroban-sdk/src/ledger.rs
@@ -92,3 +92,23 @@ impl Ledger {
         unsafe { Bytes::unchecked_new(bin_obj.in_env(env)) }
     }
 }
+
+#[cfg(any(test, feature = "testutils"))]
+use crate::testutils;
+
+#[cfg(any(test, feature = "testutils"))]
+#[cfg_attr(feature = "docs", doc(cfg(feature = "testutils")))]
+impl testutils::Ledger for Ledger {
+    fn set_info(&self, li: testutils::LedgerInfo) {
+        let env = self.env();
+        env.host().set_ledger_info(li);
+    }
+
+    fn with_mut_info<F>(&self, f: F)
+    where
+        F: FnMut(&mut internal::LedgerInfo),
+    {
+        let env = self.env();
+        env.host().with_mut_ledger_info(f).unwrap();
+    }
+}

--- a/soroban-sdk/src/ledger.rs
+++ b/soroban-sdk/src/ledger.rs
@@ -99,7 +99,7 @@ use crate::testutils;
 #[cfg(any(test, feature = "testutils"))]
 #[cfg_attr(feature = "docs", doc(cfg(feature = "testutils")))]
 impl testutils::Ledger for Ledger {
-    fn set_info(&self, li: testutils::LedgerInfo) {
+    fn set(&self, li: testutils::LedgerInfo) {
         let env = self.env();
         env.host().set_ledger_info(li);
     }

--- a/soroban-sdk/src/testutils.rs
+++ b/soroban-sdk/src/testutils.rs
@@ -18,7 +18,7 @@ pub trait ContractFunctionSet {
 /// Test utilities for [`Ledger`][crate::ledger::Ledger].
 pub trait Ledger {
     /// Set ledger info.
-    fn set_info(&self, l: LedgerInfo);
+    fn set(&self, l: LedgerInfo);
 
     /// Modify the ledger info.
     fn with_mut_info<F>(&self, f: F)

--- a/soroban-sdk/src/testutils.rs
+++ b/soroban-sdk/src/testutils.rs
@@ -15,6 +15,17 @@ pub trait ContractFunctionSet {
     fn call(&self, func: &Symbol, env: Env, args: &[RawVal]) -> Option<RawVal>;
 }
 
+/// Test utilities for [`Ledger`][crate::ledger::Ledger].
+pub trait Ledger {
+    /// Set ledger info.
+    fn set_info(&self, l: LedgerInfo);
+
+    /// Modify the ledger info.
+    fn with_mut_info<F>(&self, f: F)
+    where
+        F: FnMut(&mut LedgerInfo);
+}
+
 /// Test utilities for [`Events`][crate::events::Events].
 pub trait Events {
     /// Returns all events that have been published by contracts.

--- a/soroban-sdk/src/testutils.rs
+++ b/soroban-sdk/src/testutils.rs
@@ -21,7 +21,7 @@ pub trait Ledger {
     fn set(&self, l: LedgerInfo);
 
     /// Modify the ledger info.
-    fn with_mut_info<F>(&self, f: F)
+    fn with_mut<F>(&self, f: F)
     where
         F: FnMut(&mut LedgerInfo);
 }


### PR DESCRIPTION
### What
Move ledger test utilities into Ledger.

### Why
Testutility consistency.

This is the pattern we implemented other areas of the SDK like logging and events. The test utilities live next to the functions they call in their real code.

So today we have:
```rust
env().ledger().protocol_version();
env().set_ledger_info(... protocol_version ...);
```

And with this change we will have:
```rust
env().ledger().protocol_version();
env().ledger().set_info(... protocol_version ...);
```

It means the test utilities are in the same place in the docs so if someone is lookingat the page for how to get the protocol version they also see the function for how to set it, and it has a nice yellow label showing that the function is only available in test utilities.