### PR TITLE
Rename var in test and rename test

### DIFF
--- a/soroban-sdk/src/tests.rs
+++ b/soroban-sdk/src/tests.rs
@@ -4,7 +4,7 @@ mod budget;
 mod contract_add_i32;
 mod contract_assert;
 mod contract_call_stack;
-mod contract_docs;
+mod contract_docs_fn;
 mod contract_invoke;
 mod contract_overlapping_type_fn_names;
 mod contract_snapshot;

--- a/soroban-sdk/src/tests/contract_docs_fn.rs
+++ b/soroban-sdk/src/tests/contract_docs_fn.rs
@@ -22,12 +22,12 @@ fn test_functional() {
 
 #[test]
 fn test_spec() {
-    let entries = ScSpecEntry::from_xdr(__SPEC_XDR_FN_ADD).unwrap();
+    let entry = ScSpecEntry::from_xdr(__SPEC_XDR_FN_ADD).unwrap();
     let expect = ScSpecEntry::FunctionV0(ScSpecFunctionV0 {
         doc: "Add adds\nthings together.".try_into().unwrap(),
         name: "add".try_into().unwrap(),
         inputs: vec![].try_into().unwrap(),
         outputs: vec![].try_into().unwrap(),
     });
-    assert_eq!(entries, expect);
+    assert_eq!(entry, expect);
 }


### PR DESCRIPTION
### What
Rename 'entries' var in test to 'entry'. Rename test from 'docs' to 'docs_fn'.

### Why
The entries variable contains a single spec entry. The plural is misleading.

The docs test contains tests only for docs on functions.