### PR TITLE
Add conversion from `Address` to `Identifier`.

### DIFF
--- a/soroban-auth/src/public_types.rs
+++ b/soroban-auth/src/public_types.rs
@@ -75,6 +75,15 @@ impl From<&AccountId> for Identifier {
     }
 }
 
+impl From<Address> for Identifier {
+    fn from(addr: Address) -> Self {
+        match addr {
+            Address::Account(a) => Identifier::Account(a),
+            Address::Contract(c) => Identifier::Contract(c),
+        }
+    }
+}
+
 /// Signature payload v0 contains the data that must be signed to authenticate
 /// the [`Identifier`] within when invoking a contract.
 ///

--- a/soroban-auth/src/public_types.rs
+++ b/soroban-auth/src/public_types.rs
@@ -84,6 +84,12 @@ impl From<Address> for Identifier {
     }
 }
 
+impl From<&Address> for Identifier {
+    fn from(addr: &Address) -> Self {
+        Identifier::from(addr.clone())
+    }
+}
+
 /// Signature payload v0 contains the data that must be signed to authenticate
 /// the [`Identifier`] within when invoking a contract.
 ///


### PR DESCRIPTION
### What

Add conversion from `Address` to `Identifier`.

### Why

Simplify code that uses `env.invoker` for getting identifiers.

### Known limitations

N/A
