### PR TITLE
Add a utility to call `__check_auth` in tests.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -838,13 +838,14 @@ checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
 name = "soroban-auth"
 version = "0.6.0"
 dependencies = [
+ "soroban-env-host",
  "soroban-sdk",
 ]
 
 [[package]]
 name = "soroban-env-common"
 version = "0.0.14"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=a66f0815ba06a2f5328ac420950690fd1642f887#a66f0815ba06a2f5328ac420950690fd1642f887"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=d39dd845d5bf31f976cdfea9bc7c2f8da8396b6b#d39dd845d5bf31f976cdfea9bc7c2f8da8396b6b"
 dependencies = [
  "crate-git-revision",
  "ethnum",
@@ -858,7 +859,7 @@ dependencies = [
 [[package]]
 name = "soroban-env-guest"
 version = "0.0.14"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=a66f0815ba06a2f5328ac420950690fd1642f887#a66f0815ba06a2f5328ac420950690fd1642f887"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=d39dd845d5bf31f976cdfea9bc7c2f8da8396b6b#d39dd845d5bf31f976cdfea9bc7c2f8da8396b6b"
 dependencies = [
  "soroban-env-common",
  "static_assertions",
@@ -867,7 +868,7 @@ dependencies = [
 [[package]]
 name = "soroban-env-host"
 version = "0.0.14"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=a66f0815ba06a2f5328ac420950690fd1642f887#a66f0815ba06a2f5328ac420950690fd1642f887"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=d39dd845d5bf31f976cdfea9bc7c2f8da8396b6b#d39dd845d5bf31f976cdfea9bc7c2f8da8396b6b"
 dependencies = [
  "backtrace",
  "curve25519-dalek",
@@ -889,7 +890,7 @@ dependencies = [
 [[package]]
 name = "soroban-env-macros"
 version = "0.0.14"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=a66f0815ba06a2f5328ac420950690fd1642f887#a66f0815ba06a2f5328ac420950690fd1642f887"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=d39dd845d5bf31f976cdfea9bc7c2f8da8396b6b#d39dd845d5bf31f976cdfea9bc7c2f8da8396b6b"
 dependencies = [
  "itertools",
  "proc-macro2",
@@ -915,7 +916,7 @@ dependencies = [
 [[package]]
 name = "soroban-native-sdk-macros"
 version = "0.0.14"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=a66f0815ba06a2f5328ac420950690fd1642f887#a66f0815ba06a2f5328ac420950690fd1642f887"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=d39dd845d5bf31f976cdfea9bc7c2f8da8396b6b#d39dd845d5bf31f976cdfea9bc7c2f8da8396b6b"
 dependencies = [
  "itertools",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,17 +37,17 @@ soroban-token-spec = { version = "0.6.0", path = "soroban-token-spec" }
 [workspace.dependencies.soroban-env-common]
 version = "0.0.14"
 git = "https://github.com/stellar/rs-soroban-env"
-rev = "a66f0815ba06a2f5328ac420950690fd1642f887"
+rev = "d39dd845d5bf31f976cdfea9bc7c2f8da8396b6b"
 
 [workspace.dependencies.soroban-env-guest]
 version = "0.0.14"
 git = "https://github.com/stellar/rs-soroban-env"
-rev = "a66f0815ba06a2f5328ac420950690fd1642f887"
+rev = "d39dd845d5bf31f976cdfea9bc7c2f8da8396b6b"
 
 [workspace.dependencies.soroban-env-host]
 version = "0.0.14"
 git = "https://github.com/stellar/rs-soroban-env"
-rev = "a66f0815ba06a2f5328ac420950690fd1642f887"
+rev = "d39dd845d5bf31f976cdfea9bc7c2f8da8396b6b"
 
 [workspace.dependencies.stellar-strkey]
 version = "0.0.7"

--- a/soroban-auth/Cargo.toml
+++ b/soroban-auth/Cargo.toml
@@ -16,5 +16,14 @@ doctest = false
 [dependencies]
 soroban-sdk = { workspace = true }
 
+[dev_dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }
+
+[target.'cfg(not(target_family="wasm"))'.dependencies]
+soroban-env-host = { workspace = true, features = ["vm", "hostfn_log_fmt_values"] }
+
+[features]
+testutils = ["soroban-env-host/testutils", "soroban-sdk/testutils"]
+
 [package.metadata.docs.rs]
 all-features = true

--- a/soroban-auth/src/lib.rs
+++ b/soroban-auth/src/lib.rs
@@ -2,6 +2,10 @@
 use soroban_sdk::RawVal;
 use soroban_sdk::{contracttype, BytesN, Symbol, Vec};
 
+#[cfg(any(feature = "testutils", test))]
+#[cfg_attr(feature = "docs", doc(cfg(feature = "testutils")))]
+pub mod testutils;
+
 #[contracttype]
 #[derive(Clone)]
 pub struct AuthorizationContext {

--- a/soroban-auth/src/testutils.rs
+++ b/soroban-auth/src/testutils.rs
@@ -1,0 +1,111 @@
+use crate::AuthorizationContext;
+use soroban_sdk::{vec, BytesN, Env, IntoVal, RawVal, Status, Vec};
+
+pub trait EnvAuthUtils {
+    /// Calls the special `__check_auth` function of the custom account
+    /// contract.
+    ///
+    /// `__check_auth` can't be called outside of the host-managed `require_auth`
+    /// calls. This test utility allows testing custom account contracts without
+    /// the need to setup complex contract call trees and enabling the enforcing
+    /// auth on the host side.
+    ///
+    /// This function requires to provide the template argument for error. Use
+    /// `soroban_sdk::Status` if `__check_auth` doesn't return a special
+    /// contract error and use the error with `contracterror` attribute
+    /// otherwise.
+    /// 
+    /// ### Examples
+    /// ```
+    /// use soroban_sdk::{contracterror, contractimpl, testutils::BytesN as _, vec, BytesN, Env, Vec, RawVal};
+    ///
+    /// use soroban_auth::{testutils::EnvAuthUtils, AuthorizationContext};
+    ///
+    /// #[contracterror]
+    /// #[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+    /// #[repr(u32)]
+    /// pub enum NoopAccountError {
+    ///     SomeError = 1,
+    /// }
+    /// struct NoopAccountContract;
+    /// #[contractimpl]
+    /// impl NoopAccountContract {
+    ///
+    ///     #[allow(non_snake_case)]
+    ///     pub fn __check_auth(
+    ///         _env: Env,
+    ///         _signature_payload: BytesN<32>,
+    ///         signatures: Vec<RawVal>,
+    ///         _auth_context: Vec<AuthorizationContext>,
+    ///     ) -> Result<(), NoopAccountError> {
+    ///         if signatures.is_empty() {
+    ///             Err(NoopAccountError::SomeError)
+    ///         } else {
+    ///             Ok(())
+    ///         }
+    ///     }
+    /// }
+    /// #[test]
+    /// fn test() {
+    /// # }
+    /// # fn main() {
+    ///     let e: Env = Default::default();
+    ///     let account_contract =
+    ///         NoopAccountContractClient::new(&e, &e.register_contract(None, NoopAccountContract {}));
+    ///     // Non-succesful call of `__check_auth` with a `contracterror` error.
+    ///     assert_eq!(
+    ///         e.invoke_account_contract_check_auth::<NoopAccountError>(
+    ///             &account_contract.contract_id,
+    ///             &BytesN::random(&e),
+    ///             &vec![&e],
+    ///             &vec![&e],
+    ///         ),
+    ///         // The inner `Result` is for conversion error and will be Ok
+    ///         // as long as a valid error type used.
+    ///         Err(Ok(NoopAccountError::SomeError))
+    ///     );
+    ///     // Succesful call of `__check_auth` with a `soroban_sdk::Status` 
+    ///     // error - this should be compatible with any error type.
+    ///     assert_eq!(
+    ///         e.invoke_account_contract_check_auth::<soroban_sdk::Status>(
+    ///             &account_contract.contract_id,
+    ///             &BytesN::random(&e),
+    ///             &vec![&e, 0_i32.into()],
+    ///             &vec![&e],
+    ///         ),
+    ///         Ok(())
+    ///     );
+    /// }
+    /// ```
+    fn invoke_account_contract_check_auth<E: TryFrom<Status>>(
+        &self,
+        contract_id: &BytesN<32>,
+        signature_payload: &BytesN<32>,
+        signatures: &Vec<RawVal>,
+        auth_context: &Vec<AuthorizationContext>,
+    ) -> Result<(), Result<E, E::Error>>;
+}
+
+impl EnvAuthUtils for Env {
+    fn invoke_account_contract_check_auth<E: TryFrom<Status>>(
+        &self,
+        contract_id: &BytesN<32>,
+        signature_payload: &BytesN<32>,
+        signatures: &Vec<RawVal>,
+        auth_context: &Vec<AuthorizationContext>,
+    ) -> Result<(), Result<E, E::Error>> {
+        let args: Vec<RawVal> = vec![
+            &self,
+            signature_payload.into_val(self),
+            signatures.into_val(self),
+            auth_context.into_val(self),
+        ];
+        let res = self
+            .host()
+            .call_account_contract_check_auth(contract_id.to_object(), args.to_object());
+        match res {
+            Ok(rv) => Ok(rv.into_val(self)),
+            Err(e) => Err(e.status.try_into()),
+        }
+    }
+}

--- a/soroban-auth/src/testutils.rs
+++ b/soroban-auth/src/testutils.rs
@@ -14,7 +14,7 @@ pub trait EnvAuthUtils {
     /// `soroban_sdk::Status` if `__check_auth` doesn't return a special
     /// contract error and use the error with `contracterror` attribute
     /// otherwise.
-    /// 
+    ///
     /// ### Examples
     /// ```
     /// use soroban_sdk::{contracterror, contractimpl, testutils::BytesN as _, vec, BytesN, Env, Vec, RawVal};
@@ -64,7 +64,7 @@ pub trait EnvAuthUtils {
     ///         // as long as a valid error type used.
     ///         Err(Ok(NoopAccountError::SomeError))
     ///     );
-    ///     // Succesful call of `__check_auth` with a `soroban_sdk::Status` 
+    ///     // Succesful call of `__check_auth` with a `soroban_sdk::Status`
     ///     // error - this should be compatible with any error type.
     ///     assert_eq!(
     ///         e.invoke_account_contract_check_auth::<soroban_sdk::Status>(

--- a/soroban-sdk/src/env.rs
+++ b/soroban-sdk/src/env.rs
@@ -463,7 +463,7 @@ use xdr::{Hash, LedgerEntry, LedgerKey, LedgerKeyContractData};
 #[cfg(any(test, feature = "testutils"))]
 #[cfg_attr(feature = "docs", doc(cfg(feature = "testutils")))]
 impl Env {
-    pub(crate) fn host(&self) -> &internal::Host {
+    pub fn host(&self) -> &internal::Host {
         &self.env_impl
     }
 

--- a/soroban-sdk/src/symbol.rs
+++ b/soroban-sdk/src/symbol.rs
@@ -23,7 +23,7 @@ use crate::{
 /// names and user-defined structure field/enum variant names. That's why
 /// these idenfiers have limited length.
 ///
-/// While Symbols up to 30 characters long are allowed, Symbols that are 9
+/// While Symbols up to 32 characters long are allowed, Symbols that are 9
 /// characters long or shorter are more efficient at runtime and also can be
 /// computed at compile time.
 #[derive(Clone)]
@@ -209,7 +209,7 @@ impl Symbol {
     ///
     /// Valid characters are `a-zA-Z0-9_` and maximum length is 9 characters.
     ///
-    /// The conversion happens at compile time.
+    /// The conversion can happen at compile time.
     ///
     /// ### Panics
     ///

--- a/soroban-sdk/src/tests/contractfile_with_sha256.rs
+++ b/soroban-sdk/src/tests/contractfile_with_sha256.rs
@@ -1,7 +1,7 @@
 use crate as soroban_sdk;
 pub const WASM: &[u8] = soroban_sdk::contractfile!(
     file = "../target/wasm32-unknown-unknown/release/test_add_u64.wasm",
-    sha256 = "4a691cf1fb566451424a769113d19336686624562ceb436f7a652ae8967343aa",
+    sha256 = "eb756067d9341b7658c8943d69a41ff548da1917f023c6b63085ebece3fd69e2",
 );
 
 #[test]

--- a/soroban-sdk/src/tests/contractfile_with_sha256.rs
+++ b/soroban-sdk/src/tests/contractfile_with_sha256.rs
@@ -1,7 +1,7 @@
 use crate as soroban_sdk;
 pub const WASM: &[u8] = soroban_sdk::contractfile!(
     file = "../target/wasm32-unknown-unknown/release/test_add_u64.wasm",
-    sha256 = "4f19178d3bbcc05e54ab93fdf402b5e57cd5f1d995227fc6e9ffb29e714aee9c",
+    sha256 = "4a691cf1fb566451424a769113d19336686624562ceb436f7a652ae8967343aa",
 );
 
 #[test]

--- a/soroban-sdk/src/tests/contractimport_with_sha256.rs
+++ b/soroban-sdk/src/tests/contractimport_with_sha256.rs
@@ -8,7 +8,7 @@ mod addcontract {
     use crate as soroban_sdk;
     soroban_sdk::contractimport!(
         file = "../target/wasm32-unknown-unknown/release/test_add_u64.wasm",
-        sha256 = "4f19178d3bbcc05e54ab93fdf402b5e57cd5f1d995227fc6e9ffb29e714aee9c",
+        sha256 = "4a691cf1fb566451424a769113d19336686624562ceb436f7a652ae8967343aa",
     );
 }
 

--- a/soroban-sdk/src/tests/contractimport_with_sha256.rs
+++ b/soroban-sdk/src/tests/contractimport_with_sha256.rs
@@ -8,7 +8,7 @@ mod addcontract {
     use crate as soroban_sdk;
     soroban_sdk::contractimport!(
         file = "../target/wasm32-unknown-unknown/release/test_add_u64.wasm",
-        sha256 = "4a691cf1fb566451424a769113d19336686624562ceb436f7a652ae8967343aa",
+        sha256 = "eb756067d9341b7658c8943d69a41ff548da1917f023c6b63085ebece3fd69e2",
     );
 }
 


### PR DESCRIPTION
### What

Add a utility to call `__check_auth` in tests. 

### Why

This probably could be achieved differently by just lifting the restriction on `__check_auth` callers in tests. However, I think that the explicit approach better conveys the fact that there is no way to call `__check_auth` on-chain and also adds a bit more type safety for the arguments.

### Known limitations

N/A