### PR TITLE
Add LedgerSnapshot::update(Host)

### DIFF
--- a/soroban-ledger-snapshot/src/lib.rs
+++ b/soroban-ledger-snapshot/src/lib.rs
@@ -8,7 +8,7 @@ use std::{
 use soroban_env_host::{
     storage::SnapshotSource,
     xdr::{LedgerEntry, LedgerKey, ScHostStorageErrorCode, ScStatus},
-    HostError, LedgerInfo,
+    Host, HostError, LedgerInfo,
 };
 
 #[derive(thiserror::Error, Debug)]
@@ -42,6 +42,23 @@ impl LedgerSnapshot {
         s.set_ledger_info(info);
         s.set_entries(entries);
         s
+    }
+
+    /// Update the snapshot with the state within the given [`Host`].
+    ///
+    /// The ledger info of the host will overwrite the ledger info in the
+    /// snapshot.  The entries in the host's storage will overwrite entries in
+    /// the snapshot. Existing entries in the snapshot that are untouched by the
+    /// host will remain.
+    pub fn update(&mut self, host: Host) {
+        let _result = host.with_ledger_info(|li| {
+            self.set_ledger_info(li.clone());
+            Ok(())
+        });
+        let _result = host.with_mut_storage(|s| {
+            self.update_entries(&s.map);
+            Ok(())
+        });
     }
 
     // Get the ledger info in the snapshot.


### PR DESCRIPTION
### What
Add LedgerSnapshot::update function that will update a snapshot with the state within a Host.

### Why
The `LedgerSnapshot` type can be updated piecemeal by calling `set_ledger_info` and `update_entries`.

@sisuresh pointed out that it would be nice if we could update both in a single call:
- https://github.com/stellar/soroban-tools/pull/309#discussion_r1049045796

There are some advantages to this, mostly around preventing foot-guns where you update one and not the other.

Close #799