### PR TITLE
Reorganize recently added random functions

### DIFF
--- a/soroban-sdk/src/accounts.rs
+++ b/soroban-sdk/src/accounts.rs
@@ -204,6 +204,14 @@ impl TryFrom<AccountId> for ScVal {
 }
 
 #[cfg(not(target_family = "wasm"))]
+impl TryFrom<AccountId> for super::xdr::AccountId {
+    type Error = ConversionError;
+    fn try_from(v: AccountId) -> Result<Self, Self::Error> {
+        (&v).try_into()
+    }
+}
+
+#[cfg(not(target_family = "wasm"))]
 impl TryFromVal<Env, ScVal> for AccountId {
     type Error = ConversionError;
     fn try_from_val(env: &Env, val: ScVal) -> Result<Self, Self::Error> {
@@ -262,6 +270,18 @@ impl AccountId {
 
     pub fn to_object(&self) -> Object {
         self.0.to_object()
+    }
+}
+
+#[cfg(feature = "testutils")]
+#[cfg_attr(feature = "docs", doc(cfg(feature = "testutils")))]
+impl crate::testutils::AccountId for AccountId {
+    fn random(env: &Env) -> AccountId {
+        xdr::AccountId(xdr::PublicKey::PublicKeyTypeEd25519(xdr::Uint256(
+            crate::testutils::random(),
+        )))
+        .try_into_val(env)
+        .unwrap()
     }
 }
 
@@ -373,7 +393,7 @@ impl Account {
 }
 
 #[cfg(any(test, feature = "testutils"))]
-use crate::testutils;
+use crate::testutils::{self, AccountId as _};
 
 #[cfg(any(test, feature = "testutils"))]
 #[cfg_attr(feature = "docs", doc(cfg(feature = "testutils")))]
@@ -385,12 +405,7 @@ impl testutils::Accounts for Accounts {
     }
 
     fn generate(&self) -> AccountId {
-        use rand::RngCore;
-        let mut bytes: [u8; 32] = Default::default();
-        rand::thread_rng().fill_bytes(&mut bytes);
-        xdr::AccountId(xdr::PublicKey::PublicKeyTypeEd25519(xdr::Uint256(bytes)))
-            .try_into_val(self.env())
-            .unwrap()
+        AccountId::random(self.env())
     }
 
     fn create(&self, id: &AccountId) {

--- a/soroban-sdk/src/bytes.rs
+++ b/soroban-sdk/src/bytes.rs
@@ -1066,6 +1066,14 @@ impl<const N: usize> BytesN<N> {
     }
 }
 
+#[cfg(feature = "testutils")]
+#[cfg_attr(feature = "docs", doc(cfg(feature = "testutils")))]
+impl<const N: usize> crate::testutils::BytesN<N> for BytesN<N> {
+    fn random(env: &Env) -> BytesN<N> {
+        BytesN::from_array(env, &crate::testutils::random())
+    }
+}
+
 impl<const N: usize> IntoIterator for BytesN<N> {
     type Item = u8;
 

--- a/soroban-sdk/src/env.rs
+++ b/soroban-sdk/src/env.rs
@@ -274,7 +274,9 @@ impl Env {
 }
 
 #[cfg(any(test, feature = "testutils"))]
-use crate::testutils::{Accounts as _, ContractFunctionSet, Ledger as _};
+use crate::testutils::{
+    random, AccountId as _, Accounts as _, BytesN as _, ContractFunctionSet, Ledger as _,
+};
 #[cfg(any(test, feature = "testutils"))]
 use std::rc::Rc;
 #[cfg(any(test, feature = "testutils"))]
@@ -408,7 +410,7 @@ impl Env {
         let contract_id = if let Some(contract_id) = contract_id.into() {
             contract_id.clone()
         } else {
-            self.random_bytes()
+            BytesN::random(self)
         };
         self.env_impl
             .register_test_contract(
@@ -495,19 +497,18 @@ impl Env {
     }
 
     fn register_contract_with_source(&self, source: xdr::ScContractCode) -> BytesN<32> {
-        use crate::testutils::random_account_id;
-        use crate::testutils::random_bytes_array;
         let prev_source_account = if let Ok(prev_acc) = self.env_impl.source_account() {
             Some(prev_acc)
         } else {
             None
         };
-        self.env_impl.set_source_account(random_account_id());
+        self.env_impl
+            .set_source_account(AccountId::random(self).try_into().unwrap());
 
         let contract_id: BytesN<32> = self
             .env_impl
             .invoke_function(xdr::HostFunction::CreateContract(xdr::CreateContractArgs {
-                contract_id: xdr::ContractId::SourceAccount(xdr::Uint256(random_bytes_array())),
+                contract_id: xdr::ContractId::SourceAccount(xdr::Uint256(random())),
                 source,
             }))
             .unwrap()

--- a/soroban-sdk/src/testutils.rs
+++ b/soroban-sdk/src/testutils.rs
@@ -4,14 +4,11 @@
 //! Utilities intended for use when testing.
 
 mod sign;
-use rand::RngCore;
 pub use sign::ed25519;
 
 pub use crate::env::testutils::*;
 
-use crate::{AccountId, BytesN, Env, RawVal, Symbol, Vec};
-
-use crate::env::xdr;
+use crate::{Env, RawVal, Symbol, Vec};
 
 #[doc(hidden)]
 pub trait ContractFunctionSet {
@@ -48,46 +45,47 @@ pub trait Logger {
     fn print(&self);
 }
 
+/// Test utilities for [`AccountId`][crate::accounts::AccountId].
+pub trait AccountId {
+    /// Generate a random account ID.
+    fn random(env: &Env) -> crate::AccountId;
+}
+
 /// Test utilities for [`Accounts`][crate::accounts::Accounts].
 pub trait Accounts {
     /// Generate an account ID.
-    fn generate(&self) -> AccountId;
+    fn generate(&self) -> crate::AccountId;
 
     /// Generate and account ID and creates an account.
-    fn generate_and_create(&self) -> AccountId;
+    fn generate_and_create(&self) -> crate::AccountId;
 
     /// Create an account.
-    fn create(&self, id: &AccountId);
+    fn create(&self, id: &crate::AccountId);
 
     /// Set the thresholds of an account.
-    fn set_thresholds(&self, id: &AccountId, low: u8, med: u8, high: u8);
+    fn set_thresholds(&self, id: &crate::AccountId, low: u8, med: u8, high: u8);
 
     /// Set the weight of a signer of an account.
     ///
     /// Setting a weight of zero removes the signer from the account.
-    fn set_signer_weight(&self, id: &AccountId, signer: &BytesN<32>, weight: u8);
+    fn set_signer_weight(&self, id: &crate::AccountId, signer: &crate::BytesN<32>, weight: u8);
 
     /// Remove an account.
-    fn remove(&self, id: &AccountId);
+    fn remove(&self, id: &crate::AccountId);
 }
 
-/// Generates a Rust array of N random bytes.
-pub fn random_bytes_array<const N: usize>() -> [u8; N] {
+/// Test utilities for [`BytesN`][crate::BytesN].
+pub trait BytesN<const N: usize> {
+    fn random(env: &Env) -> crate::BytesN<N>;
+}
+
+/// Generates an array of N random bytes.
+///
+/// The value returned is not cryptographically secure and is only intended for
+/// use in tests.
+pub fn random<const N: usize>() -> [u8; N] {
+    use rand::RngCore;
     let mut arr = [0u8; N];
     rand::thread_rng().fill_bytes(&mut arr);
     arr
-}
-
-/// Generates a random Stellar `AccountId` XDR.
-pub fn random_account_id() -> xdr::AccountId {
-    xdr::AccountId(xdr::PublicKey::PublicKeyTypeEd25519(xdr::Uint256(
-        random_bytes_array(),
-    )))
-}
-
-impl Env {
-    /// Generates a Host-owned array of `N` random bytes.
-    pub fn random_bytes<const N: usize>(&self) -> BytesN<N> {
-        BytesN::from_array(self, &random_bytes_array())
-    }
 }


### PR DESCRIPTION
### What


### Why
Most other test utilities relating to types are on the types themselves on a testutils only trait. These random functions were just added but we added them to the global and Env namespaces. The Env namespace will have a tendency to become a default space to put everything. While some thing should belong there, testutilities relating to types are better namespaced on their own type using the existing pattern to avoid crowding.