### PR TITLE
Use the updated `source_account()` interface.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -838,7 +838,7 @@ dependencies = [
 [[package]]
 name = "soroban-env-common"
 version = "0.0.14"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=d06aaddca61f011cc64ec098b464233423197c3a#d06aaddca61f011cc64ec098b464233423197c3a"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=7241dbd90048f1a5ce465c39aefa3fc14ec989c5#7241dbd90048f1a5ce465c39aefa3fc14ec989c5"
 dependencies = [
  "crate-git-revision",
  "serde",
@@ -851,7 +851,7 @@ dependencies = [
 [[package]]
 name = "soroban-env-guest"
 version = "0.0.14"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=d06aaddca61f011cc64ec098b464233423197c3a#d06aaddca61f011cc64ec098b464233423197c3a"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=7241dbd90048f1a5ce465c39aefa3fc14ec989c5#7241dbd90048f1a5ce465c39aefa3fc14ec989c5"
 dependencies = [
  "soroban-env-common",
  "static_assertions",
@@ -860,7 +860,7 @@ dependencies = [
 [[package]]
 name = "soroban-env-host"
 version = "0.0.14"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=d06aaddca61f011cc64ec098b464233423197c3a#d06aaddca61f011cc64ec098b464233423197c3a"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=7241dbd90048f1a5ce465c39aefa3fc14ec989c5#7241dbd90048f1a5ce465c39aefa3fc14ec989c5"
 dependencies = [
  "backtrace",
  "curve25519-dalek",
@@ -882,7 +882,7 @@ dependencies = [
 [[package]]
 name = "soroban-env-macros"
 version = "0.0.14"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=d06aaddca61f011cc64ec098b464233423197c3a#d06aaddca61f011cc64ec098b464233423197c3a"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=7241dbd90048f1a5ce465c39aefa3fc14ec989c5#7241dbd90048f1a5ce465c39aefa3fc14ec989c5"
 dependencies = [
  "itertools",
  "proc-macro2",
@@ -908,7 +908,7 @@ dependencies = [
 [[package]]
 name = "soroban-native-sdk-macros"
 version = "0.0.14"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=d06aaddca61f011cc64ec098b464233423197c3a#d06aaddca61f011cc64ec098b464233423197c3a"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=7241dbd90048f1a5ce465c39aefa3fc14ec989c5#7241dbd90048f1a5ce465c39aefa3fc14ec989c5"
 dependencies = [
  "itertools",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,17 +37,17 @@ soroban-token-spec = { version = "0.6.0", path = "soroban-token-spec" }
 [workspace.dependencies.soroban-env-common]
 version = "0.0.14"
 git = "https://github.com/stellar/rs-soroban-env"
-rev = "d06aaddca61f011cc64ec098b464233423197c3a"
+rev = "7241dbd90048f1a5ce465c39aefa3fc14ec989c5"
 
 [workspace.dependencies.soroban-env-guest]
 version = "0.0.14"
 git = "https://github.com/stellar/rs-soroban-env"
-rev = "d06aaddca61f011cc64ec098b464233423197c3a"
+rev = "7241dbd90048f1a5ce465c39aefa3fc14ec989c5"
 
 [workspace.dependencies.soroban-env-host]
 version = "0.0.14"
 git = "https://github.com/stellar/rs-soroban-env"
-rev = "d06aaddca61f011cc64ec098b464233423197c3a"
+rev = "7241dbd90048f1a5ce465c39aefa3fc14ec989c5"
 
 [workspace.dependencies.stellar-strkey]
 version = "0.0.7"

--- a/soroban-sdk/src/env.rs
+++ b/soroban-sdk/src/env.rs
@@ -593,11 +593,7 @@ impl Env {
     }
 
     fn register_contract_with_source(&self, source: xdr::ScContractCode) -> BytesN<32> {
-        let prev_source_account = if let Ok(prev_acc) = self.env_impl.source_account() {
-            Some(prev_acc)
-        } else {
-            None
-        };
+        let prev_source_account = self.env_impl.source_account();
         self.env_impl
             .set_source_account(xdr::AccountId(xdr::PublicKey::PublicKeyTypeEd25519(
                 xdr::Uint256(random()),


### PR DESCRIPTION
### What

Use the updated `source_account()` interface with option instead of result.

### Why

Catching up to env update.

### Known limitations

N/A
