### PR TITLE
Make contract_id optional in contract registrations

### DIFF
--- a/soroban-sdk/src/tests/contract_add_i32.rs
+++ b/soroban-sdk/src/tests/contract_add_i32.rs
@@ -1,5 +1,5 @@
 use crate as soroban_sdk;
-use soroban_sdk::{contractimpl, BytesN, Env};
+use soroban_sdk::{contractimpl, Env};
 use stellar_xdr::{ReadXdr, ScSpecEntry, ScSpecFunctionInputV0, ScSpecFunctionV0, ScSpecTypeDef};
 
 pub struct Contract;
@@ -14,8 +14,7 @@ impl Contract {
 #[test]
 fn test_functional() {
     let e = Env::default();
-    let contract_id = BytesN::from_array(&e, &[0; 32]);
-    e.register_contract(&contract_id, Contract);
+    let contract_id = e.register_contract(None, Contract);
 
     let a = 10i32;
     let b = 12i32;

--- a/soroban-sdk/src/tests/contract_invoke.rs
+++ b/soroban-sdk/src/tests/contract_invoke.rs
@@ -1,5 +1,5 @@
 use crate as soroban_sdk;
-use soroban_sdk::{contractimpl, xdr::ScStatusType, BytesN, Env, Status};
+use soroban_sdk::{contractimpl, xdr::ScStatusType, Env, Status};
 use stellar_xdr::ScVmErrorCode;
 
 pub struct Contract;
@@ -15,8 +15,7 @@ impl Contract {
 #[should_panic(expected = "I panicked")]
 fn test_invoke() {
     let e = Env::default();
-    let contract_id = BytesN::from_array(&e, &[0; 32]);
-    e.register_contract(&contract_id, Contract);
+    let contract_id = e.register_contract(None, Contract);
 
     ContractClient::new(&e, &contract_id).panic();
 }
@@ -27,8 +26,7 @@ fn test_invoke() {
 #[should_panic(expected = "I panicked")]
 fn test_try_invoke() {
     let e = Env::default();
-    let contract_id = BytesN::from_array(&e, &[0; 32]);
-    e.register_contract(&contract_id, Contract);
+    let contract_id = e.register_contract(None, Contract);
 
     let res = ContractClient::new(&e, &contract_id).try_panic();
     assert_eq!(

--- a/soroban-sdk/src/tests/contract_invoker_account.rs
+++ b/soroban-sdk/src/tests/contract_invoker_account.rs
@@ -1,5 +1,5 @@
 use crate as soroban_sdk;
-use soroban_sdk::{accounts::Account, contractimpl, BytesN, Env};
+use soroban_sdk::{accounts::Account, contractimpl, Env};
 
 pub struct Contract;
 
@@ -17,8 +17,7 @@ impl Contract {
 #[test]
 fn test_hello() {
     let e = Env::default();
-    let contract_id = BytesN::from_array(&e, &[0; 32]);
-    e.register_contract(&contract_id, Contract);
+    let contract_id = e.register_contract(None, Contract);
     let client = ContractClient::new(&e, &contract_id);
 
     let exists = client.exists();

--- a/soroban-sdk/src/tests/contract_invoker_client.rs
+++ b/soroban-sdk/src/tests/contract_invoker_client.rs
@@ -1,5 +1,5 @@
 use crate as soroban_sdk;
-use soroban_sdk::{contractimpl, testutils::Accounts, Address, BytesN, Env};
+use soroban_sdk::{contractimpl, testutils::Accounts, Address, Env};
 
 pub struct Contract;
 
@@ -15,8 +15,7 @@ extern crate std;
 #[test]
 fn test() {
     let e = Env::default();
-    let contract_id = BytesN::from_array(&e, &[0; 32]);
-    e.register_contract(&contract_id, Contract);
+    let contract_id = e.register_contract(None, Contract);
     let client = ContractClient::new(&e, &contract_id);
 
     let default = e.source_account();

--- a/soroban-sdk/src/tests/contract_udt_enum.rs
+++ b/soroban-sdk/src/tests/contract_udt_enum.rs
@@ -1,6 +1,6 @@
 use crate as soroban_sdk;
 use soroban_sdk::{
-    contractimpl, contracttype, symbol, vec, BytesN, ConversionError, Env, IntoVal, TryFromVal,
+    contractimpl, contracttype, symbol, vec, ConversionError, Env, IntoVal, TryFromVal,
 };
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
@@ -22,8 +22,7 @@ impl Contract {
 #[test]
 fn test_functional() {
     let env = Env::default();
-    let contract_id = BytesN::from_array(&env, &[0; 32]);
-    env.register_contract(&contract_id, Contract);
+    let contract_id = env.register_contract(None, Contract);
     let client = ContractClient::new(&env, &contract_id);
 
     let a = Udt::Aaa;

--- a/soroban-sdk/src/tests/contract_udt_struct.rs
+++ b/soroban-sdk/src/tests/contract_udt_struct.rs
@@ -1,7 +1,5 @@
 use crate as soroban_sdk;
-use soroban_sdk::{
-    contractimpl, contracttype, map, symbol, BytesN, ConversionError, Env, TryFromVal,
-};
+use soroban_sdk::{contractimpl, contracttype, map, symbol, ConversionError, Env, TryFromVal};
 use stellar_xdr::{
     ReadXdr, ScSpecEntry, ScSpecFunctionInputV0, ScSpecFunctionV0, ScSpecTypeDef, ScSpecTypeTuple,
     ScSpecTypeUdt,
@@ -26,8 +24,7 @@ impl Contract {
 #[test]
 fn test_functional() {
     let env = Env::default();
-    let contract_id = BytesN::from_array(&env, &[0; 32]);
-    env.register_contract(&contract_id, Contract);
+    let contract_id = env.register_contract(None, Contract);
 
     let a = Udt { a: 5, b: 7 };
     let b = Udt { a: 10, b: 14 };

--- a/soroban-sdk/src/tests/contract_udt_struct_tuple.rs
+++ b/soroban-sdk/src/tests/contract_udt_struct_tuple.rs
@@ -1,7 +1,7 @@
 use crate as soroban_sdk;
 use soroban_sdk::{
-    contractimpl, contracttype, vec, BytesN, ConversionError, Env, IntoVal, RawVal, TryFromVal,
-    TryIntoVal, Vec,
+    contractimpl, contracttype, vec, ConversionError, Env, IntoVal, RawVal, TryFromVal, TryIntoVal,
+    Vec,
 };
 use stellar_xdr::{
     ReadXdr, ScSpecEntry, ScSpecFunctionInputV0, ScSpecFunctionV0, ScSpecTypeDef, ScSpecTypeTuple,
@@ -33,8 +33,7 @@ fn test_conversion() {
 #[test]
 fn test_functional() {
     let env = Env::default();
-    let contract_id = BytesN::from_array(&env, &[0; 32]);
-    env.register_contract(&contract_id, Contract);
+    let contract_id = env.register_contract(None, Contract);
 
     let a = Udt(5, 7);
     let b = Udt(10, 14);

--- a/soroban-sdk/src/tests/contractimport_with_sha256.rs
+++ b/soroban-sdk/src/tests/contractimport_with_sha256.rs
@@ -1,8 +1,9 @@
 use crate as soroban_sdk;
 use soroban_sdk::{contractimpl, BytesN, Env};
-use stellar_xdr::{ScSpecEntry, ScSpecFunctionInputV0, ScSpecFunctionV0, ScSpecTypeDef};
+use stellar_xdr::{
+    ScSpecEntry, ScSpecFunctionInputV0, ScSpecFunctionV0, ScSpecTypeBytesN, ScSpecTypeDef,
+};
 
-const ADD_CONTRACT_ID: [u8; 32] = [0; 32];
 mod addcontract {
     use crate as soroban_sdk;
     soroban_sdk::contractimport!(
@@ -15,8 +16,8 @@ pub struct Contract;
 
 #[contractimpl]
 impl Contract {
-    pub fn add_with(env: Env, x: u64, y: u64) -> u64 {
-        addcontract::Client::new(&env, &ADD_CONTRACT_ID).add(&x, &y)
+    pub fn add_with(env: Env, contract_id: BytesN<32>, x: u64, y: u64) -> u64 {
+        addcontract::Client::new(&env, &contract_id).add(&x, &y)
     }
 }
 
@@ -24,16 +25,14 @@ impl Contract {
 fn test_functional() {
     let e = Env::default();
 
-    let add_contract_id = BytesN::from_array(&e, &ADD_CONTRACT_ID);
-    e.register_contract_wasm(&add_contract_id, addcontract::WASM);
+    let add_contract_id = e.register_contract_wasm(None, addcontract::WASM);
 
-    let contract_id = BytesN::from_array(&e, &[1; 32]);
-    e.register_contract(&contract_id, Contract);
+    let contract_id = e.register_contract(None, Contract);
     let client = ContractClient::new(&e, &contract_id);
 
     let x = 10u64;
     let y = 12u64;
-    let z = client.add_with(&x, &y);
+    let z = client.add_with(&add_contract_id, &x, &y);
     assert!(z == 22);
 }
 
@@ -43,6 +42,10 @@ fn test_spec() {
     let expect = vec![ScSpecEntry::FunctionV0(ScSpecFunctionV0 {
         name: "add_with".try_into().unwrap(),
         inputs: vec![
+            ScSpecFunctionInputV0 {
+                name: "contract_id".try_into().unwrap(),
+                type_: ScSpecTypeDef::BytesN(ScSpecTypeBytesN { n: 32 }),
+            },
             ScSpecFunctionInputV0 {
                 name: "x".try_into().unwrap(),
                 type_: ScSpecTypeDef::U64,


### PR DESCRIPTION
### What
Make contract_id optional in contract registrations.

### Why
Simplify examples and tutorials.

Note that this change is a non-breaking change that is completely backwards compatible change with all existing uses of these functions.