### PR TITLE
Remove superfluous env parameters

### DIFF
--- a/soroban-sdk-macros/src/derive_client.rs
+++ b/soroban-sdk-macros/src/derive_client.rs
@@ -104,7 +104,7 @@ pub fn derive_client(crate_path: &Path, ty: &str, name: &str, fns: &[syn_ext::Fn
             }
 
             pub fn address(&self) -> #crate_path::Address {
-                #crate_path::Address::from_contract_id(&self.env, &self.contract_id)
+                #crate_path::Address::from_contract_id(&self.contract_id)
             }
 
             #(#fns)*

--- a/soroban-sdk/src/address.rs
+++ b/soroban-sdk/src/address.rs
@@ -202,7 +202,8 @@ impl Address {
     /// Prefer using the `Address` directly as input or output argument. Only
     /// use this in special cases, for example to get an Address of a freshly
     /// deployed contract.
-    pub fn from_contract_id(env: &Env, contract_id: &BytesN<32>) -> Self {
+    pub fn from_contract_id(contract_id: &BytesN<32>) -> Self {
+        let env = contract_id.env();
         unsafe {
             Self::unchecked_new(
                 env.clone(),
@@ -217,7 +218,8 @@ impl Address {
     ///
     /// Prefer using the `Address` directly as input or output argument. Only
     /// use this in special cases, like for cross-chain interoperability.
-    pub fn from_account_id(env: &Env, account_pk: &BytesN<32>) -> Self {
+    pub fn from_account_id(account_pk: &BytesN<32>) -> Self {
+        let env = account_pk.env().clone();
         unsafe {
             Self::unchecked_new(
                 env.clone(),

--- a/soroban-sdk/src/tests/address.rs
+++ b/soroban-sdk/src/tests/address.rs
@@ -3,7 +3,7 @@ use crate::{Address, BytesN, Env};
 #[test]
 fn test_account_address_conversions() {
     let env = Env::default();
-    let account_address = Address::from_account_id(&env, &BytesN::from_array(&env, &[222u8; 32]));
+    let account_address = Address::from_account_id(&BytesN::from_array(&env, &[222u8; 32]));
     assert_eq!(
         account_address.account_id(),
         Some(BytesN::from_array(&env, &[222u8; 32]))
@@ -14,7 +14,7 @@ fn test_account_address_conversions() {
 #[test]
 fn test_contract_address_conversions() {
     let env = Env::default();
-    let contract_address = Address::from_contract_id(&env, &BytesN::from_array(&env, &[111u8; 32]));
+    let contract_address = Address::from_contract_id(&BytesN::from_array(&env, &[111u8; 32]));
     assert_eq!(
         contract_address.contract_id(),
         Some(BytesN::from_array(&env, &[111u8; 32]))


### PR DESCRIPTION
### What
Remove env parameters from `Address::from_*` functions.

### Why
The functions do not need to explicitly receive an `Env` because the type they're converting from is already an `Env`-aware type and the type can be implicitly ported using the already known `Env`.