### PR TITLE
(minimal) Adapt to introduction of Env::Error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -841,7 +841,7 @@ dependencies = [
 [[package]]
 name = "soroban-env-common"
 version = "0.0.12"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=d803b0922d1d9eb4d3cfde5e6d574c7776c23388#d803b0922d1d9eb4d3cfde5e6d574c7776c23388"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=96ea6dcbb2a57208b2ba1dc202490b92d4ba537e#96ea6dcbb2a57208b2ba1dc202490b92d4ba537e"
 dependencies = [
  "crate-git-revision",
  "serde",
@@ -854,7 +854,7 @@ dependencies = [
 [[package]]
 name = "soroban-env-guest"
 version = "0.0.12"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=d803b0922d1d9eb4d3cfde5e6d574c7776c23388#d803b0922d1d9eb4d3cfde5e6d574c7776c23388"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=96ea6dcbb2a57208b2ba1dc202490b92d4ba537e#96ea6dcbb2a57208b2ba1dc202490b92d4ba537e"
 dependencies = [
  "soroban-env-common",
  "static_assertions",
@@ -863,7 +863,7 @@ dependencies = [
 [[package]]
 name = "soroban-env-host"
 version = "0.0.12"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=d803b0922d1d9eb4d3cfde5e6d574c7776c23388#d803b0922d1d9eb4d3cfde5e6d574c7776c23388"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=96ea6dcbb2a57208b2ba1dc202490b92d4ba537e#96ea6dcbb2a57208b2ba1dc202490b92d4ba537e"
 dependencies = [
  "backtrace",
  "curve25519-dalek",
@@ -885,7 +885,7 @@ dependencies = [
 [[package]]
 name = "soroban-env-macros"
 version = "0.0.12"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=d803b0922d1d9eb4d3cfde5e6d574c7776c23388#d803b0922d1d9eb4d3cfde5e6d574c7776c23388"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=96ea6dcbb2a57208b2ba1dc202490b92d4ba537e#96ea6dcbb2a57208b2ba1dc202490b92d4ba537e"
 dependencies = [
  "itertools",
  "proc-macro2",
@@ -911,7 +911,7 @@ dependencies = [
 [[package]]
 name = "soroban-native-sdk-macros"
 version = "0.0.12"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=d803b0922d1d9eb4d3cfde5e6d574c7776c23388#d803b0922d1d9eb4d3cfde5e6d574c7776c23388"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=96ea6dcbb2a57208b2ba1dc202490b92d4ba537e#96ea6dcbb2a57208b2ba1dc202490b92d4ba537e"
 dependencies = [
  "itertools",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,17 +37,17 @@ soroban-token-spec = { version = "0.4.3", path = "soroban-token-spec" }
 [workspace.dependencies.soroban-env-common]
 version = "0.0.12"
 git = "https://github.com/stellar/rs-soroban-env"
-rev = "d803b0922d1d9eb4d3cfde5e6d574c7776c23388"
+rev = "96ea6dcbb2a57208b2ba1dc202490b92d4ba537e"
 
 [workspace.dependencies.soroban-env-guest]
 version = "0.0.12"
 git = "https://github.com/stellar/rs-soroban-env"
-rev = "d803b0922d1d9eb4d3cfde5e6d574c7776c23388"
+rev = "96ea6dcbb2a57208b2ba1dc202490b92d4ba537e"
 
 [workspace.dependencies.soroban-env-host]
 version = "0.0.12"
 git = "https://github.com/stellar/rs-soroban-env"
-rev = "d803b0922d1d9eb4d3cfde5e6d574c7776c23388"
+rev = "96ea6dcbb2a57208b2ba1dc202490b92d4ba537e"
 
 [workspace.dependencies.stellar-strkey]
 version = "0.0.6"

--- a/soroban-sdk/src/accounts.rs
+++ b/soroban-sdk/src/accounts.rs
@@ -6,6 +6,7 @@ use core::{cmp::Ordering, fmt::Debug};
 use crate::{
     env::internal::xdr,
     env::internal::{Env as _, EnvBase as _, RawVal, RawValConvertible},
+    unwrap::UnwrapInfallible,
     BytesN, ConversionError, Env, Object, TryFromVal,
 };
 
@@ -65,7 +66,11 @@ impl Accounts {
     /// Gets the account for the account ID.
     pub fn get(&self, id: &AccountId) -> Option<Account> {
         let env = id.env();
-        if env.account_exists(id.to_object()).is_true() {
+        if env
+            .account_exists(id.to_object())
+            .unwrap_infallible()
+            .is_true()
+        {
             Some(Account(id.clone()))
         } else {
             None
@@ -120,7 +125,10 @@ impl PartialOrd for AccountId {
 impl Ord for AccountId {
     fn cmp(&self, other: &Self) -> core::cmp::Ordering {
         self.env.check_same_env(&other.env);
-        let v = self.env.obj_cmp(self.obj.to_raw(), other.obj.to_raw());
+        let v = self
+            .env
+            .obj_cmp(self.obj.to_raw(), other.obj.to_raw())
+            .unwrap_infallible();
         v.cmp(&0)
     }
 }
@@ -328,13 +336,17 @@ impl Account {
     /// Returns if the account exists.
     pub fn exists(id: &AccountId) -> bool {
         let env = id.env();
-        env.account_exists(id.to_object()).is_true()
+        env.account_exists(id.to_object())
+            .unwrap_infallible()
+            .is_true()
     }
 
     /// Returns the low threshold for the Stellar account.
     pub fn low_threshold(&self) -> u8 {
         let env = self.env();
-        let val = env.account_get_low_threshold(self.to_object());
+        let val = env
+            .account_get_low_threshold(self.to_object())
+            .unwrap_infallible();
         let threshold_u32 = unsafe { <u32 as RawValConvertible>::unchecked_from_val(val) };
         threshold_u32 as u8
     }
@@ -342,7 +354,9 @@ impl Account {
     /// Returns the medium threshold for the Stellar account.
     pub fn medium_threshold(&self) -> u8 {
         let env = self.env();
-        let val = env.account_get_medium_threshold(self.to_object());
+        let val = env
+            .account_get_medium_threshold(self.to_object())
+            .unwrap_infallible();
         let threshold_u32 = unsafe { <u32 as RawValConvertible>::unchecked_from_val(val) };
         threshold_u32 as u8
     }
@@ -350,7 +364,9 @@ impl Account {
     /// Returns the high threshold for the Stellar account.
     pub fn high_threshold(&self) -> u8 {
         let env = self.env();
-        let val = env.account_get_high_threshold(self.to_object());
+        let val = env
+            .account_get_high_threshold(self.to_object())
+            .unwrap_infallible();
         let threshold_u32 = unsafe { <u32 as RawValConvertible>::unchecked_from_val(val) };
         threshold_u32 as u8
     }
@@ -359,7 +375,9 @@ impl Account {
     /// the signer does not exist for the account, returns zero (`0`).
     pub fn signer_weight(&self, signer: &BytesN<32>) -> u8 {
         let env = self.env();
-        let val = env.account_get_signer_weight(self.to_object(), signer.to_object());
+        let val = env
+            .account_get_signer_weight(self.to_object(), signer.to_object())
+            .unwrap_infallible();
         let weight_u32 = unsafe { <u32 as RawValConvertible>::unchecked_from_val(val) };
         weight_u32 as u8
     }

--- a/soroban-sdk/src/crypto.rs
+++ b/soroban-sdk/src/crypto.rs
@@ -1,5 +1,5 @@
 //! Crypto contains functions for cryptographic functions.
-use crate::{env::internal, Bytes, BytesN, Env};
+use crate::{env::internal, unwrap::UnwrapInfallible, Bytes, BytesN, Env};
 
 /// Crypto provides access to cryptographic functions.
 pub struct Crypto {
@@ -18,7 +18,7 @@ impl Crypto {
     /// Returns the SHA-256 hash of the data.
     pub fn sha256(&self, data: &Bytes) -> BytesN<32> {
         let env = self.env();
-        let bin = internal::Env::compute_hash_sha256(env, data.into());
+        let bin = internal::Env::compute_hash_sha256(env, data.into()).unwrap_infallible();
         unsafe { BytesN::unchecked_new(env.clone(), bin) }
     }
 

--- a/soroban-sdk/src/deploy.rs
+++ b/soroban-sdk/src/deploy.rs
@@ -37,7 +37,7 @@
 //! # #[cfg(not(feature = "testutils"))]
 //! # fn main() { }
 //! ```
-use crate::{env::internal::Env as _, Bytes, BytesN, Env, IntoVal};
+use crate::{env::internal::Env as _, unwrap::UnwrapInfallible, Bytes, BytesN, Env, IntoVal};
 
 /// Deployer provides access to deploying contracts.
 pub struct Deployer {
@@ -105,10 +105,12 @@ impl DeployerWithCurrentContract {
     /// Returns the deployed contract's ID.
     pub fn deploy(&self, wasm_hash: &impl IntoVal<Env, BytesN<32>>) -> BytesN<32> {
         let env = &self.env;
-        let id = env.create_contract_from_contract(
-            wasm_hash.into_val(env).to_object(),
-            self.salt.to_object(),
-        );
+        let id = env
+            .create_contract_from_contract(
+                wasm_hash.into_val(env).to_object(),
+                self.salt.to_object(),
+            )
+            .unwrap_infallible();
         unsafe { BytesN::<32>::unchecked_new(env.clone(), id) }
     }
 }

--- a/soroban-sdk/src/events.rs
+++ b/soroban-sdk/src/events.rs
@@ -5,6 +5,7 @@ use core::fmt::Debug;
 use crate::{contracttype, Bytes, BytesN, Map};
 use crate::{
     env::internal::{self},
+    unwrap::UnwrapInfallible,
     ConversionError, Env, IntoVal, RawVal, TryFromVal, Vec,
 };
 
@@ -115,7 +116,8 @@ impl Events {
         D: IntoVal<Env, RawVal>,
     {
         let env = self.env();
-        internal::Env::contract_event(env, topics.into_val(env).to_object(), data.into_val(env));
+        internal::Env::contract_event(env, topics.into_val(env).to_object(), data.into_val(env))
+            .unwrap_infallible();
     }
 }
 

--- a/soroban-sdk/src/ledger.rs
+++ b/soroban-sdk/src/ledger.rs
@@ -1,6 +1,7 @@
 //! Ledger contains types for retrieving information about the current ledger.
 use crate::{
     env::internal::{self, RawValConvertible},
+    unwrap::UnwrapInfallible,
     Bytes, Env,
 };
 
@@ -54,7 +55,7 @@ impl Ledger {
     /// Returns the version of the protocol that the ledger created with.
     pub fn protocol_version(&self) -> u32 {
         let env = self.env();
-        let val = internal::Env::get_ledger_version(env);
+        let val = internal::Env::get_ledger_version(env).unwrap_infallible();
         unsafe { u32::unchecked_from_val(val) }
     }
 
@@ -64,7 +65,7 @@ impl Ledger {
     /// that is sequential, incremented by one for each new ledger.
     pub fn sequence(&self) -> u32 {
         let env = self.env();
-        let val = internal::Env::get_ledger_sequence(env);
+        let val = internal::Env::get_ledger_sequence(env).unwrap_infallible();
         unsafe { u32::unchecked_from_val(val) }
     }
 
@@ -75,8 +76,8 @@ impl Ledger {
     /// at 00:00:00 UTC.
     pub fn timestamp(&self) -> u64 {
         let env = self.env();
-        let obj = internal::Env::get_ledger_timestamp(env);
-        internal::Env::obj_to_u64(env, obj)
+        let obj = internal::Env::get_ledger_timestamp(env).unwrap_infallible();
+        internal::Env::obj_to_u64(env, obj).unwrap_infallible()
     }
 
     /// Returns the network passphrase.
@@ -88,7 +89,7 @@ impl Ledger {
     /// > Test SDF Network ; September 2015
     pub fn network_passphrase(&self) -> Bytes {
         let env = self.env();
-        let bin_obj = internal::Env::get_ledger_network_passphrase(env);
+        let bin_obj = internal::Env::get_ledger_network_passphrase(env).unwrap_infallible();
         unsafe { Bytes::unchecked_new(env.clone(), bin_obj) }
     }
 }

--- a/soroban-sdk/src/logging.rs
+++ b/soroban-sdk/src/logging.rs
@@ -5,6 +5,7 @@ use core::fmt::Debug;
 
 use crate::{
     env::internal::{self, EnvBase},
+    unwrap::UnwrapInfallible,
     Bytes, Env, IntoVal, RawVal, Vec,
 };
 
@@ -130,7 +131,8 @@ impl Logger {
             if cfg!(target_family = "wasm") {
                 let fmt: Bytes = fmt.into_val(env);
                 let args: Vec<RawVal> = Vec::from_slice(env, args);
-                internal::Env::log_fmt_values(env, fmt.to_object(), args.to_object());
+                internal::Env::log_fmt_values(env, fmt.to_object(), args.to_object())
+                    .unwrap_infallible();
             } else {
                 env.log_static_fmt_general(fmt, args, &[]).unwrap();
             }

--- a/soroban-sdk/src/serde.rs
+++ b/soroban-sdk/src/serde.rs
@@ -22,7 +22,9 @@
 //! assert_eq!(roundtrip, Ok(value));
 //! ```
 
-use crate::{env::internal::Env as _, Bytes, Env, IntoVal, RawVal, TryFromVal};
+use crate::{
+    env::internal::Env as _, unwrap::UnwrapInfallible, Bytes, Env, IntoVal, RawVal, TryFromVal,
+};
 
 /// Implemented by types that can be serialized to [Bytes].
 ///
@@ -45,7 +47,7 @@ where
 {
     fn serialize(self, env: &Env) -> Bytes {
         let val: RawVal = self.into_val(env);
-        let bin = env.serialize_to_bytes(val);
+        let bin = env.serialize_to_bytes(val).unwrap_infallible();
         unsafe { Bytes::unchecked_new(env.clone(), bin) }
     }
 }
@@ -57,7 +59,7 @@ where
     type Error = T::Error;
 
     fn deserialize(env: &Env, b: &Bytes) -> Result<Self, Self::Error> {
-        let t = env.deserialize_from_bytes(b.into());
+        let t = env.deserialize_from_bytes(b.into()).unwrap_infallible();
         T::try_from_val(env, &t)
     }
 }

--- a/soroban-sdk/src/set.rs
+++ b/soroban-sdk/src/set.rs
@@ -1,5 +1,7 @@
 use core::{cmp::Ordering, fmt::Debug, iter::FusedIterator};
 
+use crate::unwrap::UnwrapInfallible;
+
 use super::{
     env::internal::Env as _, xdr::ScObjectType, ConversionError, Env, IntoVal, Map, Object, RawVal,
     TryFromVal, Vec,
@@ -133,7 +135,10 @@ where
         if self.is_empty() {
             None
         } else {
-            Some(T::try_from_val(env, &env.map_min_key(self.to_object())))
+            Some(T::try_from_val(
+                env,
+                &env.map_min_key(self.to_object()).unwrap_infallible(),
+            ))
         }
     }
 
@@ -142,7 +147,10 @@ where
         if self.is_empty() {
             None
         } else {
-            Some(T::try_from_val(env, &env.map_max_key(self.to_object())))
+            Some(T::try_from_val(
+                env,
+                &env.map_max_key(self.to_object()).unwrap_infallible(),
+            ))
         }
     }
 

--- a/soroban-sdk/src/storage.rs
+++ b/soroban-sdk/src/storage.rs
@@ -3,6 +3,7 @@ use core::fmt::Debug;
 
 use crate::{
     env::internal::{self, RawVal},
+    unwrap::UnwrapInfallible,
     Env, IntoVal, TryFromVal,
 };
 
@@ -73,7 +74,7 @@ impl Storage {
         K: IntoVal<Env, RawVal>,
     {
         let env = self.env();
-        let rv = internal::Env::has_contract_data(env, key.into_val(env));
+        let rv = internal::Env::has_contract_data(env, key.into_val(env)).unwrap_infallible();
         rv.is_true()
     }
 
@@ -98,9 +99,9 @@ impl Storage {
     {
         let env = self.env();
         let key = key.into_val(env);
-        let has = internal::Env::has_contract_data(env, key);
+        let has = internal::Env::has_contract_data(env, key).unwrap_infallible();
         if has.is_true() {
-            let rv = internal::Env::get_contract_data(env, key);
+            let rv = internal::Env::get_contract_data(env, key).unwrap_infallible();
             Some(V::try_from_val(env, &rv))
         } else {
             None
@@ -121,7 +122,7 @@ impl Storage {
         V: TryFromVal<Env, RawVal>,
     {
         let env = self.env();
-        let rv = internal::Env::get_contract_data(env, key.into_val(env));
+        let rv = internal::Env::get_contract_data(env, key.into_val(env)).unwrap_infallible();
         V::try_from_val(env, &rv)
     }
 
@@ -137,7 +138,8 @@ impl Storage {
         V: IntoVal<Env, RawVal>,
     {
         let env = self.env();
-        internal::Env::put_contract_data(env, key.into_val(env), val.into_val(env));
+        internal::Env::put_contract_data(env, key.into_val(env), val.into_val(env))
+            .unwrap_infallible();
     }
 
     #[inline(always)]
@@ -146,6 +148,6 @@ impl Storage {
         K: IntoVal<Env, RawVal>,
     {
         let env = self.env();
-        internal::Env::del_contract_data(env, key.into_val(env));
+        internal::Env::del_contract_data(env, key.into_val(env)).unwrap_infallible();
     }
 }

--- a/soroban-sdk/src/unwrap.rs
+++ b/soroban-sdk/src/unwrap.rs
@@ -1,3 +1,5 @@
+use core::convert::Infallible;
+
 pub trait UnwrapOptimized {
     type Output;
     fn unwrap_optimized(self) -> Self::Output;
@@ -30,5 +32,39 @@ impl<T, E: core::fmt::Debug> UnwrapOptimized for Result<T, E> {
         }
         #[cfg(not(target_family = "wasm"))]
         self.unwrap()
+    }
+}
+
+pub trait UnwrapInfallible {
+    type Output;
+    fn unwrap_infallible(self) -> Self::Output;
+}
+
+impl<T> UnwrapInfallible for Result<T, Infallible> {
+    type Output = T;
+
+    fn unwrap_infallible(self) -> Self::Output {
+        match self {
+            Ok(ok) => ok,
+            // In the following `Err(never)` branch we convert a type from
+            // `Infallible` to `!`. Both of these are empty types and are
+            // essentially synonyms in rust, they differ only due to historical
+            // reasons that will eventually be eliminated. `Infallible` is a
+            // version we can put in a structure, and `!` is one that gets some
+            // special control-flow treatments.
+            //
+            // Specifically: the type `!` of the resulting expression will be
+            // considered an acceptable inhabitant of any type -- including
+            // `Self::Output` -- since it's an impossible path to execute, this
+            // is considered a harmless convenience in the type system, a bit
+            // like defining zero-divided-by-anything as zero.
+            //
+            // We could also write an infinite `loop {}` here or
+            // `unreachable!()` or similar expressions of type `!`, but
+            // destructuring the `never` variable into an empty set of cases is
+            // the most honest since it's statically checked to _be_ infallible,
+            // not just an assertion of our hopes.)
+            Err(never) => match never {},
+        }
     }
 }


### PR DESCRIPTION
This is a "minimal" version of https://github.com/stellar/rs-soroban-sdk/pull/833, accompanying / adapting to https://github.com/stellar/rs-soroban-env/pull/638.

If this minimal approach is preferred, this PR and https://github.com/stellar/rs-soroban-env/pull/638 should be merged together. Otherwise the more-invasive pair #833 and https://github.com/stellar/rs-soroban-env/pull/633 should be merged together.

This one does much less rearranging and makes no difference to the emitted code at all. It just pushes around where the non-infallible `Env::Error` cases get escalated: formerly it happened in `impl Env for CheckedEnv`, now there's a new internal SDK function `internal::reject_err` that does the work. Infallible errors also need to be explicitly unwrapped in a bunch of places but this is just a type-level thing, operationally it's a no-op.

(I should also note: I could do an "even more minimal" version of this where `soroban_sdk::env::Env` _does not implement_ `soroban_env_common:env::Env`, in which case the "error rejections" could be buried in the macro-generated code in the SDK and we could remove all the `.unwrap_infallible` calls in the SDK bodies. I don't know how important it is for the SDK's Env to implement the common Env.)