### PR TITLE
Add missing tests and comments

### DIFF
--- a/soroban-sdk/src/env.rs
+++ b/soroban-sdk/src/env.rs
@@ -434,6 +434,8 @@ impl Env {
     /// with that contract ID. Providing `None` causes a random ID to be
     /// assigned to the contract.
     ///
+    /// Registering a contract that is already registered replaces it.
+    ///
     /// Returns the contract ID of the registered contract.
     ///
     /// ### Examples
@@ -519,6 +521,10 @@ impl Env {
     }
 
     /// Register a contract in a WASM file with the [Env] for testing.
+    ///
+    /// Passing a contract ID for the first arguments registers the contract
+    /// with that contract ID. Providing `None` causes a random ID to be
+    /// assigned to the contract.
     ///
     /// Registering a contract that is already registered replaces it.
     ///

--- a/soroban-sdk/src/tests/contractimport.rs
+++ b/soroban-sdk/src/tests/contractimport.rs
@@ -11,12 +11,26 @@ mod addcontract {
     );
 }
 
+mod subcontract {
+    use crate as soroban_sdk;
+    pub struct Contract;
+    #[soroban_sdk::contractimpl]
+    impl Contract {
+        pub fn sub(a: u64, b: u64) -> u64 {
+            a - b
+        }
+    }
+}
+
 pub struct Contract;
 
 #[contractimpl(crate_path = "crate")]
 impl Contract {
     pub fn add_with(env: Env, contract_id: BytesN<32>, x: u64, y: u64) -> u64 {
         addcontract::Client::new(&env, &contract_id).add(&x, &y)
+    }
+    pub fn sub_with(env: Env, contract_id: BytesN<32>, x: u64, y: u64) -> u64 {
+        subcontract::ContractClient::new(&env, &contract_id).sub(&x, &y)
     }
 }
 
@@ -49,6 +63,45 @@ fn test_register_at_id() {
     let y = 12u64;
     let z = client.add_with(&add_contract_id, &x, &y);
     assert!(z == 22);
+}
+
+#[test]
+fn test_reregister_wasm() {
+    let e = Env::default();
+
+    // Register a contract with code that will fail, to ensure this code isn't
+    // the code that gets activated when invoked.
+    let add_contract_id = e.register_contract_wasm(None, &[]);
+    // Reregister the contract with different code replacing the code. This is
+    // the contract we expect to be executed.
+    e.register_contract_wasm(&add_contract_id, addcontract::WASM);
+
+    let contract_id = e.register_contract(None, Contract);
+    let client = ContractClient::new(&e, &contract_id);
+
+    let x = 10u64;
+    let y = 12u64;
+    let z = client.add_with(&add_contract_id, &x, &y);
+    assert!(z == 22);
+}
+
+#[test]
+fn test_reregister_over_wasm_with_rust_impl() {
+    let e = Env::default();
+
+    // Register a contract with wasm.
+    let other_contract_id = e.register_contract_wasm(None, addcontract::WASM);
+    // Reregister the contract with a rust impl instead that does something
+    // different.
+    e.register_contract(&other_contract_id, subcontract::Contract);
+
+    let contract_id = e.register_contract(None, Contract);
+    let client = ContractClient::new(&e, &contract_id);
+
+    let x = 12u64;
+    let y = 10u64;
+    let z = client.sub_with(&other_contract_id, &x, &y);
+    assert!(z == 2);
 }
 
 #[test]


### PR DESCRIPTION
### What
Add missing tests that capture existing behavios and update comments to accurately describe the behavior too.

### Why
There are no tests for this behavior that exists. There were missing comments that also don't elude to this behavior.