### PR TITLE
Fix contractimpl for empty impl blocks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1117,6 +1117,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "test_empty2"
+version = "0.3.2"
+dependencies = [
+ "soroban-sdk",
+]
+
+[[package]]
 name = "test_errors"
 version = "0.3.2"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
     "soroban-ledger-snapshot",
     "soroban-token-spec",
     "tests/empty",
+    "tests/empty2",
     "tests/add_u64",
     "tests/add_i128",
     "tests/add_u128",

--- a/soroban-sdk-macros/src/derive_fn.rs
+++ b/soroban-sdk-macros/src/derive_fn.rs
@@ -251,7 +251,7 @@ pub fn derive_contract_function_set<'a>(
                 env: soroban_sdk::Env,
                 args: &[soroban_sdk::RawVal],
             ) -> Option<soroban_sdk::RawVal> {
-                match func.to_str().as_ref() {
+                match ::core::convert::AsRef::<str>::as_ref(&func.to_str()) {
                     #(
                         #(#attrs)*
                         #idents => {

--- a/tests/empty2/Cargo.toml
+++ b/tests/empty2/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "test_empty2"
+version.workspace = true
+authors = ["Stellar Development Foundation <info@stellar.org>"]
+license = "Apache-2.0"
+edition = "2021"
+publish = false
+rust-version = "1.66"
+
+[lib]
+crate-type = ["cdylib"]
+doctest = false
+
+[dependencies]
+soroban-sdk = {path = "../../soroban-sdk"}
+
+[dev-dependencies]
+soroban-sdk = {path = "../../soroban-sdk", features = ["testutils"]}

--- a/tests/empty2/src/lib.rs
+++ b/tests/empty2/src/lib.rs
@@ -1,0 +1,22 @@
+#![no_std]
+use soroban_sdk::contractimpl;
+
+pub struct Contract;
+
+#[contractimpl]
+impl Contract {}
+
+#[cfg(test)]
+mod test {
+    use soroban_sdk::{BytesN, Env};
+
+    use crate::{Contract, ContractClient};
+
+    #[test]
+    fn test_hello() {
+        let e = Env::default();
+        let contract_id = BytesN::from_array(&e, &[0; 32]);
+        e.register_contract(&contract_id, Contract);
+        let _client = ContractClient::new(&e, &contract_id);
+    }
+}


### PR DESCRIPTION
### What

Use the fully-qualified name of an `AsRef` inside of `#[contractimpl]`.

### Why

When a contract defines no methods, it fails to compile when `features = "testutils"` because a particular `match` block has no cases to provide the type inference to decide which impl of `AsRef` to call.

The resulting error:

```
error[E0283]: type annotations needed
 --> src/lib.rs:8:1
  |
8 | #[contractimpl]
  | ^^^^^^^^^^^^^^^
  |
  = note: multiple `impl`s satisfying `soroban_env_common::symbol::SymbolStr: AsRef<_>` found in the `soroban_env_common` crate:
          - impl AsRef<[u8]> for soroban_env_common::symbol::SymbolStr;
          - impl AsRef<str> for soroban_env_common::symbol::SymbolStr;
  = note: this error originates in the attribute macro `contractimpl` (in Nightly builds, run with -Z macro-backtrace for more info)
help: try using a fully qualified path to specify the expected types
  |
8 | <soroban_env_common::symbol::SymbolStr as AsRef<T>>::as_ref(&#[contractimpl])
  | +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++     
```

### Known limitations

n/a