### PR TITLE
Add ability to get current Budget from env in tests

### DIFF
--- a/soroban-sdk/src/env.rs
+++ b/soroban-sdk/src/env.rs
@@ -273,7 +273,8 @@ impl Env {
 
 #[cfg(any(test, feature = "testutils"))]
 use crate::testutils::{
-    random, AccountId as _, Accounts as _, BytesN as _, ContractFunctionSet, Ledger as _,
+    budget::Budget, random, AccountId as _, Accounts as _, BytesN as _, ContractFunctionSet,
+    Ledger as _,
 };
 #[cfg(any(test, feature = "testutils"))]
 use soroban_ledger_snapshot::LedgerSnapshot;
@@ -659,14 +660,9 @@ impl Env {
         self.to_snapshot().write_file(p).unwrap();
     }
 
-    /// Reset the budget that tracks the resources consumed for the environment.
-    pub fn reset_budget(&self) {
-        self.env_impl.with_budget(|b| b.reset_default())
-    }
-
     /// Get the budget that tracks the resources consumed for the environment.
-    pub fn budget(&self) -> crate::testutils::Budget {
-        self.env_impl.with_budget(|b| b.clone())
+    pub fn budget(&self) -> Budget {
+        self.env_impl.with_budget(|b| Budget::new(b.clone()))
     }
 }
 

--- a/soroban-sdk/src/env.rs
+++ b/soroban-sdk/src/env.rs
@@ -27,6 +27,8 @@ pub mod internal {
 // the SDK in the crate::testutils mod.
 #[cfg(any(test, feature = "testutils"))]
 pub mod testutils {
+    pub use super::internal::budget::Budget;
+    pub use super::internal::budget::CostType;
     pub use super::internal::LedgerInfo;
 }
 
@@ -655,6 +657,11 @@ impl Env {
     /// If there is any error writing the file.
     pub fn to_snapshot_file(&self, p: impl AsRef<Path>) {
         self.to_snapshot().write_file(p).unwrap();
+    }
+
+    /// Get the budget for the environment that tracks the resources consumed.
+    pub fn budget(&self) -> crate::testutils::Budget {
+        self.env_impl.with_budget(|b| b.clone())
     }
 }
 

--- a/soroban-sdk/src/env.rs
+++ b/soroban-sdk/src/env.rs
@@ -659,7 +659,12 @@ impl Env {
         self.to_snapshot().write_file(p).unwrap();
     }
 
-    /// Get the budget for the environment that tracks the resources consumed.
+    /// Reset the budget that tracks the resources consumed for the environment.
+    pub fn reset_budget(&self) {
+        self.env_impl.with_budget(|b| b.reset_default())
+    }
+
+    /// Get the budget that tracks the resources consumed for the environment.
     pub fn budget(&self) -> crate::testutils::Budget {
         self.env_impl.with_budget(|b| b.clone())
     }

--- a/soroban-sdk/src/tests.rs
+++ b/soroban-sdk/src/tests.rs
@@ -1,5 +1,6 @@
 #![cfg(test)]
 
+mod budget;
 mod contract_add_i32;
 mod contract_assert;
 mod contract_call_stack;
@@ -16,4 +17,3 @@ mod contractimport;
 mod contractimport_with_error;
 mod contractimport_with_sha256;
 mod contracttoken;
-mod budget;

--- a/soroban-sdk/src/tests.rs
+++ b/soroban-sdk/src/tests.rs
@@ -16,3 +16,4 @@ mod contractimport;
 mod contractimport_with_error;
 mod contractimport_with_sha256;
 mod contracttoken;
+mod budget;

--- a/soroban-sdk/src/tests/budget.rs
+++ b/soroban-sdk/src/tests/budget.rs
@@ -20,7 +20,8 @@ fn test_budget() {
 
     e.budget().reset();
     let b = client.add();
-    println!("{}", e.budget());
+    e.budget().print();
+
     assert_eq!(e.budget().input(CostType::BytesAppend), 36);
     assert_eq!(
         b,

--- a/soroban-sdk/src/tests/budget.rs
+++ b/soroban-sdk/src/tests/budget.rs
@@ -1,12 +1,14 @@
 use crate as soroban_sdk;
-use soroban_sdk::{contractimpl, testutils::CostType, Env};
+use soroban_sdk::{contractimpl, testutils::budget::CostType, Bytes, Env};
 
 pub struct Contract;
 
 #[contractimpl]
 impl Contract {
-    pub fn add(a: i32, b: i32) -> i32 {
-        a + b
+    pub fn add(e: Env) -> Bytes {
+        let mut b = Bytes::from_array(&e, b"abcdefghijklmnopqrstuvwyxz");
+        b.append(&Bytes::from_array(&e, b"0123456789"));
+        b
     }
 }
 
@@ -16,16 +18,12 @@ fn test_budget() {
     let contract_id = e.register_contract(None, Contract);
     let client = ContractClient::new(&e, &contract_id);
 
-    let a = 10i32;
-    let b = 12i32;
-    e.reset_budget();
-    let c = client.add(&a, &b);
-    assert_eq!(c, 22);
-
-    let budget = e.budget();
-    eprintln!("Cpu Insns: {}", budget.get_cpu_insns_count());
-    eprintln!("Mem Bytes: {}", budget.get_mem_bytes_count());
-    for cost_type in CostType::variants() {
-        eprintln!("Cost ({cost_type:?}): {}", budget.get_input(*cost_type));
-    }
+    e.budget().reset();
+    let b = client.add();
+    println!("{}", e.budget());
+    assert_eq!(e.budget().get(CostType::BytesAppend), 36);
+    assert_eq!(
+        b,
+        Bytes::from_array(&e, b"abcdefghijklmnopqrstuvwyxz0123456789")
+    );
 }

--- a/soroban-sdk/src/tests/budget.rs
+++ b/soroban-sdk/src/tests/budget.rs
@@ -1,0 +1,31 @@
+use crate as soroban_sdk;
+use soroban_sdk::{contractimpl, testutils::CostType, Env};
+
+pub struct Contract;
+
+#[contractimpl]
+impl Contract {
+    pub fn add(a: i32, b: i32) -> i32 {
+        a + b
+    }
+}
+
+#[test]
+fn test_budget() {
+    let e = Env::default();
+    let contract_id = e.register_contract(None, Contract);
+    let client = ContractClient::new(&e, &contract_id);
+
+    let a = 10i32;
+    let b = 12i32;
+    e.reset_budget();
+    let c = client.add(&a, &b);
+    assert_eq!(c, 22);
+
+    let budget = e.budget();
+    eprintln!("Cpu Insns: {}", budget.get_cpu_insns_count());
+    eprintln!("Mem Bytes: {}", budget.get_mem_bytes_count());
+    for cost_type in CostType::variants() {
+        eprintln!("Cost ({cost_type:?}): {}", budget.get_input(*cost_type));
+    }
+}

--- a/soroban-sdk/src/tests/budget.rs
+++ b/soroban-sdk/src/tests/budget.rs
@@ -21,7 +21,7 @@ fn test_budget() {
     e.budget().reset();
     let b = client.add();
     println!("{}", e.budget());
-    assert_eq!(e.budget().get(CostType::BytesAppend), 36);
+    assert_eq!(e.budget().input(CostType::BytesAppend), 36);
     assert_eq!(
         b,
         Bytes::from_array(&e, b"abcdefghijklmnopqrstuvwyxz0123456789")

--- a/soroban-sdk/src/testutils.rs
+++ b/soroban-sdk/src/testutils.rs
@@ -4,9 +4,8 @@
 //! Utilities intended for use when testing.
 
 mod sign;
-pub use sign::ed25519;
 
-pub use crate::env::testutils::*;
+pub use sign::ed25519;
 
 use crate::{Env, RawVal, Symbol, Vec};
 
@@ -14,6 +13,9 @@ use crate::{Env, RawVal, Symbol, Vec};
 pub trait ContractFunctionSet {
     fn call(&self, func: &Symbol, env: Env, args: &[RawVal]) -> Option<RawVal>;
 }
+
+#[doc(inline)]
+pub use crate::env::internal::LedgerInfo;
 
 /// Test utilities for [`Ledger`][crate::ledger::Ledger].
 pub trait Ledger {
@@ -27,6 +29,70 @@ pub trait Ledger {
     fn with_mut<F>(&self, f: F)
     where
         F: FnMut(&mut LedgerInfo);
+}
+
+pub mod budget {
+    use core::fmt::Display;
+
+    #[doc(inline)]
+    pub use crate::env::internal::budget::CostType;
+
+    /// Budget that tracks the resources consumed for the environment.
+    ///
+    /// ### Examples
+    ///
+    /// ```
+    /// use soroban_sdk::{Env, Symbol};
+    ///
+    /// # #[cfg(feature = "testutils")]
+    /// # fn main() {
+    /// #     let env = Env::default();
+    /// env.budget().reset();
+    /// // ...
+    /// println!("{}", env.budget());
+    /// # }
+    /// # #[cfg(not(feature = "testutils"))]
+    /// # fn main() { }
+    /// ```
+    pub struct Budget(crate::env::internal::budget::Budget);
+
+    impl Display for Budget {
+        fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+            writeln!(f, "CPU Instructions: {}", self.get_cpu_instruction_count())?;
+            writeln!(f, "Memory Bytes: {}", self.get_memory_bytes_count())?;
+            for cost_type in CostType::variants() {
+                writeln!(f, "{cost_type:?}: {}", self.get(*cost_type))?;
+            }
+            Ok(())
+        }
+    }
+
+    impl Budget {
+        pub(crate) fn new(b: crate::env::internal::budget::Budget) -> Self {
+            Self(b)
+        }
+
+        /// Reset the budget.
+        pub fn reset(&mut self) {
+            self.0.reset_default();
+            self.0.reset_unlimited();
+        }
+
+        /// Get the CPU instruction count.
+        pub fn get_cpu_instruction_count(&self) -> u64 {
+            self.0.get_cpu_insns_count()
+        }
+
+        /// Get the memory bytes used.
+        pub fn get_memory_bytes_count(&self) -> u64 {
+            self.0.get_mem_bytes_count()
+        }
+
+        /// Get other cost counts.
+        pub fn get(&self, cost_type: CostType) -> u64 {
+            self.0.get_input(cost_type)
+        }
+    }
 }
 
 /// Test utilities for [`Events`][crate::events::Events].

--- a/soroban-sdk/src/testutils.rs
+++ b/soroban-sdk/src/testutils.rs
@@ -45,9 +45,9 @@ pub mod budget {
     ///
     /// Inputs feed into those cost dimensions.
     ///
-    /// Note that some budgets – CPU instructions, memory, and VM cost types –
-    /// are likely to be underestimated when running Rust code compared to
-    /// running the WASM equivalent.
+    /// Note that all cost dimensions – CPU instructions, memory – and the VM
+    /// cost type inputs are likely to be underestimated when running Rust code
+    /// compared to running the WASM equivalent.
     ///
     /// ### Examples
     ///

--- a/soroban-sdk/src/testutils.rs
+++ b/soroban-sdk/src/testutils.rs
@@ -39,6 +39,10 @@ pub mod budget {
 
     /// Budget that tracks the resources consumed for the environment.
     ///
+    /// Note that some budgets – CPU instructions, memory, and VM cost types –
+    /// are likely to be underestimated when running Rust code compared to
+    /// running the WASM equivalent.
+    ///
     /// ### Examples
     ///
     /// ```
@@ -79,16 +83,25 @@ pub mod budget {
         }
 
         /// Get the CPU instruction count.
+        ///
+        /// Note that CPU instructions are likely to be underestimated when
+        /// running Rust code compared to running the WASM equivalent.
         pub fn get_cpu_instruction_count(&self) -> u64 {
             self.0.get_cpu_insns_count()
         }
 
         /// Get the memory bytes used.
+        ///
+        /// Note that memory is likely to be underestimated when running Rust
+        /// code compared to running the WASM equivalent.
         pub fn get_memory_bytes_count(&self) -> u64 {
             self.0.get_mem_bytes_count()
         }
 
         /// Get other cost counts.
+        ///
+        /// Note that VM cost types are likely to be underestimated when running
+        /// Rust code compared to running the WASM equivalent.
         pub fn get(&self, cost_type: CostType) -> u64 {
             self.0.get_input(cost_type)
         }


### PR DESCRIPTION
### What
Add ability to get current Budget from env in tests.

### Why
It would be helpful for developers to be able to query their resource usage inside tests. While some things won't be completely equal to a WASM contract running, such as the WASM instruction count, other costs are measurable.

@tyvdh mentioned this would be useful for upcoming quests.