### PR TITLE
Add missing docs for macros

### DIFF
--- a/soroban-sdk-macros/src/lib.rs
+++ b/soroban-sdk-macros/src/lib.rs
@@ -55,10 +55,6 @@ pub fn symbol(input: TokenStream) -> TokenStream {
     }
 }
 
-/// Exports the publicly accessible functions in the implementation.
-///
-/// Functions that are publicly accessible in the implementation are invocable
-/// by other contracts, or directly by transactions, when deployed.
 #[proc_macro_attribute]
 pub fn contractimpl(_metadata: TokenStream, input: TokenStream) -> TokenStream {
     let imp = parse_macro_input!(input as ItemImpl);
@@ -123,23 +119,6 @@ struct ContractTypeArgs {
     export: Option<bool>,
 }
 
-/// Generates conversions from the struct/enum from/into a `RawVal`.
-///
-/// There are some constraints on the types that are supported:
-/// - Enums with integer values must have an explicit integer literal for every
-/// variant.
-/// - Enums with unit variants are supported.
-/// - Enums with tuple-like variants with a maximum of one tuple field are
-/// supported. The tuple field must be of a type that is also convertible to and
-/// from `RawVal`.
-/// - Enums with struct-like variants are not supported.
-/// - Structs are supported. All fields must be of a type that is also
-/// convertible to and from `RawVal`.
-/// - All variant names, field names, and type names must be 10-characters or
-/// less in length.
-///
-/// Includes the type in the contract spec so that clients can generate bindings
-/// for the type.
 #[proc_macro_attribute]
 pub fn contracttype(metadata: TokenStream, input: TokenStream) -> TokenStream {
     let args = parse_macro_input!(metadata as AttributeArgs);
@@ -197,15 +176,6 @@ pub fn contracttype(metadata: TokenStream, input: TokenStream) -> TokenStream {
     .into()
 }
 
-/// Generates conversions from the repr(u32) enum from/into a `Status`.
-///
-/// There are some constraints on the types that are supported:
-/// - Enum must derive `Copy`.
-/// - Enum variants must have an explicit integer literal.
-/// - Enum variants must have a value convertible to u32.
-///
-/// Includes the type in the contract spec so that clients can generate bindings
-/// for the type.
 #[proc_macro_attribute]
 pub fn contracterror(metadata: TokenStream, input: TokenStream) -> TokenStream {
     let args = parse_macro_input!(metadata as AttributeArgs);
@@ -255,7 +225,6 @@ struct ContractFileArgs {
     sha256: darling::util::SpannedValue<String>,
 }
 
-#[doc(hidden)]
 #[proc_macro]
 pub fn contractfile(metadata: TokenStream) -> TokenStream {
     let args = parse_macro_input!(metadata as AttributeArgs);
@@ -297,7 +266,6 @@ struct ContractClientArgs {
     name: String,
 }
 
-#[doc(hidden)]
 #[proc_macro_attribute]
 pub fn contractclient(metadata: TokenStream, input: TokenStream) -> TokenStream {
     let args = parse_macro_input!(metadata as AttributeArgs);
@@ -322,51 +290,6 @@ struct ContractImportArgs {
     #[darling(default)]
     sha256: darling::util::SpannedValue<Option<String>>,
 }
-
-/// Import a contract from its WASM file.
-///
-/// Generates in the current module:
-/// - A `Contract` trait that matches the contracts interface.
-/// - A `ContractClient` struct that has functions for each function in the
-/// contract.
-/// - Types for all contract types defined in the contract.
-///
-/// ### Examples
-///
-/// ```ignore
-/// use soroban_sdk::{BytesN, Env, Symbol};
-///
-/// mod contract_a {
-///     soroban_sdk::contractimport!(file = "contract_a.wasm");
-/// }
-///
-/// pub struct ContractB;
-///
-/// #[contractimpl]
-/// impl ContractB {
-///     pub fn add_with(env: Env, contract_id: BytesN<32>, x: u32, y: u32) -> u32 {
-///         let client = contract_a::ContractClient::new(&env, contract_id);
-///         client.add(&x, &y)
-///     }
-/// }
-///
-/// #[test]
-/// fn test() {
-///     let env = Env::default();
-///     // Register contract A using the imported WASM.
-///     let contract_a_id = env.register_contract_wasm(None, contract_a::WASM);
-///     let contract_b_id = BytesN::from_array(&env, &[1; 32]);
-///     // Register contract B defined in this crate.
-///     env.register_contract(&contract_b_id, ContractB);
-///
-///     // Create a client for calling contract B.
-///     let client = ContractBClient::new(&env, &contract_b_id);
-///
-///     // Invoke contract B via its client.
-///     let sum = client.add_with(&contract_a_id, &5, &7);
-///     assert_eq!(sum, 12);
-/// }
-/// ```
 #[proc_macro]
 pub fn contractimport(metadata: TokenStream) -> TokenStream {
     let attr_args = parse_macro_input!(metadata as AttributeArgs);

--- a/soroban-sdk/src/lib.rs
+++ b/soroban-sdk/src/lib.rs
@@ -141,8 +141,7 @@ pub use bytes_lit::bytesmin as __bytes_lit_bytesmin;
 /// # fn main() { }
 /// ```
 ///
-/// Defining an error and that error causing a panic that can be asserted on
-/// with `should_panic`.
+/// Testing invocations that cause errors with `should_panic` instead of `try_`.
 ///
 /// ```should_panic
 /// # use soroban_sdk::{contracterror, contractimpl, Env};

--- a/soroban-sdk/src/lib.rs
+++ b/soroban-sdk/src/lib.rs
@@ -146,7 +146,7 @@ pub use bytes_lit::bytesmin as __bytes_lit_bytesmin;
 ///
 /// ```should_panic
 /// # use soroban_sdk::{contracterror, contractimpl, Env};
-///
+/// #
 /// # #[contracterror]
 /// # #[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
 /// # #[repr(u32)]
@@ -154,9 +154,9 @@ pub use bytes_lit::bytesmin as __bytes_lit_bytesmin;
 /// #     MyError = 1,
 /// #     AnotherError = 2,
 /// # }
-///
+/// #
 /// # pub struct Contract;
-///
+/// #
 /// # #[contractimpl]
 /// # impl Contract {
 /// #     pub fn causeerror(env: Env) -> Result<(), Error> {

--- a/soroban-sdk/src/lib.rs
+++ b/soroban-sdk/src/lib.rs
@@ -85,9 +85,279 @@ pub use bytes_lit::bytes as __bytes_lit_bytes;
 #[doc(hidden)]
 pub use bytes_lit::bytesmin as __bytes_lit_bytesmin;
 
-pub use soroban_sdk_macros::{
-    contractclient, contracterror, contractfile, contractimpl, contractimport, contracttype,
-};
+/// Generates conversions from the repr(u32) enum from/into a `Status`.
+///
+/// There are some constraints on the types that are supported:
+/// - Enum must derive `Copy`.
+/// - Enum variants must have an explicit integer literal.
+/// - Enum variants must have a value convertible to u32.
+///
+/// Includes the type in the contract spec so that clients can generate bindings
+/// for the type.
+///
+/// ### Examples
+///
+/// Defining an error and capturing errors using the `try_` variant.
+///
+/// ```
+/// use soroban_sdk::{contracterror, contractimpl, Env};
+///
+/// #[contracterror]
+/// #[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+/// #[repr(u32)]
+/// pub enum Error {
+///     MyError = 1,
+///     AnotherError = 2,
+/// }
+///
+/// pub struct Contract;
+///
+/// #[contractimpl]
+/// impl Contract {
+///     pub fn causeerror(env: Env) -> Result<(), Error> {
+///         Err(Error::MyError)
+///     }
+/// }
+///
+/// #[test]
+/// fn test() {
+/// # }
+/// # #[cfg(feature = "testutils")]
+/// # fn main() {
+///     let env = Env::default();
+///
+///     // Register the contract defined in this crate.
+///     let contract_id = env.register_contract(None, Contract);
+///
+///     // Create a client for calling the contract.
+///     let client = ContractClient::new(&env, &contract_id);
+///
+///     // Invoke contract causeerror function, but use the try_ variant that
+///     // will capture the error so we can inspect.
+///     let result = client.try_causeerror();
+///     assert_eq!(result, Err(Ok(Error::MyError)));
+/// }
+/// # #[cfg(not(feature = "testutils"))]
+/// # fn main() { }
+/// ```
+///
+/// Defining an error and that error causing a panic that can be asserted on
+/// with `should_panic`.
+///
+/// ```should_panic
+/// use soroban_sdk::{contracterror, contractimpl, Env};
+///
+/// #[contracterror]
+/// #[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+/// #[repr(u32)]
+/// pub enum Error {
+///     MyError = 1,
+///     AnotherError = 2,
+/// }
+///
+/// pub struct Contract;
+///
+/// #[contractimpl]
+/// impl Contract {
+///     pub fn causeerror(env: Env) -> Result<(), Error> {
+///         Err(Error::MyError)
+///     }
+/// }
+///
+/// #[test]
+/// #[should_panic(expected = "ContractError(1)")]
+/// fn test() {
+/// # panic!("ContractError(1)");
+/// # }
+/// # #[cfg(feature = "testutils")]
+/// # fn main() {
+///     let env = Env::default();
+///
+///     // Register the contract defined in this crate.
+///     let contract_id = env.register_contract(None, Contract);
+///
+///     // Create a client for calling the contract.
+///     let client = ContractClient::new(&env, &contract_id);
+///
+///     // Invoke contract causeerror function.
+///     client.causeerror();
+/// }
+/// # #[cfg(not(feature = "testutils"))]
+/// # fn main() { }
+/// ```
+pub use soroban_sdk_macros::contracterror;
+
+/// Import a contract from its WASM file.
+///
+/// Generates in the current module:
+/// - A `Contract` trait that matches the contracts interface.
+/// - A `ContractClient` struct that has functions for each function in the
+/// contract.
+/// - Types for all contract types defined in the contract.
+///
+/// ### Examples
+///
+/// ```ignore
+/// use soroban_sdk::{contractimpl, BytesN, Env, Symbol};
+///
+/// mod contract_a {
+///     soroban_sdk::contractimport!(file = "contract_a.wasm");
+/// }
+///
+/// pub struct ContractB;
+///
+/// #[contractimpl]
+/// impl ContractB {
+///     pub fn add_with(env: Env, contract_id: BytesN<32>, x: u32, y: u32) -> u32 {
+///         let client = contract_a::ContractClient::new(&env, contract_id);
+///         client.add(&x, &y)
+///     }
+/// }
+///
+/// #[test]
+/// fn test() {
+///     let env = Env::default();
+///
+///     // Register contract A using the imported WASM.
+///     let contract_a_id = env.register_contract_wasm(None, contract_a::WASM);
+///
+///     // Register contract B defined in this crate.
+///     let contract_b_id = env.register_contract(None, ContractB);
+///
+///     // Create a client for calling contract B.
+///     let client = ContractBClient::new(&env, &contract_b_id);
+///
+///     // Invoke contract B via its client.
+///     let sum = client.add_with(&contract_a_id, &5, &7);
+///     assert_eq!(sum, 12);
+/// }
+/// ```
+pub use soroban_sdk_macros::contractimport;
+
+/// Exports the publicly accessible functions in the implementation.
+///
+/// Functions that are publicly accessible in the implementation are invocable
+/// by other contracts, or directly by transactions, when deployed.
+///
+/// ### Examples
+///
+/// Define a contract with one function, `hello`, and call it from within a test
+/// using the generated client.
+///
+/// ```
+/// use soroban_sdk::{contractimpl, symbol, vec, BytesN, Env, Symbol, Vec};
+///
+/// pub struct HelloContract;
+///
+/// #[contractimpl]
+/// impl HelloContract {
+///     pub fn hello(env: Env, to: Symbol) -> Vec<Symbol> {
+///         vec![&env, symbol!("Hello"), to]
+///     }
+/// }
+///
+/// #[test]
+/// fn test() {
+/// # }
+/// # #[cfg(feature = "testutils")]
+/// # fn main() {
+///     let env = Env::default();
+///     let contract_id = env.register_contract(None, HelloContract);
+///     let client = HelloContractClient::new(&env, &contract_id);
+///
+///     let words = client.hello(&symbol!("Dev"));
+///
+///     assert_eq!(words, vec![&env, symbol!("Hello"), symbol!("Dev"),]);
+/// }
+/// # #[cfg(not(feature = "testutils"))]
+/// # fn main() { }
+/// ```
+pub use soroban_sdk_macros::contractimpl;
+
+/// Generates conversions from the struct/enum from/into a `RawVal`.
+///
+/// There are some constraints on the types that are supported:
+/// - Enums with integer values must have an explicit integer literal for every
+/// variant.
+/// - Enums with unit variants are supported.
+/// - Enums with tuple-like variants with a maximum of one tuple field are
+/// supported. The tuple field must be of a type that is also convertible to and
+/// from `RawVal`.
+/// - Enums with struct-like variants are not supported.
+/// - Structs are supported. All fields must be of a type that is also
+/// convertible to and from `RawVal`.
+/// - All variant names, field names, and type names must be 10-characters or
+/// less in length.
+///
+/// Includes the type in the contract spec so that clients can generate bindings
+/// for the type.
+pub use soroban_sdk_macros::contracttype;
+
+/// Generates a contract client for a trait.
+///
+/// Can be used to create clients for contracts that live outside the current
+/// crate, using a trait that has been published as a standard or shared
+/// interface.
+///
+/// Primarily useful when needing to generate a client for someone elses
+/// contract where they have only shared a trait interface.
+///
+/// Note that [`contractimpl`] also automatically generates a client, and so it
+/// is unnecessary to use [`contractclient`] for contracts that live in the
+/// current crate.
+///
+/// Note that [`contractimport`] also automatically generates a client when
+/// importing someone elses contract where they have shared a .wasm file.
+///
+/// ### Examples
+///
+/// ```
+/// use soroban_sdk::{contractclient, contractimpl, symbol, vec, BytesN, Env, Symbol, Vec};
+///
+/// #[contractclient(name = "Client")]
+/// pub trait HelloInteface {
+///     fn hello(env: Env, to: Symbol) -> Vec<Symbol>;
+/// }
+///
+/// pub struct HelloContract;
+///
+/// #[contractimpl]
+/// impl HelloContract {
+///     pub fn hello(env: Env, to: Symbol) -> Vec<Symbol> {
+///         vec![&env, symbol!("Hello"), to]
+///     }
+/// }
+///
+/// #[test]
+/// fn test() {
+/// # }
+/// # #[cfg(feature = "testutils")]
+/// # fn main() {
+///     let env = Env::default();
+///
+///     // Register the hello contract.
+///     let contract_id = env.register_contract(None, HelloContract);
+///
+///     // Create a client for the hello contract, that was constructed using
+///     // the trait.
+///     let client = Client::new(&env, &contract_id);
+///
+///     let words = client.hello(&symbol!("Dev"));
+///
+///     assert_eq!(words, vec![&env, symbol!("Hello"), symbol!("Dev"),]);
+/// }
+/// # #[cfg(not(feature = "testutils"))]
+/// # fn main() { }
+pub use soroban_sdk_macros::contractclient;
+
+/// Loads a WASM contract into a constant that can be registered in tests or
+/// used in deployments to install the contract code.
+///
+/// Note that [`contractimport`] also automatically imports the contract file
+/// into a constant, and so it is usually unnecessary to use [`contractfile`]
+/// directly, unless you specifically want to only load the contract file
+/// without generating a client for it.
+pub use soroban_sdk_macros::contractfile;
 
 /// Create a [Symbol] with the given string.
 ///

--- a/soroban-sdk/src/lib.rs
+++ b/soroban-sdk/src/lib.rs
@@ -145,25 +145,25 @@ pub use bytes_lit::bytesmin as __bytes_lit_bytesmin;
 /// with `should_panic`.
 ///
 /// ```should_panic
-/// use soroban_sdk::{contracterror, contractimpl, Env};
+/// # use soroban_sdk::{contracterror, contractimpl, Env};
 ///
-/// #[contracterror]
-/// #[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
-/// #[repr(u32)]
-/// pub enum Error {
-///     MyError = 1,
-///     AnotherError = 2,
-/// }
+/// # #[contracterror]
+/// # #[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+/// # #[repr(u32)]
+/// # pub enum Error {
+/// #     MyError = 1,
+/// #     AnotherError = 2,
+/// # }
 ///
-/// pub struct Contract;
+/// # pub struct Contract;
 ///
-/// #[contractimpl]
-/// impl Contract {
-///     pub fn causeerror(env: Env) -> Result<(), Error> {
-///         Err(Error::MyError)
-///     }
-/// }
-///
+/// # #[contractimpl]
+/// # impl Contract {
+/// #     pub fn causeerror(env: Env) -> Result<(), Error> {
+/// #         Err(Error::MyError)
+/// #     }
+/// # }
+/// #
 /// #[test]
 /// #[should_panic(expected = "ContractError(1)")]
 /// fn test() {

--- a/soroban-sdk/src/lib.rs
+++ b/soroban-sdk/src/lib.rs
@@ -187,7 +187,8 @@ pub use bytes_lit::bytesmin as __bytes_lit_bytesmin;
 /// ```
 pub use soroban_sdk_macros::contracterror;
 
-/// Import a contract from its WASM file.
+/// Import a contract from its WASM file, generating a client, types, and
+/// constant holding the contract file.
 ///
 /// Generates in the current module:
 /// - A `Contract` trait that matches the contracts interface.
@@ -234,7 +235,7 @@ pub use soroban_sdk_macros::contracterror;
 /// ```
 pub use soroban_sdk_macros::contractimport;
 
-/// Exports the publicly accessible functions in the implementation.
+/// Exports the publicly accessible functions to the Soroban environment.
 ///
 /// Functions that are publicly accessible in the implementation are invocable
 /// by other contracts, or directly by transactions, when deployed.
@@ -293,7 +294,7 @@ pub use soroban_sdk_macros::contractimpl;
 /// for the type.
 pub use soroban_sdk_macros::contracttype;
 
-/// Generates a contract client for a trait.
+/// Generates a client for a contract trait.
 ///
 /// Can be used to create clients for contracts that live outside the current
 /// crate, using a trait that has been published as a standard or shared
@@ -350,8 +351,8 @@ pub use soroban_sdk_macros::contracttype;
 /// # fn main() { }
 pub use soroban_sdk_macros::contractclient;
 
-/// Loads a WASM contract into a constant that can be registered in tests or
-/// used in deployments to install the contract code.
+/// Import a contract from its WASM file, generating a constant holding the
+/// contract file.
 ///
 /// Note that [`contractimport`] also automatically imports the contract file
 /// into a constant, and so it is usually unnecessary to use [`contractfile`]


### PR DESCRIPTION
### What
Add missing docs for macros

### Why
We should document the macros really well since macros are often difficult to understand what they are doing.