### PR TITLE
Add Env::as_contract for testutils

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -900,7 +900,6 @@ dependencies = [
 [[package]]
 name = "soroban-env-host"
 version = "0.0.9"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=c04c2332#c04c2332fd3ed3ee0e4b72c68c618c7f45f44ba1"
 dependencies = [
  "backtrace",
  "dyn-fmt",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -880,7 +880,7 @@ dependencies = [
 [[package]]
 name = "soroban-env-common"
 version = "0.0.9"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=c04c2332#c04c2332fd3ed3ee0e4b72c68c618c7f45f44ba1"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=0cba65a5#0cba65a5d4daa664a65e16a5631889b5a3775e5e"
 dependencies = [
  "soroban-env-macros",
  "soroban-wasmi",
@@ -891,7 +891,7 @@ dependencies = [
 [[package]]
 name = "soroban-env-guest"
 version = "0.0.9"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=c04c2332#c04c2332fd3ed3ee0e4b72c68c618c7f45f44ba1"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=0cba65a5#0cba65a5d4daa664a65e16a5631889b5a3775e5e"
 dependencies = [
  "soroban-env-common",
  "static_assertions",
@@ -900,7 +900,7 @@ dependencies = [
 [[package]]
 name = "soroban-env-host"
 version = "0.0.9"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=c04c2332#c04c2332fd3ed3ee0e4b72c68c618c7f45f44ba1"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=0cba65a5#0cba65a5d4daa664a65e16a5631889b5a3775e5e"
 dependencies = [
  "backtrace",
  "dyn-fmt",
@@ -923,7 +923,7 @@ dependencies = [
 [[package]]
 name = "soroban-env-macros"
 version = "0.0.9"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=c04c2332#c04c2332fd3ed3ee0e4b72c68c618c7f45f44ba1"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=0cba65a5#0cba65a5d4daa664a65e16a5631889b5a3775e5e"
 dependencies = [
  "itertools",
  "proc-macro2",
@@ -935,7 +935,7 @@ dependencies = [
 [[package]]
 name = "soroban-native-sdk-macros"
 version = "0.0.9"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=c04c2332#c04c2332fd3ed3ee0e4b72c68c618c7f45f44ba1"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=0cba65a5#0cba65a5d4daa664a65e16a5631889b5a3775e5e"
 dependencies = [
  "itertools",
  "proc-macro2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -880,7 +880,7 @@ dependencies = [
 [[package]]
 name = "soroban-env-common"
 version = "0.0.9"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=0cba65a5#0cba65a5d4daa664a65e16a5631889b5a3775e5e"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=adad06cc#adad06ccef08c0ec7b6c29c5b741867e6d47e879"
 dependencies = [
  "soroban-env-macros",
  "soroban-wasmi",
@@ -891,7 +891,7 @@ dependencies = [
 [[package]]
 name = "soroban-env-guest"
 version = "0.0.9"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=0cba65a5#0cba65a5d4daa664a65e16a5631889b5a3775e5e"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=adad06cc#adad06ccef08c0ec7b6c29c5b741867e6d47e879"
 dependencies = [
  "soroban-env-common",
  "static_assertions",
@@ -900,7 +900,7 @@ dependencies = [
 [[package]]
 name = "soroban-env-host"
 version = "0.0.9"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=0cba65a5#0cba65a5d4daa664a65e16a5631889b5a3775e5e"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=adad06cc#adad06ccef08c0ec7b6c29c5b741867e6d47e879"
 dependencies = [
  "backtrace",
  "dyn-fmt",
@@ -923,7 +923,7 @@ dependencies = [
 [[package]]
 name = "soroban-env-macros"
 version = "0.0.9"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=0cba65a5#0cba65a5d4daa664a65e16a5631889b5a3775e5e"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=adad06cc#adad06ccef08c0ec7b6c29c5b741867e6d47e879"
 dependencies = [
  "itertools",
  "proc-macro2",
@@ -935,7 +935,7 @@ dependencies = [
 [[package]]
 name = "soroban-native-sdk-macros"
 version = "0.0.9"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=0cba65a5#0cba65a5d4daa664a65e16a5631889b5a3775e5e"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=adad06cc#adad06ccef08c0ec7b6c29c5b741867e6d47e879"
 dependencies = [
  "itertools",
  "proc-macro2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -900,6 +900,7 @@ dependencies = [
 [[package]]
 name = "soroban-env-host"
 version = "0.0.9"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=c04c2332#c04c2332fd3ed3ee0e4b72c68c618c7f45f44ba1"
 dependencies = [
  "backtrace",
  "dyn-fmt",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ soroban-spec = { path = "soroban-spec" }
 soroban-sdk-macros = { path = "soroban-sdk-macros" }
 soroban-env-common = { git = "https://github.com/stellar/rs-soroban-env", rev = "c04c2332" }
 soroban-env-guest = { git = "https://github.com/stellar/rs-soroban-env", rev = "c04c2332" }
-soroban-env-host = { git = "https://github.com/stellar/rs-soroban-env", rev = "c04c2332" }
+# soroban-env-host = { git = "https://github.com/stellar/rs-soroban-env", rev = "c04c2332" }
 soroban-env-macros = { git = "https://github.com/stellar/rs-soroban-env", rev = "c04c2332" }
 soroban-native-sdk-macros = { git = "https://github.com/stellar/rs-soroban-env", rev = "c04c2332" }
 stellar-xdr = { git = "https://github.com/stellar/rs-stellar-xdr", rev = "e88f9fa7" }
@@ -41,7 +41,7 @@ wasmi = { package = "soroban-wasmi", git = "https://github.com/stellar/wasmi", r
 
 # soroban-env-common = { path = "../rs-soroban-env/soroban-env-common" }
 # soroban-env-guest = { path = "../rs-soroban-env/soroban-env-guest" }
-# soroban-env-host = { path = "../rs-soroban-env/soroban-env-host" }
+soroban-env-host = { path = "../rs-soroban-env/soroban-env-host" }
 # soroban-env-macros = { path = "../rs-soroban-env/soroban-env-macros" }
 # soroban-native-sdk-macros = { path = "../rs-soroban-env/soroban-native-sdk-macros" }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,17 +31,17 @@ soroban-sdk = { path = "soroban-sdk" }
 soroban-auth = { path = "soroban-auth" }
 soroban-spec = { path = "soroban-spec" }
 soroban-sdk-macros = { path = "soroban-sdk-macros" }
-soroban-env-common = { git = "https://github.com/stellar/rs-soroban-env", rev = "c04c2332" }
-soroban-env-guest = { git = "https://github.com/stellar/rs-soroban-env", rev = "c04c2332" }
-# soroban-env-host = { git = "https://github.com/stellar/rs-soroban-env", rev = "c04c2332" }
-soroban-env-macros = { git = "https://github.com/stellar/rs-soroban-env", rev = "c04c2332" }
-soroban-native-sdk-macros = { git = "https://github.com/stellar/rs-soroban-env", rev = "c04c2332" }
+soroban-env-common = { git = "https://github.com/stellar/rs-soroban-env", rev = "0cba65a5" }
+soroban-env-guest = { git = "https://github.com/stellar/rs-soroban-env", rev = "0cba65a5" }
+soroban-env-host = { git = "https://github.com/stellar/rs-soroban-env", rev = "0cba65a5" }
+soroban-env-macros = { git = "https://github.com/stellar/rs-soroban-env", rev = "0cba65a5" }
+soroban-native-sdk-macros = { git = "https://github.com/stellar/rs-soroban-env", rev = "0cba65a5" }
 stellar-xdr = { git = "https://github.com/stellar/rs-stellar-xdr", rev = "e88f9fa7" }
 wasmi = { package = "soroban-wasmi", git = "https://github.com/stellar/wasmi", rev = "d1ec0036" }
 
 # soroban-env-common = { path = "../rs-soroban-env/soroban-env-common" }
 # soroban-env-guest = { path = "../rs-soroban-env/soroban-env-guest" }
-soroban-env-host = { path = "../rs-soroban-env/soroban-env-host" }
+# soroban-env-host = { path = "../rs-soroban-env/soroban-env-host" }
 # soroban-env-macros = { path = "../rs-soroban-env/soroban-env-macros" }
 # soroban-native-sdk-macros = { path = "../rs-soroban-env/soroban-native-sdk-macros" }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,11 +31,11 @@ soroban-sdk = { path = "soroban-sdk" }
 soroban-auth = { path = "soroban-auth" }
 soroban-spec = { path = "soroban-spec" }
 soroban-sdk-macros = { path = "soroban-sdk-macros" }
-soroban-env-common = { git = "https://github.com/stellar/rs-soroban-env", rev = "0cba65a5" }
-soroban-env-guest = { git = "https://github.com/stellar/rs-soroban-env", rev = "0cba65a5" }
-soroban-env-host = { git = "https://github.com/stellar/rs-soroban-env", rev = "0cba65a5" }
-soroban-env-macros = { git = "https://github.com/stellar/rs-soroban-env", rev = "0cba65a5" }
-soroban-native-sdk-macros = { git = "https://github.com/stellar/rs-soroban-env", rev = "0cba65a5" }
+soroban-env-common = { git = "https://github.com/stellar/rs-soroban-env", rev = "5875af05" }
+soroban-env-guest = { git = "https://github.com/stellar/rs-soroban-env", rev = "5875af05" }
+soroban-env-host = { git = "https://github.com/stellar/rs-soroban-env", rev = "5875af05" }
+soroban-env-macros = { git = "https://github.com/stellar/rs-soroban-env", rev = "5875af05" }
+soroban-native-sdk-macros = { git = "https://github.com/stellar/rs-soroban-env", rev = "5875af05" }
 stellar-xdr = { git = "https://github.com/stellar/rs-stellar-xdr", rev = "e88f9fa7" }
 wasmi = { package = "soroban-wasmi", git = "https://github.com/stellar/wasmi", rev = "d1ec0036" }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,11 +31,11 @@ soroban-sdk = { path = "soroban-sdk" }
 soroban-auth = { path = "soroban-auth" }
 soroban-spec = { path = "soroban-spec" }
 soroban-sdk-macros = { path = "soroban-sdk-macros" }
-soroban-env-common = { git = "https://github.com/stellar/rs-soroban-env", rev = "5875af05" }
-soroban-env-guest = { git = "https://github.com/stellar/rs-soroban-env", rev = "5875af05" }
-soroban-env-host = { git = "https://github.com/stellar/rs-soroban-env", rev = "5875af05" }
-soroban-env-macros = { git = "https://github.com/stellar/rs-soroban-env", rev = "5875af05" }
-soroban-native-sdk-macros = { git = "https://github.com/stellar/rs-soroban-env", rev = "5875af05" }
+soroban-env-common = { git = "https://github.com/stellar/rs-soroban-env", rev = "adad06cc" }
+soroban-env-guest = { git = "https://github.com/stellar/rs-soroban-env", rev = "adad06cc" }
+soroban-env-host = { git = "https://github.com/stellar/rs-soroban-env", rev = "adad06cc" }
+soroban-env-macros = { git = "https://github.com/stellar/rs-soroban-env", rev = "adad06cc" }
+soroban-native-sdk-macros = { git = "https://github.com/stellar/rs-soroban-env", rev = "adad06cc" }
 stellar-xdr = { git = "https://github.com/stellar/rs-stellar-xdr", rev = "e88f9fa7" }
 wasmi = { package = "soroban-wasmi", git = "https://github.com/stellar/wasmi", rev = "d1ec0036" }
 

--- a/soroban-sdk/src/bytes.rs
+++ b/soroban-sdk/src/bytes.rs
@@ -887,6 +887,15 @@ impl<const N: usize> TryFrom<Bytes> for BytesN<N> {
     }
 }
 
+impl<const N: usize> TryFrom<&Bytes> for BytesN<N> {
+    type Error = ConversionError;
+
+    #[inline(always)]
+    fn try_from(bin: &Bytes) -> Result<Self, Self::Error> {
+        bin.clone().try_into()
+    }
+}
+
 impl<const N: usize> From<BytesN<N>> for RawVal {
     #[inline(always)]
     fn from(v: BytesN<N>) -> Self {
@@ -1076,10 +1085,29 @@ impl<const N: usize> TryFrom<Bytes> for [u8; N] {
     }
 }
 
+impl<const N: usize> TryFrom<&Bytes> for [u8; N] {
+    type Error = ConversionError;
+
+    fn try_from(bin: &Bytes) -> Result<Self, Self::Error> {
+        let fixed: BytesN<N> = bin.try_into()?;
+        Ok(fixed.into())
+    }
+}
+
 impl<const N: usize> From<BytesN<N>> for [u8; N] {
     fn from(bin: BytesN<N>) -> Self {
         let mut res = [0u8; N];
         for (i, b) in bin.into_iter().enumerate() {
+            res[i] = b;
+        }
+        res
+    }
+}
+
+impl<const N: usize> From<&BytesN<N>> for [u8; N] {
+    fn from(bin: &BytesN<N>) -> Self {
+        let mut res = [0u8; N];
+        for (i, b) in bin.iter().enumerate() {
             res[i] = b;
         }
         res

--- a/soroban-sdk/src/env.rs
+++ b/soroban-sdk/src/env.rs
@@ -346,6 +346,27 @@ impl Env {
             .unwrap()
     }
 
+    /// Run the closure as if executed by the given contract ID.
+    ///
+    /// Used to write or read contract data, or take other actions in tests for
+    /// setting up tests or asserting on internal state.
+    pub fn as_contract<T>(&self, id: BytesN<32>, f: impl FnOnce() -> T) -> T
+    where
+        T: IntoVal<Env, RawVal> + TryFromVal<Env, RawVal>,
+        T::Error: core::fmt::Debug,
+    {
+        let id: [u8; 32] = id.into();
+        let func = Symbol::from_str("");
+        let result = self
+            .env_impl
+            .with_artificial_test_contract_frame(id.into(), func, || {
+                let t = f();
+                Ok(t.into_val(self))
+            })
+            .unwrap();
+        <_ as TryFromVal<_, _>>::try_from_val(self, result).unwrap()
+    }
+
     /// Register a contract with the [Env] for testing.
     ///
     /// Passing a contract ID for the first arguments registers the contract

--- a/soroban-sdk/src/env.rs
+++ b/soroban-sdk/src/env.rs
@@ -355,7 +355,7 @@ impl Env {
         let func = Symbol::from_str("");
         let mut t: Option<T> = None;
         self.env_impl
-            .with_artificial_test_contract_frame(id.into(), func, || {
+            .with_test_contract_frame(id.into(), func, || {
                 t = Some(f());
                 Ok(().into())
             })

--- a/soroban-sdk/src/tests.rs
+++ b/soroban-sdk/src/tests.rs
@@ -6,6 +6,7 @@ mod contract_call_stack;
 mod contract_invoke;
 mod contract_invoker_account;
 mod contract_invoker_client;
+mod contract_store;
 mod contract_udt_enum;
 mod contract_udt_struct;
 mod contract_udt_struct_tuple;

--- a/soroban-sdk/src/tests/contract_store.rs
+++ b/soroban-sdk/src/tests/contract_store.rs
@@ -18,5 +18,8 @@ fn test() {
 
     client.store(&2, &4);
 
-    e.as_contract(contract_id, || e.data().get::<_, i32>(2));
+    assert_eq!(
+        e.as_contract(&contract_id, || e.data().get::<_, i32>(2)),
+        Some(Ok(4))
+    );
 }

--- a/soroban-sdk/src/tests/contract_store.rs
+++ b/soroban-sdk/src/tests/contract_store.rs
@@ -1,0 +1,22 @@
+use crate as soroban_sdk;
+use soroban_sdk::{contractimpl, Env};
+
+pub struct Contract;
+
+#[contractimpl]
+impl Contract {
+    pub fn store(env: Env, k: i32, v: i32) {
+        env.data().set(k, v)
+    }
+}
+
+#[test]
+fn test() {
+    let e = Env::default();
+    let contract_id = e.register_contract(None, Contract);
+    let client = ContractClient::new(&e, &contract_id);
+
+    client.store(&2, &4);
+
+    e.as_contract(contract_id, || e.data().get::<_, i32>(2));
+}


### PR DESCRIPTION
### What
Add Env::as_contract that executes a function inside a test frame artificially created that may not reference a contract that is actually deployed.

### Why
To support providing functionality where logic is executed as a contract, without the contract having to provide that logic itself. This is helpful in testing.

Dependent on https://github.com/stellar/rs-soroban-env/pull/565

Close #739