### PR TITLE
Replace BytesN<32> for contract IDs with Address

### DIFF
--- a/soroban-sdk-macros/src/derive_client.rs
+++ b/soroban-sdk-macros/src/derive_client.rs
@@ -123,7 +123,7 @@ pub fn derive_client(crate_path: &Path, ty: &str, name: &str, fns: &[syn_ext::Fn
         #[doc = #client_doc]
         pub struct #client_ident<'a> {
             pub env: #crate_path::Env,
-            pub contract_id: #crate_path::BytesN<32>,
+            pub contract_id: #crate_path::Address,
             #[doc(hidden)]
             #[cfg(not(any(test, feature = "testutils")))]
             _phantom: core::marker::PhantomData<&'a ()>,
@@ -139,10 +139,10 @@ pub fn derive_client(crate_path: &Path, ty: &str, name: &str, fns: &[syn_ext::Fn
         }
 
         impl<'a> #client_ident<'a> {
-            pub fn new(env: &#crate_path::Env, contract_id: &impl #crate_path::IntoVal<#crate_path::Env, #crate_path::BytesN<32>>) -> Self {
+            pub fn new(env: &#crate_path::Env, contract_id: &#crate_path::Address) -> Self {
                 Self {
                     env: env.clone(),
-                    contract_id: contract_id.into_val(env),
+                    contract_id: contract_id.clone(),
                     #[cfg(not(any(test, feature = "testutils")))]
                     _phantom: core::marker::PhantomData,
                     #[cfg(any(test, feature = "testutils"))]
@@ -155,7 +155,7 @@ pub fn derive_client(crate_path: &Path, ty: &str, name: &str, fns: &[syn_ext::Fn
             }
 
             pub fn address(&self) -> #crate_path::Address {
-                #crate_path::Address::from_contract_id(&self.contract_id)
+                self.contract_id.clone()
             }
 
             /// Set authorizations in the environment which will be consumed by

--- a/soroban-sdk-macros/src/derive_client.rs
+++ b/soroban-sdk-macros/src/derive_client.rs
@@ -75,7 +75,7 @@ pub fn derive_client(crate_path: &Path, ty: &str, name: &str, fns: &[syn_ext::Fn
                     }
                     use #crate_path::{IntoVal,FromVal};
                     self.env.invoke_contract(
-                        &self.contract_id,
+                        &self.contract,
                         &#crate_path::Symbol::new(&self.env, &#fn_name),
                         #crate_path::vec![&self.env, #(#fn_input_names.into_val(&self.env)),*],
                     )
@@ -101,7 +101,7 @@ pub fn derive_client(crate_path: &Path, ty: &str, name: &str, fns: &[syn_ext::Fn
                     }
                     use #crate_path::{IntoVal,FromVal};
                     self.env.try_invoke_contract(
-                        &self.contract_id,
+                        &self.contract,
                         &#crate_path::Symbol::new(&self.env, &#fn_name),
                         #crate_path::vec![&self.env, #(#fn_input_names.into_val(&self.env)),*],
                     )
@@ -123,7 +123,7 @@ pub fn derive_client(crate_path: &Path, ty: &str, name: &str, fns: &[syn_ext::Fn
         #[doc = #client_doc]
         pub struct #client_ident<'a> {
             pub env: #crate_path::Env,
-            pub contract_id: #crate_path::Address,
+            pub contract: #crate_path::Address,
             #[doc(hidden)]
             #[cfg(not(any(test, feature = "testutils")))]
             _phantom: core::marker::PhantomData<&'a ()>,
@@ -139,10 +139,10 @@ pub fn derive_client(crate_path: &Path, ty: &str, name: &str, fns: &[syn_ext::Fn
         }
 
         impl<'a> #client_ident<'a> {
-            pub fn new(env: &#crate_path::Env, contract_id: &#crate_path::Address) -> Self {
+            pub fn new(env: &#crate_path::Env, contract: &#crate_path::Address) -> Self {
                 Self {
                     env: env.clone(),
-                    contract_id: contract_id.clone(),
+                    contract: contract.clone(),
                     #[cfg(not(any(test, feature = "testutils")))]
                     _phantom: core::marker::PhantomData,
                     #[cfg(any(test, feature = "testutils"))]
@@ -154,10 +154,6 @@ pub fn derive_client(crate_path: &Path, ty: &str, name: &str, fns: &[syn_ext::Fn
                 }
             }
 
-            pub fn address(&self) -> #crate_path::Address {
-                self.contract_id.clone()
-            }
-
             /// Set authorizations in the environment which will be consumed by
             /// contracts when they invoke `Address::require_auth` or
             /// `Address::require_auth_for_args` functions.
@@ -167,7 +163,7 @@ pub fn derive_client(crate_path: &Path, ty: &str, name: &str, fns: &[syn_ext::Fn
             pub fn set_auths(&self, auths: &'a [#crate_path::xdr::ContractAuth]) -> Self {
                 Self {
                     env: self.env.clone(),
-                    contract_id: self.contract_id.clone(),
+                    contract: self.contract.clone(),
                     set_auths: Some(auths),
                     mock_auths: self.mock_auths.clone(),
                     mock_all_auths: false,
@@ -183,7 +179,7 @@ pub fn derive_client(crate_path: &Path, ty: &str, name: &str, fns: &[syn_ext::Fn
             pub fn mock_auths(&self, mock_auths: &'a [#crate_path::testutils::MockAuth<'a>]) -> Self {
                 Self {
                     env: self.env.clone(),
-                    contract_id: self.contract_id.clone(),
+                    contract: self.contract.clone(),
                     set_auths: self.set_auths.clone(),
                     mock_auths: Some(mock_auths),
                     mock_all_auths: false,
@@ -199,7 +195,7 @@ pub fn derive_client(crate_path: &Path, ty: &str, name: &str, fns: &[syn_ext::Fn
             pub fn mock_all_auths(&self) -> Self {
                 Self {
                     env: self.env.clone(),
-                    contract_id: self.contract_id.clone(),
+                    contract: self.contract.clone(),
                     set_auths: None,
                     mock_auths: None,
                     mock_all_auths: true,

--- a/soroban-sdk/src/address.rs
+++ b/soroban-sdk/src/address.rs
@@ -249,15 +249,25 @@ impl Address {
 
     /// Returns 32-byte contract identifier corresponding to this `Address`.
     ///
-    /// ### Panics
-    ///
-    /// If Address is not a contract.
-    pub(crate) fn contract_id(&self) -> BytesN<32> {
+    /// Returns None if the Address is not a contract.
+    pub(crate) fn try_contract_id(&self) -> Option<BytesN<32>> {
         let rv = self.env.address_to_contract_id(self.obj).unwrap_optimized();
         if let Ok(()) = rv.try_into_val(&self.env) {
-            panic!("Address is not a Contract ID")
+            None
         } else {
-            rv.try_into_val(&self.env).unwrap_optimized()
+            Some(rv.try_into_val(&self.env).unwrap_optimized())
+        }
+    }
+
+    /// Returns 32-byte contract identifier corresponding to this `Address`.
+    ///
+    /// ### Panics
+    ///
+    /// If Address is not a contract ID.
+    pub(crate) fn contract_id(&self) -> BytesN<32> {
+        match self.try_contract_id() {
+            Some(contract_id) => contract_id,
+            None => panic!("Address is not a Contract ID"),
         }
     }
 

--- a/soroban-sdk/src/address.rs
+++ b/soroban-sdk/src/address.rs
@@ -261,26 +261,6 @@ impl Address {
         }
     }
 
-    /// Returns 32-byte Stellar account identifier (public key) corresponding
-    /// to this `Address`.
-    ///
-    /// Returns `None` when this `Address` does not belong to an account.
-    ///
-    /// Avoid using the returned account identifier for authorization purposes
-    /// and prefer using `Address` directly whenever possible. This is only
-    /// useful in special cases, like for cross-chain interoperability.
-    pub fn account_id(&self) -> Option<BytesN<32>> {
-        let rv = self
-            .env
-            .address_to_account_public_key(self.obj)
-            .unwrap_optimized();
-        if let Ok(()) = rv.try_into_val(&self.env) {
-            None
-        } else {
-            Some(rv.try_into_val(&self.env).unwrap_optimized())
-        }
-    }
-
     #[inline(always)]
     pub(crate) unsafe fn unchecked_new(env: Env, obj: AddressObject) -> Self {
         Self { env, obj }

--- a/soroban-sdk/src/address.rs
+++ b/soroban-sdk/src/address.rs
@@ -236,7 +236,7 @@ impl Address {
     /// Prefer using the `Address` directly as input or output argument. Only
     /// use this in special cases, for example to get an Address of a freshly
     /// deployed contract.
-    pub fn from_contract_id(contract_id: &BytesN<32>) -> Self {
+    pub(crate) fn from_contract_id(contract_id: &BytesN<32>) -> Self {
         let env = contract_id.env();
         unsafe {
             Self::unchecked_new(
@@ -298,6 +298,10 @@ impl crate::testutils::Address for Address {
     fn random(env: &Env) -> Self {
         let sc_addr = ScVal::Address(ScAddress::Contract(Hash(random())));
         Self::try_from_val(env, &sc_addr).unwrap()
+    }
+
+    fn from_contract_id(contract_id: &crate::BytesN<32>) -> crate::Address {
+        Self::from_contract_id(contract_id)
     }
 
     fn contract_id(&self) -> crate::BytesN<32> {

--- a/soroban-sdk/src/address.rs
+++ b/soroban-sdk/src/address.rs
@@ -247,22 +247,6 @@ impl Address {
         }
     }
 
-    /// Creates an `Address` corresponding to the provided Stellar account
-    /// 32-byte identifier (public key).
-    ///
-    /// Prefer using the `Address` directly as input or output argument. Only
-    /// use this in special cases, like for cross-chain interoperability.
-    pub fn from_account_id(account_pk: &BytesN<32>) -> Self {
-        let env = account_pk.env().clone();
-        unsafe {
-            Self::unchecked_new(
-                env.clone(),
-                env.account_public_key_to_address(account_pk.to_object())
-                    .unwrap_optimized(),
-            )
-        }
-    }
-
     /// Returns 32-byte contract identifier corresponding to this `Address`.
     ///
     /// Returns `None` when this `Address` does not belong to a contract.
@@ -273,26 +257,6 @@ impl Address {
     /// given its `Address`.
     pub fn contract_id(&self) -> Option<BytesN<32>> {
         let rv = self.env.address_to_contract_id(self.obj).unwrap_optimized();
-        if let Ok(()) = rv.try_into_val(&self.env) {
-            None
-        } else {
-            Some(rv.try_into_val(&self.env).unwrap_optimized())
-        }
-    }
-
-    /// Returns 32-byte Stellar account identifier (public key) corresponding
-    /// to this `Address`.
-    ///
-    /// Returns `None` when this `Address` does not belong to an account.
-    ///
-    /// Avoid using the returned account identifier for authorization purposes
-    /// and prefer using `Address` directly whenever possible. This is only
-    /// useful in special cases, like for cross-chain interoperability.
-    pub fn account_id(&self) -> Option<BytesN<32>> {
-        let rv = self
-            .env
-            .address_to_account_public_key(self.obj)
-            .unwrap_optimized();
         if let Ok(()) = rv.try_into_val(&self.env) {
             None
         } else {

--- a/soroban-sdk/src/address.rs
+++ b/soroban-sdk/src/address.rs
@@ -249,18 +249,15 @@ impl Address {
 
     /// Returns 32-byte contract identifier corresponding to this `Address`.
     ///
-    /// Returns `None` when this `Address` does not belong to a contract.
+    /// ### Panics
     ///
-    /// Avoid using the returned contract identifier for authorization purposes
-    /// and prefer using `Address` directly whenever possible. This is only
-    /// useful in special cases, for example, to be able to invoke a contract
-    /// given its `Address`.
-    pub fn contract_id(&self) -> Option<BytesN<32>> {
+    /// If Address is not a contract.
+    pub(crate) fn contract_id(&self) -> BytesN<32> {
         let rv = self.env.address_to_contract_id(self.obj).unwrap_optimized();
         if let Ok(()) = rv.try_into_val(&self.env) {
-            None
+            panic!("Address is not a Contract ID")
         } else {
-            Some(rv.try_into_val(&self.env).unwrap_optimized())
+            rv.try_into_val(&self.env).unwrap_optimized()
         }
     }
 
@@ -301,5 +298,9 @@ impl crate::testutils::Address for Address {
     fn random(env: &Env) -> Self {
         let sc_addr = ScVal::Address(ScAddress::Contract(Hash(random())));
         Self::try_from_val(env, &sc_addr).unwrap()
+    }
+
+    fn contract_id(&self) -> crate::BytesN<32> {
+        self.contract_id()
     }
 }

--- a/soroban-sdk/src/deploy.rs
+++ b/soroban-sdk/src/deploy.rs
@@ -28,8 +28,7 @@
 //! # #[cfg(feature = "testutils")]
 //! # fn main() {
 //! #     let env = Env::default();
-//! #     let contract_id = BytesN::from_array(&env, &[0; 32]);
-//! #     env.register_contract(&contract_id, Contract);
+//! #     let contract_id = env.register_contract(None, Contract);
 //! #     // Install the contract code before deploying its instance.
 //! #     let wasm_hash = env.install_contract_wasm(&[0u8; 100]);
 //! #     ContractClient::new(&env, &contract_id).f(&wasm_hash);

--- a/soroban-sdk/src/deploy.rs
+++ b/soroban-sdk/src/deploy.rs
@@ -37,7 +37,7 @@
 //! # #[cfg(not(feature = "testutils"))]
 //! # fn main() { }
 //! ```
-use crate::{env::internal::Env as _, unwrap::UnwrapInfallible, BytesN, Env, IntoVal};
+use crate::{env::internal::Env as _, unwrap::UnwrapInfallible, Address, BytesN, Env, IntoVal};
 
 /// Deployer provides access to deploying contracts.
 pub struct Deployer {
@@ -71,13 +71,13 @@ impl Deployer {
     /// given contract ID and the provided salt.
     pub fn with_other_contract(
         &self,
-        contract_id: &impl IntoVal<Env, BytesN<32>>,
+        contract_id: &Address,
         salt: &impl IntoVal<Env, BytesN<32>>,
     ) -> DeployerWithOtherContract {
         let env = self.env();
         DeployerWithOtherContract {
             env: env.clone(),
-            contract_id: contract_id.into_val(env),
+            contract_id: contract_id.clone(),
             salt: salt.into_val(env),
         }
     }
@@ -93,7 +93,7 @@ pub struct DeployerWithCurrentContract {
 impl DeployerWithCurrentContract {
     /// Return the ID of the contract defined by the deployer.
     #[doc(hidden)]
-    pub fn id(&self) -> BytesN<32> {
+    pub fn id(&self) -> Address {
         todo!()
     }
 
@@ -124,14 +124,14 @@ impl DeployerWithCurrentContract {
 /// contract ID or an ed25519 public key.
 pub struct DeployerWithOtherContract {
     env: Env,
-    contract_id: BytesN<32>,
+    contract_id: Address,
     salt: BytesN<32>,
 }
 
 impl DeployerWithOtherContract {
     #[doc(hidden)]
     /// Return the ID of the contract defined by the deployer.
-    pub fn id(&self) -> BytesN<32> {
+    pub fn id(&self) -> Address {
         todo!()
     }
 }

--- a/soroban-sdk/src/env.rs
+++ b/soroban-sdk/src/env.rs
@@ -408,9 +408,12 @@ impl Env {
         T: TryFromVal<Env, RawVal>,
         E: TryFrom<Status>,
     {
+        let Some(contract_id) = contract_id.try_contract_id() else {
+            return Err(E::try_from(Status::from_status(xdr::ScStatus::UnknownError(xdr::ScUnknownErrorCode::General))));
+        };
         let rv = internal::Env::try_call(
             self,
-            contract_id.contract_id().to_object(),
+            contract_id.to_object(),
             func.to_val(),
             args.to_object(),
         )

--- a/soroban-sdk/src/env.rs
+++ b/soroban-sdk/src/env.rs
@@ -317,7 +317,7 @@ impl Env {
     ///
     /// ### Examples
     /// ```
-    /// use soroban_sdk::{contractimpl, BytesN, Env, Symbol};
+    /// use soroban_sdk::{contractimpl, log, BytesN, Env, Symbol};
     ///
     /// pub struct Contract;
     ///
@@ -328,8 +328,7 @@ impl Env {
     ///         assert_eq!(stack.len(), 1);
     ///
     ///         let outer = stack.get(0).unwrap().unwrap();
-    ///         assert_eq!(outer.0, BytesN::from_array(&env, &[0; 32]));
-    ///         assert_eq!(outer.1, Symbol::short("hello"));
+    ///         log!(&env, "{}", outer);
     ///     }
     /// }
     /// #[test]
@@ -338,8 +337,7 @@ impl Env {
     /// # #[cfg(feature = "testutils")]
     /// # fn main() {
     ///     let env = Env::default();
-    ///     let contract_id = BytesN::from_array(&env, &[0; 32]);
-    ///     env.register_contract(&contract_id, Contract);
+    ///     let contract_id = env.register_contract(None, Contract);
     ///     let client = ContractClient::new(&env, &contract_id);
     ///     client.hello();
     /// }
@@ -538,8 +536,7 @@ impl Env {
     /// # }
     /// # fn main() {
     ///     let env = Env::default();
-    ///     let contract_id = BytesN::from_array(&env, &[0; 32]);
-    ///     env.register_contract(&contract_id, HelloContract);
+    ///     let contract_id = env.register_contract(None, HelloContract);
     /// }
     /// ```
     pub fn register_contract<'a, T: ContractFunctionSet + 'static>(
@@ -943,7 +940,7 @@ impl Env {
     ///         env.auths(),
     ///         std::vec![(
     ///             address.clone(),
-    ///             client.contract_id.clone(),
+    ///             client.contract.clone(),
     ///             Symbol::short("transfer"),
     ///             (&address, 1000_i128,).into_val(&env)
     ///         )]
@@ -954,7 +951,7 @@ impl Env {
     ///         env.auths(),
     ///         std::vec![(
     ///             address.clone(),
-    ///             client.contract_id.clone(),
+    ///             client.contract.clone(),
     ///             Symbol::short("transfer2"),
     ///             // `transfer2` requires auth for (amount / 2) == (1000 / 2) == 500.
     ///             (500_i128,).into_val(&env)

--- a/soroban-sdk/src/env.rs
+++ b/soroban-sdk/src/env.rs
@@ -346,10 +346,20 @@ impl Env {
     /// # #[cfg(not(feature = "testutils"))]
     /// # fn main() { }
     /// ```
-    // TODO: Change BytesN<32> to Address.
-    pub fn call_stack(&self) -> Vec<(BytesN<32>, crate::Symbol)> {
+    pub fn call_stack(&self) -> Vec<(Address, crate::Symbol)> {
+        // TODO: Change host fn to return Addresses, so that contracts do not
+        // need to iterate over the call stack and do conversion.
         let stack = internal::Env::get_current_call_stack(self).unwrap_infallible();
-        unsafe { Vec::unchecked_new(self.clone(), stack) }
+
+        let stack =
+            unsafe { Vec::<(BytesN<32>, crate::Symbol)>::unchecked_new(self.clone(), stack) };
+
+        let mut stack_with_addresses = Vec::new(self);
+        for (id, sym) in stack.iter_unchecked() {
+            stack_with_addresses.push_back((Address::from_contract_id(&id), sym));
+        }
+
+        stack_with_addresses
     }
 
     /// Invokes a function of a contract that is registered in the [Env].

--- a/soroban-sdk/src/env.rs
+++ b/soroban-sdk/src/env.rs
@@ -301,16 +301,6 @@ impl Env {
         unsafe { Address::unchecked_new(self.clone(), address) }
     }
 
-    /// Get the 32-byte hash identifier of the current executing contract.
-    ///
-    /// Prefer `current_contract_address` for the most cases, unless dealing
-    /// with contract-specific functions (like the call stacks).
-    pub fn current_contract_id(&self) -> Address {
-        let id = internal::Env::get_current_contract_id(self).unwrap_infallible();
-        let id = unsafe { BytesN::<32>::unchecked_new(self.clone(), id) };
-        Address::from_contract_id(&id)
-    }
-
     #[doc(hidden)]
     pub(crate) fn require_auth_for_args(&self, address: &Address, args: Vec<RawVal>) {
         internal::Env::require_auth_for_args(self, address.to_object(), args.to_object())

--- a/soroban-sdk/src/env.rs
+++ b/soroban-sdk/src/env.rs
@@ -305,9 +305,10 @@ impl Env {
     ///
     /// Prefer `current_contract_address` for the most cases, unless dealing
     /// with contract-specific functions (like the call stacks).
-    pub fn current_contract_id(&self) -> BytesN<32> {
+    pub fn current_contract_id(&self) -> Address {
         let id = internal::Env::get_current_contract_id(self).unwrap_infallible();
-        unsafe { BytesN::<32>::unchecked_new(self.clone(), id) }
+        let id = unsafe { BytesN::<32>::unchecked_new(self.clone(), id) };
+        Address::from_contract_id(&id)
     }
 
     #[doc(hidden)]
@@ -355,6 +356,7 @@ impl Env {
     /// # #[cfg(not(feature = "testutils"))]
     /// # fn main() { }
     /// ```
+    // TODO: Change BytesN<32> to Address.
     pub fn call_stack(&self) -> Vec<(BytesN<32>, crate::Symbol)> {
         let stack = internal::Env::get_current_call_stack(self).unwrap_infallible();
         unsafe { Vec::unchecked_new(self.clone(), stack) }
@@ -375,7 +377,7 @@ impl Env {
     /// into the type `T`.
     pub fn invoke_contract<T>(
         &self,
-        contract_id: &BytesN<32>,
+        contract_id: &Address,
         func: &crate::Symbol,
         args: Vec<RawVal>,
     ) -> T
@@ -384,7 +386,7 @@ impl Env {
     {
         let rv = internal::Env::call(
             self,
-            contract_id.to_object(),
+            contract_id.contract_id().to_object(),
             func.to_val(),
             args.to_object(),
         )
@@ -398,7 +400,7 @@ impl Env {
     /// returns an error if the invocation fails for any reason.
     pub fn try_invoke_contract<T, E>(
         &self,
-        contract_id: &BytesN<32>,
+        contract_id: &Address,
         func: &crate::Symbol,
         args: Vec<RawVal>,
     ) -> Result<Result<T, T::Error>, Result<E, E::Error>>
@@ -408,7 +410,7 @@ impl Env {
     {
         let rv = internal::Env::try_call(
             self,
-            contract_id.to_object(),
+            contract_id.contract_id().to_object(),
             func.to_val(),
             args.to_object(),
         )
@@ -446,7 +448,7 @@ impl Env {
 
 #[cfg(any(test, feature = "testutils"))]
 use crate::testutils::{
-    budget::Budget, random, BytesN as _, ContractFunctionSet, Ledger as _, MockAuth,
+    budget::Budget, random, Address as _, ContractFunctionSet, Ledger as _, MockAuth,
     MockAuthContract,
 };
 #[cfg(any(test, feature = "testutils"))]
@@ -539,9 +541,9 @@ impl Env {
     /// ```
     pub fn register_contract<'a, T: ContractFunctionSet + 'static>(
         &self,
-        contract_id: impl Into<Option<&'a BytesN<32>>>,
+        contract_id: impl Into<Option<&'a Address>>,
         contract: T,
-    ) -> BytesN<32> {
+    ) -> Address {
         struct InternalContractFunctionSet<T: ContractFunctionSet>(pub(crate) T);
         impl<T: ContractFunctionSet> internal::ContractFunctionSet for InternalContractFunctionSet<T> {
             fn call(
@@ -565,11 +567,11 @@ impl Env {
         let contract_id = if let Some(contract_id) = contract_id.into() {
             contract_id.clone()
         } else {
-            BytesN::random(self)
+            Address::random(self)
         };
         self.env_impl
             .register_test_contract(
-                contract_id.to_object(),
+                contract_id.contract_id().to_object(),
                 Rc::new(InternalContractFunctionSet(contract)),
             )
             .unwrap();
@@ -602,9 +604,9 @@ impl Env {
     /// ```
     pub fn register_contract_wasm<'a>(
         &self,
-        contract_id: impl Into<Option<&'a BytesN<32>>>,
+        contract_id: impl Into<Option<&'a Address>>,
         contract_wasm: &[u8],
-    ) -> BytesN<32> {
+    ) -> Address {
         let wasm_hash: BytesN<32> = self.install_contract_wasm(contract_wasm);
         self.register_contract_with_optional_contract_id_and_executable(
             contract_id,
@@ -619,7 +621,7 @@ impl Env {
     /// The contract will wrap a randomly-generated Stellar asset. This function
     /// is useful for using in the tests when an arbitrary token contract
     /// instance is needed.
-    pub fn register_stellar_asset_contract(&self, admin: Address) -> BytesN<32> {
+    pub fn register_stellar_asset_contract(&self, admin: Address) -> Address {
         let issuer_pk = random();
         let issuer_id = xdr::AccountId(xdr::PublicKey::PublicKeyTypeEd25519(xdr::Uint256(
             issuer_pk.clone(),
@@ -716,14 +718,14 @@ impl Env {
             })
             .unwrap();
 
-        token_id
+        Address::from_contract_id(&token_id)
     }
 
     fn register_contract_with_optional_contract_id_and_executable<'a>(
         &self,
-        contract_id: impl Into<Option<&'a BytesN<32>>>,
+        contract_id: impl Into<Option<&'a Address>>,
         executable: xdr::ScContractExecutable,
-    ) -> BytesN<32> {
+    ) -> Address {
         if let Some(contract_id) = contract_id.into() {
             self.register_contract_with_contract_id_and_executable(contract_id, executable);
             contract_id.clone()
@@ -732,7 +734,7 @@ impl Env {
         }
     }
 
-    fn register_contract_with_source(&self, executable: xdr::ScContractExecutable) -> BytesN<32> {
+    fn register_contract_with_source(&self, executable: xdr::ScContractExecutable) -> Address {
         let prev_source_account = self.env_impl.source_account();
         self.env_impl
             .set_source_account(xdr::AccountId(xdr::PublicKey::PublicKeyTypeEd25519(
@@ -757,7 +759,8 @@ impl Env {
         } else {
             self.env_impl.remove_source_account();
         }
-        contract_id
+
+        Address::from_contract_id(&contract_id)
     }
 
     /// Set authorizations in the environment which will be consumed by
@@ -824,10 +827,7 @@ impl Env {
     /// ```
     pub fn mock_auths(&self, auths: &[MockAuth]) {
         for a in auths {
-            let Some(contract_id) = a.address.contract_id() else {
-                panic!("mocking auth is only supported with contract addresses")
-            };
-            self.register_contract(&contract_id, MockAuthContract);
+            self.register_contract(a.address, MockAuthContract);
         }
         let auths = auths
             .iter()
@@ -961,7 +961,7 @@ impl Env {
     /// # #[cfg(not(feature = "testutils"))]
     /// # fn main() { }
     /// ```
-    pub fn auths(&self) -> std::vec::Vec<(Address, BytesN<32>, crate::Symbol, Vec<RawVal>)> {
+    pub fn auths(&self) -> std::vec::Vec<(Address, Address, crate::Symbol, Vec<RawVal>)> {
         use xdr::{ScBytes, ScVal};
         let authorizations = self.env_impl.get_authenticated_authorizations().unwrap();
         authorizations
@@ -973,11 +973,13 @@ impl Env {
                 }
                 (
                     Address::try_from_val(self, &ScVal::Address(a.0.clone())).unwrap(),
-                    BytesN::<32>::try_from_val(
-                        self,
-                        &ScVal::Bytes(ScBytes(a.1.as_slice().to_vec().try_into().unwrap())),
-                    )
-                    .unwrap(),
+                    Address::from_contract_id(
+                        &BytesN::<32>::try_from_val(
+                            self,
+                            &ScVal::Bytes(ScBytes(a.1.as_slice().to_vec().try_into().unwrap())),
+                        )
+                        .unwrap(),
+                    ),
                     crate::Symbol::try_from_val(self, &a.2).unwrap(),
                     args,
                 )
@@ -987,10 +989,10 @@ impl Env {
 
     fn register_contract_with_contract_id_and_executable(
         &self,
-        contract_id: &BytesN<32>,
+        contract_id: &Address,
         executable: xdr::ScContractExecutable,
     ) {
-        let contract_id_hash = Hash(contract_id.into());
+        let contract_id_hash = Hash(contract_id.contract_id().into());
         let data_key = xdr::ScVal::LedgerKeyContractExecutable;
         let key = Rc::new(LedgerKey::ContractData(LedgerKeyContractData {
             contract_id: contract_id_hash.clone(),
@@ -1050,8 +1052,8 @@ impl Env {
     ///
     /// Used to write or read contract data, or take other actions in tests for
     /// setting up tests or asserting on internal state.
-    pub fn as_contract<T>(&self, id: &BytesN<32>, f: impl FnOnce() -> T) -> T {
-        let id: [u8; 32] = id.into();
+    pub fn as_contract<T>(&self, id: &Address, f: impl FnOnce() -> T) -> T {
+        let id: [u8; 32] = id.contract_id().into();
         let func = Symbol::from_small_str("");
         let mut t: Option<T> = None;
         self.env_impl

--- a/soroban-sdk/src/events.rs
+++ b/soroban-sdk/src/events.rs
@@ -122,12 +122,12 @@ impl Events {
 }
 
 #[cfg(any(test, feature = "testutils"))]
-use crate::{testutils, xdr, TryIntoVal};
+use crate::{testutils, xdr, Address, BytesN, TryIntoVal};
 
 #[cfg(any(test, feature = "testutils"))]
 #[cfg_attr(feature = "docs", doc(cfg(feature = "testutils")))]
 impl testutils::Events for Events {
-    fn all(&self) -> Vec<(crate::BytesN<32>, Vec<RawVal>, RawVal)> {
+    fn all(&self) -> Vec<(crate::Address, Vec<RawVal>, RawVal)> {
         let env = self.env();
         let mut vec = Vec::new(env);
         self.env()
@@ -145,7 +145,7 @@ impl testutils::Events for Events {
                 }) = e.event
                 {
                     vec.push_back((
-                        contract_id.0.into_val(env),
+                        Address::from_contract_id(&BytesN::from_array(env, &contract_id.0)),
                         topics.try_into_val(env).unwrap(),
                         data.try_into_val(env).unwrap(),
                     ))

--- a/soroban-sdk/src/events.rs
+++ b/soroban-sdk/src/events.rs
@@ -2,11 +2,9 @@
 use core::fmt::Debug;
 
 #[cfg(doc)]
-use crate::{contracttype, Bytes, BytesN, Map};
+use crate::{contracttype, Bytes, Map};
 use crate::{
-    env::internal::{self},
-    unwrap::UnwrapInfallible,
-    ConversionError, Env, IntoVal, RawVal, TryFromVal, Vec,
+    env::internal, unwrap::UnwrapInfallible, ConversionError, Env, IntoVal, RawVal, TryFromVal, Vec,
 };
 
 // TODO: consolidate with host::events::TOPIC_BYTES_LENGTH_LIMIT
@@ -42,8 +40,7 @@ const TOPIC_BYTES_LENGTH_LIMIT: u32 = 32;
 /// # #[cfg(feature = "testutils")]
 /// # fn main() {
 /// #     let env = Env::default();
-/// #     let contract_id = BytesN::from_array(&env, &[0; 32]);
-/// #     env.register_contract(&contract_id, Contract);
+/// #     let contract_id = env.register_contract(None, Contract);
 /// #     ContractClient::new(&env, &contract_id).f();
 /// # }
 /// # #[cfg(not(feature = "testutils"))]
@@ -107,7 +104,7 @@ impl Events {
     ///
     /// - [Vec]
     /// - [Map]
-    /// - [Bytes]/[BytesN] longer than 32 bytes
+    /// - [Bytes]/[BytesN][crate::BytesN] longer than 32 bytes
     /// - [contracttype]
     #[inline(always)]
     pub fn publish<T, D>(&self, topics: T, data: D)

--- a/soroban-sdk/src/storage.rs
+++ b/soroban-sdk/src/storage.rs
@@ -46,8 +46,7 @@ use crate::{
 /// # #[cfg(feature = "testutils")]
 /// # fn main() {
 /// #     let env = Env::default();
-/// #     let contract_id = BytesN::from_array(&env, &[0; 32]);
-/// #     env.register_contract(&contract_id, Contract);
+/// #     let contract_id = env.register_contract(None, Contract);
 /// #     ContractClient::new(&env, &contract_id).f();
 /// # }
 /// # #[cfg(not(feature = "testutils"))]

--- a/soroban-sdk/src/tests/address.rs
+++ b/soroban-sdk/src/tests/address.rs
@@ -1,30 +1,21 @@
-use soroban_env_host::TryIntoVal;
-
 use crate::{
     xdr::{AccountId, Hash, PublicKey, ScAddress, Uint256},
-    Address, BytesN, Env,
+    Address, BytesN, Env, TryFromVal, TryIntoVal,
 };
 
 #[test]
 fn test_account_address_conversions() {
     let env = Env::default();
-    let account_address = Address::from_account_id(&BytesN::from_array(&env, &[222u8; 32]));
-    assert_eq!(
-        account_address.account_id(),
-        Some(BytesN::from_array(&env, &[222u8; 32]))
-    );
-    assert_eq!(account_address.contract_id(), None);
 
-    let scaddress: ScAddress = (&account_address).try_into().unwrap();
-    assert_eq!(
-        scaddress,
-        ScAddress::Account(AccountId(PublicKey::PublicKeyTypeEd25519(Uint256(
-            [222u8; 32]
-        ))))
-    );
+    let scaddress = ScAddress::Account(AccountId(PublicKey::PublicKeyTypeEd25519(Uint256(
+        [222u8; 32],
+    ))));
 
-    let account_address_rt: Address = scaddress.try_into_val(&env).unwrap();
-    assert_eq!(account_address_rt, account_address);
+    let address = Address::try_from_val(&env, &scaddress).unwrap();
+    assert_eq!(address.contract_id(), None);
+
+    let scaddress_roundtrip: ScAddress = (&address).try_into().unwrap();
+    assert_eq!(scaddress, scaddress_roundtrip,);
 }
 
 #[test]
@@ -35,7 +26,6 @@ fn test_contract_address_conversions() {
         contract_address.contract_id(),
         Some(BytesN::from_array(&env, &[111u8; 32]))
     );
-    assert_eq!(contract_address.account_id(), None);
 
     let scaddress: ScAddress = (&contract_address).try_into().unwrap();
     assert_eq!(scaddress, ScAddress::Contract(Hash([111u8; 32])));

--- a/soroban-sdk/src/tests/address.rs
+++ b/soroban-sdk/src/tests/address.rs
@@ -12,7 +12,6 @@ fn test_account_address_conversions() {
     ))));
 
     let address = Address::try_from_val(&env, &scaddress).unwrap();
-    assert_eq!(address.contract_id(), None);
 
     let scaddress_roundtrip: ScAddress = (&address).try_into().unwrap();
     assert_eq!(scaddress, scaddress_roundtrip,);
@@ -24,7 +23,7 @@ fn test_contract_address_conversions() {
     let contract_address = Address::from_contract_id(&BytesN::from_array(&env, &[111u8; 32]));
     assert_eq!(
         contract_address.contract_id(),
-        Some(BytesN::from_array(&env, &[111u8; 32]))
+        BytesN::from_array(&env, &[111u8; 32])
     );
 
     let scaddress: ScAddress = (&contract_address).try_into().unwrap();

--- a/soroban-sdk/src/tests/contract_call_stack.rs
+++ b/soroban-sdk/src/tests/contract_call_stack.rs
@@ -1,11 +1,11 @@
 use crate::{self as soroban_sdk, Symbol};
-use soroban_sdk::{contractimpl, BytesN, Env};
+use soroban_sdk::{contractimpl, Address, BytesN, Env};
 
 pub struct OuterContract;
 
 #[contractimpl]
 impl OuterContract {
-    pub fn outer(env: Env, contract_id: BytesN<32>) {
+    pub fn outer(env: Env, contract_id: Address) {
         let check_call_stack = || {
             let stack = env.call_stack();
             assert_eq!(stack.len(), 1);
@@ -47,10 +47,10 @@ impl InnerContract {
 fn test() {
     let e = Env::default();
 
-    let inner_contract_id = BytesN::from_array(&e, &[0; 32]);
+    let inner_contract_id = Address::from_contract_id(&BytesN::from_array(&e, &[0; 32]));
     e.register_contract(&inner_contract_id, InnerContract);
 
-    let contract_id = BytesN::from_array(&e, &[1; 32]);
+    let contract_id = Address::from_contract_id(&BytesN::from_array(&e, &[1; 32]));
     e.register_contract(&contract_id, OuterContract);
     let client = OuterContractClient::new(&e, &contract_id);
 

--- a/soroban-sdk/src/tests/contract_call_stack.rs
+++ b/soroban-sdk/src/tests/contract_call_stack.rs
@@ -10,7 +10,10 @@ impl OuterContract {
             let stack = env.call_stack();
             assert_eq!(stack.len(), 1);
             let outer = stack.get(0).unwrap().unwrap();
-            assert_eq!(outer.0, BytesN::from_array(&env, &[1u8; 32]));
+            assert_eq!(
+                outer.0,
+                Address::from_contract_id(&BytesN::from_array(&env, &[1u8; 32]))
+            );
             assert_eq!(outer.1, Symbol::short("outer"));
         };
 
@@ -34,11 +37,17 @@ impl InnerContract {
         assert_eq!(stack.len(), 2);
 
         let outer = stack.get(0).unwrap().unwrap();
-        assert_eq!(outer.0, BytesN::from_array(&env, &[1u8; 32]));
+        assert_eq!(
+            outer.0,
+            Address::from_contract_id(&BytesN::from_array(&env, &[1u8; 32]))
+        );
         assert_eq!(outer.1, Symbol::short("outer"));
 
         let inner = stack.get(1).unwrap().unwrap();
-        assert_eq!(inner.0, BytesN::from_array(&env, &[0u8; 32]));
+        assert_eq!(
+            inner.0,
+            Address::from_contract_id(&BytesN::from_array(&env, &[0u8; 32]))
+        );
         assert_eq!(inner.1, Symbol::short("inner"));
     }
 }

--- a/soroban-sdk/src/tests/contract_snapshot.rs
+++ b/soroban-sdk/src/tests/contract_snapshot.rs
@@ -1,5 +1,5 @@
-use crate::{self as soroban_sdk, BytesN};
-use soroban_sdk::{contractimpl, Env};
+use crate::{self as soroban_sdk};
+use soroban_sdk::{contractimpl, xdr, Address, Env, TryFromVal};
 
 pub struct Contract;
 
@@ -16,8 +16,8 @@ impl Contract {
 #[test]
 fn test() {
     let e = Env::default();
-    let contract_id = [0u8; 32];
-    e.register_contract(&BytesN::from_array(&e, &contract_id), Contract);
+    let contract_id = e.register_contract(None, Contract);
+    let contract_id_xdr = xdr::ScAddress::try_from(&contract_id).unwrap();
     let client = ContractClient::new(&e, &contract_id);
 
     client.store(&2, &4);
@@ -26,7 +26,8 @@ fn test() {
     let snapshot = e.to_snapshot();
 
     let e = Env::from_snapshot(snapshot);
-    e.register_contract(&BytesN::from_array(&e, &contract_id), Contract);
+    let contract_id = Address::try_from_val(&e, &contract_id_xdr).unwrap();
+    e.register_contract(&contract_id, Contract);
     let client = ContractClient::new(&e, &contract_id);
 
     assert_eq!(client.get(&2), 4);

--- a/soroban-sdk/src/tests/contractimport.rs
+++ b/soroban-sdk/src/tests/contractimport.rs
@@ -1,8 +1,6 @@
 use crate as soroban_sdk;
-use soroban_sdk::{contractimpl, BytesN, Env};
-use stellar_xdr::{
-    ScSpecEntry, ScSpecFunctionInputV0, ScSpecFunctionV0, ScSpecTypeBytesN, ScSpecTypeDef,
-};
+use soroban_sdk::{contractimpl, Address, BytesN, Env};
+use stellar_xdr::{ScSpecEntry, ScSpecFunctionInputV0, ScSpecFunctionV0, ScSpecTypeDef};
 
 mod addcontract {
     use crate as soroban_sdk;
@@ -26,10 +24,10 @@ pub struct Contract;
 
 #[contractimpl(crate_path = "crate")]
 impl Contract {
-    pub fn add_with(env: Env, contract_id: BytesN<32>, x: u64, y: u64) -> u64 {
+    pub fn add_with(env: Env, contract_id: Address, x: u64, y: u64) -> u64 {
         addcontract::Client::new(&env, &contract_id).add(&x, &y)
     }
-    pub fn sub_with(env: Env, contract_id: BytesN<32>, x: u64, y: u64) -> u64 {
+    pub fn sub_with(env: Env, contract_id: Address, x: u64, y: u64) -> u64 {
         subcontract::ContractClient::new(&env, &contract_id).sub(&x, &y)
     }
 }
@@ -53,7 +51,7 @@ fn test_functional() {
 fn test_register_at_id() {
     let e = Env::default();
 
-    let add_contract_id = BytesN::from_array(&e, &[1; 32]);
+    let add_contract_id = Address::from_contract_id(&BytesN::from_array(&e, &[1; 32]));
     e.register_contract_wasm(&add_contract_id, addcontract::WASM);
 
     let contract_id = e.register_contract(None, Contract);
@@ -114,7 +112,7 @@ fn test_spec() {
             ScSpecFunctionInputV0 {
                 doc: "".try_into().unwrap(),
                 name: "contract_id".try_into().unwrap(),
-                type_: ScSpecTypeDef::BytesN(ScSpecTypeBytesN { n: 32 }),
+                type_: ScSpecTypeDef::Address,
             },
             ScSpecFunctionInputV0 {
                 doc: "".try_into().unwrap(),

--- a/soroban-sdk/src/tests/contractimport_with_error.rs
+++ b/soroban-sdk/src/tests/contractimport_with_error.rs
@@ -1,5 +1,5 @@
 use crate as soroban_sdk;
-use soroban_sdk::{contractimpl, BytesN, Env, Symbol};
+use soroban_sdk::{contractimpl, Address, Env, Symbol};
 
 mod errcontract {
     use crate as soroban_sdk;
@@ -12,7 +12,7 @@ pub struct Contract;
 
 #[contractimpl]
 impl Contract {
-    pub fn hello_with(env: Env, contract_id: BytesN<32>, flag: u32) -> Symbol {
+    pub fn hello_with(env: Env, contract_id: Address, flag: u32) -> Symbol {
         errcontract::Client::new(&env, &contract_id).hello(&flag)
     }
 }

--- a/soroban-sdk/src/tests/contractimport_with_sha256.rs
+++ b/soroban-sdk/src/tests/contractimport_with_sha256.rs
@@ -1,8 +1,6 @@
 use crate as soroban_sdk;
-use soroban_sdk::{contractimpl, BytesN, Env};
-use stellar_xdr::{
-    ScSpecEntry, ScSpecFunctionInputV0, ScSpecFunctionV0, ScSpecTypeBytesN, ScSpecTypeDef,
-};
+use soroban_sdk::{contractimpl, Address, Env};
+use stellar_xdr::{ScSpecEntry, ScSpecFunctionInputV0, ScSpecFunctionV0, ScSpecTypeDef};
 
 mod addcontract {
     use crate as soroban_sdk;
@@ -16,7 +14,7 @@ pub struct Contract;
 
 #[contractimpl]
 impl Contract {
-    pub fn add_with(env: Env, contract_id: BytesN<32>, x: u64, y: u64) -> u64 {
+    pub fn add_with(env: Env, contract_id: Address, x: u64, y: u64) -> u64 {
         addcontract::Client::new(&env, &contract_id).add(&x, &y)
     }
 }
@@ -46,7 +44,7 @@ fn test_spec() {
             ScSpecFunctionInputV0 {
                 doc: "".try_into().unwrap(),
                 name: "contract_id".try_into().unwrap(),
-                type_: ScSpecTypeDef::BytesN(ScSpecTypeBytesN { n: 32 }),
+                type_: ScSpecTypeDef::Address,
             },
             ScSpecFunctionInputV0 {
                 doc: "".try_into().unwrap(),

--- a/soroban-sdk/src/tests/token_client.rs
+++ b/soroban-sdk/src/tests/token_client.rs
@@ -4,7 +4,7 @@ use soroban_sdk::{
     contractimpl, contracttype,
     testutils::{Address as _, MockAuth, MockAuthInvoke},
     token::Client as TokenClient,
-    Address, BytesN, Env, IntoVal, Symbol,
+    Address, Env, IntoVal, Symbol,
 };
 
 #[contracttype]
@@ -12,7 +12,7 @@ pub enum DataKey {
     Token,
 }
 
-fn get_token(e: &Env) -> BytesN<32> {
+fn get_token(e: &Env) -> Address {
     e.storage().get_unchecked(&DataKey::Token).unwrap()
 }
 
@@ -20,11 +20,11 @@ pub struct TestContract;
 
 #[contractimpl]
 impl TestContract {
-    pub fn init(e: Env, contract: BytesN<32>) {
+    pub fn init(e: Env, contract: Address) {
         e.storage().set(&DataKey::Token, &contract);
     }
 
-    pub fn get_token(e: Env) -> BytesN<32> {
+    pub fn get_token(e: Env) -> Address {
         get_token(&e)
     }
 

--- a/soroban-sdk/src/testutils.rs
+++ b/soroban-sdk/src/testutils.rs
@@ -143,7 +143,7 @@ pub trait Events {
     /// - Contract ID
     /// - Event Topics as a [`Vec<RawVal>`]
     /// - Event Data as a [`RawVal`]
-    fn all(&self) -> Vec<(crate::BytesN<32>, Vec<RawVal>, RawVal)>;
+    fn all(&self) -> Vec<(crate::Address, Vec<RawVal>, RawVal)>;
 }
 
 /// Test utilities for [`Logger`][crate::logging::Logger].
@@ -179,4 +179,11 @@ pub trait Address {
     /// shouldn't normally matter though, as contracts should be agnostic to
     /// the underlying Address value.
     fn random(env: &Env) -> crate::Address;
+
+    /// Get the contract ID of an Address as a BytesN<32>.
+    ///
+    /// ### Panics
+    ///
+    /// If the Address is not a Contract.
+    fn contract_id(&self) -> crate::BytesN<32>;
 }

--- a/soroban-sdk/src/testutils.rs
+++ b/soroban-sdk/src/testutils.rs
@@ -180,6 +180,9 @@ pub trait Address {
     /// the underlying Address value.
     fn random(env: &Env) -> crate::Address;
 
+    /// Creates an `Address` corresponding to the provided contract identifier.
+    fn from_contract_id(contract_id: &crate::BytesN<32>) -> crate::Address;
+
     /// Get the contract ID of an Address as a BytesN<32>.
     ///
     /// ### Panics

--- a/soroban-sdk/src/testutils/mock_auth.rs
+++ b/soroban-sdk/src/testutils/mock_auth.rs
@@ -1,6 +1,6 @@
 #![cfg(any(test, feature = "testutils"))]
 
-use crate::{contractimpl, xdr, Address, BytesN, RawVal, Vec};
+use crate::{contractimpl, xdr, Address, RawVal, Vec};
 
 #[doc(hidden)]
 pub struct MockAuthContract;
@@ -20,7 +20,7 @@ pub struct MockAuth<'a> {
 
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct MockAuthInvoke<'a> {
-    pub contract: &'a BytesN<32>,
+    pub contract: &'a Address,
     pub fn_name: &'a str,
     pub args: Vec<RawVal>,
     pub sub_invokes: &'a [MockAuthInvoke<'a>],
@@ -48,7 +48,7 @@ impl<'a> From<MockAuth<'a>> for xdr::ContractAuth {
 impl<'a> From<&MockAuthInvoke<'a>> for xdr::AuthorizedInvocation {
     fn from(value: &MockAuthInvoke<'a>) -> Self {
         Self {
-            contract_id: xdr::Hash(value.contract.to_array()),
+            contract_id: xdr::Hash(value.contract.contract_id().to_array()),
             function_name: value.fn_name.try_into().unwrap(),
             args: value.args.clone().try_into().unwrap(),
             sub_invocations: value

--- a/tests/add_u64/src/lib.rs
+++ b/tests/add_u64/src/lib.rs
@@ -12,15 +12,14 @@ impl Contract {
 
 #[cfg(test)]
 mod test {
-    use soroban_sdk::{BytesN, Env};
+    use soroban_sdk::Env;
 
     use crate::{Contract, ContractClient};
 
     #[test]
     fn test_add() {
         let e = Env::default();
-        let contract_id = BytesN::from_array(&e, &[0; 32]);
-        e.register_contract(&contract_id, Contract);
+        let contract_id = e.register_contract(None, Contract);
         let client = ContractClient::new(&e, &contract_id);
 
         let x = 10u64;

--- a/tests/auth/src/lib.rs
+++ b/tests/auth/src/lib.rs
@@ -1,5 +1,5 @@
 #![no_std]
-use soroban_sdk::{contractimpl, Address, BytesN, Env, IntoVal};
+use soroban_sdk::{contractimpl, Address, Env, IntoVal};
 
 pub struct ContractA;
 
@@ -84,11 +84,10 @@ mod test_a {
     fn test_with_real_contract_auth_approve() {
         let e = Env::default();
 
-        let auth_contract_id = e.register_contract(None, auth_approve::Contract);
         let contract_id = e.register_contract(None, ContractA);
         let client = ContractAClient::new(&e, &contract_id);
 
-        let a = Address::from_contract_id(&auth_contract_id);
+        let a = e.register_contract(None, auth_approve::Contract);
         let a_xdr: ScAddress = (&a).try_into().unwrap();
 
         let r = client
@@ -98,7 +97,7 @@ mod test_a {
                     nonce: 0,
                 }),
                 root_invocation: AuthorizedInvocation {
-                    contract_id: contract_id.to_array().into(),
+                    contract_id: contract_id.contract_id().to_array().into(),
                     function_name: StringM::try_from("fn1").unwrap().into(),
                     args: std::vec![ScVal::Address(a_xdr)].try_into().unwrap(),
                     sub_invocations: VecM::default(),
@@ -124,11 +123,10 @@ mod test_a {
     fn test_with_real_contract_auth_decline() {
         let e = Env::default();
 
-        let auth_contract_id = e.register_contract(None, auth_decline::Contract);
         let contract_id = e.register_contract(None, ContractA);
         let client = ContractAClient::new(&e, &contract_id);
 
-        let a = Address::from_contract_id(&auth_contract_id);
+        let a = e.register_contract(None, auth_decline::Contract);
         let a_xdr: ScAddress = (&a).try_into().unwrap();
 
         let r = client
@@ -138,7 +136,7 @@ mod test_a {
                     nonce: 0,
                 }),
                 root_invocation: AuthorizedInvocation {
-                    contract_id: contract_id.to_array().into(),
+                    contract_id: contract_id.contract_id().to_array().into(),
                     function_name: StringM::try_from("fn1").unwrap().into(),
                     args: std::vec![ScVal::Address(a_xdr)].try_into().unwrap(),
                     sub_invocations: VecM::default(),
@@ -205,7 +203,7 @@ pub struct ContractB;
 
 #[contractimpl]
 impl ContractB {
-    pub fn fn2(e: Env, a: Address, sub: BytesN<32>) -> u64 {
+    pub fn fn2(e: Env, a: Address, sub: Address) -> u64 {
         a.require_auth_for_args((1, 2).into_val(&e));
         let client = ContractAClient::new(&e, &sub);
         client.fn1(&a)
@@ -305,12 +303,11 @@ mod test_b {
     fn test_with_real_contract_auth_approve() {
         let e = Env::default();
 
-        let auth_contract_id = e.register_contract(None, auth_approve::Contract);
         let contract_a_id = e.register_contract(None, ContractA);
         let contract_b_id = e.register_contract(None, ContractB);
         let client = ContractBClient::new(&e, &contract_b_id);
 
-        let a = Address::from_contract_id(&auth_contract_id);
+        let a = e.register_contract(None, auth_approve::Contract);
         let a_xdr: ScAddress = (&a).try_into().unwrap();
 
         let r = client
@@ -320,11 +317,11 @@ mod test_b {
                     nonce: 0,
                 }),
                 root_invocation: AuthorizedInvocation {
-                    contract_id: contract_b_id.to_array().into(),
+                    contract_id: contract_b_id.contract_id().to_array().into(),
                     function_name: StringM::try_from("fn2").unwrap().into(),
                     args: std::vec![ScVal::I32(1), ScVal::I32(2),].try_into().unwrap(),
                     sub_invocations: [AuthorizedInvocation {
-                        contract_id: contract_a_id.to_array().into(),
+                        contract_id: contract_a_id.contract_id().to_array().into(),
                         function_name: StringM::try_from("fn1").unwrap().into(),
                         args: std::vec![ScVal::Address(a_xdr.clone())].try_into().unwrap(),
                         sub_invocations: [].try_into().unwrap(),
@@ -361,12 +358,11 @@ mod test_b {
     fn test_with_real_contract_auth_decline() {
         let e = Env::default();
 
-        let auth_contract_id = e.register_contract(None, auth_decline::Contract);
         let contract_a_id = e.register_contract(None, ContractA);
         let contract_b_id = e.register_contract(None, ContractB);
         let client = ContractBClient::new(&e, &contract_b_id);
 
-        let a = Address::from_contract_id(&auth_contract_id);
+        let a = e.register_contract(None, auth_decline::Contract);
         let a_xdr: ScAddress = (&a).try_into().unwrap();
 
         let r = client
@@ -376,11 +372,11 @@ mod test_b {
                     nonce: 0,
                 }),
                 root_invocation: AuthorizedInvocation {
-                    contract_id: contract_b_id.to_array().into(),
+                    contract_id: contract_b_id.contract_id().to_array().into(),
                     function_name: StringM::try_from("fn2").unwrap().into(),
                     args: std::vec![ScVal::I32(1), ScVal::I32(2),].try_into().unwrap(),
                     sub_invocations: [AuthorizedInvocation {
-                        contract_id: contract_a_id.to_array().into(),
+                        contract_id: contract_a_id.contract_id().to_array().into(),
                         function_name: StringM::try_from("fn1").unwrap().into(),
                         args: std::vec![ScVal::Address(a_xdr.clone())].try_into().unwrap(),
                         sub_invocations: [].try_into().unwrap(),

--- a/tests/empty/src/lib.rs
+++ b/tests/empty/src/lib.rs
@@ -10,15 +10,14 @@ impl Contract {
 
 #[cfg(test)]
 mod test {
-    use soroban_sdk::{BytesN, Env};
+    use soroban_sdk::Env;
 
     use crate::{Contract, ContractClient};
 
     #[test]
     fn test_hello() {
         let e = Env::default();
-        let contract_id = BytesN::from_array(&e, &[0; 32]);
-        e.register_contract(&contract_id, Contract);
+        let contract_id = e.register_contract(None, Contract);
         let client = ContractClient::new(&e, &contract_id);
 
         client.empty();

--- a/tests/empty2/src/lib.rs
+++ b/tests/empty2/src/lib.rs
@@ -8,15 +8,14 @@ impl Contract {}
 
 #[cfg(test)]
 mod test {
-    use soroban_sdk::{BytesN, Env};
+    use soroban_sdk::Env;
 
     use crate::{Contract, ContractClient};
 
     #[test]
     fn test_hello() {
         let e = Env::default();
-        let contract_id = BytesN::from_array(&e, &[0; 32]);
-        e.register_contract(&contract_id, Contract);
+        let contract_id = e.register_contract(None, Contract);
         let _client = ContractClient::new(&e, &contract_id);
     }
 }

--- a/tests/errors/src/lib.rs
+++ b/tests/errors/src/lib.rs
@@ -39,7 +39,7 @@ impl Contract {
 mod test {
     use soroban_sdk::{
         xdr::{ScStatus, ScUnknownErrorCode},
-        BytesN, Env, Status, Symbol,
+        Env, Status, Symbol,
     };
 
     use crate::{Contract, ContractClient, Error};
@@ -47,8 +47,7 @@ mod test {
     #[test]
     fn hello_ok() {
         let e = Env::default();
-        let contract_id = BytesN::from_array(&e, &[0; 32]);
-        e.register_contract(&contract_id, Contract);
+        let contract_id = e.register_contract(None, Contract);
         let client = ContractClient::new(&e, &contract_id);
 
         let res = client.hello(&0);
@@ -59,8 +58,7 @@ mod test {
     #[test]
     fn try_hello_ok() {
         let e = Env::default();
-        let contract_id = BytesN::from_array(&e, &[0; 32]);
-        e.register_contract(&contract_id, Contract);
+        let contract_id = e.register_contract(None, Contract);
         let client = ContractClient::new(&e, &contract_id);
 
         let res = client.try_hello(&0);
@@ -71,8 +69,7 @@ mod test {
     #[test]
     fn try_hello_error() {
         let e = Env::default();
-        let contract_id = BytesN::from_array(&e, &[0; 32]);
-        e.register_contract(&contract_id, Contract);
+        let contract_id = e.register_contract(None, Contract);
         let client = ContractClient::new(&e, &contract_id);
 
         let res = client.try_hello(&1);
@@ -83,8 +80,7 @@ mod test {
     #[test]
     fn try_hello_error_panic() {
         let e = Env::default();
-        let contract_id = BytesN::from_array(&e, &[0; 32]);
-        e.register_contract(&contract_id, Contract);
+        let contract_id = e.register_contract(None, Contract);
         let client = ContractClient::new(&e, &contract_id);
 
         let res = client.try_hello(&2);
@@ -95,8 +91,7 @@ mod test {
     #[test]
     fn try_hello_error_panic_string() {
         let e = Env::default();
-        let contract_id = BytesN::from_array(&e, &[0; 32]);
-        e.register_contract(&contract_id, Contract);
+        let contract_id = e.register_contract(None, Contract);
         let client = ContractClient::new(&e, &contract_id);
 
         let res = client.try_hello(&3);

--- a/tests/events/src/lib.rs
+++ b/tests/events/src/lib.rs
@@ -20,15 +20,14 @@ impl Contract {
 #[cfg(test)]
 mod test {
     extern crate alloc;
-    use soroban_sdk::{testutils::Events, vec, BytesN, Env, IntoVal, Symbol};
+    use soroban_sdk::{testutils::Events, vec, Env, IntoVal, Symbol};
 
     use crate::{Contract, ContractClient};
 
     #[test]
     fn test_pub_event() {
         let env = Env::default();
-        let contract_id = BytesN::from_array(&env, &[0; 32]);
-        env.register_contract(&contract_id, Contract);
+        let contract_id = env.register_contract(None, Contract);
         let client = ContractClient::new(&env, &contract_id);
 
         client.hello();

--- a/tests/import_contract/src/lib.rs
+++ b/tests/import_contract/src/lib.rs
@@ -1,5 +1,5 @@
 #![no_std]
-use soroban_sdk::{contractimpl, BytesN, Env};
+use soroban_sdk::{contractimpl, Address, Env};
 
 mod addcontract {
     soroban_sdk::contractimport!(
@@ -11,14 +11,14 @@ pub struct Contract;
 
 #[contractimpl]
 impl Contract {
-    pub fn add_with(env: Env, contract_id: BytesN<32>, x: u64, y: u64) -> u64 {
+    pub fn add_with(env: Env, contract_id: Address, x: u64, y: u64) -> u64 {
         addcontract::Client::new(&env, &contract_id).add(&x, &y)
     }
 }
 
 #[cfg(test)]
 mod test {
-    use soroban_sdk::{BytesN, Env};
+    use soroban_sdk::Env;
 
     use crate::{addcontract, Contract, ContractClient};
 
@@ -27,8 +27,7 @@ mod test {
         let e = Env::default();
         let add_contract_id = e.register_contract_wasm(None, addcontract::WASM);
 
-        let contract_id = BytesN::from_array(&e, &[1; 32]);
-        e.register_contract(&contract_id, Contract);
+        let contract_id = e.register_contract(None, Contract);
         let client = ContractClient::new(&e, &contract_id);
 
         let x = 10u64;

--- a/tests/invoke_contract/src/lib.rs
+++ b/tests/invoke_contract/src/lib.rs
@@ -1,12 +1,12 @@
 #![no_std]
-use soroban_sdk::{contractimpl, vec, BytesN, Env, IntoVal, Symbol};
+use soroban_sdk::{contractimpl, vec, Address, Env, IntoVal, Symbol};
 
 pub struct Contract;
 
 #[contractimpl]
 impl Contract {
     // TODO: Prevent arg overlap with generated args.
-    pub fn add_with(env: Env, x: i32, y: i32, contract_id: BytesN<32>) -> i32 {
+    pub fn add_with(env: Env, x: i32, y: i32, contract_id: Address) -> i32 {
         env.invoke_contract(
             &contract_id,
             &Symbol::short("add"),
@@ -26,7 +26,7 @@ impl AddContract {
 
 #[cfg(test)]
 mod test {
-    use soroban_sdk::{BytesN, Env};
+    use soroban_sdk::Env;
 
     use crate::{AddContract, Contract, ContractClient};
 
@@ -34,11 +34,9 @@ mod test {
     fn test_add() {
         let e = Env::default();
 
-        let add_contract_id = BytesN::from_array(&e, &[0; 32]);
-        e.register_contract(&add_contract_id, AddContract);
+        let add_contract_id = e.register_contract(None, AddContract);
 
-        let contract_id = BytesN::from_array(&e, &[1; 32]);
-        e.register_contract(&contract_id, Contract);
+        let contract_id = e.register_contract(None, Contract);
         let client = ContractClient::new(&e, &contract_id);
 
         let x = 10i32;

--- a/tests/logging/src/lib.rs
+++ b/tests/logging/src/lib.rs
@@ -30,15 +30,14 @@ mod test {
     extern crate std;
     use std::string::ToString;
 
-    use soroban_sdk::{testutils::Logger, BytesN, Env};
+    use soroban_sdk::{testutils::Logger, Env};
 
     use crate::{Contract, ContractClient};
 
     #[test]
     fn test_logging() {
         let env = Env::default();
-        let contract_id = BytesN::from_array(&env, &[0; 32]);
-        env.register_contract(&contract_id, Contract);
+        let contract_id = env.register_contract(None, Contract);
         let client = ContractClient::new(&env, &contract_id);
 
         client.hello();

--- a/tests/udt/src/lib.rs
+++ b/tests/udt/src/lib.rs
@@ -53,7 +53,7 @@ impl Contract {
 #[cfg(test)]
 mod test {
     use super::*;
-    use soroban_sdk::{vec, xdr::ScVal, Bytes, BytesN, Env, TryFromVal};
+    use soroban_sdk::{vec, xdr::ScVal, Bytes, Env, TryFromVal};
 
     #[test]
     fn test_serializing() {
@@ -78,8 +78,7 @@ mod test {
     #[test]
     fn test_add() {
         let e = Env::default();
-        let contract_id = BytesN::from_array(&e, &[0; 32]);
-        e.register_contract(&contract_id, Contract);
+        let contract_id = e.register_contract(None, Contract);
         let client = ContractClient::new(&e, &contract_id);
 
         let udt = UdtStruct {


### PR DESCRIPTION
### What
Replace BytesN<32> for contract IDs with Address.

### Why
Exposing contract IDs as BytesN<32> is too low level and results in contracts binding themselves to an implementation detail. Contracts are deployed to an Address, and accounts are also an Address, and as much as possile contract developers shouldn't think about these differently, especially once folks start using contracts for authentication.

In all cases we currently use BytesN<32> for a contract ID we can trivially replace it with an Address.

The functions remain for building Addresses from BytesN purely for test capabilities, because in some edge case situations it will be necessary to define a contract ID in a test.

Close https://github.com/stellar/rs-soroban-sdk/issues/868
