### PR TITLE
Rename panic_error! to panic_with_error!

### DIFF
--- a/soroban-sdk/src/env.rs
+++ b/soroban-sdk/src/env.rs
@@ -87,7 +87,7 @@ impl Env {
     ///
     /// Equivalent to `panic!`, but with an error value instead of a string.
     #[doc(hidden)]
-    pub fn panic_error(&self, error: impl Into<Status>) {
+    pub fn panic_with_error(&self, error: impl Into<Status>) {
         _ = internal::Env::fail_with_status(self, error.into());
         unreachable!()
     }

--- a/soroban-sdk/src/lib.rs
+++ b/soroban-sdk/src/lib.rs
@@ -126,10 +126,19 @@ pub use soroban_sdk_macros::symbol;
 ///
 /// See [`contracterror`] for how to define an error type.
 #[macro_export]
+macro_rules! panic_with_error {
+    ($env:expr, $error:expr) => {{
+        $env.panic_with_error($error);
+        unreachable!();
+    }};
+}
+
+#[doc(hidden)]
+#[deprecated(note = "use panic_with_error!")]
+#[macro_export]
 macro_rules! panic_error {
     ($env:expr, $error:expr) => {{
-        $env.panic_error($error);
-        unreachable!();
+        $crate::panic_with_error!($env, $error);
     }};
 }
 
@@ -151,7 +160,7 @@ macro_rules! panic_error {
 macro_rules! assert_with_error {
     ($env:expr, $cond:expr, $error:expr) => {{
         if !($cond) {
-            $crate::panic_error!($env, $error);
+            $crate::panic_with_error!($env, $error);
         }
     }};
 }

--- a/tests/errors/src/lib.rs
+++ b/tests/errors/src/lib.rs
@@ -1,5 +1,5 @@
 #![no_std]
-use soroban_sdk::{contracterror, contractimpl, panic_error, symbol, Env, Symbol};
+use soroban_sdk::{contracterror, contractimpl, panic_with_error, symbol, Env, Symbol};
 
 pub struct Contract;
 
@@ -18,7 +18,7 @@ impl Contract {
         } else if flag == 1 {
             Err(Error::AnError)
         } else if flag == 2 {
-            panic_error!(&env, Error::AnError)
+            panic_with_error!(&env, Error::AnError)
         } else if flag == 3 {
             panic!("an error")
         } else {


### PR DESCRIPTION
### What
Rename `panic_error!` to `panic_with_error!`.

### Why
For consistency with `assert_with_error!` introduced in #749.