### PR TITLE
Expose reset budget functions to testutils

### DIFF
--- a/soroban-sdk/src/tests/budget.rs
+++ b/soroban-sdk/src/tests/budget.rs
@@ -18,7 +18,7 @@ fn test_budget() {
     let contract_id = e.register_contract(None, Contract);
     let client = ContractClient::new(&e, &contract_id);
 
-    e.budget().reset();
+    e.budget().reset_default();
     let b = client.add();
     e.budget().print();
 

--- a/soroban-sdk/src/testutils.rs
+++ b/soroban-sdk/src/testutils.rs
@@ -87,7 +87,26 @@ pub mod budget {
         /// Reset the budget.
         pub fn reset(&mut self) {
             self.0.reset_default();
+        }
+
+        pub fn reset_unlimited(&mut self) {
             self.0.reset_unlimited();
+        }
+
+        pub fn reset_limits(&mut self, cpu: u64, mem: u64) {
+            self.0.reset_limits(cpu, mem);
+        }
+
+        pub fn reset_unlimited_cpu(&mut self) {
+            self.0.reset_unlimited_cpu();
+        }
+
+        pub fn reset_unlimited_mem(&mut self) {
+            self.0.reset_unlimited_mem();
+        }
+
+        pub fn reset_inputs(&mut self) {
+            self.0.reset_inputs();
         }
 
         /// Returns the CPU instruction cost.

--- a/soroban-sdk/src/testutils.rs
+++ b/soroban-sdk/src/testutils.rs
@@ -85,7 +85,7 @@ pub mod budget {
         }
 
         /// Reset the budget.
-        pub fn reset(&mut self) {
+        pub fn reset_default(&mut self) {
             self.0.reset_default();
         }
 
@@ -95,14 +95,6 @@ pub mod budget {
 
         pub fn reset_limits(&mut self, cpu: u64, mem: u64) {
             self.0.reset_limits(cpu, mem);
-        }
-
-        pub fn reset_unlimited_cpu(&mut self) {
-            self.0.reset_unlimited_cpu();
-        }
-
-        pub fn reset_unlimited_mem(&mut self) {
-            self.0.reset_unlimited_mem();
         }
 
         pub fn reset_inputs(&mut self) {

--- a/soroban-sdk/src/testutils.rs
+++ b/soroban-sdk/src/testutils.rs
@@ -57,7 +57,7 @@ pub mod budget {
     /// # #[cfg(feature = "testutils")]
     /// # fn main() {
     /// #     let env = Env::default();
-    /// env.budget().reset();
+    /// env.budget().reset_default();
     /// // ...
     /// println!("{}", env.budget());
     /// # }


### PR DESCRIPTION
### What

This PR exposes the various reset budget functions to the testutils.

### Why

The ability to change the budget to arbitrary values was [just recently](https://github.com/stellar/rs-soroban-env/pull/677) added to the soroban-env.  
This PR also aims to allow this during the testing stage of a contract, as suggested here:
https://discord.com/channels/897514728459468821/1076187600668340384/1076187600668340384

### Known limitations

Previously the `reset` method in the test utils set the budget limits to unlimited.  
As this PR introduces the `reset_unlimited` functionality, the `reset` function was changed to only reset to the default budget limits.  
This change might be breaking in rare circumstances. 