### PR TITLE
Use `String` for `log_fmt_values`.

### DIFF
--- a/soroban-sdk/src/logging.rs
+++ b/soroban-sdk/src/logging.rs
@@ -3,7 +3,11 @@
 //! See [`log`][crate::log] for how to conveniently log debug events.
 use core::fmt::Debug;
 
-use crate::{env::internal::EnvBase, Bytes, Env, IntoVal, RawVal, Vec};
+use crate::{
+    env::internal::{self, EnvBase},
+    unwrap::UnwrapInfallible,
+    Env, IntoVal, RawVal, Vec,
+};
 
 /// Log a debug event.
 ///
@@ -125,11 +129,10 @@ impl Logger {
             // building on non-WASM environments where the environment Host is
             // directly available, use the log static variants.
             if cfg!(target_family = "wasm") {
-                let _fmt: Bytes = fmt.into_val(env);
-                let _args: Vec<RawVal> = Vec::from_slice(env, args);
-                // TODO: use String type when we have it
-                // internal::Env::log_fmt_values(env, fmt.to_object(), args.to_object())
-                //     .unwrap_infallible();
+                let fmt: crate::String = fmt.into_val(env);
+                let args: Vec<RawVal> = Vec::from_slice(env, args);
+                internal::Env::log_fmt_values(env, fmt.to_object(), args.to_object())
+                    .unwrap_infallible();
             } else {
                 env.log_static_fmt_general(fmt, args, &[]).unwrap();
             }


### PR DESCRIPTION
### What

Use `String` for `log_fmt_values`.

### Why

Fix logging

### Known limitations

N/A
