### PR TITLE
Add utils for converting from/to contract/account ids.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -838,7 +838,7 @@ dependencies = [
 [[package]]
 name = "soroban-env-common"
 version = "0.0.14"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=dc7f13554c9c318fbae7a5ffb043ca43156f79d7#dc7f13554c9c318fbae7a5ffb043ca43156f79d7"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=5695440da452837555d8f7f259cc33341fdf07b0#5695440da452837555d8f7f259cc33341fdf07b0"
 dependencies = [
  "crate-git-revision",
  "serde",
@@ -851,7 +851,7 @@ dependencies = [
 [[package]]
 name = "soroban-env-guest"
 version = "0.0.14"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=dc7f13554c9c318fbae7a5ffb043ca43156f79d7#dc7f13554c9c318fbae7a5ffb043ca43156f79d7"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=5695440da452837555d8f7f259cc33341fdf07b0#5695440da452837555d8f7f259cc33341fdf07b0"
 dependencies = [
  "soroban-env-common",
  "static_assertions",
@@ -860,7 +860,7 @@ dependencies = [
 [[package]]
 name = "soroban-env-host"
 version = "0.0.14"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=dc7f13554c9c318fbae7a5ffb043ca43156f79d7#dc7f13554c9c318fbae7a5ffb043ca43156f79d7"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=5695440da452837555d8f7f259cc33341fdf07b0#5695440da452837555d8f7f259cc33341fdf07b0"
 dependencies = [
  "backtrace",
  "curve25519-dalek",
@@ -882,7 +882,7 @@ dependencies = [
 [[package]]
 name = "soroban-env-macros"
 version = "0.0.14"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=dc7f13554c9c318fbae7a5ffb043ca43156f79d7#dc7f13554c9c318fbae7a5ffb043ca43156f79d7"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=5695440da452837555d8f7f259cc33341fdf07b0#5695440da452837555d8f7f259cc33341fdf07b0"
 dependencies = [
  "itertools",
  "proc-macro2",
@@ -908,7 +908,7 @@ dependencies = [
 [[package]]
 name = "soroban-native-sdk-macros"
 version = "0.0.14"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=dc7f13554c9c318fbae7a5ffb043ca43156f79d7#dc7f13554c9c318fbae7a5ffb043ca43156f79d7"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=5695440da452837555d8f7f259cc33341fdf07b0#5695440da452837555d8f7f259cc33341fdf07b0"
 dependencies = [
  "itertools",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,17 +37,17 @@ soroban-token-spec = { version = "0.6.0", path = "soroban-token-spec" }
 [workspace.dependencies.soroban-env-common]
 version = "0.0.14"
 git = "https://github.com/stellar/rs-soroban-env"
-rev = "dc7f13554c9c318fbae7a5ffb043ca43156f79d7"
+rev = "5695440da452837555d8f7f259cc33341fdf07b0"
 
 [workspace.dependencies.soroban-env-guest]
 version = "0.0.14"
 git = "https://github.com/stellar/rs-soroban-env"
-rev = "dc7f13554c9c318fbae7a5ffb043ca43156f79d7"
+rev = "5695440da452837555d8f7f259cc33341fdf07b0"
 
 [workspace.dependencies.soroban-env-host]
 version = "0.0.14"
 git = "https://github.com/stellar/rs-soroban-env"
-rev = "dc7f13554c9c318fbae7a5ffb043ca43156f79d7"
+rev = "5695440da452837555d8f7f259cc33341fdf07b0"
 
 [workspace.dependencies.stellar-strkey]
 version = "0.0.7"

--- a/soroban-sdk/src/tests.rs
+++ b/soroban-sdk/src/tests.rs
@@ -1,5 +1,6 @@
 #![cfg(test)]
 
+mod address;
 mod budget;
 mod contract_add_i32;
 mod contract_assert;

--- a/soroban-sdk/src/tests/address.rs
+++ b/soroban-sdk/src/tests/address.rs
@@ -1,0 +1,23 @@
+use crate::{Address, BytesN, Env};
+
+#[test]
+fn test_account_address_conversions() {
+    let env = Env::default();
+    let account_address = Address::from_account_id(&env, &BytesN::from_array(&env, &[222u8; 32]));
+    assert_eq!(
+        account_address.account_id(),
+        Some(BytesN::from_array(&env, &[222u8; 32]))
+    );
+    assert_eq!(account_address.contract_id(), None);
+}
+
+#[test]
+fn test_contract_address_conversions() {
+    let env = Env::default();
+    let contract_address = Address::from_contract_id(&env, &BytesN::from_array(&env, &[111u8; 32]));
+    assert_eq!(
+        contract_address.contract_id(),
+        Some(BytesN::from_array(&env, &[111u8; 32]))
+    );
+    assert_eq!(contract_address.account_id(), None);
+}

--- a/soroban-sdk/src/tests/contractfile_with_sha256.rs
+++ b/soroban-sdk/src/tests/contractfile_with_sha256.rs
@@ -1,7 +1,7 @@
 use crate as soroban_sdk;
 pub const WASM: &[u8] = soroban_sdk::contractfile!(
     file = "../target/wasm32-unknown-unknown/release/test_add_u64.wasm",
-    sha256 = "8defec8d424eb76db7e1d66a7d19e31ff34afae5dafdf5fca9ec59ed53ab9a63",
+    sha256 = "50ef498f6a4ed5f793f4b0cacc3283eec3d134f88f4e597936efa558c5ba5093",
 );
 
 #[test]

--- a/soroban-sdk/src/tests/contractimport_with_sha256.rs
+++ b/soroban-sdk/src/tests/contractimport_with_sha256.rs
@@ -8,7 +8,7 @@ mod addcontract {
     use crate as soroban_sdk;
     soroban_sdk::contractimport!(
         file = "../target/wasm32-unknown-unknown/release/test_add_u64.wasm",
-        sha256 = "8defec8d424eb76db7e1d66a7d19e31ff34afae5dafdf5fca9ec59ed53ab9a63",
+        sha256 = "50ef498f6a4ed5f793f4b0cacc3283eec3d134f88f4e597936efa558c5ba5093",
     );
 }
 

--- a/soroban-sdk/src/testutils.rs
+++ b/soroban-sdk/src/testutils.rs
@@ -170,11 +170,6 @@ pub(crate) fn random<const N: usize>() -> [u8; N] {
 }
 
 pub trait Address {
-    /// Build an address from a contract identifier.
-    ///
-    /// This is useful to create an Address of the registered contract.
-    fn from_contract_id(env: &Env, contract_id: &crate::BytesN<32>) -> crate::Address;
-
     /// Create a random Address.
     ///
     /// Implementation note: this always builds the contract addresses now. This


### PR DESCRIPTION
### What

Add utils for converting from/to contract/account ids.

### Why

This covers some relatively rare, but seemingly useful Address use cases, such as transferring tokens to the newly deployed contracts or supporting cross-chain bridges.

### Known limitations

N/A
