### PR TITLE
Hide as/to_object fns on SDK types

### DIFF
--- a/soroban-sdk/src/address.rs
+++ b/soroban-sdk/src/address.rs
@@ -282,11 +282,11 @@ impl Address {
         self.obj.to_raw()
     }
 
-    pub fn as_object(&self) -> &AddressObject {
+    pub(crate) fn as_object(&self) -> &AddressObject {
         &self.obj
     }
 
-    pub fn to_object(&self) -> AddressObject {
+    pub(crate) fn to_object(&self) -> AddressObject {
         self.obj
     }
 }

--- a/soroban-sdk/src/bytes.rs
+++ b/soroban-sdk/src/bytes.rs
@@ -299,11 +299,11 @@ impl Bytes {
         self.obj.to_raw()
     }
 
-    pub fn as_object(&self) -> &BytesObject {
+    pub(crate) fn as_object(&self) -> &BytesObject {
         &self.obj
     }
 
-    pub fn to_object(&self) -> BytesObject {
+    pub(crate) fn to_object(&self) -> BytesObject {
         self.obj
     }
 
@@ -886,11 +886,11 @@ impl<const N: usize> BytesN<N> {
         self.0.to_raw()
     }
 
-    pub fn as_object(&self) -> &BytesObject {
+    pub(crate) fn as_object(&self) -> &BytesObject {
         self.0.as_object()
     }
 
-    pub fn to_object(&self) -> BytesObject {
+    pub(crate) fn to_object(&self) -> BytesObject {
         self.0.to_object()
     }
 

--- a/soroban-sdk/src/string.rs
+++ b/soroban-sdk/src/string.rs
@@ -188,11 +188,11 @@ impl String {
         self.obj.to_raw()
     }
 
-    pub fn as_object(&self) -> &StringObject {
+    pub(crate) fn as_object(&self) -> &StringObject {
         &self.obj
     }
 
-    pub fn to_object(&self) -> StringObject {
+    pub(crate) fn to_object(&self) -> StringObject {
         self.obj
     }
 

--- a/soroban-sdk/src/vec.rs
+++ b/soroban-sdk/src/vec.rs
@@ -341,11 +341,11 @@ impl<T> Vec<T> {
         self.obj.to_raw()
     }
 
-    pub fn as_object(&self) -> &VecObject {
+    pub(crate) fn as_object(&self) -> &VecObject {
         &self.obj
     }
 
-    pub fn to_object(&self) -> VecObject {
+    pub(crate) fn to_object(&self) -> VecObject {
         self.obj
     }
 }


### PR DESCRIPTION
### What
Hide `as_object` and `to_object` fns on SDK types.

### Why
The functions aren't usable in meaningful ways by users and are part of the environment plumbing. We can hide them from users which keeps the interface that developers see smaller and less cluttered by things that don't matter to them.

Note that the `as_raw` and `to_raw` are usable and are still public and accessible to developers.

