### PR TITLE
Add accounts test utilities

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -686,7 +686,7 @@ dependencies = [
 [[package]]
 name = "soroban-env-common"
 version = "0.0.5"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=6cdd397b#6cdd397b41350c809f23ac30c8defeb60da562fa"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=fb8a384e#fb8a384eb73b1d157c13b073efa9c82ff490119f"
 dependencies = [
  "soroban-env-macros",
  "soroban-wasmi",
@@ -697,7 +697,7 @@ dependencies = [
 [[package]]
 name = "soroban-env-guest"
 version = "0.0.5"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=6cdd397b#6cdd397b41350c809f23ac30c8defeb60da562fa"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=fb8a384e#fb8a384eb73b1d157c13b073efa9c82ff490119f"
 dependencies = [
  "soroban-env-common",
  "static_assertions",
@@ -706,7 +706,7 @@ dependencies = [
 [[package]]
 name = "soroban-env-host"
 version = "0.0.5"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=6cdd397b#6cdd397b41350c809f23ac30c8defeb60da562fa"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=fb8a384e#fb8a384eb73b1d157c13b073efa9c82ff490119f"
 dependencies = [
  "backtrace",
  "dyn-fmt",
@@ -729,7 +729,7 @@ dependencies = [
 [[package]]
 name = "soroban-env-macros"
 version = "0.0.5"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=6cdd397b#6cdd397b41350c809f23ac30c8defeb60da562fa"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=fb8a384e#fb8a384eb73b1d157c13b073efa9c82ff490119f"
 dependencies = [
  "itertools",
  "proc-macro2",
@@ -741,7 +741,7 @@ dependencies = [
 [[package]]
 name = "soroban-native-sdk-macros"
 version = "0.0.5"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=6cdd397b#6cdd397b41350c809f23ac30c8defeb60da562fa"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=fb8a384e#fb8a384eb73b1d157c13b073efa9c82ff490119f"
 dependencies = [
  "itertools",
  "proc-macro2",
@@ -848,7 +848,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 [[package]]
 name = "stellar-xdr"
 version = "0.0.2"
-source = "git+https://github.com/stellar/rs-stellar-xdr?rev=1bcc6fe3#1bcc6fe3a15cb4f7cd157b4f4a50a93b491c3d10"
+source = "git+https://github.com/stellar/rs-stellar-xdr?rev=88ded341#88ded341ffbf54372ce851f766610ef978784d2a"
 dependencies = [
  "base64",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -232,7 +232,7 @@ checksum = "c762bae6dcaf24c4c84667b8579785430908723d5c889f469d76a41d59cc7a9d"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
- "rand",
+ "rand 0.7.3",
  "serde",
  "sha2 0.9.9",
  "zeroize",
@@ -268,7 +268,18 @@ checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.9.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4eb1a864a501629691edf6c15a593b7a51eebaa1e8468e9ddc623de7c9b58ec6"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.11.0+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -506,11 +517,22 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
 dependencies = [
- "getrandom",
+ "getrandom 0.1.16",
  "libc",
- "rand_chacha",
+ "rand_chacha 0.2.2",
  "rand_core 0.5.1",
  "rand_hc",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -524,12 +546,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
+]
+
+[[package]]
 name = "rand_core"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
 dependencies = [
- "getrandom",
+ "getrandom 0.1.16",
 ]
 
 [[package]]
@@ -537,6 +569,9 @@ name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.7",
+]
 
 [[package]]
 name = "rand_hc"
@@ -644,7 +679,7 @@ name = "soroban-auth"
 version = "0.0.4"
 dependencies = [
  "ed25519-dalek",
- "rand",
+ "rand 0.7.3",
  "soroban-sdk",
 ]
 
@@ -721,6 +756,7 @@ dependencies = [
  "bytes-lit",
  "ed25519-dalek",
  "hex",
+ "rand 0.8.5",
  "soroban-env-guest",
  "soroban-env-host",
  "soroban-sdk-macros",
@@ -770,7 +806,7 @@ name = "soroban-token-spec"
 version = "0.0.4"
 dependencies = [
  "ed25519-dalek",
- "rand",
+ "rand 0.7.3",
  "soroban-auth",
  "soroban-sdk",
 ]
@@ -987,6 +1023,12 @@ name = "wasi"
 version = "0.9.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
+
+[[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasmparser"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,12 +23,12 @@ soroban-sdk = { path = "soroban-sdk" }
 soroban-auth = { path = "soroban-auth" }
 soroban-spec = { path = "soroban-spec" }
 soroban-sdk-macros = { path = "soroban-sdk-macros" }
-soroban-env-common = { git = "https://github.com/stellar/rs-soroban-env", rev = "6cdd397b" }
-soroban-env-guest = { git = "https://github.com/stellar/rs-soroban-env", rev = "6cdd397b" }
-soroban-env-host = { git = "https://github.com/stellar/rs-soroban-env", rev = "6cdd397b" }
-soroban-env-macros = { git = "https://github.com/stellar/rs-soroban-env", rev = "6cdd397b" }
-soroban-native-sdk-macros = { git = "https://github.com/stellar/rs-soroban-env", rev = "6cdd397b" }
-stellar-xdr = { git = "https://github.com/stellar/rs-stellar-xdr", rev = "1bcc6fe3" }
+soroban-env-common = { git = "https://github.com/stellar/rs-soroban-env", rev = "fb8a384e" }
+soroban-env-guest = { git = "https://github.com/stellar/rs-soroban-env", rev = "fb8a384e" }
+soroban-env-host = { git = "https://github.com/stellar/rs-soroban-env", rev = "fb8a384e" }
+soroban-env-macros = { git = "https://github.com/stellar/rs-soroban-env", rev = "fb8a384e" }
+soroban-native-sdk-macros = { git = "https://github.com/stellar/rs-soroban-env", rev = "fb8a384e" }
+stellar-xdr = { git = "https://github.com/stellar/rs-stellar-xdr", rev = "88ded341" }
 wasmi = { package = "soroban-wasmi", git = "https://github.com/stellar/wasmi", rev = "a61b6df" }
 
 # soroban-env-common = { path = "../rs-soroban-env/soroban-env-common" }

--- a/soroban-auth/src/lib.rs
+++ b/soroban-auth/src/lib.rs
@@ -17,7 +17,7 @@
 
 mod tests;
 
-use soroban_sdk::{serde::Serialize, Account, BytesN, Env, IntoVal, RawVal, Symbol, Vec};
+use soroban_sdk::{serde::Serialize, BytesN, Env, IntoVal, RawVal, Symbol, Vec};
 
 pub mod testutils;
 
@@ -42,7 +42,7 @@ fn verify_ed25519_signature(env: &Env, auth: &Ed25519Signature, name: Symbol, ar
 }
 
 fn verify_account_signatures(env: &Env, auth: &AccountSignatures, name: Symbol, args: Vec<RawVal>) {
-    let acc = Account::from_id(&auth.account_id).unwrap();
+    let acc = env.accounts().get(&auth.account_id).unwrap();
 
     let msg = SignaturePayloadV0 {
         name,

--- a/soroban-auth/src/public_types.rs
+++ b/soroban-auth/src/public_types.rs
@@ -1,4 +1,6 @@
-use soroban_sdk::{contracttype, AccountId, Bytes, BytesN, Env, Invoker, RawVal, Symbol, Vec};
+use soroban_sdk::{
+    accounts::AccountId, contracttype, Bytes, BytesN, Env, Invoker, RawVal, Symbol, Vec,
+};
 
 /// An Ed25519 signature contains a single signature for the
 /// [`SignaturePayload`].

--- a/soroban-auth/src/tests/test_ed25519.rs
+++ b/soroban-auth/src/tests/test_ed25519.rs
@@ -1,6 +1,10 @@
 extern crate std;
 
-use soroban_sdk::{contractimpl, symbol, testutils::LedgerInfo, BytesN, Env};
+use soroban_sdk::{
+    contractimpl, symbol,
+    testutils::{Ledger, LedgerInfo},
+    BytesN, Env,
+};
 
 use crate::{
     testutils::ed25519::{generate, sign},
@@ -28,7 +32,7 @@ fn test() {
     env.register_contract(&contract_id, ExampleContract);
     let client = ExampleContractClient::new(&env, &contract_id);
 
-    env.set_ledger(LedgerInfo {
+    env.ledger().set_info(LedgerInfo {
         base_reserve: 0,
         network_passphrase: "soroban-auth test".as_bytes().to_vec(),
         protocol_version: 0,

--- a/soroban-auth/src/tests/test_ed25519.rs
+++ b/soroban-auth/src/tests/test_ed25519.rs
@@ -32,7 +32,7 @@ fn test() {
     env.register_contract(&contract_id, ExampleContract);
     let client = ExampleContractClient::new(&env, &contract_id);
 
-    env.ledger().set_info(LedgerInfo {
+    env.ledger().set(LedgerInfo {
         base_reserve: 0,
         network_passphrase: "soroban-auth test".as_bytes().to_vec(),
         protocol_version: 0,

--- a/soroban-sdk/Cargo.toml
+++ b/soroban-sdk/Cargo.toml
@@ -24,12 +24,14 @@ soroban-env-guest = { version = "0.0.5" }
 [target.'cfg(not(target_family="wasm"))'.dependencies]
 soroban-env-host = { version = "0.0.5", features = ["vm", "hostfn_log_fmt_values"] }
 ed25519-dalek = { version = "1.0.1", optional = true }
+rand = "0.8.5"
 
 [dev-dependencies]
 soroban-env-host = { version = "0.0.5", features = ["vm", "hostfn_log_fmt_values", "testutils"] }
 stellar-xdr = { version = "0.0.2", features = ["next", "std"] }
 soroban-spec = "0.0.4"
 ed25519-dalek = "1.0.1"
+rand = "0.8.5"
 hex = "0.4.3"
 
 [features]

--- a/soroban-sdk/src/accounts.rs
+++ b/soroban-sdk/src/accounts.rs
@@ -1,3 +1,6 @@
+//! Accounts contains types for accessing accounts in the current ledger.
+//!
+//! See [`Accounts`][Accounts] for examples.
 use core::{cmp::Ordering, fmt::Debug};
 
 use crate::{

--- a/soroban-sdk/src/accounts.rs
+++ b/soroban-sdk/src/accounts.rs
@@ -405,7 +405,7 @@ impl testutils::Accounts for Accounts {
             let xdr::PublicKey::PublicKeyTypeEd25519(Uint256(account_id_ed25519)) = a.account_id.0;
             if signer == &account_id_ed25519 {
                 // Master key.
-                a.thresholds[0] = weight.into();
+                a.thresholds.0[0] = weight.into();
             } else {
                 // Additional signer.
                 let mut signers = a.signers.to_vec();

--- a/soroban-sdk/src/accounts.rs
+++ b/soroban-sdk/src/accounts.rs
@@ -389,7 +389,6 @@ impl testutils::Accounts for Accounts {
     }
 
     fn set_thresholds(&self, id: &AccountId, low: u8, medium: u8, high: u8) {
-        let env = self.env();
         let id: xdr::AccountId = id.try_into().unwrap();
         self.update_account_ledger_entry(&id, |a| {
             a.thresholds.0[1] = low;
@@ -399,7 +398,6 @@ impl testutils::Accounts for Accounts {
     }
 
     fn set_signer_weight(&self, id: &AccountId, signer: &BytesN<32>, weight: u8) {
-        let env = self.env();
         let id: xdr::AccountId = id.try_into().unwrap();
         self.update_account_ledger_entry(&id, |a| {
             let mut signers = a.signers.to_vec();

--- a/soroban-sdk/src/accounts.rs
+++ b/soroban-sdk/src/accounts.rs
@@ -325,20 +325,7 @@ fn default_account_ledger_entry(id: &xdr::AccountId) -> xdr::AccountEntry {
 #[cfg_attr(feature = "docs", doc(cfg(feature = "testutils")))]
 impl testutils::Accounts for Accounts {
     fn create(&self, id: &xdr::AccountId) {
-        let env = self.env();
-        env.host()
-            .with_mut_storage(|storage| {
-                let k = xdr::LedgerKey::Account(xdr::LedgerKeyAccount {
-                    account_id: id.clone(),
-                });
-                let v = xdr::LedgerEntry {
-                    data: xdr::LedgerEntryData::Account(default_account_ledger_entry(id)),
-                    last_modified_ledger_seq: 0,
-                    ext: xdr::LedgerEntryExt::V0,
-                };
-                storage.put(&k, &v)
-            })
-            .unwrap();
+        self.with_mut(id, |_| {})
     }
 
     fn set(&self, a: xdr::AccountEntry) {
@@ -390,6 +377,18 @@ impl testutils::Accounts for Accounts {
                     panic!("ledger entry is not an account");
                 }
                 storage.put(&k, &v)
+            })
+            .unwrap();
+    }
+
+    fn remove(&self, id: &xdr::AccountId) {
+        let env = self.env();
+        env.host()
+            .with_mut_storage(|storage| {
+                let k = xdr::LedgerKey::Account(xdr::LedgerKeyAccount {
+                    account_id: id.clone(),
+                });
+                storage.del(&k)
             })
             .unwrap();
     }

--- a/soroban-sdk/src/accounts.rs
+++ b/soroban-sdk/src/accounts.rs
@@ -368,6 +368,12 @@ use crate::{env::internal::xdr, testutils};
 #[cfg(any(test, feature = "testutils"))]
 #[cfg_attr(feature = "docs", doc(cfg(feature = "testutils")))]
 impl testutils::Accounts for Accounts {
+    fn generate_and_create(&self) -> AccountId {
+        let id = self.generate();
+        self.create(&id);
+        id
+    }
+
     fn generate(&self) -> AccountId {
         use rand::RngCore;
         let mut bytes: [u8; 32] = Default::default();

--- a/soroban-sdk/src/accounts.rs
+++ b/soroban-sdk/src/accounts.rs
@@ -1,7 +1,5 @@
 use core::{cmp::Ordering, fmt::Debug};
 
-use stellar_xdr::Uint256;
-
 use crate::{
     env::internal::{Env as _, RawVal, RawValConvertible},
     env::EnvObj,
@@ -402,7 +400,8 @@ impl testutils::Accounts for Accounts {
     fn set_signer_weight(&self, id: &AccountId, signer: &BytesN<32>, weight: u8) {
         let id: xdr::AccountId = id.try_into().unwrap();
         self.update_account_ledger_entry(&id, |a| {
-            let xdr::PublicKey::PublicKeyTypeEd25519(Uint256(account_id_ed25519)) = a.account_id.0;
+            let xdr::PublicKey::PublicKeyTypeEd25519(xdr::Uint256(account_id_ed25519)) =
+                a.account_id.0;
             if signer == &account_id_ed25519 {
                 // Master key.
                 a.thresholds.0[0] = weight.into();

--- a/soroban-sdk/src/accounts.rs
+++ b/soroban-sdk/src/accounts.rs
@@ -68,11 +68,13 @@ impl Accounts {
     }
 }
 
-/// Account ID is a Stellar account ID.
+/// Account ID is an identifier for an account.
 ///
 /// The ID is opaque and does not expose the identifier to the contract, but the
-/// value is unique and can be used as a key in maps, or compared with other
-/// account identifiers.
+/// value can be used as a key in maps, or compared with other account
+/// identifiers.
+///
+/// In tests account identifiers can be generated using [`Accounts`].
 #[derive(Clone)]
 pub struct AccountId(EnvObj);
 
@@ -255,6 +257,8 @@ impl AccountId {
 
 /// Account provides access to information about an accounts thresholds and
 /// signers.
+///
+/// In tests accounts can be generated using [`Accounts`].
 #[derive(Clone)]
 pub struct Account(AccountId);
 

--- a/soroban-sdk/src/accounts.rs
+++ b/soroban-sdk/src/accounts.rs
@@ -253,8 +253,8 @@ impl AccountId {
     }
 }
 
-/// Account references a Stellar account and provides access to information
-/// about the account, such as its thresholds and signers.
+/// Account provides access to information about an accounts thresholds and
+/// signers.
 #[derive(Clone)]
 pub struct Account(AccountId);
 

--- a/soroban-sdk/src/accounts.rs
+++ b/soroban-sdk/src/accounts.rs
@@ -30,10 +30,10 @@ impl Accounts {
     /// Gets the account for the account ID.
     pub fn get(&self, id: &AccountId) -> Option<Account> {
         let env = id.env();
-        if env.account_exists(id.to_object()).is_false() {
-            None
-        } else {
+        if env.account_exists(id.to_object()).is_true() {
             Some(Account(id.clone()))
+        } else {
+            None
         }
     }
 }

--- a/soroban-sdk/src/bytes.rs
+++ b/soroban-sdk/src/bytes.rs
@@ -717,9 +717,37 @@ impl<const N: usize> PartialEq for BytesN<N> {
     }
 }
 
+impl<const N: usize> PartialEq<[u8; N]> for BytesN<N> {
+    fn eq(&self, other: &[u8; N]) -> bool {
+        let other: BytesN<N> = other.into_val(self.env());
+        self.eq(&other)
+    }
+}
+
+impl<const N: usize> PartialEq<BytesN<N>> for [u8; N] {
+    fn eq(&self, other: &BytesN<N>) -> bool {
+        let self_: BytesN<N> = self.into_val(other.env());
+        self_.eq(other)
+    }
+}
+
 impl<const N: usize> PartialOrd for BytesN<N> {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         Some(Ord::cmp(self, other))
+    }
+}
+
+impl<const N: usize> PartialOrd<[u8; N]> for BytesN<N> {
+    fn partial_cmp(&self, other: &[u8; N]) -> Option<Ordering> {
+        let other: BytesN<N> = other.into_val(self.env());
+        self.partial_cmp(&other)
+    }
+}
+
+impl<const N: usize> PartialOrd<BytesN<N>> for [u8; N] {
+    fn partial_cmp(&self, other: &BytesN<N>) -> Option<Ordering> {
+        let self_: BytesN<N> = self.into_val(other.env());
+        self_.partial_cmp(other)
     }
 }
 
@@ -786,6 +814,18 @@ impl<const N: usize> IntoVal<Env, BytesN<N>> for [u8; N] {
 impl<const N: usize> IntoVal<Env, BytesN<N>> for &[u8; N] {
     fn into_val(self, env: &Env) -> BytesN<N> {
         BytesN::from_array(env, self)
+    }
+}
+
+impl<const N: usize> IntoVal<Env, [u8; N]> for BytesN<N> {
+    fn into_val(self, _env: &Env) -> [u8; N] {
+        self.to_array()
+    }
+}
+
+impl<const N: usize> IntoVal<Env, [u8; N]> for &BytesN<N> {
+    fn into_val(self, _env: &Env) -> [u8; N] {
+        self.to_array()
     }
 }
 
@@ -1001,6 +1041,14 @@ impl<const N: usize> BytesN<N> {
         let env = self.env();
         env.bytes_copy_to_slice(self.to_object(), RawVal::U32_ZERO, slice)
             .unwrap();
+    }
+
+    /// Copy the bytes in [BytesN] into an array.
+    #[inline(always)]
+    pub fn to_array(&self) -> [u8; N] {
+        let mut array = [0u8; N];
+        self.copy_into_slice(&mut array);
+        array
     }
 
     pub fn iter(&self) -> BinIter {

--- a/soroban-sdk/src/env.rs
+++ b/soroban-sdk/src/env.rs
@@ -50,11 +50,9 @@ pub use internal::Val;
 pub type EnvVal = internal::EnvVal<Env, RawVal>;
 pub type EnvObj = internal::EnvVal<Env, Object>;
 
-use crate::invoker::Invoker;
-use crate::AccountId;
 use crate::{
-    data::Data, deploy::Deployer, events::Events, ledger::Ledger, logging::Logger, Bytes, BytesN,
-    Vec,
+    accounts::Accounts, data::Data, deploy::Deployer, events::Events, invoker::Invoker,
+    ledger::Ledger, logging::Logger, AccountId, Bytes, BytesN, Vec,
 };
 
 /// The [Env] type provides access to the environment the contract is executing
@@ -152,6 +150,12 @@ impl Env {
     #[inline(always)]
     pub fn ledger(&self) -> Ledger {
         Ledger::new(self)
+    }
+
+    /// Get an [Accounts] for accessing accounts in the current ledger.
+    #[inline(always)]
+    pub fn accounts(&self) -> Accounts {
+        Accounts::new(self)
     }
 
     /// Get the [Logger] for logging debug events.
@@ -270,7 +274,7 @@ impl Env {
 }
 
 #[cfg(any(test, feature = "testutils"))]
-use crate::testutils::{ContractFunctionSet, Ledger as _};
+use crate::testutils::{Accounts as _, ContractFunctionSet, Ledger as _};
 #[cfg(any(test, feature = "testutils"))]
 use core::fmt::Debug;
 #[cfg(any(test, feature = "testutils"))]
@@ -328,31 +332,8 @@ impl Env {
     /// Sets the source account in the [Env], which will be accessible via
     /// [Env::invoker] when the current executing contract is directly invoked.
     pub fn set_source_account(&self, account_id: xdr::AccountId) {
-        self.env_impl.set_source_account(account_id.clone());
-        self.env_impl
-            .with_mut_storage(|storage| {
-                let k = xdr::LedgerKey::Account(xdr::LedgerKeyAccount {
-                    account_id: account_id.clone(),
-                });
-                let v = xdr::LedgerEntry {
-                    data: xdr::LedgerEntryData::Account(xdr::AccountEntry {
-                        account_id,
-                        balance: 0,
-                        flags: 0,
-                        home_domain: xdr::VecM::default(),
-                        inflation_dest: None,
-                        num_sub_entries: 0,
-                        seq_num: xdr::SequenceNumber(0),
-                        thresholds: xdr::Thresholds([0; 4]),
-                        signers: xdr::VecM::default(),
-                        ext: xdr::AccountEntryExt::V0,
-                    }),
-                    last_modified_ledger_seq: 0,
-                    ext: xdr::LedgerEntryExt::V0,
-                };
-                storage.put(&k, &v)
-            })
-            .unwrap();
+        self.accounts().create(&account_id);
+        self.env_impl.set_source_account(account_id);
     }
 
     /// Register a contract with the [Env] for testing.

--- a/soroban-sdk/src/env.rs
+++ b/soroban-sdk/src/env.rs
@@ -314,9 +314,7 @@ impl Env {
 
         let env = Env { env_impl };
 
-        env.set_source_account(xdr::AccountId(xdr::PublicKey::PublicKeyTypeEd25519(
-            xdr::Uint256([0; 32]),
-        )));
+        env.set_source_account(env.accounts().generate());
 
         env.ledger().set(internal::LedgerInfo {
             protocol_version: 0,
@@ -331,9 +329,10 @@ impl Env {
 
     /// Sets the source account in the [Env], which will be accessible via
     /// [Env::invoker] when the current executing contract is directly invoked.
-    pub fn set_source_account(&self, account_id: xdr::AccountId) {
+    pub fn set_source_account(&self, account_id: AccountId) {
         self.accounts().create(&account_id);
-        self.env_impl.set_source_account(account_id);
+        self.env_impl
+            .set_source_account((&account_id).try_into().unwrap());
     }
 
     /// Register a contract with the [Env] for testing.

--- a/soroban-sdk/src/env.rs
+++ b/soroban-sdk/src/env.rs
@@ -314,7 +314,7 @@ impl Env {
             xdr::Uint256([0; 32]),
         )));
 
-        env.ledger().set_info(internal::LedgerInfo {
+        env.ledger().set(internal::LedgerInfo {
             protocol_version: 0,
             sequence_number: 0,
             timestamp: 0,

--- a/soroban-sdk/src/env.rs
+++ b/soroban-sdk/src/env.rs
@@ -270,7 +270,7 @@ impl Env {
 }
 
 #[cfg(any(test, feature = "testutils"))]
-use crate::testutils::ContractFunctionSet;
+use crate::testutils::{ContractFunctionSet, Ledger as _};
 #[cfg(any(test, feature = "testutils"))]
 use core::fmt::Debug;
 #[cfg(any(test, feature = "testutils"))]
@@ -314,7 +314,7 @@ impl Env {
             xdr::Uint256([0; 32]),
         )));
 
-        env.set_ledger(internal::LedgerInfo {
+        env.ledger().set_info(internal::LedgerInfo {
             protocol_version: 0,
             sequence_number: 0,
             timestamp: 0,
@@ -353,19 +353,6 @@ impl Env {
                 storage.put(&k, &v)
             })
             .unwrap();
-    }
-
-    /// Sets ledger information in the [Env], which will be accessible via
-    /// [Env::ledger].
-    pub fn set_ledger(&self, li: internal::LedgerInfo) {
-        self.env_impl.set_ledger_info(li)
-    }
-
-    pub fn with_mut_ledger_info<F>(&self, f: F)
-    where
-        F: FnMut(&mut internal::LedgerInfo),
-    {
-        self.env_impl.with_mut_ledger_info(f).unwrap();
     }
 
     /// Register a contract with the [Env] for testing.

--- a/soroban-sdk/src/invoker.rs
+++ b/soroban-sdk/src/invoker.rs
@@ -1,4 +1,4 @@
-use crate::{contracttype, AccountId, BytesN};
+use crate::{accounts::AccountId, contracttype, BytesN};
 
 /// Invoker is the invoker of a contract.
 // The Invoker type is a contracttype and transmitted to the host like an enum,

--- a/soroban-sdk/src/ledger.rs
+++ b/soroban-sdk/src/ledger.rs
@@ -104,7 +104,7 @@ impl testutils::Ledger for Ledger {
         env.host().set_ledger_info(li);
     }
 
-    fn with_mut_info<F>(&self, f: F)
+    fn with_mut<F>(&self, f: F)
     where
         F: FnMut(&mut internal::LedgerInfo),
     {

--- a/soroban-sdk/src/ledger.rs
+++ b/soroban-sdk/src/ledger.rs
@@ -92,3 +92,23 @@ impl Ledger {
         unsafe { Bytes::unchecked_new(bin_obj.in_env(env)) }
     }
 }
+
+#[cfg(any(test, feature = "testutils"))]
+use crate::testutils;
+
+#[cfg(any(test, feature = "testutils"))]
+#[cfg_attr(feature = "docs", doc(cfg(feature = "testutils")))]
+impl testutils::Ledger for Ledger {
+    fn set_info(&self, li: testutils::LedgerInfo) {
+        let env = self.env();
+        env.host().set_ledger_info(li);
+    }
+
+    fn with_mut_info<F>(&self, f: F)
+    where
+        F: FnMut(&mut internal::LedgerInfo),
+    {
+        let env = self.env();
+        env.host().with_mut_ledger_info(f).unwrap();
+    }
+}

--- a/soroban-sdk/src/ledger.rs
+++ b/soroban-sdk/src/ledger.rs
@@ -99,7 +99,7 @@ use crate::testutils;
 #[cfg(any(test, feature = "testutils"))]
 #[cfg_attr(feature = "docs", doc(cfg(feature = "testutils")))]
 impl testutils::Ledger for Ledger {
-    fn set_info(&self, li: testutils::LedgerInfo) {
+    fn set(&self, li: testutils::LedgerInfo) {
         let env = self.env();
         env.host().set_ledger_info(li);
     }

--- a/soroban-sdk/src/lib.rs
+++ b/soroban-sdk/src/lib.rs
@@ -168,7 +168,7 @@ pub use envhidden::*;
 
 mod operators;
 
-mod account;
+pub mod accounts;
 mod bigint;
 mod bytes;
 pub mod data;
@@ -180,7 +180,7 @@ pub mod logging;
 mod map;
 mod set;
 mod vec;
-pub use account::{Account, AccountId};
+pub use accounts::AccountId;
 pub use bigint::{BigInt, Sign};
 pub use bytes::{Bytes, BytesN};
 pub use invoker::Invoker;

--- a/soroban-sdk/src/logging.rs
+++ b/soroban-sdk/src/logging.rs
@@ -67,7 +67,7 @@ use crate::{
 /// assert_eq!(
 ///     env.logger().all(),
 ///     std::vec![
-///         "a log entry: I32(5), Symbol(another), Object(Vec(3))".to_string(),
+///         "a log entry: I32(5), Symbol(another), Object(Vec(4))".to_string(),
 ///     ],
 /// );
 /// # }

--- a/soroban-sdk/src/tests/contract_invoker_account.rs
+++ b/soroban-sdk/src/tests/contract_invoker_account.rs
@@ -1,5 +1,5 @@
 use crate as soroban_sdk;
-use soroban_sdk::{contractimpl, Account, BytesN, Env};
+use soroban_sdk::{accounts::Account, contractimpl, BytesN, Env};
 
 pub struct Contract;
 

--- a/soroban-sdk/src/testutils.rs
+++ b/soroban-sdk/src/testutils.rs
@@ -18,7 +18,7 @@ pub trait ContractFunctionSet {
 /// Test utilities for [`Ledger`][crate::ledger::Ledger].
 pub trait Ledger {
     /// Set ledger info.
-    fn set_info(&self, l: LedgerInfo);
+    fn set(&self, l: LedgerInfo);
 
     /// Modify the ledger info.
     fn with_mut_info<F>(&self, f: F)

--- a/soroban-sdk/src/testutils.rs
+++ b/soroban-sdk/src/testutils.rs
@@ -8,7 +8,7 @@ pub use sign::ed25519;
 
 pub use crate::env::testutils::*;
 
-use crate::{xdr, BytesN, Env, RawVal, Symbol, Vec};
+use crate::{xdr, AccountId, BytesN, Env, RawVal, Symbol, Vec};
 
 #[doc(hidden)]
 pub trait ContractFunctionSet {
@@ -46,19 +46,19 @@ pub trait Logger {
 /// Test utilities for [`Accounts`][crate::accounts::Accounts].
 pub trait Accounts {
     /// Create a random account.
-    fn generate(&self) -> xdr::AccountId;
+    fn generate(&self) -> AccountId;
 
     /// Create an account.
-    fn create(&self, id: &xdr::AccountId);
+    fn create(&self, id: &AccountId);
 
     /// Set the thresholds of an account.
-    fn set_thresholds(&self, id: &xdr::AccountId, low: u8, med: u8, high: u8);
+    fn set_thresholds(&self, id: &AccountId, low: u8, med: u8, high: u8);
 
     /// Set the weight of a signer of an account.
     ///
     /// Setting a weight of zero removes the signer from the account.
-    fn set_signer_weight(&self, id: &xdr::AccountId, signer: &BytesN<32>, weight: u8);
+    fn set_signer_weight(&self, id: &AccountId, signer: &BytesN<32>, weight: u8);
 
     /// Remove an account.
-    fn remove(&self, id: &xdr::AccountId);
+    fn remove(&self, id: &AccountId);
 }

--- a/soroban-sdk/src/testutils.rs
+++ b/soroban-sdk/src/testutils.rs
@@ -48,6 +48,9 @@ pub trait Accounts {
     /// Generate an account ID.
     fn generate(&self) -> AccountId;
 
+    /// Generate and account ID and creates an account.
+    fn generate_and_create(&self) -> AccountId;
+
     /// Create an account.
     fn create(&self, id: &AccountId);
 

--- a/soroban-sdk/src/testutils.rs
+++ b/soroban-sdk/src/testutils.rs
@@ -15,6 +15,17 @@ pub trait ContractFunctionSet {
     fn call(&self, func: &Symbol, env: Env, args: &[RawVal]) -> Option<RawVal>;
 }
 
+/// Test utilities for [`Ledger`][crate::ledger::Ledger].
+pub trait Ledger {
+    /// Set ledger info.
+    fn set_info(&self, l: LedgerInfo);
+
+    /// Modify the ledger info.
+    fn with_mut_info<F>(&self, f: F)
+    where
+        F: FnMut(&mut LedgerInfo);
+}
+
 /// Test utilities for [`Events`][crate::events::Events].
 pub trait Events {
     /// Returns all events that have been published by contracts.

--- a/soroban-sdk/src/testutils.rs
+++ b/soroban-sdk/src/testutils.rs
@@ -8,7 +8,7 @@ pub use sign::ed25519;
 
 pub use crate::env::testutils::*;
 
-use crate::{Env, RawVal, Symbol, Vec};
+use crate::{xdr, Env, RawVal, Symbol, Vec};
 
 #[doc(hidden)]
 pub trait ContractFunctionSet {
@@ -41,4 +41,20 @@ pub trait Events {
 pub trait Logger {
     /// Returns all debug events that have been logged.
     fn all(&self) -> std::vec::Vec<String>;
+}
+
+/// Test utilities for [`Accounts`][crate::accounts::Accounts].
+pub trait Accounts {
+    /// Create an account.
+    fn create(&self, id: &xdr::AccountId);
+
+    /// Set the details for an account.
+    ///
+    /// Creates the account if the account does not exist. Updates the details if it does.
+    fn set(&self, l: xdr::AccountEntry);
+
+    /// Modify an account.
+    fn with_mut<F>(&self, id: &xdr::AccountId, f: F)
+    where
+        F: FnMut(&mut xdr::AccountEntry);
 }

--- a/soroban-sdk/src/testutils.rs
+++ b/soroban-sdk/src/testutils.rs
@@ -8,7 +8,7 @@ pub use sign::ed25519;
 
 pub use crate::env::testutils::*;
 
-use crate::{xdr, AccountId, BytesN, Env, RawVal, Symbol, Vec};
+use crate::{AccountId, BytesN, Env, RawVal, Symbol, Vec};
 
 #[doc(hidden)]
 pub trait ContractFunctionSet {

--- a/soroban-sdk/src/testutils.rs
+++ b/soroban-sdk/src/testutils.rs
@@ -45,7 +45,7 @@ pub trait Logger {
 
 /// Test utilities for [`Accounts`][crate::accounts::Accounts].
 pub trait Accounts {
-    /// Create a random account.
+    /// Generate an account ID.
     fn generate(&self) -> AccountId;
 
     /// Create an account.

--- a/soroban-sdk/src/testutils.rs
+++ b/soroban-sdk/src/testutils.rs
@@ -8,7 +8,7 @@ pub use sign::ed25519;
 
 pub use crate::env::testutils::*;
 
-use crate::{xdr, Env, RawVal, Symbol, Vec};
+use crate::{xdr, BytesN, Env, RawVal, Symbol, Vec};
 
 #[doc(hidden)]
 pub trait ContractFunctionSet {
@@ -45,18 +45,19 @@ pub trait Logger {
 
 /// Test utilities for [`Accounts`][crate::accounts::Accounts].
 pub trait Accounts {
+    /// Create a random account.
+    fn generate(&self) -> xdr::AccountId;
+
     /// Create an account.
     fn create(&self, id: &xdr::AccountId);
 
-    /// Set the details for an account.
-    ///
-    /// Creates the account if the account does not exist. Updates the details if it does.
-    fn set(&self, l: xdr::AccountEntry);
+    /// Set the thresholds of an account.
+    fn set_thresholds(&self, id: &xdr::AccountId, low: u8, med: u8, high: u8);
 
-    /// Modify an account.
-    fn with_mut<F>(&self, id: &xdr::AccountId, f: F)
-    where
-        F: FnMut(&mut xdr::AccountEntry);
+    /// Set the weight of a signer of an account.
+    ///
+    /// Setting a weight of zero removes the signer from the account.
+    fn set_signer_weight(&self, id: &xdr::AccountId, signer: &BytesN<32>, weight: u8);
 
     /// Remove an account.
     fn remove(&self, id: &xdr::AccountId);

--- a/soroban-sdk/src/testutils.rs
+++ b/soroban-sdk/src/testutils.rs
@@ -21,7 +21,7 @@ pub trait Ledger {
     fn set(&self, l: LedgerInfo);
 
     /// Modify the ledger info.
-    fn with_mut_info<F>(&self, f: F)
+    fn with_mut<F>(&self, f: F)
     where
         F: FnMut(&mut LedgerInfo);
 }

--- a/soroban-sdk/src/testutils.rs
+++ b/soroban-sdk/src/testutils.rs
@@ -57,4 +57,7 @@ pub trait Accounts {
     fn with_mut<F>(&self, id: &xdr::AccountId, f: F)
     where
         F: FnMut(&mut xdr::AccountEntry);
+
+    /// Remove an account.
+    fn remove(&self, id: &xdr::AccountId);
 }

--- a/soroban-sdk/src/xdr.rs
+++ b/soroban-sdk/src/xdr.rs
@@ -36,3 +36,6 @@ pub use super::env::xdr::{
     ScSpecTypeVec, ScSpecUdtStructFieldV0, ScSpecUdtStructV0, ScSpecUdtUnionCaseV0,
     ScSpecUdtUnionV0,
 };
+
+// XDR for ledger entries.
+pub use super::env::xdr::{AccountEntry, AccountId};

--- a/soroban-token-spec/src/public_types.rs
+++ b/soroban-token-spec/src/public_types.rs
@@ -1,4 +1,4 @@
-use soroban_sdk::{contracttype, AccountId, Bytes, BytesN};
+use soroban_sdk::{accounts::AccountId, contracttype, Bytes, BytesN};
 
 #[derive(Clone)]
 #[contracttype]


### PR DESCRIPTION
### What
Add accounts test utilities. Move lookup of accounts under an `env.accounts().get()` function.

### Why
The account lookup was setup differently to how we lookup other data. To add test utilities in the same way we have test utilities for other functionality the env.accounts() was required too. For both reasons moved the account lookup into an Accounts type accessible via env.accounts().

The main account utilities of creating an account was moved out of env.set_source_account() so it can be used separately.

Close https://github.com/stellar/rs-soroban-sdk/issues/181 https://github.com/stellar/rs-soroban-env/issues/491

### Known Limitations

These test utilities are rather raw, as the developer has to specify an entire AccountEntry. I think we can consider how nice we make this later on, as the use cases for accounts are more power user level. What is provided here is enough that someone knowing what they are doing will be able to find a place to start.

### Todo

- [x] Default thresholds and signer. 
- [x] Additional signers.
- [ ] ~Trustlines. (time permitting)~
- [x] Inline docs/examples.