### PR TITLE
Update main example in Rust docs to use auto generated contract id

### DIFF
--- a/soroban-sdk/src/lib.rs
+++ b/soroban-sdk/src/lib.rs
@@ -25,8 +25,7 @@
 //! # #[cfg(feature = "testutils")]
 //! # fn main() {
 //!     let env = Env::default();
-//!     let contract_id = BytesN::from_array(&env, &[0; 32]);
-//!     env.register_contract(&contract_id, HelloContract);
+//!     let contract_id = env.register_contract(None, HelloContract);
 //!     let client = HelloContractClient::new(&env, &contract_id);
 //!
 //!     let words = client.hello(&symbol!("Dev"));


### PR DESCRIPTION
### What
Update main example in Rust docs to use auto generated contract id.

### Why
It's what we do in examples by default since it doesn't require coming up with a contract ID. The tooling will generate one for you.