### PR TITLE
Hide warnings about snake case in generated client

### DIFF
--- a/soroban-sdk-macros/src/derive_spec_fn.rs
+++ b/soroban-sdk-macros/src/derive_spec_fn.rs
@@ -154,6 +154,7 @@ pub fn derive_fn_spec(
     // Generated code.
     Ok(quote! {
         #[doc(hidden)]
+        #[allow(non_snake_case)]
         #(#attrs)*
         #export_attr
         pub static #spec_ident: [u8; #spec_xdr_len] = #ty::#spec_fn_ident();


### PR DESCRIPTION
### What
Hide variable name format warnings in generated client.

### Why
Functions that have double underscores cause a warning in the generated proc macros. The `__check_auth` function causes our proc macros to generate a warning.