### PR TITLE
Add common derives to generated contract types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1134,6 +1134,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "test_errors"
+version = "0.2.0"
+dependencies = [
+ "soroban-sdk",
+]
+
+[[package]]
 name = "test_events"
 version = "0.2.0"
 dependencies = [
@@ -1156,13 +1163,6 @@ dependencies = [
 
 [[package]]
 name = "test_logging"
-version = "0.2.0"
-dependencies = [
- "soroban-sdk",
-]
-
-[[package]]
-name = "test_result"
 version = "0.2.0"
 dependencies = [
  "soroban-sdk",

--- a/soroban-sdk/src/tests.rs
+++ b/soroban-sdk/src/tests.rs
@@ -11,4 +11,5 @@ mod contract_udt_struct;
 mod contract_udt_struct_tuple;
 mod contractfile_with_sha256;
 mod contractimport;
+mod contractimport_with_error;
 mod contractimport_with_sha256;

--- a/soroban-sdk/src/tests/contractimport_with_error.rs
+++ b/soroban-sdk/src/tests/contractimport_with_error.rs
@@ -1,0 +1,31 @@
+use crate as soroban_sdk;
+use soroban_sdk::{contractimpl, symbol, BytesN, Env, Symbol};
+
+mod errcontract {
+    use crate as soroban_sdk;
+    soroban_sdk::contractimport!(
+        file = "../target/wasm32-unknown-unknown/release/test_errors.wasm"
+    );
+}
+
+pub struct Contract;
+
+#[contractimpl]
+impl Contract {
+    pub fn hello_with(env: Env, contract_id: BytesN<32>, flag: u32) -> Symbol {
+        errcontract::Client::new(&env, &contract_id).hello(&flag)
+    }
+}
+
+#[test]
+fn test_functional() {
+    let e = Env::default();
+
+    let err_contract_id = e.register_contract_wasm(None, errcontract::WASM);
+
+    let contract_id = e.register_contract(None, Contract);
+    let client = ContractClient::new(&e, &contract_id);
+
+    let z = client.hello_with(&err_contract_id, &0);
+    assert!(z == symbol!("hello"));
+}

--- a/soroban-spec/src/gen/rust.rs
+++ b/soroban-spec/src/gen/rust.rs
@@ -133,14 +133,17 @@ pub trait Contract {
     fn add(env: soroban_sdk::Env, a: UdtEnum, b: UdtEnum) -> i64;
 }
 #[soroban_sdk::contracttype(export = false)]
+#[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd)]
 pub struct UdtTuple(pub i64, pub soroban_sdk::Vec<i64>);
 #[soroban_sdk::contracttype(export = false)]
+#[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd)]
 pub struct UdtStruct {
     pub a: i64,
     pub b: i64,
     pub c: soroban_sdk::Vec<i64>,
 }
 #[soroban_sdk::contracttype(export = false)]
+#[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd)]
 pub enum UdtEnum {
     UdtA,
     UdtB(UdtStruct),
@@ -148,6 +151,7 @@ pub enum UdtEnum {
     UdtD(UdtTuple),
 }
 #[soroban_sdk::contracttype(export = false)]
+#[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd)]
 pub enum UdtEnum2 {
     A = 10,
     B = 15,

--- a/soroban-spec/src/gen/rust/types.rs
+++ b/soroban-spec/src/gen/rust/types.rs
@@ -31,6 +31,7 @@ pub fn generate_struct(spec: &ScSpecUdtStructV0) -> TokenStream {
         });
         quote! {
             #[soroban_sdk::contracttype(export = false)]
+            #[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
             pub struct #ident ( #(#fields),* );
         }
     } else {
@@ -42,6 +43,7 @@ pub fn generate_struct(spec: &ScSpecUdtStructV0) -> TokenStream {
         });
         quote! {
             #[soroban_sdk::contracttype(export = false)]
+            #[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
             pub struct #ident { #(#fields,)* }
         }
     }
@@ -68,6 +70,7 @@ pub fn generate_union(spec: &ScSpecUdtUnionV0) -> TokenStream {
         });
         quote! {
             #[soroban_sdk::contracttype(export = false)]
+            #[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
             pub enum #ident { #(#variants,)* }
         }
     }
@@ -90,6 +93,7 @@ pub fn generate_enum(spec: &ScSpecUdtEnumV0) -> TokenStream {
         });
         quote! {
             #[soroban_sdk::contracttype(export = false)]
+            #[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
             pub enum #ident { #(#variants,)* }
         }
     }
@@ -112,6 +116,7 @@ pub fn generate_error_enum(spec: &ScSpecUdtErrorEnumV0) -> TokenStream {
         });
         quote! {
             #[soroban_sdk::contracterror(export = false)]
+            #[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
             pub enum #ident { #(#variants,)* }
         }
     }

--- a/soroban-spec/src/gen/rust/types.rs
+++ b/soroban-spec/src/gen/rust/types.rs
@@ -31,7 +31,7 @@ pub fn generate_struct(spec: &ScSpecUdtStructV0) -> TokenStream {
         });
         quote! {
             #[soroban_sdk::contracttype(export = false)]
-            #[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
+            #[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd)]
             pub struct #ident ( #(#fields),* );
         }
     } else {
@@ -43,7 +43,7 @@ pub fn generate_struct(spec: &ScSpecUdtStructV0) -> TokenStream {
         });
         quote! {
             #[soroban_sdk::contracttype(export = false)]
-            #[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
+            #[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd)]
             pub struct #ident { #(#fields,)* }
         }
     }
@@ -70,7 +70,7 @@ pub fn generate_union(spec: &ScSpecUdtUnionV0) -> TokenStream {
         });
         quote! {
             #[soroban_sdk::contracttype(export = false)]
-            #[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
+            #[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd)]
             pub enum #ident { #(#variants,)* }
         }
     }
@@ -93,7 +93,7 @@ pub fn generate_enum(spec: &ScSpecUdtEnumV0) -> TokenStream {
         });
         quote! {
             #[soroban_sdk::contracttype(export = false)]
-            #[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
+            #[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd)]
             pub enum #ident { #(#variants,)* }
         }
     }
@@ -116,7 +116,7 @@ pub fn generate_error_enum(spec: &ScSpecUdtErrorEnumV0) -> TokenStream {
         });
         quote! {
             #[soroban_sdk::contracterror(export = false)]
-            #[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
+            #[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
             pub enum #ident { #(#variants,)* }
         }
     }

--- a/tests/errors/Cargo.toml
+++ b/tests/errors/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "test_result"
+name = "test_errors"
 version = "0.2.0"
 authors = ["Stellar Development Foundation <info@stellar.org>"]
 license = "Apache-2.0"


### PR DESCRIPTION
### What
Add common derives to generated contract types.

### Why
Some of them are required, and all of them are convenient to have on the data objects/types that are generated by contract imports.

 Close #758 