### PR TITLE
Update rust CI job publish-dry-run params

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -77,5 +77,5 @@ jobs:
     uses: stellar/actions/.github/workflows/rust-publish-dry-run.yml@main
     with:
       runs-on: ${{ matrix.sys.os }}
+      target: --target ${{ matrix.sys.target }}
       cargo-hack-feature-options: ${{ matrix.sys.cargo-hack-feature-options }}
-      cargo-package-options: --target ${{ matrix.sys.target }}


### PR DESCRIPTION
### What
Update rust CI job publish-dry-run params.

### Why
Recently updated in stellar/actions.