### PR TITLE
Allow same named types and functions

### DIFF
--- a/soroban-sdk-macros/src/derive_enum.rs
+++ b/soroban-sdk-macros/src/derive_enum.rs
@@ -150,7 +150,7 @@ pub fn derive_type_enum(
         let spec_xdr = spec_entry.to_xdr().unwrap();
         let spec_xdr_lit = proc_macro2::Literal::byte_string(spec_xdr.as_slice());
         let spec_xdr_len = spec_xdr.len();
-        let spec_ident = format_ident!("__SPEC_XDR_{}", enum_ident.to_string().to_uppercase());
+        let spec_ident = format_ident!("__SPEC_XDR_TYPE_{}", enum_ident.to_string().to_uppercase());
         Some(quote! {
             #[cfg_attr(target_family = "wasm", link_section = "contractspecv0")]
             pub static #spec_ident: [u8; #spec_xdr_len] = #enum_ident::spec_xdr();

--- a/soroban-sdk-macros/src/derive_enum_int.rs
+++ b/soroban-sdk-macros/src/derive_enum_int.rs
@@ -69,7 +69,7 @@ pub fn derive_type_enum_int(
         let spec_xdr = spec_entry.to_xdr().unwrap();
         let spec_xdr_lit = proc_macro2::Literal::byte_string(spec_xdr.as_slice());
         let spec_xdr_len = spec_xdr.len();
-        let spec_ident = format_ident!("__SPEC_XDR_{}", enum_ident.to_string().to_uppercase());
+        let spec_ident = format_ident!("__SPEC_XDR_TYPE_{}", enum_ident.to_string().to_uppercase());
         Some(quote! {
             #[cfg_attr(target_family = "wasm", link_section = "contractspecv0")]
             pub static #spec_ident: [u8; #spec_xdr_len] = #enum_ident::spec_xdr();

--- a/soroban-sdk-macros/src/derive_error_enum_int.rs
+++ b/soroban-sdk-macros/src/derive_error_enum_int.rs
@@ -66,7 +66,7 @@ pub fn derive_type_error_enum_int(
         let spec_xdr = spec_entry.to_xdr().unwrap();
         let spec_xdr_lit = proc_macro2::Literal::byte_string(spec_xdr.as_slice());
         let spec_xdr_len = spec_xdr.len();
-        let spec_ident = format_ident!("__SPEC_XDR_{}", enum_ident.to_string().to_uppercase());
+        let spec_ident = format_ident!("__SPEC_XDR_TYPE_{}", enum_ident.to_string().to_uppercase());
         Some(quote! {
             #[cfg_attr(target_family = "wasm", link_section = "contractspecv0")]
             pub static #spec_ident: [u8; #spec_xdr_len] = #enum_ident::spec_xdr();

--- a/soroban-sdk-macros/src/derive_fn.rs
+++ b/soroban-sdk-macros/src/derive_fn.rs
@@ -168,7 +168,7 @@ pub fn derive_fn(
     let spec_xdr = spec_entry.to_xdr().unwrap();
     let spec_xdr_lit = proc_macro2::Literal::byte_string(spec_xdr.as_slice());
     let spec_xdr_len = spec_xdr.len();
-    let spec_ident = format_ident!("__SPEC_XDR_{}", ident.to_string().to_uppercase());
+    let spec_ident = format_ident!("__SPEC_XDR_FN_{}", ident.to_string().to_uppercase());
     let spec_fn_ident = format_ident!("spec_xdr_{}", ident.to_string());
 
     // If errors have occurred, render them instead.

--- a/soroban-sdk-macros/src/derive_struct.rs
+++ b/soroban-sdk-macros/src/derive_struct.rs
@@ -95,7 +95,7 @@ pub fn derive_type_struct(
         let spec_xdr = spec_entry.to_xdr().unwrap();
         let spec_xdr_lit = proc_macro2::Literal::byte_string(spec_xdr.as_slice());
         let spec_xdr_len = spec_xdr.len();
-        let spec_ident = format_ident!("__SPEC_XDR_{}", ident.to_string().to_uppercase());
+        let spec_ident = format_ident!("__SPEC_XDR_TYPE_{}", ident.to_string().to_uppercase());
         Some(quote! {
             #[cfg_attr(target_family = "wasm", link_section = "contractspecv0")]
             pub static #spec_ident: [u8; #spec_xdr_len] = #ident::spec_xdr();

--- a/soroban-sdk-macros/src/derive_struct_tuple.rs
+++ b/soroban-sdk-macros/src/derive_struct_tuple.rs
@@ -83,7 +83,7 @@ pub fn derive_type_struct_tuple(
         let spec_xdr = spec_entry.to_xdr().unwrap();
         let spec_xdr_lit = proc_macro2::Literal::byte_string(spec_xdr.as_slice());
         let spec_xdr_len = spec_xdr.len();
-        let spec_ident = format_ident!("__SPEC_XDR_{}", ident.to_string().to_uppercase());
+        let spec_ident = format_ident!("__SPEC_XDR_TYPE_{}", ident.to_string().to_uppercase());
         Some(quote! {
             #[cfg_attr(target_family = "wasm", link_section = "contractspecv0")]
             pub static #spec_ident: [u8; #spec_xdr_len] = #ident::spec_xdr();

--- a/soroban-sdk/src/tests.rs
+++ b/soroban-sdk/src/tests.rs
@@ -7,6 +7,7 @@ mod contract_call_stack;
 mod contract_invoke;
 mod contract_invoker_account;
 mod contract_invoker_client;
+mod contract_overlapping_type_fn_names;
 mod contract_snapshot;
 mod contract_store;
 mod contract_udt_enum;

--- a/soroban-sdk/src/tests/contract_add_i32.rs
+++ b/soroban-sdk/src/tests/contract_add_i32.rs
@@ -24,7 +24,7 @@ fn test_functional() {
 
 #[test]
 fn test_spec() {
-    let entries = ScSpecEntry::from_xdr(__SPEC_XDR_ADD).unwrap();
+    let entries = ScSpecEntry::from_xdr(__SPEC_XDR_FN_ADD).unwrap();
     let expect = ScSpecEntry::FunctionV0(ScSpecFunctionV0 {
         name: "add".try_into().unwrap(),
         inputs: vec![

--- a/soroban-sdk/src/tests/contract_overlapping_type_fn_names.rs
+++ b/soroban-sdk/src/tests/contract_overlapping_type_fn_names.rs
@@ -1,0 +1,27 @@
+use crate as soroban_sdk;
+use soroban_sdk::{contractimpl, contracttype, Env};
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[contracttype]
+pub struct State {
+    pub a: i32,
+}
+
+pub struct Contract;
+
+#[contractimpl]
+impl Contract {
+    pub fn state() -> State {
+        State { a: 1 }
+    }
+}
+
+#[test]
+fn test_functional() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, Contract);
+
+    let client = ContractClient::new(&env, &contract_id);
+    let s = client.state();
+    assert_eq!(s, State { a: 1 });
+}

--- a/soroban-sdk/src/tests/contract_udt_struct.rs
+++ b/soroban-sdk/src/tests/contract_udt_struct.rs
@@ -59,7 +59,7 @@ fn test_error_on_partial_decode() {
 
 #[test]
 fn test_spec() {
-    let entries = ScSpecEntry::from_xdr(__SPEC_XDR_ADD).unwrap();
+    let entries = ScSpecEntry::from_xdr(__SPEC_XDR_FN_ADD).unwrap();
     let expect = ScSpecEntry::FunctionV0(ScSpecFunctionV0 {
         name: "add".try_into().unwrap(),
         inputs: vec![

--- a/soroban-sdk/src/tests/contract_udt_struct_tuple.rs
+++ b/soroban-sdk/src/tests/contract_udt_struct_tuple.rs
@@ -68,7 +68,7 @@ fn test_error_on_partial_decode() {
 
 #[test]
 fn test_spec() {
-    let entries = ScSpecEntry::from_xdr(__SPEC_XDR_ADD).unwrap();
+    let entries = ScSpecEntry::from_xdr(__SPEC_XDR_FN_ADD).unwrap();
     let expect = ScSpecEntry::FunctionV0(ScSpecFunctionV0 {
         name: "add".try_into().unwrap(),
         inputs: std::vec![


### PR DESCRIPTION
### What
Change the names of the static variables that contain the spec XDR to include a type or function qualifier for the kind of entry the spec contains.

### Why
To allow same named types and functions in contracts. When a type and function have the same name today they result in  two static variables that have the same names. Adding a qualifier to what they are to those variables names will stop them from colliding.

Close #828