### PR TITLE
Fix bug in contracterror

### DIFF
--- a/soroban-sdk-macros/src/derive_error_enum_int.rs
+++ b/soroban-sdk-macros/src/derive_error_enum_int.rs
@@ -146,7 +146,7 @@ pub fn derive_type_error_enum_int(
         impl #path::IntoVal<#path::Env, #path::RawVal> for #enum_ident {
             #[inline(always)]
             fn into_val(self, env: &#path::Env) -> #path::RawVal {
-                let status: Status = self.into();
+                let status: #path::Status = self.into();
                 status.into_val(env)
             }
         }
@@ -154,7 +154,7 @@ pub fn derive_type_error_enum_int(
         impl #path::IntoVal<#path::Env, #path::RawVal> for &#enum_ident {
             #[inline(always)]
             fn into_val(self, env: &#path::Env) -> #path::RawVal {
-                let status: Status = self.into();
+                let status: #path::Status = self.into();
                 status.into_val(env)
             }
         }

--- a/tests/errors/src/lib.rs
+++ b/tests/errors/src/lib.rs
@@ -1,5 +1,5 @@
 #![no_std]
-use soroban_sdk::{contracterror, contractimpl, panic_error, symbol, Env, Status, Symbol};
+use soroban_sdk::{contracterror, contractimpl, panic_error, symbol, Env, Symbol};
 
 pub struct Contract;
 


### PR DESCRIPTION
### What
Qualify the `Status` type referenced from code generated by the `contracterror` macro.

### Why
So that contract developers do not need to manually import `Status` into the code when they don't see the type in their code.