### PR TITLE
Add more support for the new types in soroban-spec.

### DIFF
--- a/soroban-spec/src/gen/json/types.rs
+++ b/soroban-spec/src/gen/json/types.rs
@@ -104,6 +104,7 @@ impl From<&ScSpecUdtErrorEnumCaseV0> for EnumCase {
 #[serde(tag = "type")]
 #[serde(rename_all = "camelCase")]
 pub enum Type {
+    Void,
     Val,
     U64,
     I64,
@@ -111,11 +112,16 @@ pub enum Type {
     I32,
     U128,
     I128,
+    U256,
+    I256,
     Bool,
     Symbol,
     Status,
     Bytes,
+    String,
     Address,
+    Timepoint,
+    Duration,
     Map { key: Box<Type>, value: Box<Type> },
     Option { value: Box<Type> },
     Result { value: Box<Type>, error: Box<Type> },
@@ -192,17 +198,17 @@ impl From<&ScSpecTypeDef> for Type {
             ScSpecTypeDef::I32 => Type::I32,
             ScSpecTypeDef::U128 => Type::U128,
             ScSpecTypeDef::I128 => Type::I128,
+            ScSpecTypeDef::U256 => Type::U256,
+            ScSpecTypeDef::I256 => Type::I256,
             ScSpecTypeDef::Bool => Type::Bool,
             ScSpecTypeDef::Symbol => Type::Symbol,
             ScSpecTypeDef::Status => Type::Status,
             ScSpecTypeDef::Bytes => Type::Bytes,
+            ScSpecTypeDef::String => Type::String,
             ScSpecTypeDef::Address => Type::Address,
-            ScSpecTypeDef::Void => todo!(),
-            ScSpecTypeDef::Timepoint => todo!(),
-            ScSpecTypeDef::Duration => todo!(),
-            ScSpecTypeDef::U256 => todo!(),
-            ScSpecTypeDef::I256 => todo!(),
-            ScSpecTypeDef::String => todo!(),
+            ScSpecTypeDef::Void => Type::Void,
+            ScSpecTypeDef::Timepoint => Type::Timepoint,
+            ScSpecTypeDef::Duration => Type::Duration,
         }
     }
 }

--- a/soroban-spec/src/gen/rust/types.rs
+++ b/soroban-spec/src/gen/rust/types.rs
@@ -147,6 +147,7 @@ pub fn generate_type_ident(spec: &ScSpecTypeDef) -> TokenStream {
         ScSpecTypeDef::Status => quote! { soroban_sdk::Status },
         ScSpecTypeDef::Bytes => quote! { soroban_sdk::Bytes },
         ScSpecTypeDef::Address => quote! { soroban_sdk::Address },
+        ScSpecTypeDef::String => quote! { soroban_sdk::String },
         ScSpecTypeDef::Option(o) => {
             let value_ident = generate_type_ident(&o.value_type);
             quote! { Option<#value_ident> }
@@ -186,6 +187,5 @@ pub fn generate_type_ident(spec: &ScSpecTypeDef) -> TokenStream {
         ScSpecTypeDef::Duration => todo!(),
         ScSpecTypeDef::U256 => todo!(),
         ScSpecTypeDef::I256 => todo!(),
-        ScSpecTypeDef::String => todo!(),
     }
 }


### PR DESCRIPTION


### What

Add more support for the new types in soroban-spec.

### Why

Supporting the value changes.

### Known limitations

We still don't have some SDK types, hence there is a few todo's left.
