### PR TITLE
Make `contract_id` public in contract clients.

### DIFF
--- a/soroban-sdk-macros/src/derive_client.rs
+++ b/soroban-sdk-macros/src/derive_client.rs
@@ -187,7 +187,7 @@ pub fn derive_client(name: &str, fns: &[ClientFn]) -> TokenStream {
     quote! {
         pub struct #client_ident {
             env: soroban_sdk::Env,
-            contract_id: soroban_sdk::BytesN<32>,
+            pub contract_id: soroban_sdk::BytesN<32>,
             #[cfg(any(test, feature = "testutils"))]
             source_account: Option<soroban_sdk::AccountId>,
         }

--- a/soroban-sdk-macros/src/derive_client.rs
+++ b/soroban-sdk-macros/src/derive_client.rs
@@ -186,10 +186,10 @@ pub fn derive_client(name: &str, fns: &[ClientFn]) -> TokenStream {
     let client_ident = format_ident!("{}", name);
     quote! {
         pub struct #client_ident {
-            env: soroban_sdk::Env,
+            pub env: soroban_sdk::Env,
             pub contract_id: soroban_sdk::BytesN<32>,
             #[cfg(any(test, feature = "testutils"))]
-            source_account: Option<soroban_sdk::AccountId>,
+            pub source_account: Option<soroban_sdk::AccountId>,
         }
 
         impl #client_ident {


### PR DESCRIPTION
### What

Make `contract_id` public in contract clients.

### Why

That's useful e.g. in testing when we want to pass the contract client around, but we also need to its identifier. The current workaround is to pass around a tuple, which is inconvenient.

### Known limitations

N/A
