### PR TITLE
Rename Client::contract to Client::address

### DIFF
--- a/soroban-sdk-macros/src/derive_client.rs
+++ b/soroban-sdk-macros/src/derive_client.rs
@@ -75,7 +75,7 @@ pub fn derive_client(crate_path: &Path, ty: &str, name: &str, fns: &[syn_ext::Fn
                     }
                     use #crate_path::{IntoVal,FromVal};
                     self.env.invoke_contract(
-                        &self.contract,
+                        &self.address,
                         &#crate_path::Symbol::new(&self.env, &#fn_name),
                         #crate_path::vec![&self.env, #(#fn_input_names.into_val(&self.env)),*],
                     )
@@ -101,7 +101,7 @@ pub fn derive_client(crate_path: &Path, ty: &str, name: &str, fns: &[syn_ext::Fn
                     }
                     use #crate_path::{IntoVal,FromVal};
                     self.env.try_invoke_contract(
-                        &self.contract,
+                        &self.address,
                         &#crate_path::Symbol::new(&self.env, &#fn_name),
                         #crate_path::vec![&self.env, #(#fn_input_names.into_val(&self.env)),*],
                     )
@@ -123,7 +123,7 @@ pub fn derive_client(crate_path: &Path, ty: &str, name: &str, fns: &[syn_ext::Fn
         #[doc = #client_doc]
         pub struct #client_ident<'a> {
             pub env: #crate_path::Env,
-            pub contract: #crate_path::Address,
+            pub address: #crate_path::Address,
             #[doc(hidden)]
             #[cfg(not(any(test, feature = "testutils")))]
             _phantom: core::marker::PhantomData<&'a ()>,
@@ -139,10 +139,10 @@ pub fn derive_client(crate_path: &Path, ty: &str, name: &str, fns: &[syn_ext::Fn
         }
 
         impl<'a> #client_ident<'a> {
-            pub fn new(env: &#crate_path::Env, contract: &#crate_path::Address) -> Self {
+            pub fn new(env: &#crate_path::Env, address: &#crate_path::Address) -> Self {
                 Self {
                     env: env.clone(),
-                    contract: contract.clone(),
+                    address: address.clone(),
                     #[cfg(not(any(test, feature = "testutils")))]
                     _phantom: core::marker::PhantomData,
                     #[cfg(any(test, feature = "testutils"))]
@@ -163,7 +163,7 @@ pub fn derive_client(crate_path: &Path, ty: &str, name: &str, fns: &[syn_ext::Fn
             pub fn set_auths(&self, auths: &'a [#crate_path::xdr::ContractAuth]) -> Self {
                 Self {
                     env: self.env.clone(),
-                    contract: self.contract.clone(),
+                    address: self.address.clone(),
                     set_auths: Some(auths),
                     mock_auths: self.mock_auths.clone(),
                     mock_all_auths: false,
@@ -179,7 +179,7 @@ pub fn derive_client(crate_path: &Path, ty: &str, name: &str, fns: &[syn_ext::Fn
             pub fn mock_auths(&self, mock_auths: &'a [#crate_path::testutils::MockAuth<'a>]) -> Self {
                 Self {
                     env: self.env.clone(),
-                    contract: self.contract.clone(),
+                    address: self.address.clone(),
                     set_auths: self.set_auths.clone(),
                     mock_auths: Some(mock_auths),
                     mock_all_auths: false,
@@ -195,7 +195,7 @@ pub fn derive_client(crate_path: &Path, ty: &str, name: &str, fns: &[syn_ext::Fn
             pub fn mock_all_auths(&self) -> Self {
                 Self {
                     env: self.env.clone(),
-                    contract: self.contract.clone(),
+                    address: self.address.clone(),
                     set_auths: None,
                     mock_auths: None,
                     mock_all_auths: true,

--- a/soroban-sdk/src/env.rs
+++ b/soroban-sdk/src/env.rs
@@ -942,7 +942,7 @@ impl Env {
     ///         env.auths(),
     ///         std::vec![(
     ///             address.clone(),
-    ///             client.contract.clone(),
+    ///             client.address.clone(),
     ///             Symbol::short("transfer"),
     ///             (&address, 1000_i128,).into_val(&env)
     ///         )]
@@ -953,7 +953,7 @@ impl Env {
     ///         env.auths(),
     ///         std::vec![(
     ///             address.clone(),
-    ///             client.contract.clone(),
+    ///             client.address.clone(),
     ///             Symbol::short("transfer2"),
     ///             // `transfer2` requires auth for (amount / 2) == (1000 / 2) == 500.
     ///             (500_i128,).into_val(&env)
@@ -1039,7 +1039,7 @@ impl Env {
     ///     // Non-succesful call of `__check_auth` with a `contracterror` error.
     ///     assert_eq!(
     ///         e.try_invoke_contract_check_auth::<NoopAccountError>(
-    ///             &account_contract.contract.contract_id(),
+    ///             &account_contract.address.contract_id(),
     ///             &BytesN::random(&e),
     ///             &vec![&e],
     ///             &vec![&e],
@@ -1052,7 +1052,7 @@ impl Env {
     ///     // error - this should be compatible with any error type.
     ///     assert_eq!(
     ///         e.try_invoke_contract_check_auth::<soroban_sdk::Status>(
-    ///             &account_contract.contract.contract_id(),
+    ///             &account_contract.address.contract_id(),
     ///             &BytesN::random(&e),
     ///             &vec![&e, 0_i32.into()],
     ///             &vec![&e],


### PR DESCRIPTION
### What
Rename the `contract` field of generated clients to `address`.

### Why
I recently renamed the `contract_id` field of generated clients to `contract` when I changed their type from a contract ID in a `BytesN<32>` to an `Address`.

I just went through and updated all the examples to use the `contract` field, and what I discovered is the code is now pretty ambiguous and hard to read. In plenty of places we have things like `token.contract` or `contract.contract`, and it's really not clear what I have a reference to. Is it a contract client, or a contract wasm, or something else?

What I also noticed is that at some point we'd added an `address()` function to generated clients, and code that was using that function read really clearly.

Renaming the field to `address` to get that same clarity.