### PR TITLE
Remove crate-types unneeded

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,10 @@ test: fmt build
 
 build: fmt
 	cargo hack build --target wasm32-unknown-unknown --release
+	cd target/wasm32-unknown-unknown/release/ && \
+		for i in *.wasm ; do \
+			ls -l "$$i"; \
+		done
 
 build-optimized: fmt
 	cargo +nightly hack build  --target wasm32-unknown-unknown --release \

--- a/soroban-sdk/Cargo.toml
+++ b/soroban-sdk/Cargo.toml
@@ -11,7 +11,6 @@ edition = "2021"
 rust-version = "1.64"
 
 [lib]
-crate-type = ["cdylib", "rlib"]
 doctest = false
 
 [dependencies]

--- a/soroban-sdk/src/tests/contractfile_with_sha256.rs
+++ b/soroban-sdk/src/tests/contractfile_with_sha256.rs
@@ -1,7 +1,7 @@
 use crate as soroban_sdk;
 pub const WASM: &[u8] = soroban_sdk::contractfile!(
     file = "../target/wasm32-unknown-unknown/release/test_add_u64.wasm",
-    sha256 = "de2bdc56dafd6b3b25b7224f7f9f33b4e32a62a1f3cc63b856244de236b690b8",
+    sha256 = "e7a0f67985ed069295c0b9cda84948ce037bf9663b6353f72b3180067dc300d0",
 );
 
 #[test]

--- a/soroban-sdk/src/tests/contractimport_with_sha256.rs
+++ b/soroban-sdk/src/tests/contractimport_with_sha256.rs
@@ -8,7 +8,7 @@ mod addcontract {
     use crate as soroban_sdk;
     soroban_sdk::contractimport!(
         file = "../target/wasm32-unknown-unknown/release/test_add_u64.wasm",
-        sha256 = "de2bdc56dafd6b3b25b7224f7f9f33b4e32a62a1f3cc63b856244de236b690b8",
+        sha256 = "e7a0f67985ed069295c0b9cda84948ce037bf9663b6353f72b3180067dc300d0",
     );
 }
 

--- a/tests/add_bigint/Cargo.toml
+++ b/tests/add_bigint/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 rust-version = "1.64"
 
 [lib]
-crate-type = ["cdylib", "rlib"]
+crate-type = ["cdylib"]
 doctest = false
 
 [dependencies]

--- a/tests/add_u64/Cargo.toml
+++ b/tests/add_u64/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 rust-version = "1.64"
 
 [lib]
-crate-type = ["cdylib", "rlib"]
+crate-type = ["cdylib"]
 doctest = false
 
 [dependencies]

--- a/tests/contract_data/Cargo.toml
+++ b/tests/contract_data/Cargo.toml
@@ -8,7 +8,7 @@ rust-version = "1.64"
 publish = false
 
 [lib]
-crate-type = ["cdylib", "rlib"]
+crate-type = ["cdylib"]
 doctest = false
 
 [dependencies]

--- a/tests/empty/Cargo.toml
+++ b/tests/empty/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 rust-version = "1.64"
 
 [lib]
-crate-type = ["cdylib", "rlib"]
+crate-type = ["cdylib"]
 doctest = false
 
 [dependencies]

--- a/tests/errors/Cargo.toml
+++ b/tests/errors/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 rust-version = "1.64"
 
 [lib]
-crate-type = ["cdylib", "rlib"]
+crate-type = ["cdylib"]
 doctest = false
 
 [dependencies]

--- a/tests/events/Cargo.toml
+++ b/tests/events/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 rust-version = "1.64"
 
 [lib]
-crate-type = ["cdylib", "rlib"]
+crate-type = ["cdylib"]
 doctest = false
 
 [dependencies]

--- a/tests/import_contract/Cargo.toml
+++ b/tests/import_contract/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 rust-version = "1.64"
 
 [lib]
-crate-type = ["cdylib", "rlib"]
+crate-type = ["cdylib"]
 doctest = false
 
 [dependencies]

--- a/tests/invoke_contract/Cargo.toml
+++ b/tests/invoke_contract/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 rust-version = "1.64"
 
 [lib]
-crate-type = ["cdylib", "rlib"]
+crate-type = ["cdylib"]
 doctest = false
 
 [dependencies]

--- a/tests/logging/Cargo.toml
+++ b/tests/logging/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 rust-version = "1.64"
 
 [lib]
-crate-type = ["cdylib", "rlib"]
+crate-type = ["cdylib"]
 doctest = false
 
 [dependencies]

--- a/tests/udt/Cargo.toml
+++ b/tests/udt/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 rust-version = "1.64"
 
 [lib]
-crate-type = ["cdylib", "rlib"]
+crate-type = ["cdylib"]
 doctest = false
 
 [dependencies]


### PR DESCRIPTION
### What
Remove crate-types unneeded.

### Why
It looks like we're building additional `rlib` artifacts for test vectors in this repo that are not needed.

It also looks like we're building an additional `cdylib` artifact for the sdk which is also not needed.