### PR TITLE
Fix doc comments and clippy warnings on ledger snapshot

### DIFF
--- a/soroban-ledger-snapshot/src/lib.rs
+++ b/soroban-ledger-snapshot/src/lib.rs
@@ -61,7 +61,7 @@ impl LedgerSnapshot {
         });
     }
 
-    // Get the ledger info in the snapshot.
+    /// Get the ledger info in the snapshot.
     pub fn ledger_info(&self) -> LedgerInfo {
         LedgerInfo {
             protocol_version: self.protocol_version,
@@ -72,7 +72,7 @@ impl LedgerSnapshot {
         }
     }
 
-    // Set the ledger info in the snapshot.
+    /// Set the ledger info in the snapshot.
     pub fn set_ledger_info(&mut self, info: LedgerInfo) {
         self.protocol_version = info.protocol_version;
         self.sequence_number = info.sequence_number;
@@ -81,14 +81,12 @@ impl LedgerSnapshot {
         self.base_reserve = info.base_reserve;
     }
 
-    // Get the entries in the snapshot.
-    pub fn entries<'a>(
-        &'a self,
-    ) -> impl IntoIterator<Item = (&'a Box<LedgerKey>, &'a Box<LedgerEntry>)> {
+    /// Get the entries in the snapshot.
+    pub fn entries(&self) -> impl IntoIterator<Item = (&Box<LedgerKey>, &Box<LedgerEntry>)> {
         self.ledger_entries.iter().map(|(k, v)| (k, v))
     }
 
-    // Replace the entries in the snapshot with the entries in the iterator.
+    /// Replace the entries in the snapshot with the entries in the iterator.
     pub fn set_entries<'a>(
         &mut self,
         entries: impl IntoIterator<Item = (&'a Box<LedgerKey>, &'a Box<LedgerEntry>)>,
@@ -99,9 +97,9 @@ impl LedgerSnapshot {
         }
     }
 
-    // Update entries in the snapshot by adding or replacing any entries that
-    // have entry in the input iterator, or removing any that does not have an
-    // entry.
+    /// Update entries in the snapshot by adding or replacing any entries that
+    /// have entry in the input iterator, or removing any that does not have an
+    /// entry.
     pub fn update_entries<'a>(
         &mut self,
         entries: impl IntoIterator<Item = &'a (Rc<LedgerKey>, Option<Rc<LedgerEntry>>)>,
@@ -113,7 +111,7 @@ impl LedgerSnapshot {
                 if let Some(i) = i {
                     self.ledger_entries[i] = new;
                 } else {
-                    self.ledger_entries.push(new)
+                    self.ledger_entries.push(new);
                 }
             } else if let Some(i) = i {
                 self.ledger_entries.swap_remove(i);

--- a/soroban-ledger-snapshot/src/lib.rs
+++ b/soroban-ledger-snapshot/src/lib.rs
@@ -8,7 +8,7 @@ use std::{
 use soroban_env_host::{
     storage::SnapshotSource,
     xdr::{LedgerEntry, LedgerKey, ScHostStorageErrorCode, ScStatus},
-    HostError, LedgerInfo,
+    Host, HostError, LedgerInfo,
 };
 
 #[derive(thiserror::Error, Debug)]
@@ -42,6 +42,23 @@ impl LedgerSnapshot {
         s.set_ledger_info(info);
         s.set_entries(entries);
         s
+    }
+
+    /// Update the snapshot with the state within the given [`Host`].
+    ///
+    /// The ledger info of the host will overwrite the ledger info in the
+    /// snapshot.  The entries in the host's storage will overwrite entries in
+    /// the snapshot. Existing entries in the snapshot that are untouched by the
+    /// host will remain.
+    pub fn update(&mut self, host: Host) {
+        let _result = host.with_ledger_info(|li| {
+            self.set_ledger_info(li.clone());
+            Ok(())
+        });
+        let _result = host.with_mut_storage(|s| {
+            self.update_entries(&s.map);
+            Ok(())
+        });
     }
 
     // Get the ledger info in the snapshot.


### PR DESCRIPTION
### What
Fix doc comments and clippy warnings on ledger snapshot

### Why
The doc comments are using the wrong number of slashes and won't show up in docs.