### PR TITLE
Remove {Try}FromVal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -841,7 +841,7 @@ dependencies = [
 [[package]]
 name = "soroban-env-common"
 version = "0.0.12"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=65498c8#65498c84ccc30df302c99b50af31752f7aa087e8"
+source = "git+https://github.com/jayz22/rs-soroban-env?rev=aae7e79#aae7e792518ccd3f086586263263944ccf3d6e4c"
 dependencies = [
  "crate-git-revision",
  "serde",
@@ -854,7 +854,7 @@ dependencies = [
 [[package]]
 name = "soroban-env-guest"
 version = "0.0.12"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=65498c8#65498c84ccc30df302c99b50af31752f7aa087e8"
+source = "git+https://github.com/jayz22/rs-soroban-env?rev=aae7e79#aae7e792518ccd3f086586263263944ccf3d6e4c"
 dependencies = [
  "soroban-env-common",
  "static_assertions",
@@ -863,7 +863,7 @@ dependencies = [
 [[package]]
 name = "soroban-env-host"
 version = "0.0.12"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=65498c8#65498c84ccc30df302c99b50af31752f7aa087e8"
+source = "git+https://github.com/jayz22/rs-soroban-env?rev=aae7e79#aae7e792518ccd3f086586263263944ccf3d6e4c"
 dependencies = [
  "backtrace",
  "curve25519-dalek",
@@ -885,7 +885,7 @@ dependencies = [
 [[package]]
 name = "soroban-env-macros"
 version = "0.0.12"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=65498c8#65498c84ccc30df302c99b50af31752f7aa087e8"
+source = "git+https://github.com/jayz22/rs-soroban-env?rev=aae7e79#aae7e792518ccd3f086586263263944ccf3d6e4c"
 dependencies = [
  "itertools",
  "proc-macro2",
@@ -911,7 +911,7 @@ dependencies = [
 [[package]]
 name = "soroban-native-sdk-macros"
 version = "0.0.12"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=65498c8#65498c84ccc30df302c99b50af31752f7aa087e8"
+source = "git+https://github.com/jayz22/rs-soroban-env?rev=aae7e79#aae7e792518ccd3f086586263263944ccf3d6e4c"
 dependencies = [
  "itertools",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,18 +35,18 @@ soroban-token-spec = { version = "0.4.0", path = "soroban-token-spec" }
 
 [workspace.dependencies.soroban-env-common]
 version = "0.0.12"
-git = "https://github.com/stellar/rs-soroban-env"
-rev = "65498c8"
+git = "https://github.com/jayz22/rs-soroban-env"
+rev = "aae7e79"
 
 [workspace.dependencies.soroban-env-guest]
 version = "0.0.12"
-git = "https://github.com/stellar/rs-soroban-env"
-rev = "65498c8"
+git = "https://github.com/jayz22/rs-soroban-env"
+rev = "aae7e79"
 
 [workspace.dependencies.soroban-env-host]
 version = "0.0.12"
-git = "https://github.com/stellar/rs-soroban-env"
-rev = "65498c8"
+git = "https://github.com/jayz22/rs-soroban-env"
+rev = "aae7e79"
 
 [workspace.dependencies.stellar-strkey]
 version = "0.0.6"

--- a/soroban-sdk-macros/src/derive_client.rs
+++ b/soroban-sdk-macros/src/derive_client.rs
@@ -91,7 +91,8 @@ impl<'a> ClientFn<'a> {
         };
         Type::Verbatim(quote! {
             Result<
-                Result<#t, <#t as soroban_sdk::TryFromVal<soroban_sdk::Env, soroban_sdk::RawVal>>::Error>,
+                // Result<#t, <#t as soroban_sdk::TryFromVal<soroban_sdk::Env, soroban_sdk::RawVal>>::Error>,
+                Result<#t, <soroban_sdk::RawVal as soroban_sdk::TryIntoVal<soroban_sdk::Env, #t>>::Error>,
                 Result<#e, <#e as TryFrom<soroban_sdk::Status>>::Error>
             >
         })

--- a/soroban-sdk-macros/src/derive_enum.rs
+++ b/soroban-sdk-macros/src/derive_enum.rs
@@ -69,7 +69,7 @@ pub fn derive_type_enum(
                         if iter.len() > 1 {
                             return Err(#path::ConversionError);
                         }
-                        Self::#ident(iter.next().ok_or(#path::ConversionError)??.try_into_val(env)?)
+                        #enum_ident::#ident(iter.next().ok_or(#path::ConversionError)??.try_into_val(env)?)
                     }
                 };
                 let into = quote! { #enum_ident::#ident(ref value) => (#discriminant_const_sym_ident, value).into_val(env) };
@@ -79,7 +79,7 @@ pub fn derive_type_enum(
                             return Err(#path::xdr::Error::Invalid);
                         }
                         let rv: #path::RawVal = iter.next().ok_or(#path::xdr::Error::Invalid)?.try_into_val(env).map_err(|_| #path::xdr::Error::Invalid)?;
-                        Self::#ident(rv.try_into_val(env).map_err(|_| #path::xdr::Error::Invalid)?)
+                        #enum_ident::#ident(rv.try_into_val(env).map_err(|_| #path::xdr::Error::Invalid)?)
                     }
                 };
                 let into_xdr = quote! { #enum_ident::#ident(value) => (#name, value).try_into().map_err(|_| #path::xdr::Error::Invalid)? };
@@ -94,7 +94,7 @@ pub fn derive_type_enum(
                         if iter.len() > 0 {
                             return Err(#path::ConversionError);
                         }
-                        Self::#ident
+                        #enum_ident::#ident
                     }
                 };
                 let into = quote! { #enum_ident::#ident => (#discriminant_const_sym_ident,).into_val(env) };
@@ -103,7 +103,7 @@ pub fn derive_type_enum(
                         if iter.len() > 0 {
                             return Err(#path::xdr::Error::Invalid);
                         }
-                        Self::#ident
+                        #enum_ident::#ident
                     }
                 };
                 let into_xdr = quote! { #enum_ident::#ident => (#name,).try_into().map_err(|_| #path::xdr::Error::Invalid)? };

--- a/soroban-sdk-macros/src/derive_enum.rs
+++ b/soroban-sdk-macros/src/derive_enum.rs
@@ -147,22 +147,6 @@ pub fn derive_type_enum(
     quote! {
         #spec_gen
 
-        // impl #path::TryFromVal<#path::Env, #path::RawVal> for #enum_ident {
-        //     type Error = #path::ConversionError;
-        //     #[inline(always)]
-        //     fn try_from_val(env: &#path::Env, val: #path::RawVal) -> Result<Self, Self::Error> {
-        //         use #path::TryIntoVal;
-        //         #(#discriminant_consts)*
-        //         let vec: #path::Vec<#path::RawVal> = val.try_into_val(env)?;
-        //         let mut iter = vec.iter();
-        //         let discriminant = iter.next().ok_or(#path::ConversionError)??;
-        //         Ok(match discriminant.get_payload() {
-        //             #(#try_froms,)*
-        //             _ => Err(#path::ConversionError{})?,
-        //         })
-        //     }
-        // }
-
         impl #path::TryIntoVal<#path::Env, #enum_ident> for #path::RawVal {
             type Error = #path::ConversionError;
             #[inline(always)]
@@ -199,32 +183,11 @@ pub fn derive_type_enum(
             }
         }
 
-        // #[cfg(any(test, feature = "testutils"))]
-        // impl #path::TryFromVal<#path::Env, #path::xdr::ScVec> for #enum_ident {
-        //     type Error = #path::xdr::Error;
-        //     #[inline(always)]
-        //     fn try_from_val(env: &#path::Env, val: #path::xdr::ScVec) -> Result<Self, Self::Error> {
-        //         use #path::xdr::Validate;
-        //         use #path::TryIntoVal;
-
-        //         let vec = val;
-        //         let mut iter = vec.iter();
-        //         let discriminant: #path::xdr::ScSymbol = iter.next().ok_or(#path::xdr::Error::Invalid)?.clone().try_into().map_err(|_| #path::xdr::Error::Invalid)?;
-        //         let discriminant_name: &str = &discriminant.to_string()?;
-
-        //         Ok(match discriminant_name {
-        //             #(#try_from_xdrs,)*
-        //             _ => Err(#path::xdr::Error::Invalid)?,
-        //         })
-        //     }
-        // }
-
         #[cfg(any(test, feature = "testutils"))]
         impl #path::TryIntoVal<#path::Env, #enum_ident> for #path::xdr::ScVec {
             type Error = #path::xdr::Error;
             #[inline(always)]
             fn try_into_val(self, env: &#path::Env) -> Result<#enum_ident, Self::Error> {
-                // <_ as #path::TryFromVal<_, _>>::try_from_val(env, self)
                 use #path::xdr::Validate;
                 use #path::TryIntoVal;
 
@@ -240,58 +203,26 @@ pub fn derive_type_enum(
             }
         }
 
-        // #[cfg(any(test, feature = "testutils"))]
-        // impl #path::TryFromVal<#path::Env, #path::xdr::ScObject> for #enum_ident {
-        //     type Error = #path::xdr::Error;
-        //     #[inline(always)]
-        //     fn try_from_val(env: &#path::Env, val: #path::xdr::ScObject) -> Result<Self, Self::Error> {
-        //         if let #path::xdr::ScObject::Vec(vec) = val {
-        //             <_ as #path::TryFromVal<_, _>>::try_from_val(env, vec)
-        //         } else {
-        //             Err(#path::xdr::Error::Invalid)
-        //         }
-        //     }
-        // }
-
         #[cfg(any(test, feature = "testutils"))]
         impl #path::TryIntoVal<#path::Env, #enum_ident> for #path::xdr::ScObject {
             type Error = #path::xdr::Error;
             #[inline(always)]
             fn try_into_val(self, env: &#path::Env) -> Result<#enum_ident, Self::Error> {
-                // <_ as #path::TryFromVal<_, _>>::try_from_val(env, self)
-
                 if let #path::xdr::ScObject::Vec(vec) = self {
-                    // <_ as #path::TryFromVal<_, _>>::try_from_val(env, vec)
                     <_ as #path::TryIntoVal<_, _>>::try_into_val(vec, env)
                 } else {
                     Err(#path::xdr::Error::Invalid)
                 }
-
             }
         }
-
-        // #[cfg(any(test, feature = "testutils"))]
-        // impl #path::TryFromVal<#path::Env, #path::xdr::ScVal> for #enum_ident {
-        //     type Error = #path::xdr::Error;
-        //     #[inline(always)]
-        //     fn try_from_val(env: &#path::Env, val: #path::xdr::ScVal) -> Result<Self, Self::Error> {
-        //         if let #path::xdr::ScVal::Object(Some(obj)) = val {
-        //             <_ as #path::TryFromVal<_, _>>::try_from_val(env, obj)
-        //         } else {
-        //             Err(#path::xdr::Error::Invalid)
-        //         }
-        //     }
-        // }
 
         #[cfg(any(test, feature = "testutils"))]
         impl #path::TryIntoVal<#path::Env, #enum_ident> for #path::xdr::ScVal {
             type Error = #path::xdr::Error;
             #[inline(always)]
             fn try_into_val(self, env: &#path::Env) -> Result<#enum_ident, Self::Error> {
-                // <_ as #path::TryFromVal<_, _>>::try_from_val(env, self)
                 if let #path::xdr::ScVal::Object(Some(obj)) = self {
-                    // <_ as #path::TryFromVal<_, _>>::try_from_val(env, obj)
-                    <_ as #path::TryIntoVal<_, _>>::try_into_val(env, obj)
+                    <_ as #path::TryIntoVal<_, _>>::try_into_val(obj, env)
                 } else {
                     Err(#path::xdr::Error::Invalid)
                 }

--- a/soroban-sdk-macros/src/derive_enum_int.rs
+++ b/soroban-sdk-macros/src/derive_enum_int.rs
@@ -47,7 +47,7 @@ pub fn derive_type_enum_int(
                 name: name.try_into().unwrap_or_else(|_| StringM::default()),
                 value: discriminant,
             };
-            let try_from = quote! { #discriminant => Self::#ident };
+            let try_from = quote! { #discriminant => #enum_ident::#ident };
             let into = quote! { #enum_ident::#ident => #discriminant.into_val(env) };
             (spec_case, try_from, into)
         })

--- a/soroban-sdk-macros/src/derive_enum_int.rs
+++ b/soroban-sdk-macros/src/derive_enum_int.rs
@@ -88,24 +88,30 @@ pub fn derive_type_enum_int(
     quote! {
         #spec_gen
 
-        impl #path::TryFromVal<#path::Env, #path::RawVal> for #enum_ident {
-            type Error = #path::ConversionError;
-            #[inline(always)]
-            fn try_from_val(env: &#path::Env, val: #path::RawVal) -> Result<Self, Self::Error> {
-                use #path::TryIntoVal;
-                let discriminant: u32 = val.try_into_val(env)?;
-                Ok(match discriminant {
-                    #(#try_froms,)*
-                    _ => Err(#path::ConversionError{})?,
-                })
-            }
-        }
+        // impl #path::TryFromVal<#path::Env, #path::RawVal> for #enum_ident {
+        //     type Error = #path::ConversionError;
+        //     #[inline(always)]
+        //     fn try_from_val(env: &#path::Env, val: #path::RawVal) -> Result<Self, Self::Error> {
+        //         use #path::TryIntoVal;
+        //         let discriminant: u32 = val.try_into_val(env)?;
+        //         Ok(match discriminant {
+        //             #(#try_froms,)*
+        //             _ => Err(#path::ConversionError{})?,
+        //         })
+        //     }
+        // }
 
         impl #path::TryIntoVal<#path::Env, #enum_ident> for #path::RawVal {
             type Error = #path::ConversionError;
             #[inline(always)]
             fn try_into_val(self, env: &#path::Env) -> Result<#enum_ident, Self::Error> {
-                <_ as #path::TryFromVal<_, _>>::try_from_val(env, self)
+                // <_ as #path::TryFromVal<_, _>>::try_from_val(env, self)
+                use #path::TryIntoVal;
+                let discriminant: u32 = self.try_into_val(env)?;
+                Ok(match discriminant {
+                    #(#try_froms,)*
+                    _ => Err(#path::ConversionError{})?,
+                })
             }
         }
 
@@ -127,25 +133,30 @@ pub fn derive_type_enum_int(
             }
         }
 
-        #[cfg(any(test, feature = "testutils"))]
-        impl #path::TryFromVal<#path::Env, #path::xdr::ScVal> for #enum_ident {
-            type Error = #path::xdr::Error;
-            #[inline(always)]
-            fn try_from_val(env: &#path::Env, val: #path::xdr::ScVal) -> Result<Self, Self::Error> {
-                let discriminant: u32 = val.try_into().map_err(|_| #path::xdr::Error::Invalid)?;
-                Ok(match discriminant {
-                    #(#try_froms,)*
-                    _ => Err(#path::xdr::Error::Invalid)?,
-                })
-            }
-        }
+        // #[cfg(any(test, feature = "testutils"))]
+        // impl #path::TryFromVal<#path::Env, #path::xdr::ScVal> for #enum_ident {
+        //     type Error = #path::xdr::Error;
+        //     #[inline(always)]
+        //     fn try_from_val(env: &#path::Env, val: #path::xdr::ScVal) -> Result<Self, Self::Error> {
+        //         let discriminant: u32 = val.try_into().map_err(|_| #path::xdr::Error::Invalid)?;
+        //         Ok(match discriminant {
+        //             #(#try_froms,)*
+        //             _ => Err(#path::xdr::Error::Invalid)?,
+        //         })
+        //     }
+        // }
 
         #[cfg(any(test, feature = "testutils"))]
         impl #path::TryIntoVal<#path::Env, #enum_ident> for #path::xdr::ScVal {
             type Error = #path::xdr::Error;
             #[inline(always)]
             fn try_into_val(self, env: &#path::Env) -> Result<#enum_ident, Self::Error> {
-                <_ as #path::TryFromVal<_, _>>::try_from_val(env, self)
+                // <_ as #path::TryFromVal<_, _>>::try_from_val(env, self)
+                let discriminant: u32 = self.try_into().map_err(|_| #path::xdr::Error::Invalid)?;
+                Ok(match discriminant {
+                    #(#try_froms,)*
+                    _ => Err(#path::xdr::Error::Invalid)?,
+                })
             }
         }
 

--- a/soroban-sdk-macros/src/derive_enum_int.rs
+++ b/soroban-sdk-macros/src/derive_enum_int.rs
@@ -88,24 +88,10 @@ pub fn derive_type_enum_int(
     quote! {
         #spec_gen
 
-        // impl #path::TryFromVal<#path::Env, #path::RawVal> for #enum_ident {
-        //     type Error = #path::ConversionError;
-        //     #[inline(always)]
-        //     fn try_from_val(env: &#path::Env, val: #path::RawVal) -> Result<Self, Self::Error> {
-        //         use #path::TryIntoVal;
-        //         let discriminant: u32 = val.try_into_val(env)?;
-        //         Ok(match discriminant {
-        //             #(#try_froms,)*
-        //             _ => Err(#path::ConversionError{})?,
-        //         })
-        //     }
-        // }
-
         impl #path::TryIntoVal<#path::Env, #enum_ident> for #path::RawVal {
             type Error = #path::ConversionError;
             #[inline(always)]
             fn try_into_val(self, env: &#path::Env) -> Result<#enum_ident, Self::Error> {
-                // <_ as #path::TryFromVal<_, _>>::try_from_val(env, self)
                 use #path::TryIntoVal;
                 let discriminant: u32 = self.try_into_val(env)?;
                 Ok(match discriminant {
@@ -133,25 +119,11 @@ pub fn derive_type_enum_int(
             }
         }
 
-        // #[cfg(any(test, feature = "testutils"))]
-        // impl #path::TryFromVal<#path::Env, #path::xdr::ScVal> for #enum_ident {
-        //     type Error = #path::xdr::Error;
-        //     #[inline(always)]
-        //     fn try_from_val(env: &#path::Env, val: #path::xdr::ScVal) -> Result<Self, Self::Error> {
-        //         let discriminant: u32 = val.try_into().map_err(|_| #path::xdr::Error::Invalid)?;
-        //         Ok(match discriminant {
-        //             #(#try_froms,)*
-        //             _ => Err(#path::xdr::Error::Invalid)?,
-        //         })
-        //     }
-        // }
-
         #[cfg(any(test, feature = "testutils"))]
         impl #path::TryIntoVal<#path::Env, #enum_ident> for #path::xdr::ScVal {
             type Error = #path::xdr::Error;
             #[inline(always)]
             fn try_into_val(self, env: &#path::Env) -> Result<#enum_ident, Self::Error> {
-                // <_ as #path::TryFromVal<_, _>>::try_from_val(env, self)
                 let discriminant: u32 = self.try_into().map_err(|_| #path::xdr::Error::Invalid)?;
                 Ok(match discriminant {
                     #(#try_froms,)*

--- a/soroban-sdk-macros/src/derive_error_enum_int.rs
+++ b/soroban-sdk-macros/src/derive_error_enum_int.rs
@@ -43,7 +43,7 @@ pub fn derive_type_error_enum_int(
                 name: name.try_into().unwrap_or_else(|_| StringM::default()),
                 value: discriminant,
             };
-            let try_from = quote! { #discriminant => #enum_ident::#ident };
+            let try_from = quote! { #discriminant => Self::#ident };
             let into =
                 quote! { #enum_ident::#ident => #path::Status::from_contract_error(#discriminant) };
             (spec_case, try_from, into)

--- a/soroban-sdk-macros/src/derive_error_enum_int.rs
+++ b/soroban-sdk-macros/src/derive_error_enum_int.rs
@@ -43,7 +43,7 @@ pub fn derive_type_error_enum_int(
                 name: name.try_into().unwrap_or_else(|_| StringM::default()),
                 value: discriminant,
             };
-            let try_from = quote! { #discriminant => Self::#ident };
+            let try_from = quote! { #discriminant => #enum_ident::#ident };
             let into =
                 quote! { #enum_ident::#ident => #path::Status::from_contract_error(#discriminant) };
             (spec_case, try_from, into)

--- a/soroban-sdk-macros/src/derive_error_enum_int.rs
+++ b/soroban-sdk-macros/src/derive_error_enum_int.rs
@@ -125,21 +125,10 @@ pub fn derive_type_error_enum_int(
             }
         }
 
-        // impl #path::TryFromVal<#path::Env, #path::RawVal> for #enum_ident {
-        //     type Error = #path::ConversionError;
-        //     #[inline(always)]
-        //     fn try_from_val(env: &#path::Env, val: #path::RawVal) -> Result<Self, Self::Error> {
-        //         use #path::TryIntoVal;
-        //         let status: #path::Status = val.try_into_val(env)?;
-        //         status.try_into().map_err(|_| #path::ConversionError)
-        //     }
-        // }
-
         impl #path::TryIntoVal<#path::Env, #enum_ident> for #path::RawVal {
             type Error = #path::ConversionError;
             #[inline(always)]
             fn try_into_val(self, env: &#path::Env) -> Result<#enum_ident, Self::Error> {
-                // <_ as #path::TryFromVal<_, _>>::try_from_val(env, self)
                 use #path::TryIntoVal;
                 let status: #path::Status = self.try_into_val(env)?;
                 status.try_into().map_err(|_| #path::ConversionError)

--- a/soroban-sdk-macros/src/derive_error_enum_int.rs
+++ b/soroban-sdk-macros/src/derive_error_enum_int.rs
@@ -125,21 +125,24 @@ pub fn derive_type_error_enum_int(
             }
         }
 
-        impl #path::TryFromVal<#path::Env, #path::RawVal> for #enum_ident {
-            type Error = #path::ConversionError;
-            #[inline(always)]
-            fn try_from_val(env: &#path::Env, val: #path::RawVal) -> Result<Self, Self::Error> {
-                use #path::TryIntoVal;
-                let status: #path::Status = val.try_into_val(env)?;
-                status.try_into().map_err(|_| #path::ConversionError)
-            }
-        }
+        // impl #path::TryFromVal<#path::Env, #path::RawVal> for #enum_ident {
+        //     type Error = #path::ConversionError;
+        //     #[inline(always)]
+        //     fn try_from_val(env: &#path::Env, val: #path::RawVal) -> Result<Self, Self::Error> {
+        //         use #path::TryIntoVal;
+        //         let status: #path::Status = val.try_into_val(env)?;
+        //         status.try_into().map_err(|_| #path::ConversionError)
+        //     }
+        // }
 
         impl #path::TryIntoVal<#path::Env, #enum_ident> for #path::RawVal {
             type Error = #path::ConversionError;
             #[inline(always)]
             fn try_into_val(self, env: &#path::Env) -> Result<#enum_ident, Self::Error> {
-                <_ as #path::TryFromVal<_, _>>::try_from_val(env, self)
+                // <_ as #path::TryFromVal<_, _>>::try_from_val(env, self)
+                use #path::TryIntoVal;
+                let status: #path::Status = self.try_into_val(env)?;
+                status.try_into().map_err(|_| #path::ConversionError)
             }
         }
 

--- a/soroban-sdk-macros/src/derive_fn.rs
+++ b/soroban-sdk-macros/src/derive_fn.rs
@@ -96,10 +96,6 @@ pub fn derive_fn(
                 });
                 let call = quote! {
                     <_ as soroban_sdk::unwrap::UnwrapOptimized>::unwrap_optimized(
-                        // <_ as soroban_sdk::TryFromVal<soroban_sdk::Env, soroban_sdk::RawVal>>::try_from_val(
-                        //     &env,
-                        //     #ident
-                        // )
                         <soroban_sdk::RawVal as soroban_sdk::TryIntoVal<soroban_sdk::Env, _>>::try_into_val(#ident, &env)
                     )
                 };

--- a/soroban-sdk-macros/src/derive_fn.rs
+++ b/soroban-sdk-macros/src/derive_fn.rs
@@ -65,14 +65,17 @@ pub fn derive_fn(
                     Ok(type_) => {
                         let name = name.try_into().unwrap_or_else(|_| {
                             const MAX: u32 = 30;
-                            errors.push(Error::new(ident.span(), format!("argument name too long, max length {} characters", MAX)));
+                            errors.push(Error::new(
+                                ident.span(),
+                                format!("argument name too long, max length {} characters", MAX),
+                            ));
                             StringM::<MAX>::default()
                         });
-                        ScSpecFunctionInputV0{ name, type_ }
-                    },
+                        ScSpecFunctionInputV0 { name, type_ }
+                    }
                     Err(e) => {
                         errors.push(e);
-                        ScSpecFunctionInputV0{
+                        ScSpecFunctionInputV0 {
                             name: "arg".try_into().unwrap(),
                             type_: ScSpecTypeDef::I32,
                         }
@@ -93,17 +96,25 @@ pub fn derive_fn(
                 });
                 let call = quote! {
                     <_ as soroban_sdk::unwrap::UnwrapOptimized>::unwrap_optimized(
-                        <_ as soroban_sdk::TryFromVal<soroban_sdk::Env, soroban_sdk::RawVal>>::try_from_val(
-                            &env,
-                            #ident
-                        )
+                        // <_ as soroban_sdk::TryFromVal<soroban_sdk::Env, soroban_sdk::RawVal>>::try_from_val(
+                        //     &env,
+                        //     #ident
+                        // )
+                        <_ as soroban_sdk::TryIntoVal<_, _>>::try_into_val(#ident, &env)
                     )
                 };
                 (spec, arg, call)
             }
             FnArg::Receiver(_) => {
                 errors.push(Error::new(a.span(), "self argument not supported"));
-                (ScSpecFunctionInputV0{ name: "".try_into().unwrap(), type_: ScSpecTypeDef::I32 } , a.clone(), quote! {})
+                (
+                    ScSpecFunctionInputV0 {
+                        name: "".try_into().unwrap(),
+                        type_: ScSpecTypeDef::I32,
+                    },
+                    a.clone(),
+                    quote! {},
+                )
             }
         })
         .multiunzip();

--- a/soroban-sdk-macros/src/derive_fn.rs
+++ b/soroban-sdk-macros/src/derive_fn.rs
@@ -100,7 +100,7 @@ pub fn derive_fn(
                         //     &env,
                         //     #ident
                         // )
-                        <_ as soroban_sdk::TryIntoVal<_, _>>::try_into_val(#ident, &env)
+                        <soroban_sdk::RawVal as soroban_sdk::TryIntoVal<soroban_sdk::Env, _>>::try_into_val(#ident, &env)
                     )
                 };
                 (spec, arg, call)

--- a/soroban-sdk-macros/src/derive_struct.rs
+++ b/soroban-sdk-macros/src/derive_struct.rs
@@ -60,7 +60,7 @@ pub fn derive_type_struct(
                     Err(#path::ConversionError)?
                 }
             };
-            
+
             let into = quote! { map.set(#map_key, (&self.#ident).into_val(env)) };
             let try_from_xdr = quote! {
                 #ident: {
@@ -115,26 +115,10 @@ pub fn derive_type_struct(
     quote! {
         #spec_gen
 
-        // impl #path::TryFromVal<#path::Env, #path::RawVal> for #ident {
-        //     type Error = #path::ConversionError;
-        //     #[inline(always)]
-        //     fn try_from_val(env: &#path::Env, val: #path::RawVal) -> Result<Self, Self::Error> {
-        //         use #path::TryIntoVal;
-        //         let map: #path::Map<#path::Symbol, #path::RawVal> = val.try_into_val(env)?;
-        //         if map.len() != #field_count_u32 {
-        //             return Err(#path::ConversionError);
-        //         }
-        //         Ok(Self{
-        //             #(#try_froms,)*
-        //         })
-        //     }
-        // }
-
         impl #path::TryIntoVal<#path::Env, #ident> for #path::RawVal {
             type Error = #path::ConversionError;
             #[inline(always)]
             fn try_into_val(self, env: &#path::Env) -> Result<#ident, Self::Error> {
-                // <_ as #path::TryFromVal<_, _>>::try_from_val(env, self)
                 use #path::TryIntoVal;
                 let map: #path::Map<#path::Symbol, #path::RawVal> = self.try_into_val(env)?;
                 if map.len() != #field_count_u32 {
@@ -164,30 +148,11 @@ pub fn derive_type_struct(
             }
         }
 
-        // #[cfg(any(test, feature = "testutils"))]
-        // impl #path::TryFromVal<#path::Env, #path::xdr::ScMap> for #ident {
-        //     type Error = #path::xdr::Error;
-        //     #[inline(always)]
-        //     fn try_from_val(env: &#path::Env, val: #path::xdr::ScMap) -> Result<Self, Self::Error> {
-        //         use #path::xdr::Validate;
-        //         use #path::TryIntoVal;
-        //         let map = val;
-        //         if map.len() != #field_count_usize {
-        //             return Err(#path::xdr::Error::Invalid);
-        //         }
-        //         map.validate()?;
-        //         Ok(Self{
-        //             #(#try_from_xdrs,)*
-        //         })
-        //     }
-        // }
-
         #[cfg(any(test, feature = "testutils"))]
         impl #path::TryIntoVal<#path::Env, #ident> for #path::xdr::ScMap {
             type Error = #path::xdr::Error;
             #[inline(always)]
             fn try_into_val(self, env: &#path::Env) -> Result<#ident, Self::Error> {
-                // <_ as #path::TryFromVal<_, _>>::try_from_val(env, self)
                 use #path::xdr::Validate;
                 use #path::TryIntoVal;
                 let map = self;
@@ -201,25 +166,11 @@ pub fn derive_type_struct(
             }
         }
 
-        // #[cfg(any(test, feature = "testutils"))]
-        // impl #path::TryFromVal<#path::Env, #path::xdr::ScObject> for #ident {
-        //     type Error = #path::xdr::Error;
-        //     #[inline(always)]
-        //     fn try_from_val(env: &#path::Env, val: #path::xdr::ScObject) -> Result<Self, Self::Error> {
-        //         if let #path::xdr::ScObject::Map(map) = val {
-        //             <_ as #path::TryFromVal<_, _>>::try_from_val(env, map)
-        //         } else {
-        //             Err(#path::xdr::Error::Invalid)
-        //         }
-        //     }
-        // }
-
         #[cfg(any(test, feature = "testutils"))]
         impl #path::TryIntoVal<#path::Env, #ident> for #path::xdr::ScObject {
             type Error = #path::xdr::Error;
             #[inline(always)]
             fn try_into_val(self, env: &#path::Env) -> Result<#ident, Self::Error> {
-                // <_ as #path::TryFromVal<_, _>>::try_from_val(env, self)
                 if let #path::xdr::ScObject::Map(map) = self {
                     <_ as #path::TryIntoVal<_, _>>::try_into_val(map, env)
                 } else {
@@ -228,25 +179,11 @@ pub fn derive_type_struct(
             }
         }
 
-        // #[cfg(any(test, feature = "testutils"))]
-        // impl #path::TryFromVal<#path::Env, #path::xdr::ScVal> for #ident {
-        //     type Error = #path::xdr::Error;
-        //     #[inline(always)]
-        //     fn try_from_val(env: &#path::Env, val: #path::xdr::ScVal) -> Result<Self, Self::Error> {
-        //         if let #path::xdr::ScVal::Object(Some(obj)) = val {
-        //             <_ as #path::TryFromVal<_, _>>::try_from_val(env, obj)
-        //         } else {
-        //             Err(#path::xdr::Error::Invalid)
-        //         }
-        //     }
-        // }
-
         #[cfg(any(test, feature = "testutils"))]
         impl #path::TryIntoVal<#path::Env, #ident> for #path::xdr::ScVal {
             type Error = #path::xdr::Error;
             #[inline(always)]
             fn try_into_val(self, env: &#path::Env) -> Result<#ident, Self::Error> {
-                // <_ as #path::TryFromVal<_, _>>::try_from_val(env, self)
                 if let #path::xdr::ScVal::Object(Some(obj)) = self {
                     <_ as #path::TryIntoVal<_, _>>::try_into_val(obj, env)
                 } else {

--- a/soroban-sdk-macros/src/derive_struct.rs
+++ b/soroban-sdk-macros/src/derive_struct.rs
@@ -114,26 +114,34 @@ pub fn derive_type_struct(
     quote! {
         #spec_gen
 
-        impl #path::TryFromVal<#path::Env, #path::RawVal> for #ident {
+        // impl #path::TryFromVal<#path::Env, #path::RawVal> for #ident {
+        //     type Error = #path::ConversionError;
+        //     #[inline(always)]
+        //     fn try_from_val(env: &#path::Env, val: #path::RawVal) -> Result<Self, Self::Error> {
+        //         use #path::TryIntoVal;
+        //         let map: #path::Map<#path::Symbol, #path::RawVal> = val.try_into_val(env)?;
+        //         if map.len() != #field_count_u32 {
+        //             return Err(#path::ConversionError);
+        //         }
+        //         Ok(Self{
+        //             #(#try_froms,)*
+        //         })
+        //     }
+        // }
+
+        impl #path::TryIntoVal<#path::Env, #ident> for #path::RawVal {
             type Error = #path::ConversionError;
             #[inline(always)]
-            fn try_from_val(env: &#path::Env, val: #path::RawVal) -> Result<Self, Self::Error> {
+            fn try_into_val(self, env: &#path::Env) -> Result<#ident, Self::Error> {
+                // <_ as #path::TryFromVal<_, _>>::try_from_val(env, self)
                 use #path::TryIntoVal;
-                let map: #path::Map<#path::Symbol, #path::RawVal> = val.try_into_val(env)?;
+                let map: #path::Map<#path::Symbol, #path::RawVal> = self.try_into_val(env)?;
                 if map.len() != #field_count_u32 {
                     return Err(#path::ConversionError);
                 }
                 Ok(Self{
                     #(#try_froms,)*
                 })
-            }
-        }
-
-        impl #path::TryIntoVal<#path::Env, #ident> for #path::RawVal {
-            type Error = #path::ConversionError;
-            #[inline(always)]
-            fn try_into_val(self, env: &#path::Env) -> Result<#ident, Self::Error> {
-                <_ as #path::TryFromVal<_, _>>::try_from_val(env, self)
             }
         }
 
@@ -155,14 +163,33 @@ pub fn derive_type_struct(
             }
         }
 
+        // #[cfg(any(test, feature = "testutils"))]
+        // impl #path::TryFromVal<#path::Env, #path::xdr::ScMap> for #ident {
+        //     type Error = #path::xdr::Error;
+        //     #[inline(always)]
+        //     fn try_from_val(env: &#path::Env, val: #path::xdr::ScMap) -> Result<Self, Self::Error> {
+        //         use #path::xdr::Validate;
+        //         use #path::TryIntoVal;
+        //         let map = val;
+        //         if map.len() != #field_count_usize {
+        //             return Err(#path::xdr::Error::Invalid);
+        //         }
+        //         map.validate()?;
+        //         Ok(Self{
+        //             #(#try_from_xdrs,)*
+        //         })
+        //     }
+        // }
+
         #[cfg(any(test, feature = "testutils"))]
-        impl #path::TryFromVal<#path::Env, #path::xdr::ScMap> for #ident {
+        impl #path::TryIntoVal<#path::Env, #ident> for #path::xdr::ScMap {
             type Error = #path::xdr::Error;
             #[inline(always)]
-            fn try_from_val(env: &#path::Env, val: #path::xdr::ScMap) -> Result<Self, Self::Error> {
+            fn try_into_val(self, env: &#path::Env) -> Result<#ident, Self::Error> {
+                // <_ as #path::TryFromVal<_, _>>::try_from_val(env, self)
                 use #path::xdr::Validate;
                 use #path::TryIntoVal;
-                let map = val;
+                let map = self;
                 if map.len() != #field_count_usize {
                     return Err(#path::xdr::Error::Invalid);
                 }
@@ -173,56 +200,57 @@ pub fn derive_type_struct(
             }
         }
 
-        #[cfg(any(test, feature = "testutils"))]
-        impl #path::TryIntoVal<#path::Env, #ident> for #path::xdr::ScMap {
-            type Error = #path::xdr::Error;
-            #[inline(always)]
-            fn try_into_val(self, env: &#path::Env) -> Result<#ident, Self::Error> {
-                <_ as #path::TryFromVal<_, _>>::try_from_val(env, self)
-            }
-        }
-
-        #[cfg(any(test, feature = "testutils"))]
-        impl #path::TryFromVal<#path::Env, #path::xdr::ScObject> for #ident {
-            type Error = #path::xdr::Error;
-            #[inline(always)]
-            fn try_from_val(env: &#path::Env, val: #path::xdr::ScObject) -> Result<Self, Self::Error> {
-                if let #path::xdr::ScObject::Map(map) = val {
-                    <_ as #path::TryFromVal<_, _>>::try_from_val(env, map)
-                } else {
-                    Err(#path::xdr::Error::Invalid)
-                }
-            }
-        }
+        // #[cfg(any(test, feature = "testutils"))]
+        // impl #path::TryFromVal<#path::Env, #path::xdr::ScObject> for #ident {
+        //     type Error = #path::xdr::Error;
+        //     #[inline(always)]
+        //     fn try_from_val(env: &#path::Env, val: #path::xdr::ScObject) -> Result<Self, Self::Error> {
+        //         if let #path::xdr::ScObject::Map(map) = val {
+        //             <_ as #path::TryFromVal<_, _>>::try_from_val(env, map)
+        //         } else {
+        //             Err(#path::xdr::Error::Invalid)
+        //         }
+        //     }
+        // }
 
         #[cfg(any(test, feature = "testutils"))]
         impl #path::TryIntoVal<#path::Env, #ident> for #path::xdr::ScObject {
             type Error = #path::xdr::Error;
             #[inline(always)]
             fn try_into_val(self, env: &#path::Env) -> Result<#ident, Self::Error> {
-                <_ as #path::TryFromVal<_, _>>::try_from_val(env, self)
-            }
-        }
-
-        #[cfg(any(test, feature = "testutils"))]
-        impl #path::TryFromVal<#path::Env, #path::xdr::ScVal> for #ident {
-            type Error = #path::xdr::Error;
-            #[inline(always)]
-            fn try_from_val(env: &#path::Env, val: #path::xdr::ScVal) -> Result<Self, Self::Error> {
-                if let #path::xdr::ScVal::Object(Some(obj)) = val {
-                    <_ as #path::TryFromVal<_, _>>::try_from_val(env, obj)
+                // <_ as #path::TryFromVal<_, _>>::try_from_val(env, self)
+                if let #path::xdr::ScObject::Map(map) = self {
+                    <_ as #path::TryIntoVal<_, _>>::try_into_val(map, env)
                 } else {
                     Err(#path::xdr::Error::Invalid)
                 }
             }
         }
 
+        // #[cfg(any(test, feature = "testutils"))]
+        // impl #path::TryFromVal<#path::Env, #path::xdr::ScVal> for #ident {
+        //     type Error = #path::xdr::Error;
+        //     #[inline(always)]
+        //     fn try_from_val(env: &#path::Env, val: #path::xdr::ScVal) -> Result<Self, Self::Error> {
+        //         if let #path::xdr::ScVal::Object(Some(obj)) = val {
+        //             <_ as #path::TryFromVal<_, _>>::try_from_val(env, obj)
+        //         } else {
+        //             Err(#path::xdr::Error::Invalid)
+        //         }
+        //     }
+        // }
+
         #[cfg(any(test, feature = "testutils"))]
         impl #path::TryIntoVal<#path::Env, #ident> for #path::xdr::ScVal {
             type Error = #path::xdr::Error;
             #[inline(always)]
             fn try_into_val(self, env: &#path::Env) -> Result<#ident, Self::Error> {
-                <_ as #path::TryFromVal<_, _>>::try_from_val(env, self)
+                // <_ as #path::TryFromVal<_, _>>::try_from_val(env, self)
+                if let #path::xdr::ScVal::Object(Some(obj)) = self {
+                    <_ as #path::TryIntoVal<_, _>>::try_into_val(obj, env)
+                } else {
+                    Err(#path::xdr::Error::Invalid)
+                }
             }
         }
 
@@ -232,7 +260,7 @@ pub fn derive_type_struct(
             #[inline(always)]
             fn try_into(self) -> Result<#path::xdr::ScMap, Self::Error> {
                 extern crate alloc;
-                use #path::TryFromVal;
+                // use #path::TryFromVal;
                 #path::xdr::ScMap::sorted_from(alloc::vec![
                     #(#into_xdrs,)*
                 ])

--- a/soroban-sdk-macros/src/derive_struct.rs
+++ b/soroban-sdk-macros/src/derive_struct.rs
@@ -60,6 +60,7 @@ pub fn derive_type_struct(
                     Err(#path::ConversionError)?
                 }
             };
+            
             let into = quote! { map.set(#map_key, (&self.#ident).into_val(env)) };
             let try_from_xdr = quote! {
                 #ident: {
@@ -139,7 +140,7 @@ pub fn derive_type_struct(
                 if map.len() != #field_count_u32 {
                     return Err(#path::ConversionError);
                 }
-                Ok(Self{
+                Ok(#ident{
                     #(#try_froms,)*
                 })
             }
@@ -194,7 +195,7 @@ pub fn derive_type_struct(
                     return Err(#path::xdr::Error::Invalid);
                 }
                 map.validate()?;
-                Ok(Self{
+                Ok(#ident{
                     #(#try_from_xdrs,)*
                 })
             }

--- a/soroban-sdk-macros/src/derive_struct_tuple.rs
+++ b/soroban-sdk-macros/src/derive_struct_tuple.rs
@@ -127,7 +127,7 @@ pub fn derive_type_struct_tuple(
                 if vec.len() != #field_count_u32 {
                     return Err(#path::ConversionError);
                 }
-                Ok(Self{
+                Ok(#ident{
                     #(#try_froms,)*
                 })
             }
@@ -180,7 +180,7 @@ pub fn derive_type_struct_tuple(
                 if vec.len() != #field_count_usize {
                     return Err(#path::xdr::Error::Invalid);
                 }
-                Ok(Self{
+                Ok(#ident{
                     #(#try_from_xdrs,)*
                 })
             }

--- a/soroban-sdk-macros/src/derive_struct_tuple.rs
+++ b/soroban-sdk-macros/src/derive_struct_tuple.rs
@@ -102,26 +102,10 @@ pub fn derive_type_struct_tuple(
     quote! {
         #spec_gen
 
-        // impl #path::TryFromVal<#path::Env, #path::RawVal> for #ident {
-        //     type Error = #path::ConversionError;
-        //     #[inline(always)]
-        //     fn try_from_val(env: &#path::Env, val: #path::RawVal) -> Result<Self, Self::Error> {
-        //         use #path::TryIntoVal;
-        //         let vec: #path::Vec<#path::RawVal> = val.try_into_val(env)?;
-        //         if vec.len() != #field_count_u32 {
-        //             return Err(#path::ConversionError);
-        //         }
-        //         Ok(Self{
-        //             #(#try_froms,)*
-        //         })
-        //     }
-        // }
-
         impl #path::TryIntoVal<#path::Env, #ident> for #path::RawVal {
             type Error = #path::ConversionError;
             #[inline(always)]
             fn try_into_val(self, env: &#path::Env) -> Result<#ident, Self::Error> {
-                // <_ as #path::TryFromVal<_, _>>::try_from_val(env, self)
                 use #path::TryIntoVal;
                 let vec: #path::Vec<#path::RawVal> = self.try_into_val(env)?;
                 if vec.len() != #field_count_u32 {
@@ -151,29 +135,11 @@ pub fn derive_type_struct_tuple(
             }
         }
 
-        // #[cfg(any(test, feature = "testutils"))]
-        // impl #path::TryFromVal<#path::Env, #path::xdr::ScVec> for #ident {
-        //     type Error = #path::xdr::Error;
-        //     #[inline(always)]
-        //     fn try_from_val(env: &#path::Env, val: #path::xdr::ScVec) -> Result<Self, Self::Error> {
-        //         use #path::xdr::Validate;
-        //         use #path::TryIntoVal;
-        //         let vec = val;
-        //         if vec.len() != #field_count_usize {
-        //             return Err(#path::xdr::Error::Invalid);
-        //         }
-        //         Ok(Self{
-        //             #(#try_from_xdrs,)*
-        //         })
-        //     }
-        // }
-
         #[cfg(any(test, feature = "testutils"))]
         impl #path::TryIntoVal<#path::Env, #ident> for #path::xdr::ScVec {
             type Error = #path::xdr::Error;
             #[inline(always)]
             fn try_into_val(self, env: &#path::Env) -> Result<#ident, Self::Error> {
-                // <_ as #path::TryFromVal<_, _>>::try_from_val(env, self)
                 use #path::xdr::Validate;
                 use #path::TryIntoVal;
                 let vec = self;
@@ -186,27 +152,12 @@ pub fn derive_type_struct_tuple(
             }
         }
 
-        // #[cfg(any(test, feature = "testutils"))]
-        // impl #path::TryFromVal<#path::Env, #path::xdr::ScObject> for #ident {
-        //     type Error = #path::xdr::Error;
-        //     #[inline(always)]
-        //     fn try_from_val(env: &#path::Env, val: #path::xdr::ScObject) -> Result<Self, Self::Error> {
-        //         if let #path::xdr::ScObject::Vec(map) = val {
-        //             <_ as #path::TryFromVal<_, _>>::try_from_val(env, map)
-        //         } else {
-        //             Err(#path::xdr::Error::Invalid)
-        //         }
-        //     }
-        // }
-
         #[cfg(any(test, feature = "testutils"))]
         impl #path::TryIntoVal<#path::Env, #ident> for #path::xdr::ScObject {
             type Error = #path::xdr::Error;
             #[inline(always)]
             fn try_into_val(self, env: &#path::Env) -> Result<#ident, Self::Error> {
-                // <_ as #path::TryFromVal<_, _>>::try_from_val(env, self)
                 if let #path::xdr::ScObject::Vec(map) = self {
-                    // <_ as #path::TryFromVal<_, _>>::try_from_val(env, map)
                     <_ as #path::TryIntoVal<_, _>>::try_into_val(map, env)
                 } else {
                     Err(#path::xdr::Error::Invalid)
@@ -214,27 +165,12 @@ pub fn derive_type_struct_tuple(
             }
         }
 
-        // #[cfg(any(test, feature = "testutils"))]
-        // impl #path::TryFromVal<#path::Env, #path::xdr::ScVal> for #ident {
-        //     type Error = #path::xdr::Error;
-        //     #[inline(always)]
-        //     fn try_from_val(env: &#path::Env, val: #path::xdr::ScVal) -> Result<Self, Self::Error> {
-        //         if let #path::xdr::ScVal::Object(Some(obj)) = val {
-        //             <_ as #path::TryFromVal<_, _>>::try_from_val(env, obj)
-        //         } else {
-        //             Err(#path::xdr::Error::Invalid)
-        //         }
-        //     }
-        // }
-
         #[cfg(any(test, feature = "testutils"))]
         impl #path::TryIntoVal<#path::Env, #ident> for #path::xdr::ScVal {
             type Error = #path::xdr::Error;
             #[inline(always)]
             fn try_into_val(self, env: &#path::Env) -> Result<#ident, Self::Error> {
-                // <_ as #path::TryFromVal<_, _>>::try_from_val(env, self)
                 if let #path::xdr::ScVal::Object(Some(obj)) = self {
-                    // <_ as #path::TryFromVal<_, _>>::try_from_val(env, obj)
                     <_ as #path::TryIntoVal<_, _>>::try_into_val(obj, env)
                 } else {
                     Err(#path::xdr::Error::Invalid)

--- a/soroban-sdk-macros/src/derive_struct_tuple.rs
+++ b/soroban-sdk-macros/src/derive_struct_tuple.rs
@@ -102,26 +102,34 @@ pub fn derive_type_struct_tuple(
     quote! {
         #spec_gen
 
-        impl #path::TryFromVal<#path::Env, #path::RawVal> for #ident {
+        // impl #path::TryFromVal<#path::Env, #path::RawVal> for #ident {
+        //     type Error = #path::ConversionError;
+        //     #[inline(always)]
+        //     fn try_from_val(env: &#path::Env, val: #path::RawVal) -> Result<Self, Self::Error> {
+        //         use #path::TryIntoVal;
+        //         let vec: #path::Vec<#path::RawVal> = val.try_into_val(env)?;
+        //         if vec.len() != #field_count_u32 {
+        //             return Err(#path::ConversionError);
+        //         }
+        //         Ok(Self{
+        //             #(#try_froms,)*
+        //         })
+        //     }
+        // }
+
+        impl #path::TryIntoVal<#path::Env, #ident> for #path::RawVal {
             type Error = #path::ConversionError;
             #[inline(always)]
-            fn try_from_val(env: &#path::Env, val: #path::RawVal) -> Result<Self, Self::Error> {
+            fn try_into_val(self, env: &#path::Env) -> Result<#ident, Self::Error> {
+                // <_ as #path::TryFromVal<_, _>>::try_from_val(env, self)
                 use #path::TryIntoVal;
-                let vec: #path::Vec<#path::RawVal> = val.try_into_val(env)?;
+                let vec: #path::Vec<#path::RawVal> = self.try_into_val(env)?;
                 if vec.len() != #field_count_u32 {
                     return Err(#path::ConversionError);
                 }
                 Ok(Self{
                     #(#try_froms,)*
                 })
-            }
-        }
-
-        impl #path::TryIntoVal<#path::Env, #ident> for #path::RawVal {
-            type Error = #path::ConversionError;
-            #[inline(always)]
-            fn try_into_val(self, env: &#path::Env) -> Result<#ident, Self::Error> {
-                <_ as #path::TryFromVal<_, _>>::try_from_val(env, self)
             }
         }
 
@@ -143,14 +151,32 @@ pub fn derive_type_struct_tuple(
             }
         }
 
+        // #[cfg(any(test, feature = "testutils"))]
+        // impl #path::TryFromVal<#path::Env, #path::xdr::ScVec> for #ident {
+        //     type Error = #path::xdr::Error;
+        //     #[inline(always)]
+        //     fn try_from_val(env: &#path::Env, val: #path::xdr::ScVec) -> Result<Self, Self::Error> {
+        //         use #path::xdr::Validate;
+        //         use #path::TryIntoVal;
+        //         let vec = val;
+        //         if vec.len() != #field_count_usize {
+        //             return Err(#path::xdr::Error::Invalid);
+        //         }
+        //         Ok(Self{
+        //             #(#try_from_xdrs,)*
+        //         })
+        //     }
+        // }
+
         #[cfg(any(test, feature = "testutils"))]
-        impl #path::TryFromVal<#path::Env, #path::xdr::ScVec> for #ident {
+        impl #path::TryIntoVal<#path::Env, #ident> for #path::xdr::ScVec {
             type Error = #path::xdr::Error;
             #[inline(always)]
-            fn try_from_val(env: &#path::Env, val: #path::xdr::ScVec) -> Result<Self, Self::Error> {
+            fn try_into_val(self, env: &#path::Env) -> Result<#ident, Self::Error> {
+                // <_ as #path::TryFromVal<_, _>>::try_from_val(env, self)
                 use #path::xdr::Validate;
                 use #path::TryIntoVal;
-                let vec = val;
+                let vec = self;
                 if vec.len() != #field_count_usize {
                     return Err(#path::xdr::Error::Invalid);
                 }
@@ -160,56 +186,59 @@ pub fn derive_type_struct_tuple(
             }
         }
 
-        #[cfg(any(test, feature = "testutils"))]
-        impl #path::TryIntoVal<#path::Env, #ident> for #path::xdr::ScVec {
-            type Error = #path::xdr::Error;
-            #[inline(always)]
-            fn try_into_val(self, env: &#path::Env) -> Result<#ident, Self::Error> {
-                <_ as #path::TryFromVal<_, _>>::try_from_val(env, self)
-            }
-        }
-
-        #[cfg(any(test, feature = "testutils"))]
-        impl #path::TryFromVal<#path::Env, #path::xdr::ScObject> for #ident {
-            type Error = #path::xdr::Error;
-            #[inline(always)]
-            fn try_from_val(env: &#path::Env, val: #path::xdr::ScObject) -> Result<Self, Self::Error> {
-                if let #path::xdr::ScObject::Vec(map) = val {
-                    <_ as #path::TryFromVal<_, _>>::try_from_val(env, map)
-                } else {
-                    Err(#path::xdr::Error::Invalid)
-                }
-            }
-        }
+        // #[cfg(any(test, feature = "testutils"))]
+        // impl #path::TryFromVal<#path::Env, #path::xdr::ScObject> for #ident {
+        //     type Error = #path::xdr::Error;
+        //     #[inline(always)]
+        //     fn try_from_val(env: &#path::Env, val: #path::xdr::ScObject) -> Result<Self, Self::Error> {
+        //         if let #path::xdr::ScObject::Vec(map) = val {
+        //             <_ as #path::TryFromVal<_, _>>::try_from_val(env, map)
+        //         } else {
+        //             Err(#path::xdr::Error::Invalid)
+        //         }
+        //     }
+        // }
 
         #[cfg(any(test, feature = "testutils"))]
         impl #path::TryIntoVal<#path::Env, #ident> for #path::xdr::ScObject {
             type Error = #path::xdr::Error;
             #[inline(always)]
             fn try_into_val(self, env: &#path::Env) -> Result<#ident, Self::Error> {
-                <_ as #path::TryFromVal<_, _>>::try_from_val(env, self)
-            }
-        }
-
-        #[cfg(any(test, feature = "testutils"))]
-        impl #path::TryFromVal<#path::Env, #path::xdr::ScVal> for #ident {
-            type Error = #path::xdr::Error;
-            #[inline(always)]
-            fn try_from_val(env: &#path::Env, val: #path::xdr::ScVal) -> Result<Self, Self::Error> {
-                if let #path::xdr::ScVal::Object(Some(obj)) = val {
-                    <_ as #path::TryFromVal<_, _>>::try_from_val(env, obj)
+                // <_ as #path::TryFromVal<_, _>>::try_from_val(env, self)
+                if let #path::xdr::ScObject::Vec(map) = self {
+                    // <_ as #path::TryFromVal<_, _>>::try_from_val(env, map)
+                    <_ as #path::TryIntoVal<_, _>>::try_into_val(map, env)
                 } else {
                     Err(#path::xdr::Error::Invalid)
                 }
             }
         }
 
+        // #[cfg(any(test, feature = "testutils"))]
+        // impl #path::TryFromVal<#path::Env, #path::xdr::ScVal> for #ident {
+        //     type Error = #path::xdr::Error;
+        //     #[inline(always)]
+        //     fn try_from_val(env: &#path::Env, val: #path::xdr::ScVal) -> Result<Self, Self::Error> {
+        //         if let #path::xdr::ScVal::Object(Some(obj)) = val {
+        //             <_ as #path::TryFromVal<_, _>>::try_from_val(env, obj)
+        //         } else {
+        //             Err(#path::xdr::Error::Invalid)
+        //         }
+        //     }
+        // }
+
         #[cfg(any(test, feature = "testutils"))]
         impl #path::TryIntoVal<#path::Env, #ident> for #path::xdr::ScVal {
             type Error = #path::xdr::Error;
             #[inline(always)]
             fn try_into_val(self, env: &#path::Env) -> Result<#ident, Self::Error> {
-                <_ as #path::TryFromVal<_, _>>::try_from_val(env, self)
+                // <_ as #path::TryFromVal<_, _>>::try_from_val(env, self)
+                if let #path::xdr::ScVal::Object(Some(obj)) = self {
+                    // <_ as #path::TryFromVal<_, _>>::try_from_val(env, obj)
+                    <_ as #path::TryIntoVal<_, _>>::try_into_val(obj, env)
+                } else {
+                    Err(#path::xdr::Error::Invalid)
+                }
             }
         }
 
@@ -219,7 +248,7 @@ pub fn derive_type_struct_tuple(
             #[inline(always)]
             fn try_into(self) -> Result<#path::xdr::ScVec, Self::Error> {
                 extern crate alloc;
-                use #path::TryFromVal;
+                // use #path::TryFromVal;
                 Ok(#path::xdr::ScVec(alloc::vec![
                     #(#into_xdrs,)*
                 ].try_into()?))

--- a/soroban-sdk/src/lib.rs
+++ b/soroban-sdk/src/lib.rs
@@ -591,11 +591,7 @@ pub use env::Env;
 pub use env::RawVal;
 
 /// Used to do conversions between values in the Soroban environment.
-pub use env::FromVal;
-/// Used to do conversions between values in the Soroban environment.
 pub use env::IntoVal;
-/// Used to do conversions between values in the Soroban environment.
-pub use env::TryFromVal;
 /// Used to do conversions between values in the Soroban environment.
 pub use env::TryIntoVal;
 

--- a/soroban-sdk/src/serde.rs
+++ b/soroban-sdk/src/serde.rs
@@ -8,7 +8,7 @@
 //! ```
 //! use soroban_sdk::{
 //!     serde::{Deserialize, Serialize},
-//!     Env, Bytes, IntoVal, TryFromVal,
+//!     Env, Bytes, IntoVal, TryIntoVal,
 //! };
 //!
 //! let env = Env::default();
@@ -22,7 +22,7 @@
 //! assert_eq!(roundtrip, Ok(value));
 //! ```
 
-use crate::{env::internal::Env as _, Bytes, Env, IntoVal, RawVal, TryFromVal};
+use crate::{env::internal::Env as _, Bytes, Env, IntoVal, RawVal, TryIntoVal};
 
 /// Implemented by types that can be serialized to [Bytes].
 ///
@@ -52,12 +52,13 @@ where
 
 impl<T> Deserialize for T
 where
-    T: TryFromVal<Env, RawVal>,
+    // T: TryFromVal<Env, RawVal>,
+    RawVal: TryIntoVal<Env, T>,
 {
-    type Error = T::Error;
+    type Error = <RawVal as TryIntoVal<Env, T>>::Error;
 
     fn deserialize(env: &Env, b: &Bytes) -> Result<Self, Self::Error> {
         let t = env.deserialize_from_bytes(b.into());
-        T::try_from_val(env, t)
+        t.try_into_val(env)
     }
 }

--- a/soroban-sdk/src/tests/contract_udt_enum.rs
+++ b/soroban-sdk/src/tests/contract_udt_enum.rs
@@ -1,7 +1,5 @@
 use crate as soroban_sdk;
-use soroban_sdk::{
-    contractimpl, contracttype, symbol, vec, ConversionError, Env, IntoVal, TryFromVal,
-};
+use soroban_sdk::{contractimpl, contracttype, symbol, vec, ConversionError, Env, IntoVal};
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 #[contracttype]

--- a/soroban-sdk/src/tests/contract_udt_enum.rs
+++ b/soroban-sdk/src/tests/contract_udt_enum.rs
@@ -1,5 +1,7 @@
 use crate as soroban_sdk;
-use soroban_sdk::{contractimpl, contracttype, symbol, vec, ConversionError, Env, IntoVal};
+use soroban_sdk::{
+    contractimpl, contracttype, symbol, vec, ConversionError, Env, IntoVal, TryIntoVal,
+};
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 #[contracttype]
@@ -37,10 +39,10 @@ fn test_error_on_partial_decode() {
     // variant name as a Symbol, and following elements are tuple-like values
     // for the variant.
     let vec = vec![&env, symbol!("Aaa").into_val(&env)].to_raw();
-    let udt = Udt::try_from_val(&env, vec);
+    let udt = vec.try_into_val(&env);
     assert_eq!(udt, Ok(Udt::Aaa));
     let vec = vec![&env, symbol!("Bbb").into_val(&env), 8.into()].to_raw();
-    let udt = Udt::try_from_val(&env, vec);
+    let udt = vec.try_into_val(&env);
     assert_eq!(udt, Ok(Udt::Bbb(8)));
 
     // If an enum has a tuple like variant with one value, but the vec has
@@ -48,9 +50,9 @@ fn test_error_on_partial_decode() {
     // encoding will not round trip the data, and therefore partial decoding is
     // relatively difficult to use safely.
     let vec = vec![&env, symbol!("Aaa").into_val(&env), 8.into()].to_raw();
-    let udt = Udt::try_from_val(&env, vec);
+    let udt: Result<Udt, _> = vec.try_into_val(&env);
     assert_eq!(udt, Err(ConversionError));
     let vec = vec![&env, symbol!("Bbb").into_val(&env), 8.into(), 9.into()].to_raw();
-    let udt = Udt::try_from_val(&env, vec);
+    let udt: Result<Udt, _> = vec.try_into_val(&env);
     assert_eq!(udt, Err(ConversionError));
 }

--- a/soroban-sdk/src/tests/contract_udt_struct.rs
+++ b/soroban-sdk/src/tests/contract_udt_struct.rs
@@ -1,5 +1,5 @@
 use crate as soroban_sdk;
-use soroban_sdk::{contractimpl, contracttype, map, symbol, ConversionError, Env, TryFromVal};
+use soroban_sdk::{contractimpl, contracttype, map, symbol, ConversionError, Env};
 use stellar_xdr::{
     ReadXdr, ScSpecEntry, ScSpecFunctionInputV0, ScSpecFunctionV0, ScSpecTypeDef, ScSpecTypeTuple,
     ScSpecTypeUdt,

--- a/soroban-sdk/src/tests/contract_udt_struct.rs
+++ b/soroban-sdk/src/tests/contract_udt_struct.rs
@@ -1,5 +1,5 @@
 use crate as soroban_sdk;
-use soroban_sdk::{contractimpl, contracttype, map, symbol, ConversionError, Env};
+use soroban_sdk::{contractimpl, contracttype, map, symbol, ConversionError, Env, TryIntoVal};
 use stellar_xdr::{
     ReadXdr, ScSpecEntry, ScSpecFunctionInputV0, ScSpecFunctionV0, ScSpecTypeDef, ScSpecTypeTuple,
     ScSpecTypeUdt,
@@ -39,7 +39,7 @@ fn test_error_on_partial_decode() {
     // Success case, a map will decode to a Udt if the symbol keys match the
     // fields.
     let map = map![&env, (symbol!("a"), 5), (symbol!("b"), 7)].to_raw();
-    let udt = Udt::try_from_val(&env, map);
+    let udt = map.try_into_val(&env);
     assert_eq!(udt, Ok(Udt { a: 5, b: 7 }));
 
     // If a struct has fields a, b, and a map is decoded into it where the map
@@ -53,7 +53,7 @@ fn test_error_on_partial_decode() {
         (symbol!("c"), 9)
     ]
     .to_raw();
-    let udt = Udt::try_from_val(&env, map);
+    let udt: Result<Udt, _> = map.try_into_val(&env);
     assert_eq!(udt, Err(ConversionError));
 }
 

--- a/soroban-sdk/src/tests/contract_udt_struct_tuple.rs
+++ b/soroban-sdk/src/tests/contract_udt_struct_tuple.rs
@@ -1,7 +1,6 @@
 use crate as soroban_sdk;
 use soroban_sdk::{
-    contractimpl, contracttype, vec, ConversionError, Env, IntoVal, RawVal, TryFromVal, TryIntoVal,
-    Vec,
+    contractimpl, contracttype, vec, ConversionError, Env, IntoVal, RawVal, TryIntoVal, Vec,
 };
 use stellar_xdr::{
     ReadXdr, ScSpecEntry, ScSpecFunctionInputV0, ScSpecFunctionV0, ScSpecTypeDef, ScSpecTypeTuple,

--- a/soroban-sdk/src/tests/contract_udt_struct_tuple.rs
+++ b/soroban-sdk/src/tests/contract_udt_struct_tuple.rs
@@ -46,14 +46,14 @@ fn test_error_on_partial_decode() {
 
     // Success case, a vec will decode to a Udt.
     let map = vec![&env, 5, 7].to_raw();
-    let udt = Udt::try_from_val(&env, map);
+    let udt = map.try_into_val(&env);
     assert_eq!(udt, Ok(Udt(5, 7)));
 
     // If a struct has 2 fields, and a vec is decoded into it where the vec has
     // 2 elements, it is an error. It is an error because all fields must be
     // assigned values.
     let map = vec![&env, 5, 7, 9].to_raw();
-    let udt = Udt::try_from_val(&env, map);
+    let udt: Result<Udt, _> = map.try_into_val(&env);
     assert_eq!(udt, Err(ConversionError));
 
     // If a struct has 2 fields, and a vec is decoded into it where the vec has
@@ -61,7 +61,7 @@ fn test_error_on_partial_decode() {
     // will not round trip the data, and therefore partial decoding is
     // relatively difficult to use safely.
     let map = vec![&env, 5, 7, 9].to_raw();
-    let udt = Udt::try_from_val(&env, map);
+    let udt: Result<Udt, _> = map.try_into_val(&env);
     assert_eq!(udt, Err(ConversionError));
 }
 

--- a/tests/udt/src/lib.rs
+++ b/tests/udt/src/lib.rs
@@ -53,7 +53,7 @@ impl Contract {
 #[cfg(test)]
 mod test {
     use super::*;
-    use soroban_sdk::{vec, xdr::ScVal, Bytes, BytesN, Env, TryFromVal};
+    use soroban_sdk::{vec, xdr::ScVal, Bytes, BytesN, Env, TryIntoVal};
 
     #[test]
     fn test_serializing() {
@@ -205,7 +205,7 @@ mod test {
             c: vec![&e, 1],
         };
         let val: ScVal = udt.clone().try_into().unwrap();
-        let roundtrip = UdtStruct::try_from_val(&e, val).unwrap();
+        let roundtrip = val.try_into_val(&e).unwrap();
         assert_eq!(udt, roundtrip);
     }
 }


### PR DESCRIPTION
### What

This is the sdk side changes necessary for https://github.com/stellar/rs-soroban-env/pull/623 which is a rebased version of https://github.com/stellar/rs-soroban-env/pull/600.

This won't work because it relies on the conversion between a `Result` and `RawVal`, which is commented out in  https://github.com/jayz22/rs-soroban-env/blob/aae7e792518ccd3f086586263263944ccf3d6e4c/soroban-env-common/src/lib.rs#L51-L54 due to the infinite recursion issue. 


### Why

[TODO: Why this change is being made. Include any context required to understand the why.]

### Known limitations

[TODO or N/A]
