### PR TITLE
Keep Address::from_contract_id

### DIFF
--- a/soroban-sdk/src/address.rs
+++ b/soroban-sdk/src/address.rs
@@ -236,7 +236,7 @@ impl Address {
     /// Prefer using the `Address` directly as input or output argument. Only
     /// use this in special cases, for example to get an Address of a freshly
     /// deployed contract.
-    pub(crate) fn from_contract_id(contract_id: &BytesN<32>) -> Self {
+    pub fn from_contract_id(contract_id: &BytesN<32>) -> Self {
         let env = contract_id.env();
         unsafe {
             Self::unchecked_new(
@@ -308,10 +308,6 @@ impl crate::testutils::Address for Address {
     fn random(env: &Env) -> Self {
         let sc_addr = ScVal::Address(ScAddress::Contract(Hash(random())));
         Self::try_from_val(env, &sc_addr).unwrap()
-    }
-
-    fn from_contract_id(contract_id: &crate::BytesN<32>) -> crate::Address {
-        Self::from_contract_id(contract_id)
     }
 
     fn contract_id(&self) -> crate::BytesN<32> {

--- a/soroban-sdk/src/testutils.rs
+++ b/soroban-sdk/src/testutils.rs
@@ -180,9 +180,6 @@ pub trait Address {
     /// the underlying Address value.
     fn random(env: &Env) -> crate::Address;
 
-    /// Creates an `Address` corresponding to the provided contract identifier.
-    fn from_contract_id(contract_id: &crate::BytesN<32>) -> crate::Address;
-
     /// Get the contract ID of an Address as a BytesN<32>.
     ///
     /// ### Panics


### PR DESCRIPTION
### What
Keep Address::from_contract_id for contracts to use.

### Why
There's an edge case where we still need to be able to construct an address from BytesN<32>, and that's with account contracts. The account contracts interface still exposes BytesN<32> unfortunately as that requires an environment change.