### PR TITLE
Rename data to storage

### DIFF
--- a/soroban-auth/src/tests/test_ed25519_with_nonce.rs
+++ b/soroban-auth/src/tests/test_ed25519_with_nonce.rs
@@ -9,7 +9,7 @@ pub enum DataKey {
 
 fn read_nonce(e: &Env, id: &Identifier) -> i128 {
     let key = DataKey::Nonce(id.clone());
-    e.data().get(key).unwrap_or(Ok(0)).unwrap()
+    e.storage().get(key).unwrap_or(Ok(0)).unwrap()
 }
 
 fn verify_and_consume_nonce(e: &Env, id: &Identifier, expected_nonce: i128) {
@@ -29,7 +29,7 @@ fn verify_and_consume_nonce(e: &Env, id: &Identifier, expected_nonce: i128) {
     if nonce != expected_nonce {
         panic!("incorrect nonce")
     }
-    e.data().set(key, &nonce + 1);
+    e.storage().set(key, &nonce + 1);
 }
 
 pub struct TestContract;

--- a/soroban-sdk/src/bytes.rs
+++ b/soroban-sdk/src/bytes.rs
@@ -104,8 +104,8 @@ macro_rules! bytesn {
 /// The array is stored in the Host and available to the Guest through the
 /// functions defined on Bytes.
 ///
-/// Bytes values can be stored as [Data], or in other types like [Vec], [Map],
-/// etc.
+/// Bytes values can be stored as [Storage], or in other types like [Vec],
+/// [Map], etc.
 ///
 /// ### Examples
 ///
@@ -668,7 +668,7 @@ impl ExactSizeIterator for BinIter {
 /// The array is stored in the Host and available to the Guest through the
 /// functions defined on Bytes.
 ///
-/// Bytes values can be stored as [Data], or in other types like [Vec], [Map],
+/// Bytes values can be stored as [Storage], or in other types like [Vec], [Map],
 /// etc.
 ///
 /// ### Examples

--- a/soroban-sdk/src/bytes.rs
+++ b/soroban-sdk/src/bytes.rs
@@ -15,7 +15,7 @@ use super::{
 
 use crate::unwrap::UnwrapOptimized;
 #[cfg(doc)]
-use crate::{data::Data, Map, Vec};
+use crate::{storage::Storage, Map, Vec};
 
 #[cfg(not(target_family = "wasm"))]
 use super::xdr::ScVal;

--- a/soroban-sdk/src/env.rs
+++ b/soroban-sdk/src/env.rs
@@ -51,8 +51,8 @@ pub type EnvVal = internal::EnvVal<Env, RawVal>;
 pub type EnvObj = internal::EnvVal<Env, Object>;
 
 use crate::{
-    accounts::Accounts, address::Address, crypto::Crypto, data::Data, deploy::Deployer,
-    events::Events, ledger::Ledger, logging::Logger, AccountId, Bytes, BytesN, Vec,
+    accounts::Accounts, address::Address, crypto::Crypto, deploy::Deployer, events::Events,
+    ledger::Ledger, logging::Logger, storage::Storage, AccountId, Bytes, BytesN, Vec,
 };
 
 /// The [Env] type provides access to the environment the contract is executing
@@ -112,8 +112,16 @@ impl Env {
     /// Get a [Data] for accessing and update contract data that has been stored
     /// by the currently executing contract.
     #[inline(always)]
-    pub fn data(&self) -> Data {
-        Data::new(self)
+    #[deprecated(note = "use env.storage()")]
+    pub fn data(&self) -> Storage {
+        self.storage()
+    }
+
+    /// Get a [Storage] for accessing and update contract data that has been stored
+    /// by the currently executing contract.
+    #[inline(always)]
+    pub fn storage(&self) -> Storage {
+        Storage::new(self)
     }
 
     /// Get [Events] for publishing events associated with the

--- a/soroban-sdk/src/env.rs
+++ b/soroban-sdk/src/env.rs
@@ -109,7 +109,7 @@ impl Env {
         }
     }
 
-    /// Get a [Data] for accessing and update contract data that has been stored
+    /// Get a [Storage] for accessing and update contract data that has been stored
     /// by the currently executing contract.
     #[inline(always)]
     #[deprecated(note = "use env.storage()")]

--- a/soroban-sdk/src/lib.rs
+++ b/soroban-sdk/src/lib.rs
@@ -609,10 +609,17 @@ mod envhidden {
 #[doc(hidden)]
 pub use envhidden::*;
 
+#[doc(hidden)]
+#[deprecated(note = "use env.storage()")]
+pub mod data {
+    #[doc(hidden)]
+    #[deprecated(note = "use env.storage()")]
+    pub use super::storage::Storage as Data;
+}
+
 pub mod accounts;
 mod bytes;
 pub mod crypto;
-pub mod data;
 pub mod deploy;
 pub mod events;
 pub mod iter;
@@ -620,6 +627,7 @@ pub mod ledger;
 pub mod logging;
 mod map;
 mod set;
+pub mod storage;
 mod vec;
 pub use accounts::AccountId;
 pub use address::Address;

--- a/soroban-sdk/src/lib.rs
+++ b/soroban-sdk/src/lib.rs
@@ -610,10 +610,10 @@ mod envhidden {
 pub use envhidden::*;
 
 #[doc(hidden)]
-#[deprecated(note = "use env.storage()")]
+#[deprecated(note = "use storage")]
 pub mod data {
     #[doc(hidden)]
-    #[deprecated(note = "use env.storage()")]
+    #[deprecated(note = "use storage::Storage")]
     pub use super::storage::Storage as Data;
 }
 

--- a/soroban-sdk/src/map.rs
+++ b/soroban-sdk/src/map.rs
@@ -56,7 +56,7 @@ macro_rules! map {
 /// Maps have at most one entry per key. Setting a value for a key in the map
 /// that already has a value for that key replaces the value.
 ///
-/// Map values can be stored as [Data], or in other types like [Vec], [Map],
+/// Map values can be stored as [Storage], or in other types like [Vec], [Map],
 /// etc.
 ///
 /// ### Examples

--- a/soroban-sdk/src/map.rs
+++ b/soroban-sdk/src/map.rs
@@ -13,7 +13,7 @@ use super::{
 use super::xdr::ScVal;
 
 #[cfg(doc)]
-use crate::data::Data;
+use crate::storage::Storage;
 
 /// Create a [Map] with the given key-value pairs.
 ///

--- a/soroban-sdk/src/storage.rs
+++ b/soroban-sdk/src/storage.rs
@@ -48,7 +48,7 @@ pub struct Storage(Env);
 
 impl Debug for Storage {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        write!(f, "Data")
+        write!(f, "Storage")
     }
 }
 

--- a/soroban-sdk/src/storage.rs
+++ b/soroban-sdk/src/storage.rs
@@ -1,4 +1,4 @@
-//! Data contains types for storing data for the currently executing contract.
+//! Storage contains types for storing data for the currently executing contract.
 use core::fmt::Debug;
 
 use crate::{
@@ -6,7 +6,7 @@ use crate::{
     Env, IntoVal, TryFromVal,
 };
 
-/// Data stores and retrieves data for the currently executing contract.
+/// Storage stores and retrieves data for the currently executing contract.
 ///
 /// All data stored can only be queried and modified by the contract that stores
 /// it. Other contracts cannot query or modify data stored by other contracts.
@@ -25,11 +25,11 @@ use crate::{
 /// # #[contractimpl]
 /// # impl Contract {
 /// #     pub fn f(env: Env) {
-/// let data = env.data();
+/// let storage = env.storage();
 /// let key = symbol!("key");
-/// env.data().set(key, 1);
-/// assert_eq!(data.has(key), true);
-/// assert_eq!(data.get::<_, i32>(key), Some(Ok(1)));
+/// env.storage().set(key, 1);
+/// assert_eq!(storage.has(key), true);
+/// assert_eq!(storage.get::<_, i32>(key), Some(Ok(1)));
 /// #     }
 /// # }
 /// #
@@ -44,23 +44,23 @@ use crate::{
 /// # fn main() { }
 /// ```
 #[derive(Clone)]
-pub struct Data(Env);
+pub struct Storage(Env);
 
-impl Debug for Data {
+impl Debug for Storage {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "Data")
     }
 }
 
-impl Data {
+impl Storage {
     #[inline(always)]
     pub(crate) fn env(&self) -> &Env {
         &self.0
     }
 
     #[inline(always)]
-    pub(crate) fn new(env: &Env) -> Data {
-        Data(env.clone())
+    pub(crate) fn new(env: &Env) -> Storage {
+        Storage(env.clone())
     }
 
     // TODO: Use Borrow<K> for all key use in these functions.
@@ -78,7 +78,7 @@ impl Data {
     }
 
     /// Returns the value there is a value stored for the given key in the
-    /// currently executing contracts data.
+    /// currently executing contract's data.
     ///
     /// ### Panics
     ///
@@ -125,7 +125,7 @@ impl Data {
         V::try_from_val(env, rv)
     }
 
-    /// Sets the value for the given key in the currently executing contracts
+    /// Sets the value for the given key in the currently executing contract's
     /// data.
     ///
     /// If the key already has a value associated with it, the old value is

--- a/soroban-sdk/src/tests/contract_snapshot.rs
+++ b/soroban-sdk/src/tests/contract_snapshot.rs
@@ -6,10 +6,10 @@ pub struct Contract;
 #[contractimpl]
 impl Contract {
     pub fn store(env: Env, k: i32, v: i32) {
-        env.data().set(k, v)
+        env.storage().set(k, v)
     }
     pub fn get(env: Env, k: i32) -> i32 {
-        env.data().get(k).unwrap().unwrap()
+        env.storage().get(k).unwrap().unwrap()
     }
 }
 

--- a/soroban-sdk/src/tests/contract_store.rs
+++ b/soroban-sdk/src/tests/contract_store.rs
@@ -6,7 +6,7 @@ pub struct Contract;
 #[contractimpl]
 impl Contract {
     pub fn store(env: Env, k: i32, v: i32) {
-        env.data().set(k, v)
+        env.storage().set(k, v)
     }
 }
 
@@ -19,7 +19,7 @@ fn test() {
     client.store(&2, &4);
 
     assert_eq!(
-        e.as_contract(&contract_id, || e.data().get::<_, i32>(2)),
+        e.as_contract(&contract_id, || e.storage().get::<_, i32>(2)),
         Some(Ok(4))
     );
 }

--- a/soroban-sdk/src/vec.rs
+++ b/soroban-sdk/src/vec.rs
@@ -89,7 +89,7 @@ impl_into_vec_for_tuple! { T0 0 T1 1 T2 2 T3 3 T4 4 T5 5 T6 6 T7 7 T8 8 T9 9 T10
 ///
 /// To store `u8`s and binary data, use [Bytes]/[BytesN] instead.
 ///
-/// Vec values can be stored as [Data], or in other types like [Vec], [Map],
+/// Vec values can be stored as [Storage], or in other types like [Vec], [Map],
 /// etc.
 ///
 /// ### Examples

--- a/soroban-sdk/src/vec.rs
+++ b/soroban-sdk/src/vec.rs
@@ -16,7 +16,7 @@ use super::{
 };
 
 #[cfg(doc)]
-use crate::{data::Data, Bytes, BytesN, Map};
+use crate::{storage::Storage, Bytes, BytesN, Map};
 
 /// Create a [Vec] with the given items.
 ///

--- a/soroban-token-spec/src/tests/use_token_contract.rs
+++ b/soroban-token-spec/src/tests/use_token_contract.rs
@@ -23,7 +23,7 @@ fn get_contract_id(e: &Env) -> Identifier {
 }
 
 fn get_token(e: &Env) -> BytesN<32> {
-    e.data().get_unchecked(DataKey::Token).unwrap()
+    e.storage().get_unchecked(DataKey::Token).unwrap()
 }
 
 pub struct TestContract;
@@ -39,7 +39,7 @@ impl TestContract {
         };
         TokenClient::new(&e, &id).init(&get_contract_id(&e), &metadata);
 
-        e.data().set(DataKey::Token, id);
+        e.storage().set(DataKey::Token, id);
     }
 
     pub fn get_token(e: Env) -> BytesN<32> {

--- a/tests/contract_data/src/lib.rs
+++ b/tests/contract_data/src/lib.rs
@@ -6,14 +6,14 @@ pub struct Contract;
 #[contractimpl]
 impl Contract {
     pub fn put(e: Env, key: Symbol, val: Symbol) {
-        e.data().set(key, val)
+        e.storage().set(key, val)
     }
 
     pub fn get(e: Env, key: Symbol) -> Option<Symbol> {
-        e.data().get(key).map(|v| v.unwrap())
+        e.storage().get(key).map(|v| v.unwrap())
     }
 
     pub fn del(e: Env, key: Symbol) {
-        e.data().remove(key)
+        e.storage().remove(key)
     }
 }

--- a/tests/errors/src/lib.rs
+++ b/tests/errors/src/lib.rs
@@ -12,7 +12,7 @@ pub enum Error {
 #[contractimpl]
 impl Contract {
     pub fn hello(env: Env, flag: u32) -> Result<Symbol, Error> {
-        env.data().set(symbol!("persisted"), true);
+        env.storage().set(symbol!("persisted"), true);
         if flag == 0 {
             Ok(symbol!("hello"))
         } else if flag == 1 {
@@ -28,7 +28,7 @@ impl Contract {
 
     #[cfg(test)]
     pub fn persisted(env: Env) -> bool {
-        env.data()
+        env.storage()
             .get(symbol!("persisted"))
             .unwrap_or(Ok(false))
             .unwrap()


### PR DESCRIPTION
### What
Rename data to storage

### Why
The name data is too generic and it is difficult to exactly imagine or narrow down what it is exactly. Storage is also rather generic, but it is more suggestive of the place to store contract data.

cc @tomerweller