### PR TITLE
Adapt to env-crate changes: fallible Env and TryFromVal using Env::Error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -841,7 +841,7 @@ dependencies = [
 [[package]]
 name = "soroban-env-common"
 version = "0.0.12"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=d803b0922d1d9eb4d3cfde5e6d574c7776c23388#d803b0922d1d9eb4d3cfde5e6d574c7776c23388"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=0f0fbdbc0fbed2d5bd8ca531986dd393511b0543#0f0fbdbc0fbed2d5bd8ca531986dd393511b0543"
 dependencies = [
  "crate-git-revision",
  "serde",
@@ -854,7 +854,7 @@ dependencies = [
 [[package]]
 name = "soroban-env-guest"
 version = "0.0.12"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=d803b0922d1d9eb4d3cfde5e6d574c7776c23388#d803b0922d1d9eb4d3cfde5e6d574c7776c23388"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=0f0fbdbc0fbed2d5bd8ca531986dd393511b0543#0f0fbdbc0fbed2d5bd8ca531986dd393511b0543"
 dependencies = [
  "soroban-env-common",
  "static_assertions",
@@ -863,7 +863,7 @@ dependencies = [
 [[package]]
 name = "soroban-env-host"
 version = "0.0.12"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=d803b0922d1d9eb4d3cfde5e6d574c7776c23388#d803b0922d1d9eb4d3cfde5e6d574c7776c23388"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=0f0fbdbc0fbed2d5bd8ca531986dd393511b0543#0f0fbdbc0fbed2d5bd8ca531986dd393511b0543"
 dependencies = [
  "backtrace",
  "curve25519-dalek",
@@ -885,7 +885,7 @@ dependencies = [
 [[package]]
 name = "soroban-env-macros"
 version = "0.0.12"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=d803b0922d1d9eb4d3cfde5e6d574c7776c23388#d803b0922d1d9eb4d3cfde5e6d574c7776c23388"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=0f0fbdbc0fbed2d5bd8ca531986dd393511b0543#0f0fbdbc0fbed2d5bd8ca531986dd393511b0543"
 dependencies = [
  "itertools",
  "proc-macro2",
@@ -911,7 +911,7 @@ dependencies = [
 [[package]]
 name = "soroban-native-sdk-macros"
 version = "0.0.12"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=d803b0922d1d9eb4d3cfde5e6d574c7776c23388#d803b0922d1d9eb4d3cfde5e6d574c7776c23388"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=0f0fbdbc0fbed2d5bd8ca531986dd393511b0543#0f0fbdbc0fbed2d5bd8ca531986dd393511b0543"
 dependencies = [
  "itertools",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,17 +37,17 @@ soroban-token-spec = { version = "0.4.3", path = "soroban-token-spec" }
 [workspace.dependencies.soroban-env-common]
 version = "0.0.12"
 git = "https://github.com/stellar/rs-soroban-env"
-rev = "d803b0922d1d9eb4d3cfde5e6d574c7776c23388"
+rev = "0f0fbdbc0fbed2d5bd8ca531986dd393511b0543"
 
 [workspace.dependencies.soroban-env-guest]
 version = "0.0.12"
 git = "https://github.com/stellar/rs-soroban-env"
-rev = "d803b0922d1d9eb4d3cfde5e6d574c7776c23388"
+rev = "0f0fbdbc0fbed2d5bd8ca531986dd393511b0543"
 
 [workspace.dependencies.soroban-env-host]
 version = "0.0.12"
 git = "https://github.com/stellar/rs-soroban-env"
-rev = "d803b0922d1d9eb4d3cfde5e6d574c7776c23388"
+rev = "0f0fbdbc0fbed2d5bd8ca531986dd393511b0543"
 
 [workspace.dependencies.stellar-strkey]
 version = "0.0.6"

--- a/soroban-sdk-macros/src/derive_client.rs
+++ b/soroban-sdk-macros/src/derive_client.rs
@@ -91,7 +91,7 @@ impl<'a> ClientFn<'a> {
         };
         Type::Verbatim(quote! {
             Result<
-                Result<#t, <#t as soroban_sdk::TryFromVal<soroban_sdk::Env, soroban_sdk::RawVal>>::Error>,
+                Result<#t, soroban_sdk::EnvError>,
                 Result<#e, <#e as TryFrom<soroban_sdk::Status>>::Error>
             >
         })

--- a/soroban-sdk-macros/src/derive_error_enum_int.rs
+++ b/soroban-sdk-macros/src/derive_error_enum_int.rs
@@ -126,18 +126,16 @@ pub fn derive_type_error_enum_int(
         }
 
         impl #path::TryFromVal<#path::Env, #path::RawVal> for #enum_ident {
-            type Error = #path::ConversionError;
             #[inline(always)]
-            fn try_from_val(env: &#path::Env, val: &#path::RawVal) -> Result<Self, Self::Error> {
-                use #path::TryIntoVal;
+            fn try_from_val(env: &#path::Env, val: &#path::RawVal) -> Result<Self, #path::EnvError> {
+                use #path::{TryIntoVal, MapErrToEnv};
                 let status: #path::Status = val.try_into_val(env)?;
-                status.try_into().map_err(|_| #path::ConversionError)
+                status.try_into().map_err(|_| #path::ConversionError).map_err_to_env(env)
             }
         }
         impl #path::TryFromVal<#path::Env, #enum_ident> for #path::RawVal {
-            type Error = #path::ConversionError;
             #[inline(always)]
-            fn try_from_val(env: &#path::Env, val: &#enum_ident) -> Result<Self, Self::Error> {
+            fn try_from_val(env: &#path::Env, val: &#enum_ident) -> Result<Self, #path::EnvError> {
                 let status: #path::Status = val.into();
                 Ok(status.into())
             }

--- a/soroban-sdk-macros/src/derive_struct.rs
+++ b/soroban-sdk-macros/src/derive_struct.rs
@@ -57,16 +57,16 @@ pub fn derive_type_struct(
                 #ident: if let Some(Ok(val)) = map.get(#map_key) {
                     val.try_into_val(env)?
                 } else {
-                    Err(#path::ConversionError)?
+                    Err(#path::ConversionError).map_err_to_env(env)?
                 }
             };
             let try_into = quote! { map.set(#map_key, (&val.#ident).try_into_val(env)?) };
             let try_from_xdr = quote! {
                 #ident: {
-                    let key = &#name.try_into().map_err(|_| #path::xdr::Error::Invalid)?;
-                    let idx = map.binary_search_by_key(key, |entry| entry.key.clone()).map_err(|_| #path::xdr::Error::Invalid)?;
-                    let rv: #path::RawVal = (&map[idx].val.clone()).try_into_val(env).map_err(|_| #path::xdr::Error::Invalid)?;
-                    rv.try_into_val(env).map_err(|_| #path::xdr::Error::Invalid)?
+                    let key = &#name.try_into().map_err(|_| #path::xdr::Error::Invalid).map_err_to_env(env)?;
+                    let idx = map.binary_search_by_key(key, |entry| entry.key.clone()).map_err(|_| #path::xdr::Error::Invalid).map_err_to_env(env)?;
+                    let rv: #path::RawVal = (&map[idx].val.clone()).try_into_val(env)?;
+                    rv.try_into_val(env)?
                 }
             };
             let into_xdr = quote! {
@@ -115,13 +115,12 @@ pub fn derive_type_struct(
         #spec_gen
 
         impl #path::TryFromVal<#path::Env, #path::RawVal> for #ident {
-            type Error = #path::ConversionError;
             #[inline(always)]
-            fn try_from_val(env: &#path::Env, val: &#path::RawVal) -> Result<Self, Self::Error> {
-                use #path::TryIntoVal;
+            fn try_from_val(env: &#path::Env, val: &#path::RawVal) -> Result<Self, #path::EnvError> {
+                use #path::{TryIntoVal, MapErrToEnv};
                 let map: #path::Map<#path::Symbol, #path::RawVal> = val.try_into_val(env)?;
                 if map.len() != #field_count_u32 {
-                    return Err(#path::ConversionError);
+                    return Err(#path::ConversionError).map_err_to_env(env);
                 }
                 Ok(Self{
                     #(#try_froms,)*
@@ -130,9 +129,8 @@ pub fn derive_type_struct(
         }
 
         impl #path::TryFromVal<#path::Env, #ident> for #path::RawVal {
-            type Error = #path::ConversionError;
             #[inline(always)]
-            fn try_from_val(env: &#path::Env, val: &#ident) -> Result<Self, Self::Error> {
+            fn try_from_val(env: &#path::Env, val: &#ident) -> Result<Self, #path::EnvError> {
                 use #path::TryIntoVal;
                 let mut map = #path::Map::<#path::Symbol, #path::RawVal>::new(env);
                 #(#try_intos;)*
@@ -142,14 +140,13 @@ pub fn derive_type_struct(
 
         #[cfg(any(test, feature = "testutils"))]
         impl #path::TryFromVal<#path::Env, #path::xdr::ScMap> for #ident {
-            type Error = #path::xdr::Error;
             #[inline(always)]
-            fn try_from_val(env: &#path::Env, val: &#path::xdr::ScMap) -> Result<Self, Self::Error> {
+            fn try_from_val(env: &#path::Env, val: &#path::xdr::ScMap) -> Result<Self, #path::EnvError> {
                 use #path::xdr::Validate;
-                use #path::TryIntoVal;
+                use #path::{TryIntoVal, MapErrToEnv};
                 let map = val;
                 if map.len() != #field_count_usize {
-                    return Err(#path::xdr::Error::Invalid);
+                    return Err(#path::xdr::Error::Invalid).map_err_to_env(env);
                 }
                 map.validate()?;
                 Ok(Self{
@@ -160,26 +157,26 @@ pub fn derive_type_struct(
 
         #[cfg(any(test, feature = "testutils"))]
         impl #path::TryFromVal<#path::Env, #path::xdr::ScObject> for #ident {
-            type Error = #path::xdr::Error;
             #[inline(always)]
-            fn try_from_val(env: &#path::Env, val: &#path::xdr::ScObject) -> Result<Self, Self::Error> {
+            fn try_from_val(env: &#path::Env, val: &#path::xdr::ScObject) -> Result<Self, #path::EnvError> {
+                use #path::MapErrToEnv;
                 if let #path::xdr::ScObject::Map(map) = val {
                     <_ as #path::TryFromVal<_, _>>::try_from_val(env, map)
                 } else {
-                    Err(#path::xdr::Error::Invalid)
+                    Err(#path::xdr::Error::Invalid).map_err_to_env(env)
                 }
             }
         }
 
         #[cfg(any(test, feature = "testutils"))]
         impl #path::TryFromVal<#path::Env, #path::xdr::ScVal> for #ident {
-            type Error = #path::xdr::Error;
             #[inline(always)]
-            fn try_from_val(env: &#path::Env, val: &#path::xdr::ScVal) -> Result<Self, Self::Error> {
+            fn try_from_val(env: &#path::Env, val: &#path::xdr::ScVal) -> Result<Self, #path::EnvError> {
+                use #path::MapErrToEnv;
                 if let #path::xdr::ScVal::Object(Some(obj)) = val {
                     <_ as #path::TryFromVal<_, _>>::try_from_val(env, obj)
                 } else {
-                    Err(#path::xdr::Error::Invalid)
+                    Err(#path::xdr::Error::Invalid).map_err_to_env(env)
                 }
             }
         }

--- a/soroban-sdk/src/crypto.rs
+++ b/soroban-sdk/src/crypto.rs
@@ -1,5 +1,5 @@
 //! Crypto contains functions for cryptographic functions.
-use crate::{env::internal, Bytes, BytesN, Env};
+use crate::{env::internal, unwrap::UnwrapOptimized, Bytes, BytesN, Env};
 
 /// Crypto provides access to cryptographic functions.
 pub struct Crypto {
@@ -18,7 +18,7 @@ impl Crypto {
     /// Returns the SHA-256 hash of the data.
     pub fn sha256(&self, data: &Bytes) -> BytesN<32> {
         let env = self.env();
-        let bin = internal::Env::compute_hash_sha256(env, data.into());
+        let bin = internal::Env::compute_hash_sha256(env, data.into()).unwrap_optimized();
         unsafe { BytesN::unchecked_new(env.clone(), bin) }
     }
 

--- a/soroban-sdk/src/deploy.rs
+++ b/soroban-sdk/src/deploy.rs
@@ -37,7 +37,7 @@
 //! # #[cfg(not(feature = "testutils"))]
 //! # fn main() { }
 //! ```
-use crate::{env::internal::Env as _, Bytes, BytesN, Env, IntoVal};
+use crate::{env::internal::Env as _, unwrap::UnwrapOptimized, Bytes, BytesN, Env, IntoVal};
 
 /// Deployer provides access to deploying contracts.
 pub struct Deployer {
@@ -105,10 +105,12 @@ impl DeployerWithCurrentContract {
     /// Returns the deployed contract's ID.
     pub fn deploy(&self, wasm_hash: &impl IntoVal<Env, BytesN<32>>) -> BytesN<32> {
         let env = &self.env;
-        let id = env.create_contract_from_contract(
-            wasm_hash.into_val(env).to_object(),
-            self.salt.to_object(),
-        );
+        let id = env
+            .create_contract_from_contract(
+                wasm_hash.into_val(env).to_object(),
+                self.salt.to_object(),
+            )
+            .unwrap_optimized();
         unsafe { BytesN::<32>::unchecked_new(env.clone(), id) }
     }
 }

--- a/soroban-sdk/src/events.rs
+++ b/soroban-sdk/src/events.rs
@@ -5,7 +5,8 @@ use core::fmt::Debug;
 use crate::{contracttype, Bytes, BytesN, Map};
 use crate::{
     env::internal::{self},
-    ConversionError, Env, IntoVal, RawVal, TryFromVal, Vec,
+    unwrap::UnwrapOptimized,
+    Env, EnvError, IntoVal, RawVal, TryFromVal, Vec,
 };
 
 // TODO: consolidate with host::events::TOPIC_BYTES_LENGTH_LIMIT
@@ -61,9 +62,7 @@ impl Debug for Events {
 pub trait Topics: IntoVal<Env, Vec<RawVal>> {}
 
 impl TryFromVal<Env, ()> for Vec<RawVal> {
-    type Error = ConversionError;
-
-    fn try_from_val(env: &Env, _v: &()) -> Result<Self, Self::Error> {
+    fn try_from_val(env: &Env, _v: &()) -> Result<Self, EnvError> {
         Ok(Vec::<RawVal>::new(env))
     }
 }
@@ -115,7 +114,8 @@ impl Events {
         D: IntoVal<Env, RawVal>,
     {
         let env = self.env();
-        internal::Env::contract_event(env, topics.into_val(env).to_object(), data.into_val(env));
+        internal::Env::contract_event(env, topics.into_val(env).to_object(), data.into_val(env))
+            .unwrap_optimized();
     }
 }
 

--- a/soroban-sdk/src/ledger.rs
+++ b/soroban-sdk/src/ledger.rs
@@ -1,6 +1,7 @@
 //! Ledger contains types for retrieving information about the current ledger.
 use crate::{
     env::internal::{self, RawValConvertible},
+    unwrap::UnwrapOptimized,
     Bytes, Env,
 };
 
@@ -54,7 +55,7 @@ impl Ledger {
     /// Returns the version of the protocol that the ledger created with.
     pub fn protocol_version(&self) -> u32 {
         let env = self.env();
-        let val = internal::Env::get_ledger_version(env);
+        let val = internal::Env::get_ledger_version(env).unwrap_optimized();
         unsafe { u32::unchecked_from_val(val) }
     }
 
@@ -64,7 +65,7 @@ impl Ledger {
     /// that is sequential, incremented by one for each new ledger.
     pub fn sequence(&self) -> u32 {
         let env = self.env();
-        let val = internal::Env::get_ledger_sequence(env);
+        let val = internal::Env::get_ledger_sequence(env).unwrap_optimized();
         unsafe { u32::unchecked_from_val(val) }
     }
 
@@ -75,8 +76,8 @@ impl Ledger {
     /// at 00:00:00 UTC.
     pub fn timestamp(&self) -> u64 {
         let env = self.env();
-        let obj = internal::Env::get_ledger_timestamp(env);
-        internal::Env::obj_to_u64(env, obj)
+        let obj = internal::Env::get_ledger_timestamp(env).unwrap_optimized();
+        internal::Env::obj_to_u64(env, obj).unwrap_optimized()
     }
 
     /// Returns the network passphrase.
@@ -88,7 +89,7 @@ impl Ledger {
     /// > Test SDF Network ; September 2015
     pub fn network_passphrase(&self) -> Bytes {
         let env = self.env();
-        let bin_obj = internal::Env::get_ledger_network_passphrase(env);
+        let bin_obj = internal::Env::get_ledger_network_passphrase(env).unwrap_optimized();
         unsafe { Bytes::unchecked_new(env.clone(), bin_obj) }
     }
 }

--- a/soroban-sdk/src/lib.rs
+++ b/soroban-sdk/src/lib.rs
@@ -562,8 +562,7 @@ pub use soroban_sdk_macros::symbol;
 #[macro_export]
 macro_rules! panic_with_error {
     ($env:expr, $error:expr) => {{
-        $env.panic_with_error($error);
-        unreachable!();
+        $env.panic_with_error($error)
     }};
 }
 
@@ -608,8 +607,8 @@ mod address;
 pub mod xdr;
 
 pub use env::ConversionError;
-
 pub use env::Env;
+pub use env::EnvError;
 /// Raw value of the Soroban smart contract platform that types can be converted
 /// to and from for storing, or passing between contracts.
 ///
@@ -619,6 +618,8 @@ pub use env::RawVal;
 pub use env::FromVal;
 /// Used to do conversions between values in the Soroban environment.
 pub use env::IntoVal;
+/// Used to convert `Status`-convertable errors to Soroban environment errors.
+pub use env::MapErrToEnv;
 /// Used to do conversions between values in the Soroban environment.
 pub use env::TryFromVal;
 /// Used to do conversions between values in the Soroban environment.

--- a/soroban-sdk/src/logging.rs
+++ b/soroban-sdk/src/logging.rs
@@ -5,6 +5,7 @@ use core::fmt::Debug;
 
 use crate::{
     env::internal::{self, EnvBase},
+    unwrap::UnwrapOptimized,
     Bytes, Env, IntoVal, RawVal, Vec,
 };
 
@@ -130,7 +131,8 @@ impl Logger {
             if cfg!(target_family = "wasm") {
                 let fmt: Bytes = fmt.into_val(env);
                 let args: Vec<RawVal> = Vec::from_slice(env, args);
-                internal::Env::log_fmt_values(env, fmt.to_object(), args.to_object());
+                internal::Env::log_fmt_values(env, fmt.to_object(), args.to_object())
+                    .unwrap_optimized();
             } else {
                 env.log_static_fmt_general(fmt, args, &[]).unwrap();
             }

--- a/soroban-sdk/src/serde.rs
+++ b/soroban-sdk/src/serde.rs
@@ -22,7 +22,10 @@
 //! assert_eq!(roundtrip, Ok(value));
 //! ```
 
-use crate::{env::internal::Env as _, Bytes, Env, IntoVal, RawVal, TryFromVal};
+use crate::{
+    env::internal::Env as _, unwrap::UnwrapOptimized, Bytes, Env, EnvError, IntoVal, RawVal,
+    TryFromVal,
+};
 
 /// Implemented by types that can be serialized to [Bytes].
 ///
@@ -45,7 +48,7 @@ where
 {
     fn serialize(self, env: &Env) -> Bytes {
         let val: RawVal = self.into_val(env);
-        let bin = env.serialize_to_bytes(val);
+        let bin = env.serialize_to_bytes(val).unwrap_optimized();
         unsafe { Bytes::unchecked_new(env.clone(), bin) }
     }
 }
@@ -54,10 +57,10 @@ impl<T> Deserialize for T
 where
     T: TryFromVal<Env, RawVal>,
 {
-    type Error = T::Error;
+    type Error = EnvError;
 
     fn deserialize(env: &Env, b: &Bytes) -> Result<Self, Self::Error> {
-        let t = env.deserialize_from_bytes(b.into());
+        let t = env.deserialize_from_bytes(b.into()).unwrap_optimized();
         T::try_from_val(env, &t)
     }
 }

--- a/soroban-sdk/src/storage.rs
+++ b/soroban-sdk/src/storage.rs
@@ -3,7 +3,8 @@ use core::fmt::Debug;
 
 use crate::{
     env::internal::{self, RawVal},
-    Env, IntoVal, TryFromVal,
+    unwrap::UnwrapOptimized,
+    Env, EnvError, IntoVal, TryFromVal,
 };
 
 /// Storage stores and retrieves data for the currently executing contract.
@@ -73,7 +74,7 @@ impl Storage {
         K: IntoVal<Env, RawVal>,
     {
         let env = self.env();
-        let rv = internal::Env::has_contract_data(env, key.into_val(env));
+        let rv = internal::Env::has_contract_data(env, key.into_val(env)).unwrap_optimized();
         rv.is_true()
     }
 
@@ -90,17 +91,16 @@ impl Storage {
     ///
     /// Add safe checked versions of these functions.
     #[inline(always)]
-    pub fn get<K, V>(&self, key: &K) -> Option<Result<V, V::Error>>
+    pub fn get<K, V>(&self, key: &K) -> Option<Result<V, EnvError>>
     where
-        V::Error: Debug,
         K: IntoVal<Env, RawVal>,
         V: TryFromVal<Env, RawVal>,
     {
         let env = self.env();
         let key = key.into_val(env);
-        let has = internal::Env::has_contract_data(env, key);
+        let has = internal::Env::has_contract_data(env, key).unwrap_optimized();
         if has.is_true() {
-            let rv = internal::Env::get_contract_data(env, key);
+            let rv = internal::Env::get_contract_data(env, key).unwrap_optimized();
             Some(V::try_from_val(env, &rv))
         } else {
             None
@@ -114,14 +114,13 @@ impl Storage {
     ///
     /// When the key does not have a value stored.
     #[inline(always)]
-    pub fn get_unchecked<K, V>(&self, key: &K) -> Result<V, V::Error>
+    pub fn get_unchecked<K, V>(&self, key: &K) -> Result<V, EnvError>
     where
-        V::Error: Debug,
         K: IntoVal<Env, RawVal>,
         V: TryFromVal<Env, RawVal>,
     {
         let env = self.env();
-        let rv = internal::Env::get_contract_data(env, key.into_val(env));
+        let rv = internal::Env::get_contract_data(env, key.into_val(env)).unwrap_optimized();
         V::try_from_val(env, &rv)
     }
 
@@ -137,7 +136,8 @@ impl Storage {
         V: IntoVal<Env, RawVal>,
     {
         let env = self.env();
-        internal::Env::put_contract_data(env, key.into_val(env), val.into_val(env));
+        internal::Env::put_contract_data(env, key.into_val(env), val.into_val(env))
+            .unwrap_optimized();
     }
 
     #[inline(always)]
@@ -146,6 +146,6 @@ impl Storage {
         K: IntoVal<Env, RawVal>,
     {
         let env = self.env();
-        internal::Env::del_contract_data(env, key.into_val(env));
+        internal::Env::del_contract_data(env, key.into_val(env)).unwrap_optimized();
     }
 }

--- a/soroban-sdk/src/tests/contract_udt_enum.rs
+++ b/soroban-sdk/src/tests/contract_udt_enum.rs
@@ -1,4 +1,5 @@
 use crate as soroban_sdk;
+use crate::MapErrToEnv;
 use soroban_sdk::{
     contractimpl, contracttype, symbol, vec, ConversionError, Env, IntoVal, RawVal, TryFromVal, Vec,
 };
@@ -51,8 +52,8 @@ fn test_error_on_partial_decode() {
     // relatively difficult to use safely.
     let vec: Vec<RawVal> = vec![&env, symbol!("Aaa").into_val(&env), 8.into()];
     let udt = Udt::try_from_val(&env, &vec.to_raw());
-    assert_eq!(udt, Err(ConversionError));
+    assert_eq!(udt, Err(ConversionError).map_err_to_env(&env));
     let vec: Vec<RawVal> = vec![&env, symbol!("Bbb").into_val(&env), 8.into(), 9.into()];
     let udt = Udt::try_from_val(&env, &vec.to_raw());
-    assert_eq!(udt, Err(ConversionError));
+    assert_eq!(udt, Err(ConversionError).map_err_to_env(&env));
 }

--- a/soroban-sdk/src/tests/contract_udt_struct.rs
+++ b/soroban-sdk/src/tests/contract_udt_struct.rs
@@ -1,4 +1,5 @@
 use crate as soroban_sdk;
+use crate::MapErrToEnv;
 use soroban_sdk::{contractimpl, contracttype, map, symbol, ConversionError, Env, TryFromVal};
 use stellar_xdr::{
     ReadXdr, ScSpecEntry, ScSpecFunctionInputV0, ScSpecFunctionV0, ScSpecTypeDef, ScSpecTypeTuple,
@@ -54,7 +55,7 @@ fn test_error_on_partial_decode() {
     ]
     .to_raw();
     let udt = Udt::try_from_val(&env, &map);
-    assert_eq!(udt, Err(ConversionError));
+    assert_eq!(udt, Err(ConversionError).map_err_to_env(&env));
 }
 
 #[test]

--- a/soroban-sdk/src/tests/contract_udt_struct_tuple.rs
+++ b/soroban-sdk/src/tests/contract_udt_struct_tuple.rs
@@ -1,7 +1,7 @@
 use crate as soroban_sdk;
 use soroban_sdk::{
-    contractimpl, contracttype, vec, ConversionError, Env, IntoVal, RawVal, TryFromVal, TryIntoVal,
-    Vec,
+    contractimpl, contracttype, vec, ConversionError, Env, IntoVal, MapErrToEnv, RawVal,
+    TryFromVal, TryIntoVal, Vec,
 };
 use stellar_xdr::{
     ReadXdr, ScSpecEntry, ScSpecFunctionInputV0, ScSpecFunctionV0, ScSpecTypeDef, ScSpecTypeTuple,
@@ -55,7 +55,7 @@ fn test_error_on_partial_decode() {
     // assigned values.
     let vec = vec![&env, 5, 7, 9].to_raw();
     let udt = Udt::try_from_val(&env, &vec);
-    assert_eq!(udt, Err(ConversionError));
+    assert_eq!(udt, Err(ConversionError).map_err_to_env(&env));
 
     // If a struct has 2 fields, and a vec is decoded into it where the vec has
     // 3 elements, it is an error. It is an error because decoding and encoding
@@ -63,7 +63,7 @@ fn test_error_on_partial_decode() {
     // relatively difficult to use safely.
     let vec = vec![&env, 5, 7, 9].to_raw();
     let udt = Udt::try_from_val(&env, &vec);
-    assert_eq!(udt, Err(ConversionError));
+    assert_eq!(udt, Err(ConversionError).map_err_to_env(&env));
 }
 
 #[test]

--- a/soroban-sdk/src/tests/contractfile_with_sha256.rs
+++ b/soroban-sdk/src/tests/contractfile_with_sha256.rs
@@ -1,7 +1,7 @@
 use crate as soroban_sdk;
 pub const WASM: &[u8] = soroban_sdk::contractfile!(
     file = "../target/wasm32-unknown-unknown/release/test_add_u64.wasm",
-    sha256 = "88d88c54624c85d4d6e4654150cd76aaf34614dfaef67c73aa4a793614687798",
+    sha256 = "6c94401d269f2cbcd141c112ad2dc08371f04d557f45386d89d3d822dae18ce1",
 );
 
 #[test]

--- a/soroban-sdk/src/tests/contractimport_with_sha256.rs
+++ b/soroban-sdk/src/tests/contractimport_with_sha256.rs
@@ -8,7 +8,7 @@ mod addcontract {
     use crate as soroban_sdk;
     soroban_sdk::contractimport!(
         file = "../target/wasm32-unknown-unknown/release/test_add_u64.wasm",
-        sha256 = "88d88c54624c85d4d6e4654150cd76aaf34614dfaef67c73aa4a793614687798",
+        sha256 = "6c94401d269f2cbcd141c112ad2dc08371f04d557f45386d89d3d822dae18ce1",
     );
 }
 


### PR DESCRIPTION
This is the SDK-side work adapting to https://github.com/stellar/rs-soroban-env/pull/633

It does two things simultaneously that, after some reflection, I'm not 100% sure should both be done. But I'm maybe 80% sure. The first should be done and the second should _probably_ be done, but we can discuss!

1. Changes `Env` to always return `Result<T, Env::Error>`. There's no more `CheckedEnv` at all, and `Env::Error` changes between `HostError` (when compiled natively `Env=Host`) and `Infallible` (when compiled for wasm `Env=Guest`). This is just part of the general "no panics in the host" work aiming to fix https://github.com/stellar/rs-soroban-env/issues/579 once and for all. As a result of this, there are a lot of unwraps in the SDK now. This is intentional, so they don't happen by accident / automatically in the previously-existing `impl Env for CheckedEnv` (which is being deleted upstream). They're all the same points where that wrapper would have panicked before, but now they're explicit. In the wasm case they should compile to no-ops because the VM will actually trap before it returns -- hence `Infallible` -- but the API still says `Result<>` on the label.
2. Changes `TryFromVal` to no longer have its own `Error`, but to always return `Result<Self, Env::Error>`. This is more contentious. It means that when someone uses `TryFromVal` in wasm code and there's some fallible-in-the-guest conversion code, it will escalate its error to an `Env::Error` before it completes, making the error behave _as if_ it was generated in the environment (and in particular, again, trapping the VM immediately rather than returning an error that a caller can scrutinize). This has some advantages: it makes the APIs less noisy (only one error type most of the time), it makes the resulting errors _richer_ when in native local testing mode (escalating to an `Env::Error=HostError` will capture a backtrace) and it .. sorta makes sense in that `TryFromVal` is explicitly the environment-assisting conversion path. If you want a non-environment-assisting conversion you can use `From` or `TryFrom` . Any time  you call `TryFromVal` you should be expecting a possibly-`Env::Error`-generating path anyways. So your result type should at most be a superset of `Env::Error`-plus-some-other-less-serious-errors?  But that can't be meaningfully represented, so `Env::Error` feels to me like a logical escalation type. But it does mean that paths that return-a-user-visible-result in local testing will trap the VM in deployment. Which is a bit weird.

One followup we might do, if we do go with the second point here, is to strip the `Result<>` returns out of some of the SDK methods that do a `TryFromVal` internally, such as `Map::get` or such, because when building for wasm they'll be returning `Result<T, Infallible>` and this is generally fairly confusing to users as a type altogether -- it can't be converted to or from much else and scrutinizing it produces dead code paths and such. So I think it'l behave nicer if we unwrap those inside the SDK methods as well. I think this is _probably_ what 99% of user code will do anyways. An ambitious user can always program against the `RawVal` API themselves -- try to do some not-trapping parts of their conversion if they want to inspect a value in the `Guest` -- but I expect nobody will do that in almost any code.

Feedback welcome!

## Code size impact

Code size changes are mixed. Some larger, some smaller. Mostly negligible. It does slightly better in the codesize-optimized cases.

### Non-size-optimized

Before:
~~~
-rwxrwxr-x 2 graydon graydon 21386 Jan 21 23:14 soroban_token_spec.wasm
-rwxrwxr-x 2 graydon graydon 505 Jan 21 23:14 test_add_i128.wasm
-rwxrwxr-x 2 graydon graydon 506 Jan 21 23:14 test_add_u128.wasm
-rwxrwxr-x 2 graydon graydon 427 Jan 21 23:14 test_add_u64.wasm
-rwxrwxr-x 2 graydon graydon 2928 Jan 21 23:14 test_alloc.wasm
-rwxrwxr-x 2 graydon graydon 523 Jan 21 23:14 test_contract_data.wasm
-rwxrwxr-x 2 graydon graydon 190 Jan 21 23:14 test_empty.wasm
-rwxrwxr-x 2 graydon graydon 131 Jan 21 23:14 test_empty2.wasm
-rwxrwxr-x 2 graydon graydon 529 Jan 21 23:14 test_errors.wasm
-rwxrwxr-x 2 graydon graydon 507 Jan 21 23:14 test_events.wasm
-rwxrwxr-x 2 graydon graydon 695 Jan 21 23:14 test_import_contract.wasm
-rwxrwxr-x 2 graydon graydon 1313 Jan 21 23:14 test_invoke_contract.wasm
-rwxrwxr-x 2 graydon graydon 190 Jan 21 23:14 test_logging.wasm
-rwxrwxr-x 2 graydon graydon 3026 Jan 21 23:14 test_udt.wasm
~~~ 

After:
~~~
-rwxrwxr-x 2 graydon graydon 21986 Jan 21 22:57 soroban_token_spec.wasm
-rwxrwxr-x 2 graydon graydon 533 Jan 21 22:57 test_add_i128.wasm
-rwxrwxr-x 2 graydon graydon 534 Jan 21 22:57 test_add_u128.wasm
-rwxrwxr-x 2 graydon graydon 393 Jan 21 22:57 test_add_u64.wasm
-rwxrwxr-x 2 graydon graydon 3002 Jan 21 22:57 test_alloc.wasm
-rwxrwxr-x 2 graydon graydon 541 Jan 21 22:57 test_contract_data.wasm
-rwxrwxr-x 2 graydon graydon 190 Jan 21 22:57 test_empty.wasm
-rwxrwxr-x 2 graydon graydon 131 Jan 21 22:57 test_empty2.wasm
-rwxrwxr-x 2 graydon graydon 493 Jan 21 22:57 test_errors.wasm
-rwxrwxr-x 2 graydon graydon 507 Jan 21 22:57 test_events.wasm
-rwxrwxr-x 2 graydon graydon 665 Jan 21 22:57 test_import_contract.wasm
-rwxrwxr-x 2 graydon graydon 1182 Jan 21 22:57 test_invoke_contract.wasm
-rwxrwxr-x 2 graydon graydon 190 Jan 21 22:57 test_logging.wasm
-rwxrwxr-x 2 graydon graydon 3266 Jan 21 22:57 test_udt.wasm
~~~

### Size-optimized

Before:
~~~
-rw-rw-r-- 1 graydon graydon 10320 Jan 21 23:12 soroban_token_spec.wasm
-rw-rw-r-- 1 graydon graydon 430 Jan 21 23:12 test_add_i128.wasm
-rw-rw-r-- 1 graydon graydon 429 Jan 21 23:12 test_add_u128.wasm
-rw-rw-r-- 1 graydon graydon 360 Jan 21 23:12 test_add_u64.wasm
-rw-rw-r-- 1 graydon graydon 1524 Jan 21 23:12 test_alloc.wasm
-rw-rw-r-- 1 graydon graydon 424 Jan 21 23:12 test_contract_data.wasm
-rw-rw-r-- 1 graydon graydon 183 Jan 21 23:12 test_empty.wasm
-rw-rw-r-- 1 graydon graydon 124 Jan 21 23:12 test_empty2.wasm
-rw-rw-r-- 1 graydon graydon 360 Jan 21 23:12 test_errors.wasm
-rw-rw-r-- 1 graydon graydon 458 Jan 21 23:12 test_events.wasm
-rw-rw-r-- 1 graydon graydon 571 Jan 21 23:12 test_import_contract.wasm
-rw-rw-r-- 1 graydon graydon 719 Jan 21 23:12 test_invoke_contract.wasm
-rw-rw-r-- 1 graydon graydon 183 Jan 21 23:12 test_logging.wasm
-rw-rw-r-- 1 graydon graydon 2561 Jan 21 23:12 test_udt.wasm
~~~

After:
~~~
-rw-rw-r-- 1 graydon graydon 9581 Jan 21 23:09 soroban_token_spec.wasm
-rw-rw-r-- 1 graydon graydon 407 Jan 21 23:09 test_add_i128.wasm
-rw-rw-r-- 1 graydon graydon 406 Jan 21 23:09 test_add_u128.wasm
-rw-rw-r-- 1 graydon graydon 282 Jan 21 23:09 test_add_u64.wasm
-rw-rw-r-- 1 graydon graydon 1488 Jan 21 23:09 test_alloc.wasm
-rw-rw-r-- 1 graydon graydon 451 Jan 21 23:09 test_contract_data.wasm
-rw-rw-r-- 1 graydon graydon 183 Jan 21 23:09 test_empty.wasm
-rw-rw-r-- 1 graydon graydon 124 Jan 21 23:09 test_empty2.wasm
-rw-rw-r-- 1 graydon graydon 383 Jan 21 23:09 test_errors.wasm
-rw-rw-r-- 1 graydon graydon 458 Jan 21 23:09 test_events.wasm
-rw-rw-r-- 1 graydon graydon 526 Jan 21 23:09 test_import_contract.wasm
-rw-rw-r-- 1 graydon graydon 767 Jan 21 23:09 test_invoke_contract.wasm
-rw-rw-r-- 1 graydon graydon 183 Jan 21 23:09 test_logging.wasm
-rw-rw-r-- 1 graydon graydon 2578 Jan 21 23:09 test_udt.wasm
~~~