### PR TITLE
Adds test for methods in vec, map and bytes (#840)

### DIFF
--- a/soroban-sdk/src/bytes.rs
+++ b/soroban-sdk/src/bytes.rs
@@ -1258,7 +1258,6 @@ mod test {
     }
 
     #[test]
-    #[should_panic]
     fn test_first_unchecked() {
         let env = Env::default();
         let mut bin = bytes![&env, [1, 2, 3, 4]];
@@ -1266,8 +1265,12 @@ mod test {
         assert_eq!(bin.first_unchecked(), 1);
         bin.remove(0);
         assert_eq!(bin.first_unchecked(), 2);
+    }
 
-        // first on empty bytes should panic
+    #[test]
+    #[should_panic(expected = "HostError: Error(Object, IndexBounds)")]
+    fn test_first_unchecked_panics() {
+        let env = Env::default();
         let bin = bytes![&env];
         bin.first_unchecked();
     }
@@ -1287,7 +1290,6 @@ mod test {
     }
 
     #[test]
-    #[should_panic]
     fn test_last_unchecked() {
         let env = Env::default();
         let mut bin = bytes![&env, [1, 2, 3, 4]];
@@ -1295,10 +1297,14 @@ mod test {
         assert_eq!(bin.last_unchecked(), 4);
         bin.remove(0);
         assert_eq!(bin.last_unchecked(), 3);
+    }
 
-        // first on empty bytes should panic
+    #[test]
+    #[should_panic(expected = "HostError: Error(Object, IndexBounds)")]
+    fn test_last_unchecked_panics() {
+        let env = Env::default();
         let bin = bytes![&env];
-        bin.first_unchecked();
+        bin.last_unchecked();
     }
 
     #[test]
@@ -1325,7 +1331,6 @@ mod test {
     }
 
     #[test]
-    #[should_panic]
     fn test_get_unchecked() {
         let env = Env::default();
         let bin = bytes![&env, [0, 1, 5, 2, 8]];
@@ -1335,8 +1340,12 @@ mod test {
         assert_eq!(bin.get_unchecked(2), 5);
         assert_eq!(bin.get_unchecked(3), 2);
         assert_eq!(bin.get_unchecked(4), 8);
+    }
 
-        // get unchecked should panic
+    #[test]
+    #[should_panic(expected = "HostError: Error(Object, IndexBounds)")]
+    fn test_get_unchecked_panics() {
+        let env = Env::default();
         let bin = bytes![&env];
         bin.get_unchecked(0);
     }
@@ -1371,7 +1380,6 @@ mod test {
     }
 
     #[test]
-    #[should_panic]
     fn test_remove_unchecked() {
         let env = Env::default();
         let mut bin = bytes![&env, [1, 2, 3, 4]];
@@ -1379,8 +1387,13 @@ mod test {
         assert_eq!(bin.remove_unchecked(2), ());
         assert_eq!(bin, bytes![&env, [1, 2, 4]]);
         assert_eq!(bin.len(), 3);
+    }
 
-        // out of bound remove panic
+    #[test]
+    #[should_panic(expected = "HostError: Error(Object, IndexBounds)")]
+    fn test_remove_unchecked_panics() {
+        let env = Env::default();
+        let mut bin = bytes![&env, [1, 2, 3, 4]];
         bin.remove_unchecked(bin.len());
     }
 
@@ -1400,7 +1413,6 @@ mod test {
     }
 
     #[test]
-    #[should_panic]
     fn test_pop_unchecked() {
         let env = Env::default();
         let mut bin = bytes![&env, [0, 1, 2, 3, 4]];
@@ -1409,8 +1421,12 @@ mod test {
         assert_eq!(bin.pop_unchecked(), 3);
         assert_eq!(bin.len(), 3);
         assert_eq!(bin, bytes![&env, [0, 1, 2]]);
+    }
 
-        // pop on empty bytes
+    #[test]
+    #[should_panic(expected = "HostError: Error(Object, IndexBounds)")]
+    fn test_pop_unchecked_panics() {
+        let env = Env::default();
         let mut bin = bytes![&env];
         bin.pop_unchecked();
     }
@@ -1437,7 +1453,6 @@ mod test {
     fn test_insert_panic() {
         let env = Env::default();
         let mut bin = bytes![&env, [0, 1, 2, 3, 4]];
-
         bin.insert(80, 44);
     }
 
@@ -1466,7 +1481,6 @@ mod test {
     fn test_slice_panic() {
         let env = Env::default();
         let bin = bytes![&env, [0, 1, 2, 3, 4]];
-
         let _ = bin.slice(..=bin.len());
     }
 }

--- a/soroban-sdk/src/bytes.rs
+++ b/soroban-sdk/src/bytes.rs
@@ -1233,4 +1233,240 @@ mod test {
         let arr_bin: BytesN<3> = bin.clone().try_into().unwrap();
         assert_eq!(format!("{:?}", arr_bin), "BytesN<3>(10, 20, 30)");
     }
+
+    #[test]
+    fn test_is_empty() {
+        let env = Env::default();
+        let mut bin = Bytes::new(&env);
+        assert_eq!(bin.is_empty(), true);
+        bin.push(10);
+        assert_eq!(bin.is_empty(), false);
+    }
+
+    #[test]
+    fn test_first() {
+        let env = Env::default();
+        let mut bin = bytes![&env, [1, 2, 3, 4]];
+
+        assert_eq!(bin.first(), Some(1));
+        bin.remove(0);
+        assert_eq!(bin.first(), Some(2));
+
+        // first on empty bytes
+        let bin = bytes![&env];
+        assert_eq!(bin.first(), None);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_first_unchecked() {
+        let env = Env::default();
+        let mut bin = bytes![&env, [1, 2, 3, 4]];
+
+        assert_eq!(bin.first_unchecked(), 1);
+        bin.remove(0);
+        assert_eq!(bin.first_unchecked(), 2);
+
+        // first on empty bytes should panic
+        let bin = bytes![&env];
+        bin.first_unchecked();
+    }
+
+    #[test]
+    fn test_last() {
+        let env = Env::default();
+        let mut bin = bytes![&env, [1, 2, 3, 4]];
+
+        assert_eq!(bin.last(), Some(4));
+        bin.remove(3);
+        assert_eq!(bin.last(), Some(3));
+
+        // last on empty bytes
+        let bin = bytes![&env];
+        assert_eq!(bin.last(), None);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_last_unchecked() {
+        let env = Env::default();
+        let mut bin = bytes![&env, [1, 2, 3, 4]];
+
+        assert_eq!(bin.last_unchecked(), 4);
+        bin.remove(0);
+        assert_eq!(bin.last_unchecked(), 3);
+
+        // first on empty bytes should panic
+        let bin = bytes![&env];
+        bin.first_unchecked();
+    }
+
+    #[test]
+    fn test_get() {
+        let env = Env::default();
+        let bin = bytes![&env, [0, 1, 5, 2, 8]];
+
+        assert_eq!(bin.get(0), Some(0));
+        assert_eq!(bin.get(1), Some(1));
+        assert_eq!(bin.get(2), Some(5));
+        assert_eq!(bin.get(3), Some(2));
+        assert_eq!(bin.get(4), Some(8));
+
+        assert_eq!(bin.get(bin.len()), None);
+        assert_eq!(bin.get(bin.len() + 1), None);
+        assert_eq!(bin.get(u32::MAX), None);
+
+        // tests on an empty vec
+        let bin = bytes![&env];
+        assert_eq!(bin.get(0), None);
+        assert_eq!(bin.get(bin.len()), None);
+        assert_eq!(bin.get(bin.len() + 1), None);
+        assert_eq!(bin.get(u32::MAX), None);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_get_unchecked() {
+        let env = Env::default();
+        let bin = bytes![&env, [0, 1, 5, 2, 8]];
+
+        assert_eq!(bin.get_unchecked(0), 0);
+        assert_eq!(bin.get_unchecked(1), 1);
+        assert_eq!(bin.get_unchecked(2), 5);
+        assert_eq!(bin.get_unchecked(3), 2);
+        assert_eq!(bin.get_unchecked(4), 8);
+
+        // get unchecked should panic
+        let bin = bytes![&env];
+        bin.get_unchecked(0);
+    }
+
+    #[test]
+    fn test_remove() {
+        let env = Env::default();
+        let mut bin = bytes![&env, [1, 2, 3, 4]];
+
+        assert_eq!(bin.remove(2), Some(()));
+        assert_eq!(bin, bytes![&env, [1, 2, 4]]);
+        assert_eq!(bin.len(), 3);
+
+        // out of bound removes
+        assert_eq!(bin.remove(bin.len()), None);
+        assert_eq!(bin.remove(bin.len() + 1), None);
+        assert_eq!(bin.remove(u32::MAX), None);
+
+        // remove rest of items
+        assert_eq!(bin.remove(0), Some(()));
+        assert_eq!(bin.remove(0), Some(()));
+        assert_eq!(bin.remove(0), Some(()));
+        assert_eq!(bin, bytes![&env]);
+        assert_eq!(bin.len(), 0);
+
+        // try remove from empty bytes
+        let mut bin = bytes![&env];
+        assert_eq!(bin.remove(0), None);
+        assert_eq!(bin.remove(bin.len()), None);
+        assert_eq!(bin.remove(bin.len() + 1), None);
+        assert_eq!(bin.remove(u32::MAX), None);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_remove_unchecked() {
+        let env = Env::default();
+        let mut bin = bytes![&env, [1, 2, 3, 4]];
+
+        assert_eq!(bin.remove_unchecked(2), ());
+        assert_eq!(bin, bytes![&env, [1, 2, 4]]);
+        assert_eq!(bin.len(), 3);
+
+        // out of bound remove panic
+        bin.remove_unchecked(bin.len());
+    }
+
+    #[test]
+    fn test_pop() {
+        let env = Env::default();
+        let mut bin = bytes![&env, [0, 1, 2, 3, 4]];
+
+        assert_eq!(bin.pop(), Some(4));
+        assert_eq!(bin.pop(), Some(3));
+        assert_eq!(bin.len(), 3);
+        assert_eq!(bin, bytes![&env, [0, 1, 2]]);
+
+        // pop on empty bytes
+        let mut bin = bytes![&env];
+        assert_eq!(bin.pop(), None);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_pop_unchecked() {
+        let env = Env::default();
+        let mut bin = bytes![&env, [0, 1, 2, 3, 4]];
+
+        assert_eq!(bin.pop_unchecked(), 4);
+        assert_eq!(bin.pop_unchecked(), 3);
+        assert_eq!(bin.len(), 3);
+        assert_eq!(bin, bytes![&env, [0, 1, 2]]);
+
+        // pop on empty bytes
+        let mut bin = bytes![&env];
+        bin.pop_unchecked();
+    }
+
+    #[test]
+    fn test_insert() {
+        let env = Env::default();
+        let mut bin = bytes![&env, [0, 1, 2, 3, 4]];
+
+        bin.insert(3, 42);
+        assert_eq!(bin, bytes![&env, [0, 1, 2, 42, 3, 4]]);
+
+        // insert at start
+        bin.insert(0, 43);
+        assert_eq!(bin, bytes![&env, [43, 0, 1, 2, 42, 3, 4]]);
+
+        // insert at end
+        bin.insert(bin.len(), 44);
+        assert_eq!(bin, bytes![&env, [43, 0, 1, 2, 42, 3, 4, 44]]);
+    }
+
+    #[test]
+    #[should_panic(expected = "HostObjectError(VecIndexOutOfBound)")]
+    fn test_insert_panic() {
+        let env = Env::default();
+        let mut bin = bytes![&env, [0, 1, 2, 3, 4]];
+
+        bin.insert(80, 44);
+    }
+
+    #[test]
+    fn test_slice() {
+        let env = Env::default();
+        let bin = bytes![&env, [0, 1, 2, 3, 4]];
+
+        let bin2 = bin.slice(2..);
+        assert_eq!(bin2, bytes![&env, [2, 3, 4]]);
+
+        let bin3 = bin.slice(3..3);
+        assert_eq!(bin3, bytes![&env]);
+
+        let bin4 = bin.slice(0..3);
+        assert_eq!(bin4, bytes![&env, [0, 1, 2]]);
+
+        let bin4 = bin.slice(3..5);
+        assert_eq!(bin4, bytes![&env, [3, 4]]);
+
+        assert_eq!(bin, bytes![&env, [0, 1, 2, 3, 4]]); // makes sure original bytes is unchanged
+    }
+
+    #[test]
+    #[should_panic(expected = "HostObjectError(VecIndexOutOfBound")]
+    fn test_slice_panic() {
+        let env = Env::default();
+        let bin = bytes![&env, [0, 1, 2, 3, 4]];
+
+        let _ = bin.slice(..=bin.len());
+    }
 }

--- a/soroban-sdk/src/bytes.rs
+++ b/soroban-sdk/src/bytes.rs
@@ -1433,7 +1433,7 @@ mod test {
     }
 
     #[test]
-    #[should_panic(expected = "HostObjectError(VecIndexOutOfBound)")]
+    #[should_panic(expected = "HostError: Error(Object, IndexBounds)")]
     fn test_insert_panic() {
         let env = Env::default();
         let mut bin = bytes![&env, [0, 1, 2, 3, 4]];
@@ -1462,7 +1462,7 @@ mod test {
     }
 
     #[test]
-    #[should_panic(expected = "HostObjectError(VecIndexOutOfBound")]
+    #[should_panic(expected = "HostError: Error(Object, IndexBounds)")]
     fn test_slice_panic() {
         let env = Env::default();
         let bin = bytes![&env, [0, 1, 2, 3, 4]];

--- a/soroban-sdk/src/bytes.rs
+++ b/soroban-sdk/src/bytes.rs
@@ -1295,7 +1295,7 @@ mod test {
         let mut bin = bytes![&env, [1, 2, 3, 4]];
 
         assert_eq!(bin.last_unchecked(), 4);
-        bin.remove(0);
+        bin.remove(3);
         assert_eq!(bin.last_unchecked(), 3);
     }
 

--- a/soroban-sdk/src/map.rs
+++ b/soroban-sdk/src/map.rs
@@ -697,10 +697,9 @@ mod test {
     }
 
     #[test]
-    #[should_panic]
+    #[should_panic(expected = "HostError: Error(Object, MissingValue)")]
     fn test_get_unchecked_panic() {
         let env = Env::default();
-
         let map: Map<u32, u32> = map![&env, (0, 0), (1, 10), (2, 20), (3, 30), (4, 40)];
         let _ = map.get_unchecked(100); // key does not exist
     }
@@ -751,10 +750,9 @@ mod test {
     }
 
     #[test]
-    #[should_panic]
+    #[should_panic(expected = "HostError: Error(Object, MissingValue)")]
     fn test_remove_unchecked_panic() {
         let env = Env::default();
-
         let mut map: Map<u32, u32> = map![&env, (0, 0), (1, 10), (2, 20), (3, 30), (4, 40)];
         map.remove_unchecked(100); // key does not exist
     }

--- a/soroban-sdk/src/map.rs
+++ b/soroban-sdk/src/map.rs
@@ -633,4 +633,129 @@ mod test {
         let values = map.values();
         assert_eq!(values, vec![&env, 0, 10, 20, 30, 40]);
     }
+
+    #[test]
+    fn test_from_array() {
+        let env = Env::default();
+
+        let map = Map::from_array(&env, [(0, 0), (1, 10), (2, 20), (3, 30), (4, 40)]);
+        assert_eq!(map, map![&env, (0, 0), (1, 10), (2, 20), (3, 30), (4, 40)]);
+
+        let map: Map<u32, u32> = Map::from_array(&env, []);
+        assert_eq!(map, map![&env]);
+    }
+
+    #[test]
+    fn test_contains_key() {
+        let env = Env::default();
+
+        let map: Map<u32, u32> = map![&env, (0, 0), (1, 10), (2, 20), (3, 30), (4, 40)];
+
+        // contains all assigned keys
+        for i in 0..map.len() {
+            assert_eq!(true, map.contains_key(i));
+        }
+
+        // does not contain keys outside range
+        assert_eq!(map.contains_key(6), false);
+        assert_eq!(map.contains_key(u32::MAX), false);
+        assert_eq!(map.contains_key(8), false);
+    }
+
+    #[test]
+    fn test_is_empty() {
+        let env = Env::default();
+
+        let mut map: Map<u32, u32> = Map::new(&env);
+        assert_eq!(map.is_empty(), true);
+        map.set(0, 0);
+        assert_eq!(map.is_empty(), false);
+    }
+
+    #[test]
+    fn test_get() {
+        let env = Env::default();
+
+        let map: Map<u32, u32> = map![&env, (0, 0), (1, 10), (2, 20), (3, 30), (4, 40)];
+        for i in 0..map.len() {
+            assert_eq!(map.get(i), Some(Ok(i * 10)));
+        }
+
+        // getting from empty map
+        let map: Map<u32, u32> = map![&env];
+        assert_eq!(map.get(2), None);
+    }
+
+    #[test]
+    fn test_get_unchecked() {
+        let env = Env::default();
+
+        let map: Map<u32, u32> = map![&env, (0, 0), (1, 10), (2, 20), (3, 30), (4, 40)];
+        for i in 0..map.len() {
+            assert_eq!(map.get_unchecked(i), Ok(i * 10));
+        }
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_get_unchecked_panic() {
+        let env = Env::default();
+
+        let map: Map<u32, u32> = map![&env, (0, 0), (1, 10), (2, 20), (3, 30), (4, 40)];
+        let _ = map.get_unchecked(100); // key does not exist
+    }
+
+    #[test]
+    fn test_remove() {
+        let env = Env::default();
+
+        let mut map: Map<u32, u32> = map![&env, (0, 0), (1, 10), (2, 20), (3, 30), (4, 40)];
+
+        assert_eq!(map.len(), 5);
+        assert_eq!(map.get(2), Some(Ok(20)),);
+        assert_eq!(map.remove(2), Some(()));
+        assert_eq!(map.get(2), None);
+        assert_eq!(map.len(), 4);
+
+        // remove all items
+        map.remove(0);
+        map.remove(1);
+        map.remove(3);
+        map.remove(4);
+        assert_eq!(map![&env], map);
+
+        // removing from empty map
+        let mut map: Map<u32, u32> = map![&env];
+        assert_eq!(map.remove(0), None);
+        assert_eq!(map.remove(u32::MAX), None);
+    }
+
+    #[test]
+    fn test_remove_unchecked() {
+        let env = Env::default();
+
+        let mut map: Map<u32, u32> = map![&env, (0, 0), (1, 10), (2, 20), (3, 30), (4, 40)];
+
+        assert_eq!(map.len(), 5);
+        assert_eq!(map.get(2), Some(Ok(20)));
+        assert_eq!(map.remove_unchecked(2), ());
+        assert_eq!(map.get(2), None);
+        assert_eq!(map.len(), 4);
+
+        // remove all items
+        map.remove_unchecked(0);
+        map.remove_unchecked(1);
+        map.remove_unchecked(3);
+        map.remove_unchecked(4);
+        assert_eq!(map![&env], map);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_remove_unchecked_panic() {
+        let env = Env::default();
+
+        let mut map: Map<u32, u32> = map![&env, (0, 0), (1, 10), (2, 20), (3, 30), (4, 40)];
+        map.remove_unchecked(100); // key does not exist
+    }
 }

--- a/soroban-sdk/src/vec.rs
+++ b/soroban-sdk/src/vec.rs
@@ -961,7 +961,7 @@ mod test {
     }
 
     #[test]
-    fn contains() {
+    fn test_contains() {
         let env = Env::default();
         let vec = vec![&env, 0, 3, 5, 7, 9, 5];
         assert_eq!(vec.contains(&2), false);
@@ -973,7 +973,7 @@ mod test {
     }
 
     #[test]
-    fn first_index_of() {
+    fn test_first_index_of() {
         let env = Env::default();
 
         let vec = vec![&env, 0, 3, 5, 7, 9, 5];
@@ -986,7 +986,7 @@ mod test {
     }
 
     #[test]
-    fn last_index_of() {
+    fn test_last_index_of() {
         let env = Env::default();
 
         let vec = vec![&env, 0, 3, 5, 7, 9, 5];
@@ -999,7 +999,7 @@ mod test {
     }
 
     #[test]
-    fn binary_search() {
+    fn test_binary_search() {
         let env = Env::default();
 
         let vec = vec![&env, 0, 3, 5, 5, 7, 9];
@@ -1036,7 +1036,7 @@ mod test {
     }
 
     #[test]
-    fn insert_and_set() {
+    fn test_insert_and_set() {
         let env = Env::default();
         let mut v = Vec::<i64>::new(&env);
         v.insert(0, 3);
@@ -1052,7 +1052,7 @@ mod test {
     }
 
     #[test]
-    fn is_empty_and_len() {
+    fn test_is_empty_and_len() {
         let env = Env::default();
 
         let mut v: Vec<i32> = vec![&env, 1, 4, 3];
@@ -1065,7 +1065,7 @@ mod test {
     }
 
     #[test]
-    fn push_pop_front() {
+    fn test_push_pop_front() {
         let env = Env::default();
 
         let mut v = Vec::<i64>::new(&env);
@@ -1083,7 +1083,7 @@ mod test {
     }
 
     #[test]
-    fn push_pop_back() {
+    fn test_push_pop_back() {
         let env = Env::default();
 
         let mut v = Vec::<i64>::new(&env);
@@ -1098,5 +1098,115 @@ mod test {
         assert_eq!(pop_unchecked, Ok(42));
         assert_eq!(v, vec![&env]);
         assert_eq!(v.pop_back(), None);
+    }
+
+    #[test]
+    fn test_get() {
+        let env = Env::default();
+
+        let v: Vec<i64> = vec![&env, 0, 3, 5, 5, 7, 9];
+
+        // get each item
+        assert_eq!(v.get(3), Some(Ok(5)));
+        assert_eq!(v.get(0), Some(Ok(0)));
+        assert_eq!(v.get(1), Some(Ok(3)));
+        assert_eq!(v.get(2), Some(Ok(5)));
+        assert_eq!(v.get(5), Some(Ok(9)));
+        assert_eq!(v.get(4), Some(Ok(7)));
+
+        assert_eq!(v.get(v.len()), None);
+        assert_eq!(v.get(v.len() + 1), None);
+        assert_eq!(v.get(u32::MAX), None);
+
+        // tests on an empty vec
+        let v = Vec::<i64>::new(&env);
+        assert_eq!(v.get(0), None);
+        assert_eq!(v.get(v.len()), None);
+        assert_eq!(v.get(v.len() + 1), None);
+        assert_eq!(v.get(u32::MAX), None);
+    }
+
+    #[test]
+    fn test_get_unchecked() {
+        let env = Env::default();
+
+        let v: Vec<i64> = vec![&env, 0, 3, 5, 5, 7, 9];
+
+        // get each item
+        assert_eq!(v.get_unchecked(3), Ok(5));
+        assert_eq!(v.get_unchecked(0), Ok(0));
+        assert_eq!(v.get_unchecked(1), Ok(3));
+        assert_eq!(v.get_unchecked(2), Ok(5));
+        assert_eq!(v.get_unchecked(5), Ok(9));
+        assert_eq!(v.get_unchecked(4), Ok(7));
+    }
+
+    #[test]
+    #[should_panic(expected = "HostObjectError(VecIndexOutOfBound)")]
+    fn test_get_unchecked_panics() {
+        let env = Env::default();
+
+        let v: Vec<i64> = vec![&env, 0, 3, 5, 5, 7, 9];
+        _ = v.get_unchecked(v.len()); // out of bound get
+    }
+
+    #[test]
+    fn test_remove() {
+        let env = Env::default();
+        let mut v: Vec<i64> = vec![&env, 0, 3, 5, 5, 7, 9];
+
+        assert_eq!(v.remove(0), Some(()));
+        assert_eq!(v.remove(2), Some(()));
+        assert_eq!(v.remove(3), Some(()));
+
+        assert_eq!(v, vec![&env, 3, 5, 7]);
+        assert_eq!(v.len(), 3);
+
+        // out of bound removes
+        assert_eq!(v.remove(v.len()), None);
+        assert_eq!(v.remove(v.len() + 1), None);
+        assert_eq!(v.remove(u32::MAX), None);
+
+        // remove rest of items
+        assert_eq!(v.remove(0), Some(()));
+        assert_eq!(v.remove(0), Some(()));
+        assert_eq!(v.remove(0), Some(()));
+        assert_eq!(v, vec![&env]);
+        assert_eq!(v.len(), 0);
+
+        // try remove from empty vec
+        assert_eq!(v.remove(0), None);
+        assert_eq!(v.remove(v.len()), None);
+        assert_eq!(v.remove(v.len() + 1), None);
+        assert_eq!(v.remove(u32::MAX), None);
+    }
+
+    #[test]
+    fn test_remove_unchecked() {
+        let env = Env::default();
+        let mut v: Vec<i64> = vec![&env, 0, 3, 5, 5, 7, 9];
+
+        assert_eq!(v.remove_unchecked(0), ());
+        assert_eq!(v.remove_unchecked(2), ());
+        assert_eq!(v.remove_unchecked(3), ());
+
+        assert_eq!(v, vec![&env, 3, 5, 7]);
+        assert_eq!(v.len(), 3);
+
+        // remove rest of items
+        assert_eq!(v.remove_unchecked(0), ());
+        assert_eq!(v.remove_unchecked(0), ());
+        assert_eq!(v.remove_unchecked(0), ());
+        assert_eq!(v, vec![&env]);
+        assert_eq!(v.len(), 0);
+    }
+
+    #[test]
+    #[should_panic(expected = "HostObjectError(VecIndexOutOfBound)")]
+    fn test_remove_unchecked_panics() {
+        let env = Env::default();
+        let mut v: Vec<i64> = vec![&env, 0, 3, 5, 5, 7, 9];
+
+        v.remove_unchecked(v.len())
     }
 }

--- a/soroban-sdk/src/vec.rs
+++ b/soroban-sdk/src/vec.rs
@@ -1145,7 +1145,6 @@ mod test {
     #[should_panic(expected = "HostError: Error(Object, IndexBounds)")]
     fn test_get_unchecked_panics() {
         let env = Env::default();
-
         let v: Vec<i64> = vec![&env, 0, 3, 5, 5, 7, 9];
         _ = v.get_unchecked(v.len()); // out of bound get
     }
@@ -1206,7 +1205,6 @@ mod test {
     fn test_remove_unchecked_panics() {
         let env = Env::default();
         let mut v: Vec<i64> = vec![&env, 0, 3, 5, 5, 7, 9];
-
         v.remove_unchecked(v.len())
     }
 }

--- a/soroban-sdk/src/vec.rs
+++ b/soroban-sdk/src/vec.rs
@@ -1142,7 +1142,7 @@ mod test {
     }
 
     #[test]
-    #[should_panic(expected = "HostObjectError(VecIndexOutOfBound)")]
+    #[should_panic(expected = "HostError: Error(Object, IndexBounds)")]
     fn test_get_unchecked_panics() {
         let env = Env::default();
 
@@ -1202,7 +1202,7 @@ mod test {
     }
 
     #[test]
-    #[should_panic(expected = "HostObjectError(VecIndexOutOfBound)")]
+    #[should_panic(expected = "HostError: Error(Object, IndexBounds)")]
     fn test_remove_unchecked_panics() {
         let env = Env::default();
         let mut v: Vec<i64> = vec![&env, 0, 3, 5, 5, 7, 9];


### PR DESCRIPTION
### What

Adds tests for the methods within the modules Vec, Map and Bytes.

Tests have been added for the following methods...

Bytes: `is_empty`, `first`, `first_unchecked`, `last`, `last_unchecked`, `get`, `get_unchecked`, `remove`, `remove_unchecked`, `pop`, `pop_unchecked`, `insert`, `slice`

Map: `from_array`, `contains_key`, `is_empty`, `get`, `get_unchecked`, `remove`, `remove_unchecked`  

Vec: `get`, `get_unchecked`, `remove`, `remove_unchecked`

### Why

These modules are the building blocks of soroban-sdk.

### Extra

I refactored some tests names in `Vec` so that they are pre-pended with the word `test`. It seems the majority of the tests follow this convention, but I also stopped short in case the renaming is not necessary. I do find its useful as an easy way to search files i.e. if you want to look for tests simply use the query "find_" on all your files.

