### PR TITLE
Remove Address::account_id facility

### DIFF
--- a/soroban-sdk/src/address.rs
+++ b/soroban-sdk/src/address.rs
@@ -247,22 +247,6 @@ impl Address {
         }
     }
 
-    /// Creates an `Address` corresponding to the provided Stellar account
-    /// 32-byte identifier (public key).
-    ///
-    /// Prefer using the `Address` directly as input or output argument. Only
-    /// use this in special cases, like for cross-chain interoperability.
-    pub fn from_account_id(account_pk: &BytesN<32>) -> Self {
-        let env = account_pk.env().clone();
-        unsafe {
-            Self::unchecked_new(
-                env.clone(),
-                env.account_public_key_to_address(account_pk.to_object())
-                    .unwrap_optimized(),
-            )
-        }
-    }
-
     /// Returns 32-byte contract identifier corresponding to this `Address`.
     ///
     /// Returns `None` when this `Address` does not belong to a contract.
@@ -273,26 +257,6 @@ impl Address {
     /// given its `Address`.
     pub fn contract_id(&self) -> Option<BytesN<32>> {
         let rv = self.env.address_to_contract_id(self.obj).unwrap_optimized();
-        if let Ok(()) = rv.try_into_val(&self.env) {
-            None
-        } else {
-            Some(rv.try_into_val(&self.env).unwrap_optimized())
-        }
-    }
-
-    /// Returns 32-byte Stellar account identifier (public key) corresponding
-    /// to this `Address`.
-    ///
-    /// Returns `None` when this `Address` does not belong to an account.
-    ///
-    /// Avoid using the returned account identifier for authorization purposes
-    /// and prefer using `Address` directly whenever possible. This is only
-    /// useful in special cases, like for cross-chain interoperability.
-    pub fn account_id(&self) -> Option<BytesN<32>> {
-        let rv = self
-            .env
-            .address_to_account_public_key(self.obj)
-            .unwrap_optimized();
         if let Ok(()) = rv.try_into_val(&self.env) {
             None
         } else {

--- a/soroban-sdk/src/tests/address.rs
+++ b/soroban-sdk/src/tests/address.rs
@@ -1,30 +1,21 @@
-use soroban_env_host::TryIntoVal;
-
 use crate::{
     xdr::{AccountId, Hash, PublicKey, ScAddress, Uint256},
-    Address, BytesN, Env,
+    Address, BytesN, Env, TryFromVal, TryIntoVal,
 };
 
 #[test]
 fn test_account_address_conversions() {
     let env = Env::default();
-    let account_address = Address::from_account_id(&BytesN::from_array(&env, &[222u8; 32]));
-    assert_eq!(
-        account_address.account_id(),
-        Some(BytesN::from_array(&env, &[222u8; 32]))
-    );
-    assert_eq!(account_address.contract_id(), None);
 
-    let scaddress: ScAddress = (&account_address).try_into().unwrap();
-    assert_eq!(
-        scaddress,
-        ScAddress::Account(AccountId(PublicKey::PublicKeyTypeEd25519(Uint256(
-            [222u8; 32]
-        ))))
-    );
+    let scaddress = ScAddress::Account(AccountId(PublicKey::PublicKeyTypeEd25519(Uint256(
+        [222u8; 32],
+    ))));
 
-    let account_address_rt: Address = scaddress.try_into_val(&env).unwrap();
-    assert_eq!(account_address_rt, account_address);
+    let address = Address::try_from_val(&env, &scaddress).unwrap();
+    assert_eq!(address.contract_id(), None);
+
+    let scaddress_roundtrip: ScAddress = (&address).try_into().unwrap();
+    assert_eq!(scaddress, scaddress_roundtrip,);
 }
 
 #[test]
@@ -35,7 +26,6 @@ fn test_contract_address_conversions() {
         contract_address.contract_id(),
         Some(BytesN::from_array(&env, &[111u8; 32]))
     );
-    assert_eq!(contract_address.account_id(), None);
 
     let scaddress: ScAddress = (&contract_address).try_into().unwrap();
     assert_eq!(scaddress, ScAddress::Contract(Hash([111u8; 32])));


### PR DESCRIPTION
### What
Remove Address::account_id and Address::from_account_id facilities.

### Why
The utility of these methods is pretty confusing, and not really aligned with where we're headed for a couple reasons.

The `account_id` function returns the ed25519 public key of an Account ID. This is the first place in the Stellar protocol where we expose an Account IDs key without context for what type of key it is. Account IDs are usually transmitted with a discriminant so that we can add new key types in the future without applications needing to be redeveloped. We could address this by renaming the function to `account_id_ed25519_public_key`.

However, renaming the function to that name makes it even clearer that there's a bigger issue at play. The only thing someone might do with an ed25519 public key is to use it for identification or signature verification. For identification contracts should use the `Address` type directly. 

That leaves the only use case as signature verification of an Account ID's public key. However, signature verification of a master key is dangerous. It makes the assumption that it is the signer of the account, and contracts have no access to signers of accounts to know if that is the case. Any contract that verifies signatures for an Account ID is ignoring the multisig signers setup of an account and could be verifying a key that is not a signer of the account.

While it feels natural to include these functions, I think they're harmful. We need to steer people towards only using `Address`. Outside of contracts Stellar developers use strkeys whenever interacting with IDs on the Stellar network. `Address` is the strkey of contracts, and folks need to use that.

Note that if there are use cases in tests where account ID `Address`es need to be tested, this can still be achieved by creating an `xdr::ScAddress` containing an `xdr::AccountId`, and then converting that to an `Address`.

Related conversation is at https://discord.com/channels/897514728459468821/1108510759513763860