### PR TITLE
WIP first pass of adapting to TryFromVal reform.

### DIFF
--- a/soroban-auth/src/lib.rs
+++ b/soroban-auth/src/lib.rs
@@ -18,9 +18,7 @@
 
 mod tests;
 
-use soroban_sdk::{
-    serde::Serialize, unwrap::UnwrapOptimized, BytesN, Env, IntoVal, RawVal, Symbol, Vec,
-};
+use soroban_sdk::{serde::Serialize, unwrap::UnwrapOptimized, BytesN, Env, RawVal, Symbol, Vec};
 
 pub mod testutils;
 
@@ -125,10 +123,14 @@ fn verify_account_signatures(env: &Env, auth: &AccountSignatures, name: Symbol, 
 /// **This function provides no replay protection. Contracts must provide their
 /// own mechanism suitable for replay prevention that prevents contract
 /// invocations to be replayable if it is important they are not.**
-pub fn verify(env: &Env, sig: &Signature, name: Symbol, args: impl IntoVal<Env, Vec<RawVal>>) {
+pub fn verify(env: &Env, sig: &Signature, name: Symbol, args: impl TryIntoVal<Env, Vec<RawVal>>) {
     match sig {
         Signature::Invoker => {}
-        Signature::Ed25519(e) => verify_ed25519_signature(env, e, name, args.into_val(env)),
-        Signature::Account(a) => verify_account_signatures(env, a, name, args.into_val(env)),
+        Signature::Ed25519(e) => {
+            verify_ed25519_signature(env, e, name, args.try_into_val(env).unwrap_optimized())
+        }
+        Signature::Account(a) => {
+            verify_account_signatures(env, a, name, args.try_into_val(env).unwrap_optimized())
+        }
     }
 }

--- a/soroban-auth/src/testutils.rs
+++ b/soroban-auth/src/testutils.rs
@@ -8,7 +8,7 @@ pub mod ed25519 {
     use core::fmt::Debug;
     use core::panic;
 
-    use soroban_sdk::{testutils::ed25519::Sign, BytesN, Env, IntoVal, RawVal, Symbol, Vec};
+    use soroban_sdk::{testutils::ed25519::Sign, BytesN, Env, RawVal, Symbol, Vec};
 
     use crate::{
         Ed25519Signature, Identifier as IdentifierValue, Signature, SignaturePayload,
@@ -66,7 +66,7 @@ pub mod ed25519 {
         signer: &(impl Identifier + Sign<SignaturePayload, Signature = [u8; 64]>),
         contract: &BytesN<32>,
         name: Symbol,
-        args: impl IntoVal<Env, Vec<RawVal>>,
+        args: impl TryIntoVal<Env, Vec<RawVal>>,
     ) -> Signature {
         let identifier = signer.identifier(env);
         let public_key = if let IdentifierValue::Ed25519(public_key) = identifier {
@@ -78,7 +78,7 @@ pub mod ed25519 {
             network: env.ledger().network_passphrase(),
             contract: contract.clone(),
             name,
-            args: args.into_val(env),
+            args: args.try_into_val(env).unwrap_optimized(),
         });
         let signature = match signer.sign(payload) {
             Ok(signature) => signature,

--- a/soroban-sdk-macros/src/derive_enum.rs
+++ b/soroban-sdk-macros/src/derive_enum.rs
@@ -72,7 +72,13 @@ pub fn derive_type_enum(
                         Self::#ident(iter.next().ok_or(#path::ConversionError)??.try_into_val(env)?)
                     }
                 };
-                let into = quote! { #enum_ident::#ident(ref value) => (#discriminant_const_sym_ident, value).into_val(env) };
+                let into = quote! {
+                    #enum_ident::#ident(ref value) => {
+                        let arr: [#path::RawVal;2] = [#discriminant_const_sym_ident.into(), value.try_into_val(env)?];
+                        Ok(#path::Vec::from_array(env, arr).into())
+
+                    }
+                };
                 let try_from_xdr = quote! {
                     #name => {
                         if iter.len() > 1 {
@@ -150,7 +156,7 @@ pub fn derive_type_enum(
         impl #path::TryFromVal<#path::Env, #path::RawVal> for #enum_ident {
             type Error = #path::ConversionError;
             #[inline(always)]
-            fn try_from_val(env: &#path::Env, val: #path::RawVal) -> Result<Self, Self::Error> {
+            fn try_from_val(env: &#path::Env, val:  &#path::RawVal) -> Result<Self, Self::Error> {
                 use #path::TryIntoVal;
                 #(#discriminant_consts)*
                 let vec: #path::Vec<#path::RawVal> = val.try_into_val(env)?;
@@ -163,29 +169,13 @@ pub fn derive_type_enum(
             }
         }
 
-        impl #path::TryIntoVal<#path::Env, #enum_ident> for #path::RawVal {
+        impl #path::TryFromVal<#path::Env, #enum_ident> for #path::RawVal {
             type Error = #path::ConversionError;
             #[inline(always)]
-            fn try_into_val(self, env: &#path::Env) -> Result<#enum_ident, Self::Error> {
-                <_ as #path::TryFromVal<_, _>>::try_from_val(env, self)
-            }
-        }
-
-        impl #path::IntoVal<#path::Env, #path::RawVal> for #enum_ident {
-            #[inline(always)]
-            fn into_val(self, env: &#path::Env) -> #path::RawVal {
+            fn try_from_val(env: &#path::Env, val: &#enum_ident) -> Result<#path::RawVal, Self::Error> {
+                use #path::TryIntoVal;
                 #(#discriminant_consts)*
-                match &self {
-                    #(#intos,)*
-                }
-            }
-        }
-
-        impl #path::IntoVal<#path::Env, #path::RawVal> for &#enum_ident {
-            #[inline(always)]
-            fn into_val(self, env: &#path::Env) -> #path::RawVal {
-                #(#discriminant_consts)*
-                match self {
+                match val {
                     #(#intos,)*
                 }
             }
@@ -195,7 +185,7 @@ pub fn derive_type_enum(
         impl #path::TryFromVal<#path::Env, #path::xdr::ScVec> for #enum_ident {
             type Error = #path::xdr::Error;
             #[inline(always)]
-            fn try_from_val(env: &#path::Env, val: #path::xdr::ScVec) -> Result<Self, Self::Error> {
+            fn try_from_val(env: &#path::Env, val:  &#path::xdr::ScVec) -> Result<Self, Self::Error> {
                 use #path::xdr::Validate;
                 use #path::TryIntoVal;
 
@@ -212,19 +202,10 @@ pub fn derive_type_enum(
         }
 
         #[cfg(any(test, feature = "testutils"))]
-        impl #path::TryIntoVal<#path::Env, #enum_ident> for #path::xdr::ScVec {
-            type Error = #path::xdr::Error;
-            #[inline(always)]
-            fn try_into_val(self, env: &#path::Env) -> Result<#enum_ident, Self::Error> {
-                <_ as #path::TryFromVal<_, _>>::try_from_val(env, self)
-            }
-        }
-
-        #[cfg(any(test, feature = "testutils"))]
         impl #path::TryFromVal<#path::Env, #path::xdr::ScObject> for #enum_ident {
             type Error = #path::xdr::Error;
             #[inline(always)]
-            fn try_from_val(env: &#path::Env, val: #path::xdr::ScObject) -> Result<Self, Self::Error> {
+            fn try_from_val(env: &#path::Env, val:  &#path::xdr::ScObject) -> Result<Self, Self::Error> {
                 if let #path::xdr::ScObject::Vec(vec) = val {
                     <_ as #path::TryFromVal<_, _>>::try_from_val(env, vec)
                 } else {
@@ -234,33 +215,15 @@ pub fn derive_type_enum(
         }
 
         #[cfg(any(test, feature = "testutils"))]
-        impl #path::TryIntoVal<#path::Env, #enum_ident> for #path::xdr::ScObject {
-            type Error = #path::xdr::Error;
-            #[inline(always)]
-            fn try_into_val(self, env: &#path::Env) -> Result<#enum_ident, Self::Error> {
-                <_ as #path::TryFromVal<_, _>>::try_from_val(env, self)
-            }
-        }
-
-        #[cfg(any(test, feature = "testutils"))]
         impl #path::TryFromVal<#path::Env, #path::xdr::ScVal> for #enum_ident {
             type Error = #path::xdr::Error;
             #[inline(always)]
-            fn try_from_val(env: &#path::Env, val: #path::xdr::ScVal) -> Result<Self, Self::Error> {
+            fn try_from_val(env: &#path::Env, val:  &#path::xdr::ScVal) -> Result<Self, Self::Error> {
                 if let #path::xdr::ScVal::Object(Some(obj)) = val {
                     <_ as #path::TryFromVal<_, _>>::try_from_val(env, obj)
                 } else {
                     Err(#path::xdr::Error::Invalid)
                 }
-            }
-        }
-
-        #[cfg(any(test, feature = "testutils"))]
-        impl #path::TryIntoVal<#path::Env, #enum_ident> for #path::xdr::ScVal {
-            type Error = #path::xdr::Error;
-            #[inline(always)]
-            fn try_into_val(self, env: &#path::Env) -> Result<#enum_ident, Self::Error> {
-                <_ as #path::TryFromVal<_, _>>::try_from_val(env, self)
             }
         }
 

--- a/soroban-sdk-macros/src/derive_error_enum_int.rs
+++ b/soroban-sdk-macros/src/derive_error_enum_int.rs
@@ -128,34 +128,19 @@ pub fn derive_type_error_enum_int(
         impl #path::TryFromVal<#path::Env, #path::RawVal> for #enum_ident {
             type Error = #path::ConversionError;
             #[inline(always)]
-            fn try_from_val(env: &#path::Env, val: #path::RawVal) -> Result<Self, Self::Error> {
+            fn try_from_val(env: &#path::Env, val:  &#path::RawVal) -> Result<Self, Self::Error> {
                 use #path::TryIntoVal;
-                let status: #path::Status = val.try_into_val(env)?;
+                let status: #path::Status = val.try_into()?;
                 status.try_into().map_err(|_| #path::ConversionError)
             }
         }
 
-        impl #path::TryIntoVal<#path::Env, #enum_ident> for #path::RawVal {
+        impl #path::TryFromVal<#path::Env, #enum_ident> for #path::RawVal {
             type Error = #path::ConversionError;
             #[inline(always)]
-            fn try_into_val(self, env: &#path::Env) -> Result<#enum_ident, Self::Error> {
-                <_ as #path::TryFromVal<_, _>>::try_from_val(env, self)
-            }
-        }
-
-        impl #path::IntoVal<#path::Env, #path::RawVal> for #enum_ident {
-            #[inline(always)]
-            fn into_val(self, env: &#path::Env) -> #path::RawVal {
-                let status: #path::Status = self.into();
-                status.into_val(env)
-            }
-        }
-
-        impl #path::IntoVal<#path::Env, #path::RawVal> for &#enum_ident {
-            #[inline(always)]
-            fn into_val(self, env: &#path::Env) -> #path::RawVal {
-                let status: #path::Status = self.into();
-                status.into_val(env)
+            fn try_from_val(env: &#path::Env, val: &#enum_ident) -> Result<#path::RawVal, Self::Error> {
+                let status: #path::Status = val.into();
+                status.try_into()
             }
         }
     }

--- a/soroban-sdk-macros/src/derive_fn.rs
+++ b/soroban-sdk-macros/src/derive_fn.rs
@@ -95,7 +95,7 @@ pub fn derive_fn(
                     <_ as soroban_sdk::unwrap::UnwrapOptimized>::unwrap_optimized(
                         <_ as soroban_sdk::TryFromVal<soroban_sdk::Env, soroban_sdk::RawVal>>::try_from_val(
                             &env,
-                            #ident
+                            &#ident
                         )
                     )
                 };
@@ -199,15 +199,16 @@ pub fn derive_fn(
             #[deprecated(note = #deprecated_note)]
             #[cfg_attr(target_family = "wasm", export_name = #wrap_export_name)]
             pub fn invoke_raw(env: soroban_sdk::Env, #(#wrap_args),*) -> soroban_sdk::RawVal {
+                use soroban_sdk::unwrap::UnwrapOptimized;
                 #use_trait;
-                <_ as soroban_sdk::IntoVal<soroban_sdk::Env, soroban_sdk::RawVal>>::into_val(
+                <_ as soroban_sdk::TryIntoVal<soroban_sdk::Env, soroban_sdk::RawVal>>::try_into_val(
                     #[allow(deprecated)]
-                    #call(
+                    &#call(
                         #env_call
                         #(#wrap_calls),*
                     ),
                     &env
-                )
+                ).unwrap_optimized()
             }
 
             #[deprecated(note = #deprecated_note)]

--- a/soroban-sdk/src/lib.rs
+++ b/soroban-sdk/src/lib.rs
@@ -616,10 +616,6 @@ pub use env::Env;
 pub use env::RawVal;
 
 /// Used to do conversions between values in the Soroban environment.
-pub use env::FromVal;
-/// Used to do conversions between values in the Soroban environment.
-pub use env::IntoVal;
-/// Used to do conversions between values in the Soroban environment.
 pub use env::TryFromVal;
 /// Used to do conversions between values in the Soroban environment.
 pub use env::TryIntoVal;

--- a/soroban-sdk/src/logging.rs
+++ b/soroban-sdk/src/logging.rs
@@ -5,7 +5,8 @@ use core::fmt::Debug;
 
 use crate::{
     env::internal::{self, EnvBase},
-    Bytes, Env, IntoVal, RawVal, Vec,
+    unwrap::UnwrapOptimized,
+    Bytes, Env, RawVal, TryIntoVal, Vec,
 };
 
 /// Log a debug event.
@@ -83,7 +84,7 @@ macro_rules! log {
         if cfg!(debug_assertions) {
             $env.logger().log($fmt, &[
                 $(
-                    <_ as $crate::IntoVal<Env, $crate::RawVal>>::into_val($args, $env)
+                    <_ as $crate::TryIntoVal<Env, $crate::RawVal>>::try_into_val($args, $env).unwrap_optimized()
                 ),*
             ]);
         }
@@ -128,7 +129,7 @@ impl Logger {
             // building on non-WASM environments where the environment Host is
             // directly available, use the log static variants.
             if cfg!(target_family = "wasm") {
-                let fmt: Bytes = fmt.into_val(env);
+                let fmt: Bytes = fmt.try_into_val(env).unwrap_optimized();
                 let args: Vec<RawVal> = Vec::from_slice(env, args);
                 internal::Env::log_fmt_values(env, fmt.to_object(), args.to_object());
             } else {

--- a/soroban-sdk/src/tests/budget.rs
+++ b/soroban-sdk/src/tests/budget.rs
@@ -16,7 +16,7 @@ impl Contract {
 fn test_budget() {
     let e = Env::default();
     let contract_id = e.register_contract(None, Contract);
-    let client = ContractClient::new(&e, &contract_id);
+    let client = ContractClient::new(&e, contract_id);
 
     e.budget().reset();
     let b = client.add();

--- a/soroban-sdk/src/tests/contract_udt_enum.rs
+++ b/soroban-sdk/src/tests/contract_udt_enum.rs
@@ -1,7 +1,5 @@
 use crate as soroban_sdk;
-use soroban_sdk::{
-    contractimpl, contracttype, symbol, vec, ConversionError, Env, IntoVal, TryFromVal,
-};
+use soroban_sdk::{contractimpl, contracttype, symbol, vec, ConversionError, Env, TryFromVal};
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 #[contracttype]
@@ -39,10 +37,10 @@ fn test_error_on_partial_decode() {
     // variant name as a Symbol, and following elements are tuple-like values
     // for the variant.
     let vec = vec![&env, symbol!("Aaa").into_val(&env)].to_raw();
-    let udt = Udt::try_from_val(&env, vec);
+    let udt = Udt::try_from_val(&env, &vec);
     assert_eq!(udt, Ok(Udt::Aaa));
     let vec = vec![&env, symbol!("Bbb").into_val(&env), 8.into()].to_raw();
-    let udt = Udt::try_from_val(&env, vec);
+    let udt = Udt::try_from_val(&env, &vec);
     assert_eq!(udt, Ok(Udt::Bbb(8)));
 
     // If an enum has a tuple like variant with one value, but the vec has
@@ -50,9 +48,9 @@ fn test_error_on_partial_decode() {
     // encoding will not round trip the data, and therefore partial decoding is
     // relatively difficult to use safely.
     let vec = vec![&env, symbol!("Aaa").into_val(&env), 8.into()].to_raw();
-    let udt = Udt::try_from_val(&env, vec);
+    let udt = Udt::try_from_val(&env, &vec);
     assert_eq!(udt, Err(ConversionError));
     let vec = vec![&env, symbol!("Bbb").into_val(&env), 8.into(), 9.into()].to_raw();
-    let udt = Udt::try_from_val(&env, vec);
+    let udt = Udt::try_from_val(&env, &vec);
     assert_eq!(udt, Err(ConversionError));
 }

--- a/soroban-sdk/src/tests/contract_udt_struct.rs
+++ b/soroban-sdk/src/tests/contract_udt_struct.rs
@@ -39,7 +39,7 @@ fn test_error_on_partial_decode() {
     // Success case, a map will decode to a Udt if the symbol keys match the
     // fields.
     let map = map![&env, (symbol!("a"), 5), (symbol!("b"), 7)].to_raw();
-    let udt = Udt::try_from_val(&env, map);
+    let udt = Udt::try_from_val(&env, &map);
     assert_eq!(udt, Ok(Udt { a: 5, b: 7 }));
 
     // If a struct has fields a, b, and a map is decoded into it where the map
@@ -53,7 +53,7 @@ fn test_error_on_partial_decode() {
         (symbol!("c"), 9)
     ]
     .to_raw();
-    let udt = Udt::try_from_val(&env, map);
+    let udt = Udt::try_from_val(&env, &map);
     assert_eq!(udt, Err(ConversionError));
 }
 

--- a/soroban-sdk/src/tests/contract_udt_struct_tuple.rs
+++ b/soroban-sdk/src/tests/contract_udt_struct_tuple.rs
@@ -1,7 +1,6 @@
 use crate as soroban_sdk;
 use soroban_sdk::{
-    contractimpl, contracttype, vec, ConversionError, Env, IntoVal, RawVal, TryFromVal, TryIntoVal,
-    Vec,
+    contractimpl, contracttype, vec, ConversionError, Env, RawVal, TryFromVal, TryIntoVal, Vec,
 };
 use stellar_xdr::{
     ReadXdr, ScSpecEntry, ScSpecFunctionInputV0, ScSpecFunctionV0, ScSpecTypeDef, ScSpecTypeTuple,
@@ -47,14 +46,14 @@ fn test_error_on_partial_decode() {
 
     // Success case, a vec will decode to a Udt.
     let map = vec![&env, 5, 7].to_raw();
-    let udt = Udt::try_from_val(&env, map);
+    let udt = Udt::try_from_val(&env, &map);
     assert_eq!(udt, Ok(Udt(5, 7)));
 
     // If a struct has 2 fields, and a vec is decoded into it where the vec has
     // 2 elements, it is an error. It is an error because all fields must be
     // assigned values.
     let map = vec![&env, 5, 7, 9].to_raw();
-    let udt = Udt::try_from_val(&env, map);
+    let udt = Udt::try_from_val(&env, &map);
     assert_eq!(udt, Err(ConversionError));
 
     // If a struct has 2 fields, and a vec is decoded into it where the vec has
@@ -62,7 +61,7 @@ fn test_error_on_partial_decode() {
     // will not round trip the data, and therefore partial decoding is
     // relatively difficult to use safely.
     let map = vec![&env, 5, 7, 9].to_raw();
-    let udt = Udt::try_from_val(&env, map);
+    let udt = Udt::try_from_val(&env, &map);
     assert_eq!(udt, Err(ConversionError));
 }
 

--- a/soroban-token-spec/src/tests/use_token_contract.rs
+++ b/soroban-token-spec/src/tests/use_token_contract.rs
@@ -1,5 +1,5 @@
 use soroban_auth::{testutils::ed25519::generate, Identifier, Signature};
-use soroban_sdk::{contractimpl, contracttype, BytesN, Env, IntoVal};
+use soroban_sdk::{contractimpl, contracttype, BytesN, Env};
 
 mod token_contract {
     soroban_sdk::contractimport!(

--- a/tests/events/src/lib.rs
+++ b/tests/events/src/lib.rs
@@ -16,7 +16,7 @@ impl Contract {
 #[cfg(test)]
 mod test {
     extern crate alloc;
-    use soroban_sdk::{symbol, testutils::Events, vec, BytesN, Env, IntoVal};
+    use soroban_sdk::{symbol, testutils::Events, vec, BytesN, Env};
 
     use crate::{Contract, ContractClient};
 

--- a/tests/invoke_contract/src/lib.rs
+++ b/tests/invoke_contract/src/lib.rs
@@ -1,5 +1,5 @@
 #![no_std]
-use soroban_sdk::{contractimpl, symbol, vec, Address, BytesN, Env, IntoVal};
+use soroban_sdk::{contractimpl, symbol, vec, Address, BytesN, Env};
 
 pub struct Contract;
 

--- a/tests/udt/src/lib.rs
+++ b/tests/udt/src/lib.rs
@@ -205,7 +205,7 @@ mod test {
             c: vec![&e, 1],
         };
         let val: ScVal = udt.clone().try_into().unwrap();
-        let roundtrip = UdtStruct::try_from_val(&e, val).unwrap();
+        let roundtrip = UdtStruct::try_from_val(&e, &val).unwrap();
         assert_eq!(udt, roundtrip);
     }
 }


### PR DESCRIPTION
Initial sketch of adapting the SDK to https://github.com/stellar/rs-soroban-env/pull/628

Doesn't work yet but gives a picture of the approach.

@leighmcculloch another approach I'm considering here is to define FromVal/IntoVal as traits _just in the SDK_ and define them as blankets that do the `val.try_into_val(env).unwrap_optimized()` thing I'm doing everywhere here (which we can hopefully specialize to optimize-away entirely when `Guest::Error==Infallible`). 

Might end up with less churn. I think I will give it a go before I push further with this version.