### PR TITLE
Undo breaking api change to registering tokens

### DIFF
--- a/soroban-sdk/src/env.rs
+++ b/soroban-sdk/src/env.rs
@@ -586,6 +586,8 @@ impl Env {
     /// with that contract ID. Providing `None` causes a random ID to be
     /// assigned to the contract.
     ///
+    /// Registering a contract that is already registered replaces it.
+    ///
     /// Returns the contract ID of the registered contract.
     ///
     /// ### Examples

--- a/soroban-sdk/src/tests.rs
+++ b/soroban-sdk/src/tests.rs
@@ -15,3 +15,4 @@ mod contractfile_with_sha256;
 mod contractimport;
 mod contractimport_with_error;
 mod contractimport_with_sha256;
+mod contracttoken;

--- a/soroban-sdk/src/tests/contracttoken.rs
+++ b/soroban-sdk/src/tests/contracttoken.rs
@@ -61,3 +61,25 @@ fn test_register_token_at_id() {
 
     assert_eq!(client.name(), Bytes::from_slice(&e, b"testme"))
 }
+
+#[test]
+fn test_reregister_over_wasm_with_token() {
+    let e = Env::default();
+
+    // Register a contract with bogus wasm.
+    let contract_id = e.register_contract_wasm(None, &[]);
+    // Reregister the contract with a token instead.
+    e.register_contract_token(&contract_id);
+    let client = TokenClient::new(&e, &contract_id);
+
+    client.init(
+        &Identifier::Account(AccountId::random(&e)),
+        &TokenMetadata {
+            name: Bytes::from_slice(&e, b"testme"),
+            decimals: 7,
+            symbol: Bytes::from_slice(&e, &[]),
+        },
+    );
+
+    assert_eq!(client.name(), Bytes::from_slice(&e, b"testme"))
+}

--- a/soroban-sdk/src/tests/contracttoken.rs
+++ b/soroban-sdk/src/tests/contracttoken.rs
@@ -1,0 +1,63 @@
+use crate as soroban_sdk;
+use soroban_sdk::{
+    contractclient, contracttype, testutils::AccountId as _, AccountId, Bytes, BytesN, Env,
+};
+
+#[contractclient(name = "TokenClient")]
+pub trait Token {
+    fn init(env: Env, admin: Identifier, metadata: TokenMetadata);
+    fn name(env: Env) -> Bytes;
+}
+
+#[derive(Clone)]
+#[contracttype]
+pub enum Identifier {
+    Account(AccountId),
+}
+
+#[derive(Clone)]
+#[contracttype]
+pub struct TokenMetadata {
+    pub name: Bytes,
+    pub symbol: Bytes,
+    pub decimals: u32,
+}
+
+#[test]
+fn test_register_token() {
+    let e = Env::default();
+
+    let contract_id = e.register_contract_token(None);
+    let client = TokenClient::new(&e, &contract_id);
+
+    client.init(
+        &Identifier::Account(AccountId::random(&e)),
+        &TokenMetadata {
+            name: Bytes::from_slice(&e, b"testme"),
+            decimals: 7,
+            symbol: Bytes::from_slice(&e, &[]),
+        },
+    );
+
+    assert_eq!(client.name(), Bytes::from_slice(&e, b"testme"))
+}
+
+#[test]
+fn test_register_token_at_id() {
+    let e = Env::default();
+
+    let contract_id = BytesN::from_array(&e, &[1; 32]);
+    e.register_contract_token(&contract_id);
+    let client = TokenClient::new(&e, &contract_id);
+
+    client.init(
+        &Identifier::Account(AccountId::random(&e)),
+        &TokenMetadata {
+            name: Bytes::from_slice(&e, b"testme"),
+            decimals: 7,
+            symbol: Bytes::from_slice(&e, &[]),
+        },
+    );
+
+    assert_eq!(client.name(), Bytes::from_slice(&e, b"testme"))
+}


### PR DESCRIPTION
### What
Add back the contract ID param to the register_contract_token function.

### Why
It was removed as part of the deployment, similar to the corresponding wasm function which we readded. Readding the same parameter here for consistency and to make the function behave as its comments and docs describe.