### PR TITLE
Rename `to_smart\classic` token fns to `import\export`.

### DIFF
--- a/soroban-token-spec/src/lib.rs
+++ b/soroban-token-spec/src/lib.rs
@@ -98,11 +98,11 @@ impl Token {
         panic!("calling into interface");
     }
 
-    pub fn to_smart(env: Env, id: Signature, nonce: BigInt, amount: i64) {
+    pub fn import(env: Env, id: Signature, nonce: BigInt, amount: i64) {
         panic!("calling into interface");
     }
 
-    pub fn to_classic(env: Env, id: Signature, nonce: BigInt, amount: i64) {
+    pub fn export(env: Env, id: Signature, nonce: BigInt, amount: i64) {
         panic!("calling into interface");
     }
 }


### PR DESCRIPTION
### What

Rename `to_smart\classic` token fns to `import\export`.

### Why

These are the new names that built-in token has.

### Known limitations

N/A
