### PR TITLE
Hide Env.host() in docs

### DIFF
--- a/soroban-sdk/src/env.rs
+++ b/soroban-sdk/src/env.rs
@@ -468,6 +468,7 @@ use xdr::{Hash, LedgerEntry, LedgerKey, LedgerKeyContractData};
 #[cfg(any(test, feature = "testutils"))]
 #[cfg_attr(feature = "docs", doc(cfg(feature = "testutils")))]
 impl Env {
+    #[doc(hidden)]
     pub fn host(&self) -> &internal::Host {
         &self.env_impl
     }


### PR DESCRIPTION
### What
Hide Env.host() in docs.

### Why
The `Env` `host` function returns a `Host`, which is an internal type that is not documented. It isn't intended for routine use and we haven't really made a plan for how power users or edge cases might use it. At the moment it is just noise in the docs, somewhat distracting and ambiguous especially as it has no docs. For these types of functions that we don't really expect people to use right now we typically hide them.