### PR TITLE
Move crypto functions

### DIFF
--- a/soroban-auth/src/lib.rs
+++ b/soroban-auth/src/lib.rs
@@ -41,7 +41,8 @@ fn verify_ed25519_signature(env: &Env, auth: &Ed25519Signature, name: Symbol, ar
     };
     let msg_bin = SignaturePayload::V0(msg).serialize(env);
 
-    env.verify_sig_ed25519(&auth.public_key, &msg_bin, &auth.signature);
+    env.crypto()
+        .ed25519_verify(&auth.public_key, &msg_bin, &auth.signature);
 }
 
 fn verify_account_signatures(env: &Env, auth: &AccountSignatures, name: Symbol, args: Vec<RawVal>) {
@@ -78,7 +79,8 @@ fn verify_account_signatures(env: &Env, auth: &AccountSignatures, name: Symbol, 
             }
         }
 
-        env.verify_sig_ed25519(&sig.public_key, &msg_bytes, &sig.signature);
+        env.crypto()
+            .ed25519_verify(&sig.public_key, &msg_bytes, &sig.signature);
         let signer_weight = acc.signer_weight(&sig.public_key);
         if signer_weight == 0 {
             panic!("signature doesn't belong to account");

--- a/soroban-sdk/src/crypto.rs
+++ b/soroban-sdk/src/crypto.rs
@@ -16,9 +16,9 @@ impl Crypto {
     }
 
     /// Computes a SHA-256 hash.
-    pub fn sha256(&self, msg: &Bytes) -> BytesN<32> {
+    pub fn sha256(&self, message: &Bytes) -> BytesN<32> {
         let env = self.env();
-        let bin_obj = internal::Env::compute_hash_sha256(env, msg.into());
+        let bin_obj = internal::Env::compute_hash_sha256(env, message.into());
         unsafe { BytesN::unchecked_new(bin_obj.in_env(env)) }
     }
 
@@ -34,13 +34,13 @@ impl Crypto {
     /// ### TODO
     ///
     /// Return a [Result] instead of panicking.
-    pub fn ed25519_verify(&self, pk: &BytesN<32>, msg: &Bytes, sig: &BytesN<64>) {
+    pub fn ed25519_verify(&self, public_key: &BytesN<32>, message: &Bytes, signature: &BytesN<64>) {
         let env = self.env();
         let _ = internal::Env::verify_sig_ed25519(
             env,
-            msg.to_object(),
-            pk.to_object(),
-            sig.to_object(),
+            message.to_object(),
+            public_key.to_object(),
+            signature.to_object(),
         );
     }
 }

--- a/soroban-sdk/src/crypto.rs
+++ b/soroban-sdk/src/crypto.rs
@@ -1,0 +1,46 @@
+//! Crypto contains functions for cryptographic functions.
+use crate::{env::internal, Bytes, BytesN, Env};
+
+/// Crypto provides access to cryptographic functions.
+pub struct Crypto {
+    env: Env,
+}
+
+impl Crypto {
+    pub(crate) fn new(env: &Env) -> Crypto {
+        Crypto { env: env.clone() }
+    }
+
+    pub fn env(&self) -> &Env {
+        &self.env
+    }
+
+    /// Computes a SHA-256 hash.
+    pub fn sha256(&self, msg: &Bytes) -> BytesN<32> {
+        let env = self.env();
+        let bin_obj = internal::Env::compute_hash_sha256(env, msg.into());
+        unsafe { BytesN::unchecked_new(bin_obj.in_env(env)) }
+    }
+
+    /// Verifies an ed25519 signature.
+    ///
+    /// The ed25519 signature (`sig`) is verified as a valid signature of the
+    /// message (`msg`) by the ed25519 public key (`pk`).
+    ///
+    /// ### Panics
+    ///
+    /// Will panic if the signature verification fails.
+    ///
+    /// ### TODO
+    ///
+    /// Return a [Result] instead of panicking.
+    pub fn ed25519_verify(&self, pk: &BytesN<32>, msg: &Bytes, sig: &BytesN<64>) {
+        let env = self.env();
+        let _ = internal::Env::verify_sig_ed25519(
+            env,
+            msg.to_object(),
+            pk.to_object(),
+            sig.to_object(),
+        );
+    }
+}

--- a/soroban-sdk/src/env.rs
+++ b/soroban-sdk/src/env.rs
@@ -51,8 +51,8 @@ pub type EnvVal = internal::EnvVal<Env, RawVal>;
 pub type EnvObj = internal::EnvVal<Env, Object>;
 
 use crate::{
-    accounts::Accounts, address::Address, data::Data, deploy::Deployer, events::Events,
-    ledger::Ledger, logging::Logger, AccountId, Bytes, BytesN, Vec,
+    accounts::Accounts, address::Address, crypto::Crypto, data::Data, deploy::Deployer,
+    events::Events, ledger::Ledger, logging::Logger, AccountId, Bytes, BytesN, Vec,
 };
 
 /// The [Env] type provides access to the environment the contract is executing
@@ -141,6 +141,12 @@ impl Env {
         Deployer::new(self)
     }
 
+    /// Get a [Crypto] for accessing the current cryptographic functions.
+    #[inline(always)]
+    pub fn crypto(&self) -> Crypto {
+        Crypto::new(self)
+    }
+
     /// Get the 32-byte hash identifier of the current executing contract.
     pub fn current_contract(&self) -> BytesN<32> {
         let id = internal::Env::get_current_contract(self);
@@ -192,31 +198,16 @@ impl Env {
         unsafe { Vec::unchecked_new(stack.in_env(self)) }
     }
 
-    /// Computes a SHA-256 hash.
+    #[doc(hidden)]
+    #[deprecated(note = "use env.crypto().sha259(msg)")]
     pub fn compute_hash_sha256(&self, msg: &Bytes) -> BytesN<32> {
-        let bin_obj = internal::Env::compute_hash_sha256(self, msg.into());
-        unsafe { BytesN::unchecked_new(bin_obj.in_env(self)) }
+        self.crypto().sha256(msg)
     }
 
-    /// Verifies an ed25519 signature.
-    ///
-    /// The ed25519 signature (`sig`) is verified as a valid signature of the
-    /// message (`msg`) by the ed25519 public key (`pk`).
-    ///
-    /// ### Panics
-    ///
-    /// Will panic if the signature verification fails.
-    ///
-    /// ### TODO
-    ///
-    /// Return a [Result] instead of panicking.
+    #[doc(hidden)]
+    #[deprecated(note = "use env.crypto().ed25519_verify(pk, msg, sig)")]
     pub fn verify_sig_ed25519(&self, pk: &BytesN<32>, msg: &Bytes, sig: &BytesN<64>) {
-        let _ = internal::Env::verify_sig_ed25519(
-            self,
-            msg.to_object(),
-            pk.to_object(),
-            sig.to_object(),
-        );
+        self.crypto().ed25519_verify(pk, msg, sig);
     }
 
     /// Invokes a function of a contract that is registered in the [Env].

--- a/soroban-sdk/src/lib.rs
+++ b/soroban-sdk/src/lib.rs
@@ -611,6 +611,7 @@ pub use envhidden::*;
 
 pub mod accounts;
 mod bytes;
+pub mod crypto;
 pub mod data;
 pub mod deploy;
 pub mod events;


### PR DESCRIPTION
### What
Move crypto functions to their own type.

### Why
For consistency with how we have most env functions live on a type to namespace them.

Note that this change is not breaking, as the existing functions are preserved.