### PR TITLE
Make errors explicit in ledger snapshot functions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -902,6 +902,7 @@ dependencies = [
  "serde",
  "serde_json",
  "soroban-env-host",
+ "thiserror",
 ]
 
 [[package]]

--- a/soroban-ledger-snapshot/Cargo.toml
+++ b/soroban-ledger-snapshot/Cargo.toml
@@ -14,6 +14,7 @@ rust-version = "1.65"
 soroban-env-host = { workspace = true, features = ["serde"] }
 serde = { version = "1.0.0", features = ["derive"] }
 serde_json = "1.0.0"
+thiserror = "1.0"
 
 [dev_dependencies]
 pretty_assertions = "1.2.1"


### PR DESCRIPTION
### What
Make errors explicit in ledger snapshot functions

### Why
So that applications can introspect the errors.

Close #795 