### PR TITLE
Add a function to update current contract's executable with provided Wasm

### DIFF
--- a/soroban-sdk/src/env.rs
+++ b/soroban-sdk/src/env.rs
@@ -442,6 +442,19 @@ impl Env {
     pub fn log_value<V: IntoVal<Env, RawVal>>(&self, v: V) {
         internal::Env::log_value(self, v.into_val(self)).unwrap_infallible();
     }
+
+    /// Replaces the executable of the current contract with the provided Wasm.
+    /// 
+    /// The Wasm blob identified by the `wasm_hash` has to be already present
+    /// on-chain (the upload happens via `INSTALL_CONTRACT_CODE` host function
+    /// or via `install_contract_wasm` test function in unit tests).
+    /// 
+    /// The function won't do anything immediately. The contract executable
+    /// will only be updated after the invocation has successfully finished.
+    pub fn update_current_contract_wasm(&self, wasm_hash: &BytesN<32>) {
+        internal::Env::update_current_contract_wasm(self, wasm_hash.to_object())
+            .unwrap_infallible();
+    }
 }
 
 #[cfg(any(test, feature = "testutils"))]

--- a/soroban-sdk/src/env.rs
+++ b/soroban-sdk/src/env.rs
@@ -444,11 +444,11 @@ impl Env {
     }
 
     /// Replaces the executable of the current contract with the provided Wasm.
-    /// 
+    ///
     /// The Wasm blob identified by the `wasm_hash` has to be already present
     /// on-chain (the upload happens via `INSTALL_CONTRACT_CODE` host function
     /// or via `install_contract_wasm` test function in unit tests).
-    /// 
+    ///
     /// The function won't do anything immediately. The contract executable
     /// will only be updated after the invocation has successfully finished.
     pub fn update_current_contract_wasm(&self, wasm_hash: &BytesN<32>) {


### PR DESCRIPTION
### What

Add a function to update current contract's executable with provided Wasm

### Why

Supporting contract updateability

### Known limitations

No doctest for now - we need some test wasm to use as we can't (at least currently) update compiled-in contract implementation.
