### PR TITLE
Update contract deployment to match the Env changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -871,7 +871,7 @@ dependencies = [
 [[package]]
 name = "soroban-env-common"
 version = "0.0.9"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=99de1bf0#99de1bf0d2026d1fdb2854a13c195c5902f088a4"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=f5d64c9c#f5d64c9c2e52d8162eceebbda204a2252b956559"
 dependencies = [
  "soroban-env-macros",
  "soroban-wasmi",
@@ -882,7 +882,7 @@ dependencies = [
 [[package]]
 name = "soroban-env-guest"
 version = "0.0.9"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=99de1bf0#99de1bf0d2026d1fdb2854a13c195c5902f088a4"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=f5d64c9c#f5d64c9c2e52d8162eceebbda204a2252b956559"
 dependencies = [
  "soroban-env-common",
  "static_assertions",
@@ -891,9 +891,10 @@ dependencies = [
 [[package]]
 name = "soroban-env-host"
 version = "0.0.9"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=99de1bf0#99de1bf0d2026d1fdb2854a13c195c5902f088a4"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=f5d64c9c#f5d64c9c2e52d8162eceebbda204a2252b956559"
 dependencies = [
  "backtrace",
+ "curve25519-dalek",
  "dyn-fmt",
  "ed25519-dalek",
  "hex",
@@ -914,7 +915,7 @@ dependencies = [
 [[package]]
 name = "soroban-env-macros"
 version = "0.0.9"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=99de1bf0#99de1bf0d2026d1fdb2854a13c195c5902f088a4"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=f5d64c9c#f5d64c9c2e52d8162eceebbda204a2252b956559"
 dependencies = [
  "itertools",
  "proc-macro2",
@@ -926,7 +927,7 @@ dependencies = [
 [[package]]
 name = "soroban-native-sdk-macros"
 version = "0.0.9"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=99de1bf0#99de1bf0d2026d1fdb2854a13c195c5902f088a4"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=f5d64c9c#f5d64c9c2e52d8162eceebbda204a2252b956559"
 dependencies = [
  "itertools",
  "proc-macro2",
@@ -1042,7 +1043,7 @@ dependencies = [
 [[package]]
 name = "stellar-xdr"
 version = "0.0.7"
-source = "git+https://github.com/stellar/rs-stellar-xdr?rev=e88f9fa7#e88f9fa7ab3d0f54efb5cee8499ef9080f4d41f4"
+source = "git+https://github.com/stellar/rs-stellar-xdr?rev=5fd7c7d4#5fd7c7d44d66452209a951be89c0c3602ab9f302"
 dependencies = [
  "base64",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,17 +32,17 @@ soroban-token-spec = { version = "0.2.1", path = "soroban-token-spec" }
 [workspace.dependencies.soroban-env-common]
 version = "0.0.9"
 git = "https://github.com/stellar/rs-soroban-env"
-rev = "99de1bf0"
+rev = "f5d64c9c"
 
 [workspace.dependencies.soroban-env-guest]
 version = "0.0.9"
 git = "https://github.com/stellar/rs-soroban-env"
-rev = "99de1bf0"
+rev = "f5d64c9c"
 
 [workspace.dependencies.soroban-env-host]
 version = "0.0.9"
 git = "https://github.com/stellar/rs-soroban-env"
-rev = "99de1bf0"
+rev = "f5d64c9c"
 
 [workspace.dependencies.stellar-strkey]
 version = "0.0.6"
@@ -52,7 +52,7 @@ rev = "5e582a8b"
 [workspace.dependencies.stellar-xdr]
 version = "0.0.7"
 git = "https://github.com/stellar/rs-stellar-xdr"
-rev = "e88f9fa7"
+rev = "5fd7c7d4"
 default-features = false
 
 # [patch."https://github.com/stellar/rs-soroban-env"]

--- a/soroban-sdk-macros/src/lib.rs
+++ b/soroban-sdk-macros/src/lib.rs
@@ -353,14 +353,9 @@ struct ContractImportArgs {
 /// #[test]
 /// fn test() {
 ///     let env = Env::default();
-///
-///     // Define IDs for contract A and B.
-///     let contract_a_id = BytesN::from_array(&env, &[0; 32]);
-///     let contract_b_id = BytesN::from_array(&env, &[1; 32]);
-///
 ///     // Register contract A using the imported WASM.
-///     env.register_contract_wasm(&contract_a_id, contract_a::WASM);
-///
+///     let contract_a_id = env.register_contract_wasm(&contract_a_id, contract_a::WASM);
+///     let contract_b_id = BytesN::from_array(&env, &[1; 32]);
 ///     // Register contract B defined in this crate.
 ///     env.register_contract(&contract_b_id, ContractB);
 ///

--- a/soroban-sdk-macros/src/lib.rs
+++ b/soroban-sdk-macros/src/lib.rs
@@ -354,7 +354,7 @@ struct ContractImportArgs {
 /// fn test() {
 ///     let env = Env::default();
 ///     // Register contract A using the imported WASM.
-///     let contract_a_id = env.register_contract_wasm(&contract_a_id, contract_a::WASM);
+///     let contract_a_id = env.register_contract_wasm(contract_a::WASM);
 ///     let contract_b_id = BytesN::from_array(&env, &[1; 32]);
 ///     // Register contract B defined in this crate.
 ///     env.register_contract(&contract_b_id, ContractB);

--- a/soroban-sdk/src/deploy.rs
+++ b/soroban-sdk/src/deploy.rs
@@ -40,7 +40,7 @@
 //! # #[cfg(not(feature = "testutils"))]
 //! # fn main() { }
 //! ```
-use crate::{env::internal::Env as _, Bytes, BytesN, Env, IntoVal, TryFromVal};
+use crate::{env::internal::Env as _, Bytes, BytesN, Env, IntoVal};
 
 /// Deployer provides access to deploying contracts.
 pub struct Deployer {
@@ -84,22 +84,6 @@ impl Deployer {
             salt: salt.into_val(env),
         }
     }
-
-    #[doc(hidden)]
-    /// Get a deployer for contracts that derive their contract IDs from the
-    /// given ed25519 public key and the provided salt.
-    pub fn with_ed25519(
-        &self,
-        public_key: impl IntoVal<Env, BytesN<32>>,
-        salt: impl IntoVal<Env, Bytes>,
-    ) -> DeployerWithEd25519 {
-        let env = self.env();
-        DeployerWithEd25519 {
-            env: env.clone(),
-            public_key: public_key.into_val(env),
-            salt: salt.into_val(env),
-        }
-    }
 }
 
 /// A deployer that deploys a contract that has its ID derived from the current
@@ -122,10 +106,12 @@ impl DeployerWithCurrentContract {
     /// will be used to derive a contract ID for the deployed contract.
     ///
     /// Returns the deployed contract's ID.
-    pub fn deploy(&self, wasm: impl IntoVal<Env, Bytes>) -> BytesN<32> {
+    pub fn deploy(&self, wasm_hash: impl IntoVal<Env, BytesN<32>>) -> BytesN<32> {
         let env = &self.env;
-        let id = env
-            .create_contract_from_contract(wasm.into_val(env).to_object(), self.salt.to_object());
+        let id = env.create_contract_from_contract(
+            wasm_hash.into_val(env).to_object(),
+            self.salt.to_object(),
+        );
         unsafe { BytesN::<32>::unchecked_new(id.in_env(env)) }
     }
 
@@ -160,59 +146,5 @@ impl DeployerWithOtherContract {
     /// Return the ID of the contract defined by the deployer.
     pub fn id(&self) -> BytesN<32> {
         todo!()
-    }
-}
-
-#[doc(hidden)]
-/// A deployer that deploys a contract that has its ID derived from the given
-/// ed25519 public key and the provided salt.
-pub struct DeployerWithEd25519 {
-    env: Env,
-    public_key: BytesN<32>,
-    salt: Bytes,
-}
-
-impl DeployerWithEd25519 {
-    #[doc(hidden)]
-    /// Return the ID of the contract defined by the deployer.
-    pub fn id(&self) -> BytesN<32> {
-        todo!()
-    }
-
-    /// Deploy a contract.
-    ///
-    /// The ed25519 public key and the given salt will be used to derive a
-    /// contract ID for the deployed contract.
-    ///
-    /// Returns the deployed contract's ID.
-    pub fn deploy(
-        &self,
-        wasm: impl IntoVal<Env, Bytes>,
-        signature: impl IntoVal<Env, BytesN<64>>,
-    ) -> BytesN<32> {
-        let env = &self.env;
-        let id = env.create_contract_from_ed25519(
-            wasm.into_val(env).to_object(),
-            self.salt.to_object(),
-            self.public_key.to_object(),
-            signature.into_val(env).to_object(),
-        );
-        BytesN::try_from_val(env, id).unwrap()
-    }
-
-    /// Deploy a built-in token contract.
-    ///
-    /// The ed25519 public key and the given salt will be used to derive a
-    /// contract ID for the deployed contract.
-    ///
-    /// Returns the deployed contract's ID.
-    pub fn deploy_token(&self, signature: impl IntoVal<Env, BytesN<64>>) -> BytesN<32> {
-        let env = &self.env;
-        let id = env.create_token_from_ed25519(
-            self.salt.to_object(),
-            self.public_key.to_object(),
-            signature.into_val(env).to_object(),
-        );
-        BytesN::try_from_val(env, id).unwrap()
     }
 }

--- a/soroban-sdk/src/deploy.rs
+++ b/soroban-sdk/src/deploy.rs
@@ -18,10 +18,10 @@
 //! #
 //! # #[contractimpl]
 //! # impl Contract {
-//! #     pub fn f(env: Env, wasm_id: BytesN<32>) {
+//! #     pub fn f(env: Env, wasm_hash: BytesN<32>) {
 //! #         let salt = [0u8; 32];
-//! #         let deployer = env.deployer().with_current_contract(&salt);
-//! #         let contract_id = deployer.deploy(&wasm_id);
+//! let deployer = env.deployer().with_current_contract(&salt);
+//! let contract_id = deployer.deploy(&wasm_hash);
 //! #     }
 //! # }
 //! #
@@ -31,8 +31,8 @@
 //! #     let contract_id = BytesN::from_array(&env, &[0; 32]);
 //! #     env.register_contract(&contract_id, Contract);
 //! #     // Install the contract code before deploying its instance.
-//! #     let wasm_id = env.install_contract_wasm(&[0u8; 100]);
-//! #     ContractClient::new(&env, &contract_id).f(&wasm_id);
+//! #     let wasm_hash = env.install_contract_wasm(&[0u8; 100]);
+//! #     ContractClient::new(&env, &contract_id).f(&wasm_hash);
 //! # }
 //! # #[cfg(not(feature = "testutils"))]
 //! # fn main() { }

--- a/soroban-sdk/src/deploy.rs
+++ b/soroban-sdk/src/deploy.rs
@@ -7,10 +7,6 @@
 //! executing contract will have an ID derived from the currently executing
 //! contract's ID.
 //!
-//! - [Deployer::with_ed25519] – A contract deployed by the currently executing
-//! contract with an ed25519 public key will have an ID derived from the ed25519
-//! public key.
-//!
 //! The deployer can be created using [Env::deployer].
 //!
 //! ### Examples
@@ -22,11 +18,10 @@
 //! #
 //! # #[contractimpl]
 //! # impl Contract {
-//! #     pub fn f(env: Env) {
-//! # let wasm = [0u8; 32];
-//! # let salt = [0u8; 32];
-//! let deployer = env.deployer().with_current_contract(&salt);
-//! let contract_id = deployer.deploy(&wasm);
+//! #     pub fn f(env: Env, wasm_id: BytesN<32>) {
+//! #         let salt = [0u8; 32];
+//! #         let deployer = env.deployer().with_current_contract(&salt);
+//! #         let contract_id = deployer.deploy(&wasm_id);
 //! #     }
 //! # }
 //! #
@@ -35,7 +30,9 @@
 //! #     let env = Env::default();
 //! #     let contract_id = BytesN::from_array(&env, &[0; 32]);
 //! #     env.register_contract(&contract_id, Contract);
-//! #     ContractClient::new(&env, &contract_id).f();
+//! #     // Install the contract code before deploying its instance.
+//! #     let wasm_id = env.install_contract_wasm(&[0u8; 100]);
+//! #     ContractClient::new(&env, &contract_id).f(&wasm_id);
 //! # }
 //! # #[cfg(not(feature = "testutils"))]
 //! # fn main() { }

--- a/soroban-sdk/src/env.rs
+++ b/soroban-sdk/src/env.rs
@@ -424,7 +424,7 @@ impl Env {
     /// Returns the hash of the installed code that can be then used for
     /// the contract deployment.
     ///
-    /// Useful for contract factory testing, otherwise use 
+    /// Useful for contract factory testing, otherwise use
     /// `register_contract_wasm` function that installs and deploys the contract
     /// in a single call.
     ///

--- a/soroban-sdk/src/env.rs
+++ b/soroban-sdk/src/env.rs
@@ -408,7 +408,7 @@ impl Env {
         let contract_id = if let Some(contract_id) = contract_id.into() {
             contract_id.clone()
         } else {
-            self.random_id_bytes()
+            self.random_bytes()
         };
         self.env_impl
             .register_test_contract(
@@ -496,7 +496,7 @@ impl Env {
 
     fn register_contract_with_source(&self, source: xdr::ScContractCode) -> BytesN<32> {
         use crate::testutils::random_account_id;
-        use crate::testutils::random_id;
+        use crate::testutils::random_bytes_array;
         let prev_source_account = if let Ok(prev_acc) = self.env_impl.source_account() {
             Some(prev_acc)
         } else {
@@ -507,7 +507,7 @@ impl Env {
         let contract_id: BytesN<32> = self
             .env_impl
             .invoke_function(xdr::HostFunction::CreateContract(xdr::CreateContractArgs {
-                contract_id: xdr::ContractId::SourceAccount(xdr::Uint256(random_id())),
+                contract_id: xdr::ContractId::SourceAccount(xdr::Uint256(random_bytes_array())),
                 source,
             }))
             .unwrap()

--- a/soroban-sdk/src/env.rs
+++ b/soroban-sdk/src/env.rs
@@ -421,10 +421,10 @@ impl Env {
 
     /// Install the contract WASM code to the [Env] for testing.
     ///
-    /// Returns the identifier of the installed code that can be then used for
+    /// Returns the hash of the installed code that can be then used for
     /// the contract deployment.
     ///
-    /// This is mostly useful for contract factory testing, otherwise use
+    /// Useful for contract factory testing, otherwise use 
     /// `register_contract_wasm` function that installs and deploys the contract
     /// in a single call.
     ///
@@ -467,9 +467,9 @@ impl Env {
     /// # }
     /// ```
     pub fn register_contract_wasm<'a>(&self, contract_wasm: &[u8]) -> BytesN<32> {
-        let wasm_id: BytesN<32> = self.install_contract_wasm(contract_wasm);
+        let wasm_hash: BytesN<32> = self.install_contract_wasm(contract_wasm);
         self.register_contract_with_source(xdr::ScContractCode::WasmRef(xdr::Hash(
-            wasm_id.to_array(),
+            wasm_hash.to_array(),
         )))
     }
 

--- a/soroban-sdk/src/env.rs
+++ b/soroban-sdk/src/env.rs
@@ -439,7 +439,7 @@ impl Env {
     /// env.install_contract_wasm(WASM);
     /// # }
     /// ```
-    pub fn install_contract_wasm<'a>(&self, contract_wasm: &[u8]) -> BytesN<32> {
+    pub fn install_contract_wasm(&self, contract_wasm: &[u8]) -> BytesN<32> {
         self.env_impl
             .invoke_function(xdr::HostFunction::InstallContractCode(
                 xdr::InstallContractCodeArgs {
@@ -466,7 +466,7 @@ impl Env {
     /// env.register_contract_wasm(WASM);
     /// # }
     /// ```
-    pub fn register_contract_wasm<'a>(&self, contract_wasm: &[u8]) -> BytesN<32> {
+    pub fn register_contract_wasm(&self, contract_wasm: &[u8]) -> BytesN<32> {
         let wasm_hash: BytesN<32> = self.install_contract_wasm(contract_wasm);
         self.register_contract_with_source(xdr::ScContractCode::WasmRef(xdr::Hash(
             wasm_hash.to_array(),
@@ -490,11 +490,11 @@ impl Env {
     /// env.register_contract_token();
     /// # }
     /// ```
-    pub fn register_contract_token<'a>(&self) -> BytesN<32> {
+    pub fn register_contract_token(&self) -> BytesN<32> {
         self.register_contract_with_source(xdr::ScContractCode::Token)
     }
 
-    fn register_contract_with_source<'a>(&self, source: xdr::ScContractCode) -> BytesN<32> {
+    fn register_contract_with_source(&self, source: xdr::ScContractCode) -> BytesN<32> {
         use crate::testutils::random_account_id;
         use crate::testutils::random_id;
         let prev_source_account = if let Ok(prev_acc) = self.env_impl.source_account() {

--- a/soroban-sdk/src/tests/contractfile_with_sha256.rs
+++ b/soroban-sdk/src/tests/contractfile_with_sha256.rs
@@ -1,7 +1,7 @@
 use crate as soroban_sdk;
 pub const WASM: &[u8] = soroban_sdk::contractfile!(
     file = "../target/wasm32-unknown-unknown/release/test_add_u64.wasm",
-    sha256 = "134b7bb632955e2851c85015852fbf1e0d6e7625029b2e38a54cb9044d9501da",
+    sha256 = "ccdd95bcb18a2c0dcf4d277cb12bd905ce2442b38d9320c294184e6a5135b6e0",
 );
 
 #[test]

--- a/soroban-sdk/src/tests/contractimport.rs
+++ b/soroban-sdk/src/tests/contractimport.rs
@@ -24,7 +24,7 @@ impl Contract {
 fn test_functional() {
     let e = Env::default();
 
-    let add_contract_id = e.register_contract_wasm(None, addcontract::WASM);
+    let add_contract_id = e.register_contract_wasm(addcontract::WASM);
 
     let contract_id = e.register_contract(None, Contract);
     let client = ContractClient::new(&e, &contract_id);

--- a/soroban-sdk/src/tests/contractimport_with_error.rs
+++ b/soroban-sdk/src/tests/contractimport_with_error.rs
@@ -21,7 +21,7 @@ impl Contract {
 fn test_functional() {
     let e = Env::default();
 
-    let err_contract_id = e.register_contract_wasm(None, errcontract::WASM);
+    let err_contract_id = e.register_contract_wasm(errcontract::WASM);
 
     let contract_id = e.register_contract(None, Contract);
     let client = ContractClient::new(&e, &contract_id);

--- a/soroban-sdk/src/tests/contractimport_with_sha256.rs
+++ b/soroban-sdk/src/tests/contractimport_with_sha256.rs
@@ -8,7 +8,7 @@ mod addcontract {
     use crate as soroban_sdk;
     soroban_sdk::contractimport!(
         file = "../target/wasm32-unknown-unknown/release/test_add_u64.wasm",
-        sha256 = "134b7bb632955e2851c85015852fbf1e0d6e7625029b2e38a54cb9044d9501da",
+        sha256 = "ccdd95bcb18a2c0dcf4d277cb12bd905ce2442b38d9320c294184e6a5135b6e0",
     );
 }
 
@@ -25,7 +25,7 @@ impl Contract {
 fn test_functional() {
     let e = Env::default();
 
-    let add_contract_id = e.register_contract_wasm(None, addcontract::WASM);
+    let add_contract_id = e.register_contract_wasm(addcontract::WASM);
 
     let contract_id = e.register_contract(None, Contract);
     let client = ContractClient::new(&e, &contract_id);

--- a/soroban-sdk/src/testutils.rs
+++ b/soroban-sdk/src/testutils.rs
@@ -4,11 +4,14 @@
 //! Utilities intended for use when testing.
 
 mod sign;
+use rand::RngCore;
 pub use sign::ed25519;
 
 pub use crate::env::testutils::*;
 
 use crate::{AccountId, BytesN, Env, RawVal, Symbol, Vec};
+
+use crate::env::xdr;
 
 #[doc(hidden)]
 pub trait ContractFunctionSet {
@@ -66,4 +69,22 @@ pub trait Accounts {
 
     /// Remove an account.
     fn remove(&self, id: &AccountId);
+}
+
+pub fn random_id() -> [u8; 32] {
+    let mut id = [0u8; 32];
+    rand::thread_rng().fill_bytes(&mut id);
+    id
+}
+
+pub fn random_account_id() -> xdr::AccountId {
+    xdr::AccountId(xdr::PublicKey::PublicKeyTypeEd25519(xdr::Uint256(
+        random_id(),
+    )))
+}
+
+impl Env {
+    pub fn random_id_bytes(&self) -> BytesN<32> {
+        BytesN::from_array(self, &random_id())
+    }
 }

--- a/soroban-sdk/src/testutils.rs
+++ b/soroban-sdk/src/testutils.rs
@@ -71,20 +71,23 @@ pub trait Accounts {
     fn remove(&self, id: &AccountId);
 }
 
-pub fn random_id() -> [u8; 32] {
-    let mut id = [0u8; 32];
-    rand::thread_rng().fill_bytes(&mut id);
-    id
+/// Generates a Rust array of N random bytes.
+pub fn random_bytes_array<const N: usize>() -> [u8; N] {
+    let mut arr = [0u8; N];
+    rand::thread_rng().fill_bytes(&mut arr);
+    arr
 }
 
+/// Generates a random Stellar `AccountId` XDR.
 pub fn random_account_id() -> xdr::AccountId {
     xdr::AccountId(xdr::PublicKey::PublicKeyTypeEd25519(xdr::Uint256(
-        random_id(),
+        random_bytes_array(),
     )))
 }
 
 impl Env {
-    pub fn random_id_bytes(&self) -> BytesN<32> {
-        BytesN::from_array(self, &random_id())
+    /// Generates a Host-owned array of `N` random bytes.
+    pub fn random_bytes<const N: usize>(&self) -> BytesN<N> {
+        BytesN::from_array(self, &random_bytes_array())
     }
 }

--- a/tests/import_contract/src/lib.rs
+++ b/tests/import_contract/src/lib.rs
@@ -1,7 +1,6 @@
 #![no_std]
-use soroban_sdk::{contractimpl, Env};
+use soroban_sdk::{contractimpl, BytesN, Env};
 
-const ADD_CONTRACT_ID: [u8; 32] = [0; 32];
 mod addcontract {
     soroban_sdk::contractimport!(
         file = "../../target/wasm32-unknown-unknown/release/test_add_u64.wasm"
@@ -12,8 +11,8 @@ pub struct Contract;
 
 #[contractimpl]
 impl Contract {
-    pub fn add_with(env: Env, x: u64, y: u64) -> u64 {
-        addcontract::Client::new(&env, &ADD_CONTRACT_ID).add(&x, &y)
+    pub fn add_with(env: Env, contract_id: BytesN<32>, x: u64, y: u64) -> u64 {
+        addcontract::Client::new(&env, &contract_id).add(&x, &y)
     }
 }
 
@@ -21,14 +20,12 @@ impl Contract {
 mod test {
     use soroban_sdk::{BytesN, Env};
 
-    use crate::{addcontract, Contract, ContractClient, ADD_CONTRACT_ID};
+    use crate::{addcontract, Contract, ContractClient};
 
     #[test]
     fn test_add() {
         let e = Env::default();
-
-        let add_contract_id = BytesN::from_array(&e, &ADD_CONTRACT_ID);
-        e.register_contract_wasm(&add_contract_id, addcontract::WASM);
+        let add_contract_id = e.register_contract_wasm(addcontract::WASM);
 
         let contract_id = BytesN::from_array(&e, &[1; 32]);
         e.register_contract(&contract_id, Contract);
@@ -36,7 +33,7 @@ mod test {
 
         let x = 10u64;
         let y = 12u64;
-        let z = client.add_with(&x, &y);
+        let z = client.add_with(&add_contract_id, &x, &y);
         assert!(z == 22);
     }
 }


### PR DESCRIPTION
### What

This change makes SDK compatible with the host/env changes to the contract deployment:

- Use new host function API to register WASM/token contracts
- Deploy contracts using WASM hash instead of WASM blobs
- Remove ED25519 deployer for the time being (until env supports it)
- Do the respective test updates

### Why

Supporting the host changes.

### Known limitations

This PR removes the possibility for registering WASM/tokens with arbitrary user-provided IDs. I don't think it's a good idea to allow that, given that in reality it's not possible to deploy contracts with arbitrary IDs. However, there could be a case for specifying the exact ID preimage for the contract in order to get a stable ID. If we think there is a use case for that, I'm open to suggestions as to what would be the best interface for that functionality.
