### PR TITLE
Set a random hidden source account for test Envs

### DIFF
--- a/soroban-sdk/src/env.rs
+++ b/soroban-sdk/src/env.rs
@@ -483,6 +483,9 @@ impl Env {
         let budget = internal::budget::Budget::default();
         let env_impl = internal::EnvImpl::with_storage_and_budget(storage, budget.clone());
         env_impl.switch_to_recording_auth();
+        env_impl.set_source_account(xdr::AccountId(xdr::PublicKey::PublicKeyTypeEd25519(
+            xdr::Uint256(random()),
+        )));
         let env = Env {
             env_impl,
             snapshot: None,

--- a/soroban-sdk/src/tests.rs
+++ b/soroban-sdk/src/tests.rs
@@ -17,3 +17,4 @@ mod contractfile_with_sha256;
 mod contractimport;
 mod contractimport_with_error;
 mod contractimport_with_sha256;
+mod env;

--- a/soroban-sdk/src/tests/env.rs
+++ b/soroban-sdk/src/tests/env.rs
@@ -1,6 +1,12 @@
 use crate::Env;
 
 #[test]
+// Env::default is expected to configure the underlying host with a source
+// account in tests so that the Env is configured similarily to how it will be
+// configured for real. Some functions in Env have in the past or may now make
+// assumptions about a source account being set. This is something small we do
+// to make sure we don't accidentally introduce Env functionality that will
+// panick in SDK tests.
 fn default_has_source_account_configured_in_host() {
     let env = Env::default();
     assert!(env.host().source_account().is_some());

--- a/soroban-sdk/src/tests/env.rs
+++ b/soroban-sdk/src/tests/env.rs
@@ -1,0 +1,7 @@
+use crate::Env;
+
+#[test]
+fn default_has_source_account_configured_in_host() {
+    let env = Env::default();
+    assert!(env.host().source_account().is_some());
+}


### PR DESCRIPTION
### What
Set a random source account for all test Envs that developers use in tests, that is hidden from the developer.

### Why
Make sure that the `Env` is configured more similar to how it will be for real outside tests. So that we can write code in Env more consistently assuming the source account will be set safely without causing errors in users of `Env`.

We used to always set a source account for the `Env` because in a real environment the source account is always set. I think it was removed as part of the auth-next work, although maybe unnecessarily. In the past we had run into some situations where it was surprising or unexpected for there to be no source account and errors arose. Today I ran into a situation where a function panicked because there was no source account.

It seems otherwise harmless to set a source account since developers have no visibility into it and it has no functional impact, so this change feels rather safe.

In the future we may want to make source accounts settable by a developer again, but there seems no need for it today and so a random one will do the job in just making sure the `Env` is configured in a way that is more similar to how it will be for real.