### PR TITLE
Use better storage error in tests

### DIFF
--- a/soroban-sdk/src/env.rs
+++ b/soroban-sdk/src/env.rs
@@ -330,7 +330,7 @@ impl Env {
             ) -> Result<xdr::LedgerEntry, soroban_env_host::HostError> {
                 use xdr::{ScHostStorageErrorCode, ScStatus};
                 let status: internal::Status =
-                    ScStatus::HostStorageError(ScHostStorageErrorCode::UnknownError).into();
+                    ScStatus::HostStorageError(ScHostStorageErrorCode::MissingKeyInGet).into();
                 Err(status.into())
             }
 


### PR DESCRIPTION
@marta-lokhova ran into this error in a test case when trying to retrieve data that didn't exist - 
```
Value: Status(HostStorageError(UnknownError))

Debug events (newest first):
   0: "escalating error 'Status(HostStorageError(UnknownError))' to panic"
   1: "contract call invocation resulted in error Status(HostStorageError(UnknownError))"
   2: "caught panic from contract function 'Symbol(attend)', propagating escalated error 'Status(HostStorageError(UnknownError))'"
   3: "escalating error 'Status(HostStorageError(UnknownError))' to panic"
   10: ... elided ...
```


This error doesn't mention the issue, which is that the key doesn't exist. With the change in this PR, the error will look like -
```
Value: Status(HostStorageError(MissingKeyInGet))

Debug events (newest first):
   0: "escalating error 'Status(HostStorageError(MissingKeyInGet))' to panic"
   1: "contract call invocation resulted in error Status(HostStorageError(MissingKeyInGet))"
   2: "caught panic from contract function 'Symbol(get)', propagating escalated error 'Status(HostStorageError(MissingKeyInGet))'"
   3: "escalating error 'Status(HostStorageError(MissingKeyInGet))' to panic"
```