### PR TITLE
Rename Serialize/Deserialize to To/FromXdr

### DIFF
--- a/soroban-sdk/src/lib.rs
+++ b/soroban-sdk/src/lib.rs
@@ -605,7 +605,6 @@ pub mod unwrap;
 mod env;
 
 mod address;
-pub use env::xdr;
 
 pub use env::ConversionError;
 
@@ -657,7 +656,7 @@ pub use map::Map;
 pub use set::Set;
 pub use vec::Vec;
 
-pub mod serde;
+pub mod xdr;
 
 pub mod testutils;
 

--- a/tests/udt/src/lib.rs
+++ b/tests/udt/src/lib.rs
@@ -57,14 +57,14 @@ mod test {
 
     #[test]
     fn test_serializing() {
-        use soroban_sdk::serde::Serialize;
+        use soroban_sdk::xdr::ToXdr;
         let e = Env::default();
         let udt = UdtStruct {
             a: 10,
             b: 12,
             c: vec![&e, 1],
         };
-        let bin = udt.serialize(&e);
+        let bin = udt.to_xdr(&e);
         assert_eq!(bin, {
             let mut bin = Bytes::new(&e);
             bin.push(0);


### PR DESCRIPTION
### What
Rename Serialize/Deserialize to To/FromXdr. Move those traits into the same module as the XDR types.

### Why
@graydon pointed out that the Serialize and Deserialize traits in the serde module were confusing, because when most people see serde they think of the serde crate, but these traits have nothing to do with serde.

While discussing this we also noticed that it was not very obvious by looking at the traits what the serialization format was.

Renaming the traits and their functions to ToXdr and FromXdr makes the serialization format explicit and removes the misleading serde name.

Moving the traits into the same module as the XDR types keeps all the XDR related functionality in the SDK together.