### PR TITLE
Allow xlm balance updates

### DIFF
--- a/soroban-sdk/src/accounts.rs
+++ b/soroban-sdk/src/accounts.rs
@@ -491,6 +491,11 @@ impl testutils::Accounts for Accounts {
             })
             .unwrap();
     }
+
+    fn update_balance(&self, id: &AccountId, new_balance: i64) {
+        let id: xdr::AccountId = id.try_into().unwrap();
+        self.update_account_ledger_entry(&id, |a| a.balance = new_balance);
+    }
 }
 
 #[cfg(any(test, feature = "testutils"))]

--- a/soroban-sdk/src/accounts.rs
+++ b/soroban-sdk/src/accounts.rs
@@ -423,16 +423,23 @@ impl testutils::Accounts for Accounts {
                 let k = xdr::LedgerKey::Account(xdr::LedgerKeyAccount {
                     account_id: id.clone(),
                 });
-                let v = xdr::LedgerEntry {
-                    data: xdr::LedgerEntryData::Account(self.default_account_ledger_entry(&id)),
-                    last_modified_ledger_seq: 0,
-                    ext: xdr::LedgerEntryExt::V0,
-                };
-                storage.put(
+
+                if !storage.has(
                     &k,
-                    &v,
                     soroban_env_host::budget::AsBudget::as_budget(env.host()),
-                )
+                )? {
+                    let v = xdr::LedgerEntry {
+                        data: xdr::LedgerEntryData::Account(self.default_account_ledger_entry(&id)),
+                        last_modified_ledger_seq: 0,
+                        ext: xdr::LedgerEntryExt::V0,
+                    };
+                    storage.put(
+                        &k,
+                        &v,
+                        soroban_env_host::budget::AsBudget::as_budget(env.host()),
+                    )?
+                }
+                Ok(())
             })
             .unwrap();
     }

--- a/soroban-sdk/src/testutils.rs
+++ b/soroban-sdk/src/testutils.rs
@@ -169,6 +169,9 @@ pub trait Accounts {
 
     /// Remove an account.
     fn remove(&self, id: &crate::AccountId);
+
+    /// Updates balance
+    fn update_balance(&self, id: &crate::AccountId, new_balance: i64);
 }
 
 /// Test utilities for [`BytesN`][crate::BytesN].

--- a/soroban-sdk/src/testutils.rs
+++ b/soroban-sdk/src/testutils.rs
@@ -170,7 +170,7 @@ pub trait Accounts {
     /// Remove an account.
     fn remove(&self, id: &crate::AccountId);
 
-    /// Updates balance
+    /// Updates the native balance of a classic account.
     fn update_balance(&self, id: &crate::AccountId, new_balance: i64);
 }
 


### PR DESCRIPTION
### What

This change allows a user to set the balance of an account ledger entry to allow testing with the XLM Stellar Asset Contract. We should consider adding similar functionality for trustlines.
