### PR TITLE
Fix token spec spec_xdr fn

### DIFF
--- a/soroban-token-spec/src/lib.rs
+++ b/soroban-token-spec/src/lib.rs
@@ -110,7 +110,7 @@ impl Token {
 
 /// Returns the XDR spec for the Token contract.
 #[doc(hidden)]
-pub const fn spec_xdr() -> [u8; 2037] {
+pub const fn spec_xdr() -> [u8; 2036] {
     let input: &[&[u8]] = &[
         &Token::spec_xdr_allowance(),
         &Token::spec_xdr_approve(),
@@ -137,7 +137,7 @@ pub const fn spec_xdr() -> [u8; 2037] {
         &soroban_auth::AccountSignatures::spec_xdr(),
     ];
 
-    let mut output = [0u8; 2037];
+    let mut output = [0u8; 2036];
     let mut input_i = 0;
     let mut output_i = 0;
     while input_i < input.len() {
@@ -151,7 +151,7 @@ pub const fn spec_xdr() -> [u8; 2037] {
         input_i += 1;
     }
     // Unfortunately we cannot call assert_eq!() in a const function
-    if output_i != output.len() - 1 {
+    if output_i != output.len() {
         panic!("unexpected output length",);
     }
     output

--- a/soroban-token-spec/src/lib.rs
+++ b/soroban-token-spec/src/lib.rs
@@ -137,6 +137,7 @@ pub const fn spec_xdr() -> [u8; 2036] {
         &soroban_auth::AccountSignatures::spec_xdr(),
     ];
 
+    // Concatenate all XDR for each item that makes up the token spec.
     let mut output = [0u8; 2036];
     let mut input_i = 0;
     let mut output_i = 0;
@@ -150,9 +151,12 @@ pub const fn spec_xdr() -> [u8; 2036] {
         }
         input_i += 1;
     }
-    // Unfortunately we cannot call assert_eq!() in a const function
+
+    // Check that the numbers of bytes written is equal to the number of bytes
+    // expected in the output.
     if output_i != output.len() {
         panic!("unexpected output length",);
     }
+
     output
 }

--- a/soroban-token-spec/src/tests/spec_xdr.rs
+++ b/soroban-token-spec/src/tests/spec_xdr.rs
@@ -1,14 +1,15 @@
-use soroban_sdk::xdr::{ReadXdr, ScSpecEntry};
+use soroban_sdk::xdr::{Error, ReadXdr, ScSpecEntry};
 
 use crate::spec_xdr;
 
 extern crate std;
 
 #[test]
-fn test_spec_xdr() {
+fn test_spec_xdr() -> Result<(), Error> {
     let xdr = spec_xdr();
     let mut cursor = std::io::Cursor::new(xdr);
-    for (i, spec_entry) in ScSpecEntry::read_xdr_iter(&mut cursor).enumerate() {
-        std::println!("{}: {:?}", i, spec_entry);
+    for spec_entry in ScSpecEntry::read_xdr_iter(&mut cursor) {
+        spec_entry?;
     }
+    Ok(())
 }

--- a/soroban-token-spec/src/tests/spec_xdr.rs
+++ b/soroban-token-spec/src/tests/spec_xdr.rs
@@ -1,7 +1,14 @@
+use soroban_sdk::xdr::{ReadXdr, ScSpecEntry};
+
 use crate::spec_xdr;
+
+extern crate std;
 
 #[test]
 fn test_spec_xdr() {
-    // it shouldn't panic
-    let _ = spec_xdr();
+    let xdr = spec_xdr();
+    let mut cursor = std::io::Cursor::new(xdr);
+    for spec_entry in ScSpecEntry::read_xdr_iter(&mut cursor) {
+        std::println!("{:?}", spec_entry);
+    }
 }

--- a/soroban-token-spec/src/tests/spec_xdr.rs
+++ b/soroban-token-spec/src/tests/spec_xdr.rs
@@ -8,7 +8,7 @@ extern crate std;
 fn test_spec_xdr() {
     let xdr = spec_xdr();
     let mut cursor = std::io::Cursor::new(xdr);
-    for spec_entry in ScSpecEntry::read_xdr_iter(&mut cursor) {
-        std::println!("{:?}", spec_entry);
+    for (i, spec_entry) in ScSpecEntry::read_xdr_iter(&mut cursor).enumerate() {
+        std::println!("{}: {:?}", i, spec_entry);
     }
 }


### PR DESCRIPTION
### What
Change the length of the output of the token specs spec xdr to match the content generated, by reducing the output by a length of 1, and updating the length check.

### Why
The fn is currently returning XDR that is not parseable because it is returning a byte buffer that has an extra zero byte on the end. The length check is checking that the index is equal to the length minus one, but the index is at that point one past the last index and so it needs to check that the index is equal to the length.
