### PR TITLE
Fix soroban-auth testutils docs

### DIFF
--- a/soroban-auth/Cargo.toml
+++ b/soroban-auth/Cargo.toml
@@ -10,8 +10,12 @@ version = "0.1.1"
 edition = "2021"
 rust-version = "1.64"
 
+[lib]
+doctest = false
+
 [features]
 testutils = ["soroban-sdk/testutils", "dep:ed25519-dalek", "dep:rand"]
+docs = []
 
 [dependencies]
 soroban-sdk = "0.1.0"
@@ -24,3 +28,6 @@ rand = { version = "0.7.3", optional = true }
 soroban-sdk = { version = "0.1.0", features = ["testutils"] }
 ed25519-dalek = { version = "1.0.1" }
 rand = { version = "0.7.3" }
+
+[package.metadata.docs.rs]
+all-features = true

--- a/soroban-auth/src/lib.rs
+++ b/soroban-auth/src/lib.rs
@@ -14,6 +14,7 @@
 //! provide their own mechanism suitable for replay prevention that prevents
 //! contract invocations to be replayable if it is important they are not.**
 #![no_std]
+#![cfg_attr(feature = "docs", feature(doc_cfg))]
 
 mod tests;
 


### PR DESCRIPTION
### What
Add the docs feature and add the nightly doc_cfg feature.

### Why
So that docs for testutils render on docs.rs, and so that functionality flagged as testutils only is displayed in docs clearly as so.