### PR TITLE
Make soroban_token_spec::spec_xdr easier to keep updated

### DIFF
--- a/soroban-token-spec/src/lib.rs
+++ b/soroban-token-spec/src/lib.rs
@@ -98,36 +98,39 @@ impl Token {
     }
 }
 
+const SPEC_XDR_INPUT: &[&[u8]] = &[
+    &Token::spec_xdr_allowance(),
+    &Token::spec_xdr_authorized(),
+    &Token::spec_xdr_balance(),
+    &Token::spec_xdr_burn(),
+    &Token::spec_xdr_burn_from(),
+    &Token::spec_xdr_clawback(),
+    &Token::spec_xdr_decimals(),
+    &Token::spec_xdr_decr_allow(),
+    &Token::spec_xdr_incr_allow(),
+    &Token::spec_xdr_mint(),
+    &Token::spec_xdr_name(),
+    &Token::spec_xdr_nonce(),
+    &Token::spec_xdr_set_admin(),
+    &Token::spec_xdr_set_auth(),
+    &Token::spec_xdr_spendable(),
+    &Token::spec_xdr_symbol(),
+    &Token::spec_xdr_xfer(),
+    &Token::spec_xdr_xfer_from(),
+    &soroban_auth::Identifier::spec_xdr(),
+    &soroban_auth::Signature::spec_xdr(),
+    &soroban_auth::Ed25519Signature::spec_xdr(),
+    &soroban_auth::AccountSignatures::spec_xdr(),
+];
+
+const SPEC_XDR_LEN: usize = 2536;
+
 /// Returns the XDR spec for the Token contract.
 #[doc(hidden)]
-pub const fn spec_xdr() -> [u8; 2012] {
-    let input: &[&[u8]] = &[
-        &Token::spec_xdr_allowance(),
-        &Token::spec_xdr_authorized(),
-        &Token::spec_xdr_balance(),
-        &Token::spec_xdr_burn(),
-        &Token::spec_xdr_burn_from(),
-        &Token::spec_xdr_clawback(),
-        &Token::spec_xdr_decimals(),
-        &Token::spec_xdr_decr_allow(),
-        &Token::spec_xdr_incr_allow(),
-        &Token::spec_xdr_mint(),
-        &Token::spec_xdr_name(),
-        &Token::spec_xdr_nonce(),
-        &Token::spec_xdr_set_admin(),
-        &Token::spec_xdr_set_auth(),
-        &Token::spec_xdr_spendable(),
-        &Token::spec_xdr_symbol(),
-        &Token::spec_xdr_xfer(),
-        &Token::spec_xdr_xfer_from(),
-        &soroban_auth::Identifier::spec_xdr(),
-        &soroban_auth::Signature::spec_xdr(),
-        &soroban_auth::Ed25519Signature::spec_xdr(),
-        &soroban_auth::AccountSignatures::spec_xdr(),
-    ];
-
+pub const fn spec_xdr() -> [u8; SPEC_XDR_LEN] {
+    let input = SPEC_XDR_INPUT;
     // Concatenate all XDR for each item that makes up the token spec.
-    let mut output = [0u8; 2012];
+    let mut output = [0u8; SPEC_XDR_LEN];
     let mut input_i = 0;
     let mut output_i = 0;
     while input_i < input.len() {

--- a/soroban-token-spec/src/lib.rs
+++ b/soroban-token-spec/src/lib.rs
@@ -123,7 +123,7 @@ const SPEC_XDR_INPUT: &[&[u8]] = &[
     &soroban_auth::AccountSignatures::spec_xdr(),
 ];
 
-const SPEC_XDR_LEN: usize = 2536;
+const SPEC_XDR_LEN: usize = 2012;
 
 /// Returns the XDR spec for the Token contract.
 #[doc(hidden)]

--- a/soroban-token-spec/src/tests/spec_xdr.rs
+++ b/soroban-token-spec/src/tests/spec_xdr.rs
@@ -1,8 +1,14 @@
 use soroban_sdk::xdr::{Error, ReadXdr, ScSpecEntry};
 
-use crate::spec_xdr;
+use crate::{spec_xdr, SPEC_XDR_INPUT, SPEC_XDR_LEN};
 
 extern crate std;
+
+#[test]
+fn test_spec_xdr_len() {
+    let len = SPEC_XDR_INPUT.iter().fold(0usize, |sum, x| sum + x.len());
+    assert_eq!(SPEC_XDR_LEN, len);
+}
 
 #[test]
 fn test_spec_xdr() -> Result<(), Error> {


### PR DESCRIPTION
### What
Change soroban_token_spec::spec_xdr to generate the final value from constant inputs, and add a test that checks that the constant inputs are valid.

### Why
The spec_xdr function has to know ahead of time what the final size of the byte slice will be because the function is a const function. Additionally the panics in the const function cannot construct an error message containing the expected length. Whenever we change the format of the spec xdr it's difficult to know what the new length is. We get a very opaque error message saying the length is wrong but not what to set it to.

By moving the inputs and expected length to be constants, and add a test that asserts the length matches the sum of the inputs, we provide a way to get the length for updating it.