### PR TITLE
Remove superfluous feature cfg

### DIFF
--- a/soroban-sdk/src/accounts.rs
+++ b/soroban-sdk/src/accounts.rs
@@ -466,7 +466,6 @@ impl testutils::Accounts for Accounts {
 
 #[cfg(any(test, feature = "testutils"))]
 impl Accounts {
-    #[cfg(any(test, feature = "testutils"))]
     fn default_account_ledger_entry(&self, id: &xdr::AccountId) -> xdr::AccountEntry {
         xdr::AccountEntry {
             account_id: id.clone(),


### PR DESCRIPTION
### What
Remove feature cfg on function.

### Why
It is already feature gated by the parent scope. There is no need to duplicate the cfg.