### PR TITLE
Reintroduce an optimized aborting unwrap

### DIFF
--- a/soroban-auth/src/lib.rs
+++ b/soroban-auth/src/lib.rs
@@ -18,7 +18,9 @@
 
 mod tests;
 
-use soroban_sdk::{serde::Serialize, BytesN, Env, IntoVal, RawVal, Symbol, Vec};
+use soroban_sdk::{
+    serde::Serialize, unwrap::UnwrapOptimized, BytesN, Env, IntoVal, RawVal, Symbol, Vec,
+};
 
 pub mod testutils;
 
@@ -43,7 +45,7 @@ fn verify_ed25519_signature(env: &Env, auth: &Ed25519Signature, name: Symbol, ar
 }
 
 fn verify_account_signatures(env: &Env, auth: &AccountSignatures, name: Symbol, args: Vec<RawVal>) {
-    let acc = env.accounts().get(&auth.account_id).unwrap();
+    let acc = env.accounts().get(&auth.account_id).unwrap_optimized();
 
     let msg = SignaturePayloadV0 {
         name,

--- a/soroban-sdk-macros/src/derive_fn.rs
+++ b/soroban-sdk-macros/src/derive_fn.rs
@@ -92,10 +92,10 @@ pub fn derive_fn(
                     ty: Box::new(Type::Verbatim(quote! { soroban_sdk::RawVal })),
                 });
                 let call = quote! {
-                    <_ as soroban_sdk::TryFromVal<soroban_sdk::Env, soroban_sdk::RawVal>>::try_from_val(
+                    <_ as soroban_sdk::unwrap::UnwrapOrPanic>::unwrap_or_panic(<_ as soroban_sdk::TryFromVal<soroban_sdk::Env, soroban_sdk::RawVal>>::try_from_val(
                         &env,
                         #ident
-                    ).unwrap()
+                    ))
                 };
                 (spec, arg, call)
             }

--- a/soroban-sdk-macros/src/derive_fn.rs
+++ b/soroban-sdk-macros/src/derive_fn.rs
@@ -92,10 +92,12 @@ pub fn derive_fn(
                     ty: Box::new(Type::Verbatim(quote! { soroban_sdk::RawVal })),
                 });
                 let call = quote! {
-                    <_ as soroban_sdk::unwrap::UnwrapOrPanic>::unwrap_or_panic(<_ as soroban_sdk::TryFromVal<soroban_sdk::Env, soroban_sdk::RawVal>>::try_from_val(
-                        &env,
-                        #ident
-                    ))
+                    <_ as soroban_sdk::unwrap::UnwrapOptimized>::unwrap_optimized(
+                        <_ as soroban_sdk::TryFromVal<soroban_sdk::Env, soroban_sdk::RawVal>>::try_from_val(
+                            &env,
+                            #ident
+                        )
+                    )
                 };
                 (spec, arg, call)
             }

--- a/soroban-sdk/src/bytes.rs
+++ b/soroban-sdk/src/bytes.rs
@@ -13,6 +13,7 @@ use super::{
     ConversionError, Env, EnvVal, Object, RawVal, TryFromVal, TryIntoVal,
 };
 
+use crate::unwrap::UnwrapOptimized;
 #[cfg(doc)]
 use crate::{data::Data, Map, Vec};
 
@@ -361,7 +362,11 @@ impl Bytes {
 
     #[inline(always)]
     pub fn from_slice(env: &Env, items: &[u8]) -> Bytes {
-        Bytes(env.bytes_new_from_slice(items).unwrap().in_env(env))
+        Bytes(
+            env.bytes_new_from_slice(items)
+                .unwrap_optimized()
+                .in_env(env),
+        )
     }
 
     #[inline(always)]
@@ -552,7 +557,7 @@ impl Bytes {
         let env = self.env();
         self.0 = env
             .bytes_copy_from_slice(self.to_object(), self.len().into(), slice)
-            .unwrap()
+            .unwrap_optimized()
             .in_env(env);
     }
 
@@ -565,7 +570,7 @@ impl Bytes {
         let env = self.env();
         self.0 = env
             .bytes_copy_from_slice(self.to_object(), i.into(), slice)
-            .unwrap()
+            .unwrap_optimized()
             .in_env(env);
     }
 
@@ -577,7 +582,7 @@ impl Bytes {
     pub fn copy_into_slice(&self, slice: &mut [u8]) {
         let env = self.env();
         env.bytes_copy_to_slice(self.to_object(), RawVal::U32_ZERO, slice)
-            .unwrap();
+            .unwrap_optimized();
     }
 
     #[must_use]
@@ -1040,7 +1045,7 @@ impl<const N: usize> BytesN<N> {
     pub fn copy_into_slice(&self, slice: &mut [u8]) {
         let env = self.env();
         env.bytes_copy_to_slice(self.to_object(), RawVal::U32_ZERO, slice)
-            .unwrap();
+            .unwrap_optimized();
     }
 
     /// Copy the bytes in [BytesN] into an array.

--- a/soroban-sdk/src/lib.rs
+++ b/soroban-sdk/src/lib.rs
@@ -133,6 +133,9 @@ macro_rules! panic_error {
     }};
 }
 
+#[doc(hidden)]
+pub mod unwrap;
+
 mod env;
 
 mod address;

--- a/soroban-sdk/src/tests/contractfile_with_sha256.rs
+++ b/soroban-sdk/src/tests/contractfile_with_sha256.rs
@@ -1,7 +1,7 @@
 use crate as soroban_sdk;
 pub const WASM: &[u8] = soroban_sdk::contractfile!(
     file = "../target/wasm32-unknown-unknown/release/test_add_u64.wasm",
-    sha256 = "e7a0f67985ed069295c0b9cda84948ce037bf9663b6353f72b3180067dc300d0",
+    sha256 = "134b7bb632955e2851c85015852fbf1e0d6e7625029b2e38a54cb9044d9501da",
 );
 
 #[test]

--- a/soroban-sdk/src/tests/contractimport_with_sha256.rs
+++ b/soroban-sdk/src/tests/contractimport_with_sha256.rs
@@ -8,7 +8,7 @@ mod addcontract {
     use crate as soroban_sdk;
     soroban_sdk::contractimport!(
         file = "../target/wasm32-unknown-unknown/release/test_add_u64.wasm",
-        sha256 = "e7a0f67985ed069295c0b9cda84948ce037bf9663b6353f72b3180067dc300d0",
+        sha256 = "134b7bb632955e2851c85015852fbf1e0d6e7625029b2e38a54cb9044d9501da",
     );
 }
 

--- a/soroban-sdk/src/unwrap.rs
+++ b/soroban-sdk/src/unwrap.rs
@@ -6,6 +6,7 @@ pub trait UnwrapOptimized {
 impl<T> UnwrapOptimized for Option<T> {
     type Output = T;
 
+    #[inline(always)]
     fn unwrap_optimized(self) -> Self::Output {
         if cfg!(target_family = "wasm") {
             match self {
@@ -21,6 +22,7 @@ impl<T> UnwrapOptimized for Option<T> {
 impl<T, E: core::fmt::Debug> UnwrapOptimized for Result<T, E> {
     type Output = T;
 
+    #[inline(always)]
     fn unwrap_optimized(self) -> Self::Output {
         if cfg!(target_family = "wasm") {
             match self {

--- a/soroban-sdk/src/unwrap.rs
+++ b/soroban-sdk/src/unwrap.rs
@@ -1,0 +1,34 @@
+pub trait UnwrapOptimized {
+    type Output;
+    fn unwrap_optimized(self) -> Self::Output;
+}
+
+impl<T> UnwrapOptimized for Option<T> {
+    type Output = T;
+
+    fn unwrap_optimized(self) -> Self::Output {
+        if cfg!(target_family = "wasm") {
+            match self {
+                Some(t) => t,
+                None => core::arch::wasm32::unreachable(),
+            }
+        } else {
+            self.unwrap()
+        }
+    }
+}
+
+impl<T, E: core::fmt::Debug> UnwrapOptimized for Result<T, E> {
+    type Output = T;
+
+    fn unwrap_optimized(self) -> Self::Output {
+        if cfg!(target_family = "wasm") {
+            match self {
+                Ok(t) => t,
+                Err(_) => core::arch::wasm32::unreachable(),
+            }
+        } else {
+            self.unwrap()
+        }
+    }
+}

--- a/soroban-sdk/src/unwrap.rs
+++ b/soroban-sdk/src/unwrap.rs
@@ -8,14 +8,13 @@ impl<T> UnwrapOptimized for Option<T> {
 
     #[inline(always)]
     fn unwrap_optimized(self) -> Self::Output {
-        if cfg!(target_family = "wasm") {
-            match self {
-                Some(t) => t,
-                None => core::arch::wasm32::unreachable(),
-            }
-        } else {
-            self.unwrap()
+        #[cfg(target_family = "wasm")]
+        match self {
+            Some(t) => t,
+            None => core::arch::wasm32::unreachable(),
         }
+        #[cfg(not(target_family = "wasm"))]
+        self.unwrap()
     }
 }
 
@@ -24,13 +23,12 @@ impl<T, E: core::fmt::Debug> UnwrapOptimized for Result<T, E> {
 
     #[inline(always)]
     fn unwrap_optimized(self) -> Self::Output {
-        if cfg!(target_family = "wasm") {
-            match self {
-                Ok(t) => t,
-                Err(_) => core::arch::wasm32::unreachable(),
-            }
-        } else {
-            self.unwrap()
+        #[cfg(target_family = "wasm")]
+        match self {
+            Ok(t) => t,
+            Err(_) => core::arch::wasm32::unreachable(),
         }
+        #[cfg(not(target_family = "wasm"))]
+        self.unwrap()
     }
 }


### PR DESCRIPTION
### What
Add an `unwrap_optimized` function to `Option` and `Result` that on wasm builds aborts immediately.

### Why
Sometime ago we had a form of this, and we removed it (https://github.com/stellar/rs-soroban-env/commit/330014541e30eb2565736061f9161c54b5d3f29c) in favor of using nightly to strip panic_fmt information that gets stuck in the resulting binary. That is still the preferred route to preventing panic info ending up in wasm32 builds because we want developers to as much as possible to have regular experience writing Rust code. But we call .unwrap() in a number of places internally in the SDK, and we could optimize those individual calls in the SDK, so we may as well so that non-nightly builds are smaller and not bloated as a result of type unwraps at function boundaries.

In the past when we had this we had it in the rs-soroban-env repo, however I think this should only belong in the SDK because it should only exist in wasm32 builds of contracts, so I'm adding it here this time.

To be clear this optimized unwrap is doc hidden and not intended for contract developers to use. We made a decision a while ago not to augment developers use of unwrap, and I think that stands, this is just for internal use.