### PR TITLE
Add back ability to register wasm contracts at any id

### DIFF
--- a/soroban-sdk-macros/src/lib.rs
+++ b/soroban-sdk-macros/src/lib.rs
@@ -354,7 +354,7 @@ struct ContractImportArgs {
 /// fn test() {
 ///     let env = Env::default();
 ///     // Register contract A using the imported WASM.
-///     let contract_a_id = env.register_contract_wasm(contract_a::WASM);
+///     let contract_a_id = env.register_contract_wasm(None, contract_a::WASM);
 ///     let contract_b_id = BytesN::from_array(&env, &[1; 32]);
 ///     // Register contract B defined in this crate.
 ///     env.register_contract(&contract_b_id, ContractB);

--- a/soroban-sdk/src/env.rs
+++ b/soroban-sdk/src/env.rs
@@ -548,7 +548,7 @@ impl Env {
                         &key,
                         &LedgerEntry {
                             ext: xdr::LedgerEntryExt::V0,
-                            last_modified_ledger_seq: 0, // TODO: Decide on what value to place here.
+                            last_modified_ledger_seq: 0,
                             data: xdr::LedgerEntryData::ContractData(xdr::ContractDataEntry {
                                 contract_id: hash.clone(),
                                 key: xdr::ScVal::Static(xdr::ScStatic::LedgerKeyContractCode),

--- a/soroban-sdk/src/env.rs
+++ b/soroban-sdk/src/env.rs
@@ -46,7 +46,6 @@ pub use internal::Symbol;
 pub use internal::TryFromVal;
 pub use internal::TryIntoVal;
 pub use internal::Val;
-use xdr::LedgerEntry;
 
 pub type EnvVal = internal::EnvVal<Env, RawVal>;
 pub type EnvObj = internal::EnvVal<Env, Object>;
@@ -285,7 +284,7 @@ use soroban_ledger_snapshot::LedgerSnapshot;
 #[cfg(any(test, feature = "testutils"))]
 use std::{path::Path, rc::Rc};
 #[cfg(any(test, feature = "testutils"))]
-use xdr::{Hash, LedgerKey, LedgerKeyContractCode};
+use xdr::{Hash, LedgerEntry, LedgerKey, LedgerKeyContractCode};
 #[cfg(any(test, feature = "testutils"))]
 #[cfg_attr(feature = "docs", doc(cfg(feature = "testutils")))]
 impl Env {

--- a/soroban-sdk/src/env.rs
+++ b/soroban-sdk/src/env.rs
@@ -546,8 +546,8 @@ impl Env {
                     storage.put(
                         &LedgerKey::ContractCode(LedgerKeyContractCode { hash: hash.clone() }),
                         &LedgerEntry {
-                            last_modified_ledger_seq: 0,
                             ext: xdr::LedgerEntryExt::V0,
+                            last_modified_ledger_seq: 0, // TODO: Decide on what value to place here.
                             data: xdr::LedgerEntryData::ContractCode(xdr::ContractCodeEntry {
                                 ext: xdr::ExtensionPoint::V0,
                                 hash,

--- a/soroban-sdk/src/env.rs
+++ b/soroban-sdk/src/env.rs
@@ -520,6 +520,8 @@ impl Env {
 
     /// Register a contract in a WASM file with the [Env] for testing.
     ///
+    /// Registering a contract that is already registered replaces it.
+    ///
     /// Returns the contract ID of the registered contract.
     ///
     /// ### Examples

--- a/soroban-sdk/src/env.rs
+++ b/soroban-sdk/src/env.rs
@@ -284,7 +284,7 @@ use soroban_ledger_snapshot::LedgerSnapshot;
 #[cfg(any(test, feature = "testutils"))]
 use std::{path::Path, rc::Rc};
 #[cfg(any(test, feature = "testutils"))]
-use xdr::{Hash, LedgerEntry, LedgerKey, LedgerKeyContractCode};
+use xdr::{Hash, LedgerEntry, LedgerKey, LedgerKeyContractData};
 #[cfg(any(test, feature = "testutils"))]
 #[cfg_attr(feature = "docs", doc(cfg(feature = "testutils")))]
 impl Env {
@@ -540,8 +540,12 @@ impl Env {
     ) -> BytesN<32> {
         let wasm_hash: BytesN<32> = self.install_contract_wasm(contract_wasm);
         if let Some(contract_id) = contract_id.into() {
-            let hash = Hash(contract_id.into());
-            let key = LedgerKey::ContractCode(LedgerKeyContractCode { hash: hash.clone() });
+            let contract_id_hash = Hash(contract_id.into());
+            let data_key = xdr::ScVal::Static(xdr::ScStatic::LedgerKeyContractCode);
+            let key = LedgerKey::ContractData(LedgerKeyContractData {
+                contract_id: contract_id_hash.clone(),
+                key: data_key.clone(),
+            });
             self.env_impl
                 .with_mut_storage(|storage| {
                     storage.put(
@@ -550,8 +554,8 @@ impl Env {
                             ext: xdr::LedgerEntryExt::V0,
                             last_modified_ledger_seq: 0,
                             data: xdr::LedgerEntryData::ContractData(xdr::ContractDataEntry {
-                                contract_id: hash.clone(),
-                                key: xdr::ScVal::Static(xdr::ScStatic::LedgerKeyContractCode),
+                                contract_id: contract_id_hash.clone(),
+                                key: data_key,
                                 val: xdr::ScVal::Object(Some(xdr::ScObject::ContractCode(
                                     xdr::ScContractCode::WasmRef(Hash(wasm_hash.into())),
                                 ))),

--- a/soroban-sdk/src/tests/contractimport.rs
+++ b/soroban-sdk/src/tests/contractimport.rs
@@ -36,6 +36,22 @@ fn test_functional() {
 }
 
 #[test]
+fn test_register_at_id() {
+    let e = Env::default();
+
+    let add_contract_id = BytesN::from_array(&e, &[1; 32]);
+    e.register_contract_wasm(&add_contract_id, addcontract::WASM);
+
+    let contract_id = e.register_contract(None, Contract);
+    let client = ContractClient::new(&e, &contract_id);
+
+    let x = 10u64;
+    let y = 12u64;
+    let z = client.add_with(&add_contract_id, &x, &y);
+    assert!(z == 22);
+}
+
+#[test]
 fn test_spec() {
     let entries = soroban_spec::read::parse_raw(&Contract::spec_xdr_add_with()).unwrap();
     let expect = vec![ScSpecEntry::FunctionV0(ScSpecFunctionV0 {

--- a/soroban-sdk/src/tests/contractimport.rs
+++ b/soroban-sdk/src/tests/contractimport.rs
@@ -24,7 +24,7 @@ impl Contract {
 fn test_functional() {
     let e = Env::default();
 
-    let add_contract_id = e.register_contract_wasm(addcontract::WASM);
+    let add_contract_id = e.register_contract_wasm(None, addcontract::WASM);
 
     let contract_id = e.register_contract(None, Contract);
     let client = ContractClient::new(&e, &contract_id);

--- a/soroban-sdk/src/tests/contractimport_with_error.rs
+++ b/soroban-sdk/src/tests/contractimport_with_error.rs
@@ -21,7 +21,7 @@ impl Contract {
 fn test_functional() {
     let e = Env::default();
 
-    let err_contract_id = e.register_contract_wasm(errcontract::WASM);
+    let err_contract_id = e.register_contract_wasm(None, errcontract::WASM);
 
     let contract_id = e.register_contract(None, Contract);
     let client = ContractClient::new(&e, &contract_id);

--- a/soroban-sdk/src/tests/contractimport_with_sha256.rs
+++ b/soroban-sdk/src/tests/contractimport_with_sha256.rs
@@ -25,7 +25,7 @@ impl Contract {
 fn test_functional() {
     let e = Env::default();
 
-    let add_contract_id = e.register_contract_wasm(addcontract::WASM);
+    let add_contract_id = e.register_contract_wasm(None, addcontract::WASM);
 
     let contract_id = e.register_contract(None, Contract);
     let client = ContractClient::new(&e, &contract_id);

--- a/tests/import_contract/src/lib.rs
+++ b/tests/import_contract/src/lib.rs
@@ -25,7 +25,7 @@ mod test {
     #[test]
     fn test_add() {
         let e = Env::default();
-        let add_contract_id = e.register_contract_wasm(addcontract::WASM);
+        let add_contract_id = e.register_contract_wasm(None, addcontract::WASM);
 
         let contract_id = BytesN::from_array(&e, &[1; 32]);
         e.register_contract(&contract_id, Contract);


### PR DESCRIPTION
### What
Add back ability to register wasm contracts at any id

### Why
To avoid breaking the API when we need the ability in the future to register wasm contracts at specific addresses.