### PR TITLE
Remove init from the token interface

### DIFF
--- a/soroban-token-spec/src/lib.rs
+++ b/soroban-token-spec/src/lib.rs
@@ -1,17 +1,9 @@
 #![no_std]
 
 use soroban_auth::{Identifier, Signature};
-use soroban_sdk::{contractimpl, contracttype, Bytes, Env};
+use soroban_sdk::{contractimpl, Bytes, Env};
 
 mod tests;
-
-#[derive(Clone)]
-#[contracttype]
-pub struct TokenMetadata {
-    pub name: Bytes,
-    pub symbol: Bytes,
-    pub decimals: u32,
-}
 
 /// The interface below was copied from
 /// https://github.com/stellar/rs-soroban-env/blob/main/soroban-env-host/src/native_contract/token/contract.rs
@@ -26,12 +18,6 @@ pub struct Token;
 #[contractimpl]
 #[allow(unused_variables)]
 impl Token {
-    /// Init creates a token contract that does not wrap an asset on the classic
-    /// side. No checks are done on the contractID.
-    pub fn init(env: Env, admin: Identifier, metadata: TokenMetadata) {
-        panic!("calling into interface");
-    }
-
     pub fn nonce(env: Env, id: Identifier) -> i128 {
         panic!("calling into interface");
     }
@@ -110,7 +96,7 @@ impl Token {
 
 /// Returns the XDR spec for the Token contract.
 #[doc(hidden)]
-pub const fn spec_xdr() -> [u8; 2036] {
+pub const fn spec_xdr() -> [u8; 1872] {
     let input: &[&[u8]] = &[
         &Token::spec_xdr_allowance(),
         &Token::spec_xdr_approve(),
@@ -120,7 +106,6 @@ pub const fn spec_xdr() -> [u8; 2036] {
         &Token::spec_xdr_export(),
         &Token::spec_xdr_freeze(),
         &Token::spec_xdr_import(),
-        &Token::spec_xdr_init(),
         &Token::spec_xdr_is_frozen(),
         &Token::spec_xdr_mint(),
         &Token::spec_xdr_name(),
@@ -130,7 +115,6 @@ pub const fn spec_xdr() -> [u8; 2036] {
         &Token::spec_xdr_unfreeze(),
         &Token::spec_xdr_xfer(),
         &Token::spec_xdr_xfer_from(),
-        &TokenMetadata::spec_xdr(),
         &soroban_auth::Identifier::spec_xdr(),
         &soroban_auth::Signature::spec_xdr(),
         &soroban_auth::Ed25519Signature::spec_xdr(),
@@ -138,7 +122,7 @@ pub const fn spec_xdr() -> [u8; 2036] {
     ];
 
     // Concatenate all XDR for each item that makes up the token spec.
-    let mut output = [0u8; 2036];
+    let mut output = [0u8; 1872];
     let mut input_i = 0;
     let mut output_i = 0;
     while input_i < input.len() {


### PR DESCRIPTION
### What

Remove the init method from the token interface because - 
1. It's not a method on the SAC.
2. Contracts should be able to customize initialization without breaking the token interface.