### PR TITLE
Remove deprecated functions

### DIFF
--- a/soroban-auth/src/lib.rs
+++ b/soroban-auth/src/lib.rs
@@ -127,9 +127,3 @@ pub fn verify(env: &Env, sig: &Signature, name: Symbol, args: impl IntoVal<Env, 
         Signature::Account(a) => verify_account_signatures(env, &a, name, args.into_val(env)),
     }
 }
-
-#[doc(hidden)]
-#[deprecated(note = "use soroban_auth::verify(...)")]
-pub fn check_auth(env: &Env, sig: &Signature, name: Symbol, args: impl IntoVal<Env, Vec<RawVal>>) {
-    verify(env, sig, name, args)
-}

--- a/soroban-auth/src/public_types.rs
+++ b/soroban-auth/src/public_types.rs
@@ -45,12 +45,6 @@ impl Signature {
             Signature::Account(a) => Identifier::Account(a.account_id.clone()),
         }
     }
-
-    #[doc(hidden)]
-    #[deprecated(note = "use Signature::identifier(...)")]
-    pub fn get_identifier(&self, env: &Env) -> Identifier {
-        self.identifier(env)
-    }
 }
 
 /// Identifier is an identifier for a authenticating party. Each [`Signature`]

--- a/soroban-spec/src/gen/rust.rs
+++ b/soroban-spec/src/gen/rust.rs
@@ -85,9 +85,6 @@ pub fn generate(specs: &[ScSpecEntry], file: &str, sha256: &str) -> TokenStream 
         #[soroban_sdk::contractclient(name = "Client")]
         #trait_
 
-        #[deprecated(note = "use Client instead of ContractClient as it has been renamed")]
-        pub type ContractClient = Client;
-
         #(#structs)*
         #(#unions)*
         #(#enums)*
@@ -135,8 +132,6 @@ mod test {
 pub trait Contract {
     fn add(env: soroban_sdk::Env, a: UdtEnum, b: UdtEnum) -> i64;
 }
-#[deprecated(note = "use Client instead of ContractClient as it has been renamed")]
-pub type ContractClient = Client;
 #[soroban_sdk::contracttype(export = false)]
 pub struct UdtTuple(pub i64, pub soroban_sdk::Vec<i64>);
 #[soroban_sdk::contracttype(export = false)]


### PR DESCRIPTION
### What
Remove deprecated functions.

### Why
They've been deprecated for a little while and we've gone through the process of removing them from all the examples and places we used them.