### PR TITLE
Add Logger::print in testutils

### DIFF
--- a/soroban-sdk/src/logging.rs
+++ b/soroban-sdk/src/logging.rs
@@ -157,4 +157,8 @@ impl testutils::Logger for Logger {
             })
             .collect::<std::vec::Vec<_>>()
     }
+
+    fn print(&self) {
+        std::println!("{}", self.all().join("\n"))
+    }
 }

--- a/soroban-sdk/src/testutils.rs
+++ b/soroban-sdk/src/testutils.rs
@@ -41,6 +41,8 @@ pub trait Events {
 pub trait Logger {
     /// Returns all debug events that have been logged.
     fn all(&self) -> std::vec::Vec<String>;
+    /// Prints all debug events to stdout.
+    fn print(&self);
 }
 
 /// Test utilities for [`Accounts`][crate::accounts::Accounts].

--- a/tests/logging/src/lib.rs
+++ b/tests/logging/src/lib.rs
@@ -33,6 +33,8 @@ mod test {
 
         client.hello();
 
+        env.logger().print();
+
         if cfg!(debug_assertions) {
             assert_eq!(
                 env.logger().all(),


### PR DESCRIPTION
### What
Add Logger::print in testutils that prints all logs to stdout.

### Why
I'm noticing that in tests if I want to include a print out of all logs in the tests I'm writing the same code over and over again. It's not much, but I think it would be reasonable to include a print function that does it. The main advantage is the developer doesn't need to figure out how to import the stdlib into their no_std crate.