### PR TITLE
Fix tests when run in some configurations

### DIFF
--- a/soroban-sdk/src/accounts.rs
+++ b/soroban-sdk/src/accounts.rs
@@ -273,7 +273,7 @@ impl AccountId {
     }
 }
 
-#[cfg(feature = "testutils")]
+#[cfg(any(test, feature = "testutils"))]
 #[cfg_attr(feature = "docs", doc(cfg(feature = "testutils")))]
 impl crate::testutils::AccountId for AccountId {
     fn random(env: &Env) -> AccountId {

--- a/soroban-sdk/src/bytes.rs
+++ b/soroban-sdk/src/bytes.rs
@@ -1066,7 +1066,7 @@ impl<const N: usize> BytesN<N> {
     }
 }
 
-#[cfg(feature = "testutils")]
+#[cfg(any(test, feature = "testutils"))]
 #[cfg_attr(feature = "docs", doc(cfg(feature = "testutils")))]
 impl<const N: usize> crate::testutils::BytesN<N> for BytesN<N> {
     fn random(env: &Env) -> BytesN<N> {


### PR DESCRIPTION
### What
Fix tests when run in some configurations where testutils isn't activated.

### Why
We should always configure code intended for tests with `test` and `testutils`, not just `testutils`. I made this mistake in a recent PR. It breaks running tests in some IDEs, although by happenstance this doesn't show up in CI because of feature unification that happens during the CI builds.