### PR TITLE
Make crate path configurable in contractimpl

### DIFF
--- a/soroban-sdk-macros/src/lib.rs
+++ b/soroban-sdk-macros/src/lib.rs
@@ -94,6 +94,7 @@ pub fn contractimpl(metadata: TokenStream, input: TokenStream) -> TokenStream {
         Err(e) => return e.write_errors().into(),
     };
     let crate_path = &args.crate_path;
+    let crate_path_str = quote!(#crate_path).to_string();
 
     let imp = parse_macro_input!(input as ItemImpl);
     let ty = &imp.self_ty;
@@ -134,7 +135,7 @@ pub fn contractimpl(metadata: TokenStream, input: TokenStream) -> TokenStream {
         Ok(derived_ok) => {
             let cfs = derive_contract_function_set(&crate_path, ty, pub_methods.into_iter());
             quote! {
-                #[#crate_path::contractclient(name = #client_ident)]
+                #[#crate_path::contractclient(crate_path = #crate_path_str, name = #client_ident)]
                 #[#crate_path::contractspecfn(name = #ty_str)]
                 #imp
                 #derived_ok

--- a/soroban-sdk-macros/src/lib.rs
+++ b/soroban-sdk-macros/src/lib.rs
@@ -93,6 +93,7 @@ pub fn contractimpl(metadata: TokenStream, input: TokenStream) -> TokenStream {
         Ok(v) => v,
         Err(e) => return e.write_errors().into(),
     };
+    let crate_path = &args.crate_path;
 
     let imp = parse_macro_input!(input as ItemImpl);
     let ty = &imp.self_ty;
@@ -118,7 +119,7 @@ pub fn contractimpl(metadata: TokenStream, input: TokenStream) -> TokenStream {
             let call = quote! { <super::#ty>::#ident };
             let trait_ident = imp.trait_.as_ref().and_then(|x| x.1.get_ident());
             derive_fn(
-                &args.crate_path,
+                &crate_path,
                 &call,
                 ident,
                 &m.attrs,
@@ -131,10 +132,10 @@ pub fn contractimpl(metadata: TokenStream, input: TokenStream) -> TokenStream {
 
     match derived {
         Ok(derived_ok) => {
-            let cfs = derive_contract_function_set(&args.crate_path, ty, pub_methods.into_iter());
+            let cfs = derive_contract_function_set(&crate_path, ty, pub_methods.into_iter());
             quote! {
-                #[soroban_sdk::contractclient(name = #client_ident)]
-                #[soroban_sdk::contractspecfn(name = #ty_str)]
+                #[#crate_path::contractclient(name = #client_ident)]
+                #[#crate_path::contractspecfn(name = #ty_str)]
                 #imp
                 #derived_ok
                 #cfs

--- a/soroban-sdk-macros/src/lib.rs
+++ b/soroban-sdk-macros/src/lib.rs
@@ -80,8 +80,20 @@ pub fn contractspecfn(metadata: TokenStream, input: TokenStream) -> TokenStream 
     }
 }
 
+#[derive(Debug, FromMeta)]
+struct ContractImplArgs {
+    #[darling(default = "default_crate_path")]
+    crate_path: Path,
+}
+
 #[proc_macro_attribute]
-pub fn contractimpl(_metadata: TokenStream, input: TokenStream) -> TokenStream {
+pub fn contractimpl(metadata: TokenStream, input: TokenStream) -> TokenStream {
+    let args = parse_macro_input!(metadata as AttributeArgs);
+    let args = match ContractImplArgs::from_list(&args) {
+        Ok(v) => v,
+        Err(e) => return e.write_errors().into(),
+    };
+
     let imp = parse_macro_input!(input as ItemImpl);
     let ty = &imp.self_ty;
     let ty_str = quote!(#ty).to_string();
@@ -106,6 +118,7 @@ pub fn contractimpl(_metadata: TokenStream, input: TokenStream) -> TokenStream {
             let call = quote! { <super::#ty>::#ident };
             let trait_ident = imp.trait_.as_ref().and_then(|x| x.1.get_ident());
             derive_fn(
+                &args.crate_path,
                 &call,
                 ident,
                 &m.attrs,
@@ -118,7 +131,7 @@ pub fn contractimpl(_metadata: TokenStream, input: TokenStream) -> TokenStream {
 
     match derived {
         Ok(derived_ok) => {
-            let cfs = derive_contract_function_set(ty, pub_methods.into_iter());
+            let cfs = derive_contract_function_set(&args.crate_path, ty, pub_methods.into_iter());
             quote! {
                 #[soroban_sdk::contractclient(name = #client_ident)]
                 #[soroban_sdk::contractspecfn(name = #ty_str)]


### PR DESCRIPTION
### What
Make crate path configurable in contractimpl

### Why
So it is possible to use the contractimpl macro in places where the crate path needs to be modified.

Other macros already support configuring crate path, so this brings the contractimpl macro up to date.