### PR TITLE
Rough first pass at generating typescript contract bindings

### DIFF
--- a/soroban-spec/src/gen.rs
+++ b/soroban-spec/src/gen.rs
@@ -1,2 +1,3 @@
 pub mod json;
 pub mod rust;
+pub mod typescript;

--- a/soroban-spec/src/gen/typescript.rs
+++ b/soroban-spec/src/gen/typescript.rs
@@ -51,6 +51,7 @@ pub fn generate(spec: &[ScSpecEntry]) -> String {
     let header = r#"import * as SorobanClient from "soroban-client";
 let xdr = SorobanClient.xdr;
 
+// TODO: Move all the non-trivial conversions to js-stellar-base and use them them from there.
 function bigintToI128(value: bigint): SorobanClient.xdr.ScVal {
   const buf = bigintToBuf(value);
   if (buf.length > 16) {
@@ -194,7 +195,6 @@ fn generate_method(method: &ScSpecFunctionV0, _spec: &[ScSpecEntry]) -> String {
         ));
     }
 
-    let names = arg_names.join(", ");
     let types = arg_types.join(", ");
     let parsers = arg_parsers.join("\n");
 

--- a/soroban-spec/src/gen/typescript.rs
+++ b/soroban-spec/src/gen/typescript.rs
@@ -1,0 +1,148 @@
+pub mod types;
+use std::{fs, io};
+
+use sha2::{Digest, Sha256};
+use stellar_xdr::{ScSpecEntry, ScSpecFunctionV0};
+
+use crate::read::{from_wasm, FromWasmError};
+use types::{generate_type_ident, generate_type_parser};
+
+#[derive(thiserror::Error, Debug)]
+pub enum GenerateFromFileError {
+    #[error("reading file: {0}")]
+    Io(io::Error),
+    #[error("sha256 does not match, expected: {expected}")]
+    VerifySha256 { expected: String },
+    #[error("parsing contract spec: {0}")]
+    Parse(stellar_xdr::Error),
+    #[error("getting contract spec: {0}")]
+    GetSpec(FromWasmError),
+}
+
+pub fn generate_from_file(
+    file: &str,
+    verify_sha256: Option<&str>,
+) -> Result<String, GenerateFromFileError> {
+    // Read file.
+    let wasm = fs::read(file).map_err(GenerateFromFileError::Io)?;
+
+    // Produce hash for file.
+    let sha256 = Sha256::digest(&wasm);
+    let sha256 = format!("{:x}", sha256);
+
+    if let Some(verify_sha256) = verify_sha256 {
+        if verify_sha256 != sha256 {
+            return Err(GenerateFromFileError::VerifySha256 { expected: sha256 });
+        }
+    }
+
+    // Generate code.
+    let code = generate_from_wasm(&wasm).map_err(GenerateFromFileError::GetSpec)?;
+    Ok(code)
+}
+
+pub fn generate_from_wasm(wasm: &[u8]) -> Result<String, FromWasmError> {
+    let spec = from_wasm(wasm)?;
+    let code = generate(&spec);
+    Ok(code)
+}
+
+pub fn generate(spec: &[ScSpecEntry]) -> String {
+    let header = r#"import * as SorobanClient from "soroban-client";
+let xdr = SorobanClient.xdr;"#
+        .to_string();
+
+    // TODO: Generate types for udts.
+    let types: Vec<String> = Vec::new();
+
+    let mut methods: Vec<String> = Vec::new();
+
+    for entry in spec {
+        match entry {
+            ScSpecEntry::FunctionV0(f) => methods.push(generate_method(f, spec)),
+            _ => todo!("generate_types"),
+        };
+    }
+
+    let klass = format!(
+        r#"export class Contract {{
+  private _contract: SorobanClient.Contract;
+
+  constructor(address: string) {{
+    this._contract = new SorobanClient.Contract(address);
+  }}
+
+{}
+}}"#,
+        methods.join("\n\n")
+    );
+
+    vec![header, types.join("\n\n"), klass].join("\n\n")
+}
+
+fn generate_method(method: &ScSpecFunctionV0, _spec: &[ScSpecEntry]) -> String {
+    let name = method.name.to_string().unwrap();
+    let mut arg_names: Vec<String> = Vec::new();
+    let mut arg_types: Vec<String> = Vec::new();
+    let mut arg_parsers: Vec<String> = Vec::new();
+
+    for input in method.inputs.iter() {
+        let input_name = input.name.to_string().unwrap();
+        arg_names.push(input_name.clone());
+        arg_types.push(format!(
+            "{}: {}",
+            &input_name,
+            generate_type_ident(&input.type_),
+        ));
+        arg_parsers.push(format!(
+            "{} = {};",
+            &input_name,
+            generate_type_parser(&input.type_, &input_name)
+        ));
+    }
+
+    let names = arg_names.join(", ");
+    let types = arg_types.join(", ");
+    let parsers = arg_parsers.join("\n");
+
+    format!(
+        r#"  {name}({types}): SorobanClient.Operation {{
+        {parsers}
+    return this._contract.call("{name}", {{ {names} }});
+  }}"#,
+    )
+}
+
+#[cfg(test)]
+mod test {
+    use pretty_assertions::assert_eq;
+
+    use super::generate;
+
+    const EXAMPLE_WASM: &[u8] =
+        include_bytes!("../../../target/wasm32-unknown-unknown/release/test_hello.wasm");
+
+    #[test]
+    fn example() {
+        let entries = crate::read::from_wasm(EXAMPLE_WASM).unwrap();
+        let code = generate(&entries).unwrap();
+        assert_eq!(
+            code,
+            r#"import * as SorobanClient from "soroban-client";
+let xdr = SorobanClient.xdr;
+
+export class Contract {
+  private _contract: SorobanClient.Contract;
+
+  constructor(address: string) {
+    this._contract = new SorobanClient.Contract(address);
+  }
+
+  hello(to: string): SorobanClient.Operation {
+    to = xdr.ScVal.scvSymbol(to);
+    return this._contract.call("hello", { to });
+  
+}"#,
+        );
+    }
+}

--- a/soroban-spec/src/gen/typescript.rs
+++ b/soroban-spec/src/gen/typescript.rs
@@ -49,7 +49,100 @@ pub fn generate_from_wasm(wasm: &[u8]) -> Result<String, FromWasmError> {
 
 pub fn generate(spec: &[ScSpecEntry]) -> String {
     let header = r#"import * as SorobanClient from "soroban-client";
-let xdr = SorobanClient.xdr;"#
+let xdr = SorobanClient.xdr;
+
+function bigintToI128(value: bigint): SorobanClient.xdr.ScVal {
+  const buf = bigintToBuf(value);
+  if (buf.length > 16) {
+    throw new Error("value overflows i128");
+  }
+
+  if (value < BigInt(0)) {
+    // Clear the top bit
+    buf[0] &= 0x7f;
+  }
+
+  // left-pad with zeros up to 16 bytes
+  let padded = Buffer.alloc(16);
+  buf.copy(padded, padded.length-buf.length);
+
+  if (value < BigInt(0)) {
+    // Set the top bit
+    padded[0] |= 0x80;
+  }
+
+  const hi = new xdr.Uint64(
+    Number(bigintFromBytes(false, ...padded.slice(4, 8))),
+    Number(bigintFromBytes(false, ...padded.slice(0, 4)))
+  );
+  const lo = new xdr.Uint64(
+    Number(bigintFromBytes(false, ...padded.slice(12, 16))),
+    Number(bigintFromBytes(false, ...padded.slice(8, 12)))
+  );
+
+  return xdr.ScVal.scvObject(xdr.ScObject.scoI128(new xdr.Int128Parts({lo, hi})));
+}
+
+function bigintToU128(value: bigint): SorobanClient.xdr.ScVal {
+  const buf = bigintToBuf(value);
+  if (buf.length > 16) {
+    throw new Error("value overflows i128");
+  }
+
+  // left-pad with zeros up to 16 bytes
+  let padded = Buffer.alloc(16);
+  buf.copy(padded, padded.length-buf.length);
+
+  const hi = new xdr.Uint64(
+    Number(bigintFromBytes(false, ...padded.slice(4, 8))),
+    Number(bigintFromBytes(false, ...padded.slice(0, 4)))
+  );
+  const lo = new xdr.Uint64(
+    Number(bigintFromBytes(false, ...padded.slice(12, 16))),
+    Number(bigintFromBytes(false, ...padded.slice(8, 12)))
+  );
+
+  return xdr.ScVal.scvObject(xdr.ScObject.scoU128(new xdr.Int128Parts({lo, hi})));
+}
+
+function bigintFromBytes(signed: boolean, ...bytes: (string | number | bigint)[]): bigint {
+    let sign = 1;
+    if (signed && bytes[0] === 0x80) {
+      // top bit is set, negative number.
+      sign = -1;
+      bytes[0] &= 0x7f;
+    }
+    let b = BigInt(0);
+    for (let byte of bytes) {
+      b <<= BigInt(8);
+      b |= BigInt(byte);
+    }
+    return BigInt(b.toString()) * BigInt(sign);
+}
+
+function bigintToBuf(bn: bigint): Buffer {
+  var hex = BigInt(bn).toString(16).replace(/^-/, '');
+  if (hex.length % 2) { hex = '0' + hex; }
+
+  var len = hex.length / 2;
+  var u8 = new Uint8Array(len);
+
+  var i = 0;
+  var j = 0;
+  while (i < len) {
+    u8[i] = parseInt(hex.slice(j, j+2), 16);
+    i += 1;
+    j += 2;
+  }
+
+  if (bn < BigInt(0)) {
+    // Set the top bit
+    u8[0] |= 0x80;
+  }
+
+  return Buffer.from(u8);
+}
+"#
         .to_string();
 
     // TODO: Generate types for udts.
@@ -82,20 +175,23 @@ let xdr = SorobanClient.xdr;"#
 
 fn generate_method(method: &ScSpecFunctionV0, _spec: &[ScSpecEntry]) -> String {
     let name = method.name.to_string().unwrap();
-    let mut arg_names: Vec<String> = Vec::new();
     let mut arg_types: Vec<String> = Vec::new();
+    let mut arg_names: Vec<String> = Vec::new();
     let mut arg_parsers: Vec<String> = Vec::new();
 
     for input in method.inputs.iter() {
         let input_name = input.name.to_string().unwrap();
-        arg_names.push(input_name.clone());
         arg_types.push(format!(
             "{}: {}",
             &input_name,
             generate_type_ident(&input.type_),
         ));
+        arg_names.push(format!(
+            "{}_xdr",
+            &input_name,
+        ));
         arg_parsers.push(format!(
-            "{} = {};",
+            "const {}_xdr = {};",
             &input_name,
             generate_type_parser(&input.type_, &input_name)
         ));
@@ -105,10 +201,15 @@ fn generate_method(method: &ScSpecFunctionV0, _spec: &[ScSpecEntry]) -> String {
     let types = arg_types.join(", ");
     let parsers = arg_parsers.join("\n");
 
+    let mut args: Vec<String> = vec![format!("\"{name}\"")];
+    args.extend(arg_names.iter().map(|x| format!("{x}")));
+    let args_param = args.join(", ");
+
+
     format!(
-        r#"  {name}({types}): SorobanClient.Operation {{
+        r#"  {name}({types}): SorobanClient.xdr.Operation {{
         {parsers}
-    return this._contract.call("{name}", {{ {names} }});
+    return this._contract.call({args_param});
   }}"#,
     )
 }

--- a/soroban-spec/src/gen/typescript.rs
+++ b/soroban-spec/src/gen/typescript.rs
@@ -143,7 +143,7 @@ function bigintToBuf(bn: bigint): Buffer {
   return Buffer.from(u8);
 }
 "#
-        .to_string();
+    .to_string();
 
     // TODO: Generate types for udts.
     let types: Vec<String> = Vec::new();
@@ -186,10 +186,7 @@ fn generate_method(method: &ScSpecFunctionV0, _spec: &[ScSpecEntry]) -> String {
             &input_name,
             generate_type_ident(&input.type_),
         ));
-        arg_names.push(format!(
-            "{}_xdr",
-            &input_name,
-        ));
+        arg_names.push(format!("{}_xdr", &input_name,));
         arg_parsers.push(format!(
             "const {}_xdr = {};",
             &input_name,
@@ -204,7 +201,6 @@ fn generate_method(method: &ScSpecFunctionV0, _spec: &[ScSpecEntry]) -> String {
     let mut args: Vec<String> = vec![format!("\"{name}\"")];
     args.extend(arg_names.iter().map(|x| format!("{x}")));
     let args_param = args.join(", ");
-
 
     format!(
         r#"  {name}({types}): SorobanClient.xdr.Operation {{

--- a/soroban-spec/src/gen/typescript/types.rs
+++ b/soroban-spec/src/gen/typescript/types.rs
@@ -57,10 +57,10 @@ pub fn generate_type_parser(spec: &ScSpecTypeDef, name: &str) -> String {
         ScSpecTypeDef::I128 => format!("bigintToI128({name})").to_string(),
         ScSpecTypeDef::U32 => format!("xdr.ScVal.scvU32({name})").to_string(),
         ScSpecTypeDef::I32 => format!("xdr.ScVal.scvI32({name})").to_string(),
-        ScSpecTypeDef::Bool => {
-            format!("xdr.ScVal.scvStatic({name} ? xdr.ScStatic.scsTrue() : xdr.ScStatic.scsFalse())")
-                .to_string()
-        }
+        ScSpecTypeDef::Bool => format!(
+            "xdr.ScVal.scvStatic({name} ? xdr.ScStatic.scsTrue() : xdr.ScStatic.scsFalse())"
+        )
+        .to_string(),
         ScSpecTypeDef::Symbol => format!("xdr.ScVal.scvSymbol({name})").to_string(),
         ScSpecTypeDef::Bytes | ScSpecTypeDef::BytesN(_) => {
             format!("xdr.ScVal.scvObject(xdr.ScObject.scoBytes(Buffer.from({name})))").to_string()

--- a/soroban-spec/src/gen/typescript/types.rs
+++ b/soroban-spec/src/gen/typescript/types.rs
@@ -52,17 +52,18 @@ pub fn generate_type_parser(spec: &ScSpecTypeDef, name: &str) -> String {
         ScSpecTypeDef::I64 => {
             format!("xdr.ScVal.scvObject(xdr.ScObject.scoI64({name}))").to_string()
         }
-        ScSpecTypeDef::U128 => todo!("generate_type_parser(u128)"),
-        ScSpecTypeDef::I128 => todo!("generate_type_parser(i128)"),
+        // TODO: Implement U128 and I128 conversion somewhere properly
+        ScSpecTypeDef::U128 => format!("bigintToU128({name})").to_string(),
+        ScSpecTypeDef::I128 => format!("bigintToI128({name})").to_string(),
         ScSpecTypeDef::U32 => format!("xdr.ScVal.scvU32({name})").to_string(),
         ScSpecTypeDef::I32 => format!("xdr.ScVal.scvI32({name})").to_string(),
         ScSpecTypeDef::Bool => {
-            format!("xdr.ScVal.scvStatic(name ? xdr.ScStatic.scsTrue() : xdr.ScStatic.scsFalse())")
+            format!("xdr.ScVal.scvStatic({name} ? xdr.ScStatic.scsTrue() : xdr.ScStatic.scsFalse())")
                 .to_string()
         }
         ScSpecTypeDef::Symbol => format!("xdr.ScVal.scvSymbol({name})").to_string(),
         ScSpecTypeDef::Bytes | ScSpecTypeDef::BytesN(_) => {
-            format!("xdr.ScVal.scvObject(xdr.ScObject.scoBytes({name}))").to_string()
+            format!("xdr.ScVal.scvObject(xdr.ScObject.scoBytes(Buffer.from({name})))").to_string()
         }
         ScSpecTypeDef::Address => format!(
             "(typeof {name} === \"string\" ? new SorobanClient.Address({name}) : {name}).toScVal()"

--- a/soroban-spec/src/gen/typescript/types.rs
+++ b/soroban-spec/src/gen/typescript/types.rs
@@ -1,0 +1,89 @@
+use stellar_xdr::ScSpecTypeDef;
+
+pub fn generate_type_ident(spec: &ScSpecTypeDef) -> String {
+    match spec {
+        // TODO: Better number handling types
+        ScSpecTypeDef::U64 | ScSpecTypeDef::I64 | ScSpecTypeDef::U128 | ScSpecTypeDef::I128 => {
+            "bigint".to_string()
+        }
+        ScSpecTypeDef::U32 | ScSpecTypeDef::I32 => "number | bigint".to_string(),
+        ScSpecTypeDef::Bool => "boolean".to_string(),
+        ScSpecTypeDef::Symbol => "string".to_string(),
+        ScSpecTypeDef::Bytes => "Buffer | Uint8Array".to_string(),
+        ScSpecTypeDef::Address => "string | SorobanClient.Address".to_string(),
+        ScSpecTypeDef::Option(o) => format!("null | {}", generate_type_ident(&o.value_type)),
+        ScSpecTypeDef::Result(_r) => todo!("generate_type_ident(Result)"),
+        ScSpecTypeDef::Vec(v) => {
+            let element_ident = generate_type_ident(&v.element_type);
+            format!("Array<{element_ident}>")
+        }
+        ScSpecTypeDef::Map(m) => {
+            let key_ident = generate_type_ident(&m.key_type);
+            let value_ident = generate_type_ident(&m.value_type);
+            format!("Record<{key_ident}, {value_ident}>")
+        }
+        ScSpecTypeDef::Set(s) => {
+            let element_ident = generate_type_ident(&s.element_type);
+            // TODO: Is there a better type than array here?
+            format!("Array<{element_ident}>")
+        }
+        ScSpecTypeDef::Tuple(t) => {
+            let type_idents = t
+                .value_types
+                .iter()
+                .map(generate_type_ident)
+                .collect::<Vec<String>>()
+                .join(", ");
+            format!("[{}]", type_idents)
+        }
+        ScSpecTypeDef::BytesN(_b) => "Buffer | Uint8Array".to_string(),
+        ScSpecTypeDef::Udt(_u) => todo!("generate_type_ident(Udt)"),
+        // TODO: Figure these out
+        ScSpecTypeDef::Val | ScSpecTypeDef::Bitset | ScSpecTypeDef::Status => "unknown".to_string(),
+    }
+}
+
+pub fn generate_type_parser(spec: &ScSpecTypeDef, name: &str) -> String {
+    match spec {
+        // TODO: Better number handling types
+        ScSpecTypeDef::U64 => {
+            format!("xdr.ScVal.scvObject(xdr.ScObject.scoU64({name}))").to_string()
+        }
+        ScSpecTypeDef::I64 => {
+            format!("xdr.ScVal.scvObject(xdr.ScObject.scoI64({name}))").to_string()
+        }
+        ScSpecTypeDef::U128 => todo!("generate_type_parser(u128)"),
+        ScSpecTypeDef::I128 => todo!("generate_type_parser(i128)"),
+        ScSpecTypeDef::U32 => format!("xdr.ScVal.scvU32({name})").to_string(),
+        ScSpecTypeDef::I32 => format!("xdr.ScVal.scvI32({name})").to_string(),
+        ScSpecTypeDef::Bool => {
+            format!("xdr.ScVal.scvStatic(name ? xdr.ScStatic.scsTrue() : xdr.ScStatic.scsFalse())")
+                .to_string()
+        }
+        ScSpecTypeDef::Symbol => format!("xdr.ScVal.scvSymbol({name})").to_string(),
+        ScSpecTypeDef::Bytes | ScSpecTypeDef::BytesN(_) => {
+            format!("xdr.ScVal.scvObject(xdr.ScObject.scoBytes({name}))").to_string()
+        }
+        ScSpecTypeDef::Address => format!(
+            "(typeof {name} === \"string\" ? new SorobanClient.Address({name}) : {name}).toScVal()"
+        )
+        .to_string(),
+        ScSpecTypeDef::Option(o) => format!(
+            "{name} === null ? xdr.ScVal.scvStatic(xdr.ScStatic.scsVoid()) : {}",
+            generate_type_parser(&o.value_type, name)
+        )
+        .to_string(),
+        ScSpecTypeDef::Result(_r) => todo!("generate_type_parser(Result)"),
+        ScSpecTypeDef::Vec(v) => format!(
+            "xdr.ScVal.scvObject(xdr.ScObject.scoVec({name}.map(elem => {})))",
+            generate_type_parser(&v.element_type, "elem")
+        ),
+        ScSpecTypeDef::Map(_m) => todo!("generate_type_parser(Map)"),
+        ScSpecTypeDef::Set(_s) => todo!("generate_type_parser(Set)"),
+        ScSpecTypeDef::Tuple(_t) => todo!("generate_type_parser(Tuple)"),
+        ScSpecTypeDef::Udt(_u) => todo!("generate_type_parser(Udt)"),
+        ScSpecTypeDef::Val => todo!(),
+        ScSpecTypeDef::Bitset => todo!(),
+        ScSpecTypeDef::Status => todo!(),
+    }
+}


### PR DESCRIPTION
### What

A rough first pass at generating typescript bindings for the contract spec.

### Why

This approach is higher maintenance (as the js sdk etc changes), and we can't reuse the rust strval.rs code. But, it also avoids all the rust->wasm->js machinery.

With this, you can do:
```typescript
import SorobanClient from 'soroban-client';
const xdr = SorobanClient.xdr;

// Import our generated binding for the hello world contract
import { Contract } from './contract';

// And we get an easy helper which can parse native js types to build our xdr.Operation
const contract = new Contract(contractId);
const operation = contract.hello("world");

// The rest of the txn sending flow is the same as before.
const server = new SorobanClient.Server('http://localhost:8000/soroban/rpc', { allowHttp: true });
const source = await server.getAccount(accountId);
const txn = new SorobanClient.TransactionBuilder(source, {
  fee: 100,
  networkPassphrase: SorobanClient.Networks.STANDALONE,
  v1: true,
})
  .addOperation(operation)
  .setTimeout(SorobanClient.TimeoutInfinite)
  .build();
console.debug("Transaction:", txn.toEnvelope().toXDR('base64').toString());
const result = await server.simulateTransaction(txn);
console.debug(result);
```

### Known limitations

- Only a few primitive types implemented so far, not UDTs, etc...
- We should push the parser code into js-stellar-base, then emit something like `const val_xdr = xdr.ScVal.fromJSON(js_obj, spec)` and `xdr.ScVal.toJSON(...)` for each.
  - Pro: Would simplify the rust parser emission
  - Con: Would spread the parser logic across two repos.
  - Pro: Would allow js apps to use the parsers as well.
- Future: Should also figure out how to generate parsers for the operation result values.