### PR TITLE
Add conversions from Address<>ScAddress

### DIFF
--- a/soroban-sdk/src/tests/address.rs
+++ b/soroban-sdk/src/tests/address.rs
@@ -1,4 +1,9 @@
-use crate::{Address, BytesN, Env};
+use soroban_env_host::TryIntoVal;
+
+use crate::{
+    xdr::{AccountId, Hash, PublicKey, ScAddress, Uint256},
+    Address, BytesN, Env,
+};
 
 #[test]
 fn test_account_address_conversions() {
@@ -9,6 +14,17 @@ fn test_account_address_conversions() {
         Some(BytesN::from_array(&env, &[222u8; 32]))
     );
     assert_eq!(account_address.contract_id(), None);
+
+    let scaddress: ScAddress = (&account_address).try_into().unwrap();
+    assert_eq!(
+        scaddress,
+        ScAddress::Account(AccountId(PublicKey::PublicKeyTypeEd25519(Uint256(
+            [222u8; 32]
+        ))))
+    );
+
+    let account_address_rt: Address = scaddress.try_into_val(&env).unwrap();
+    assert_eq!(account_address_rt, account_address);
 }
 
 #[test]
@@ -20,4 +36,10 @@ fn test_contract_address_conversions() {
         Some(BytesN::from_array(&env, &[111u8; 32]))
     );
     assert_eq!(contract_address.account_id(), None);
+
+    let scaddress: ScAddress = (&contract_address).try_into().unwrap();
+    assert_eq!(scaddress, ScAddress::Contract(Hash([111u8; 32])));
+
+    let contract_address_rt: Address = scaddress.try_into_val(&env).unwrap();
+    assert_eq!(contract_address_rt, contract_address);
 }


### PR DESCRIPTION
### What
Add conversions from Address<>ScAddress.

### Why
There are conversions from ScVal<>Address, but not directly to ScAddress, which is inconvenient. It's more convenient to be able to convert directly between the two.