### PR TITLE
Add fuzzing support with docs; RawVal comparison proptests

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -47,7 +47,7 @@ jobs:
     - run: rustup update
     - run: rustup +nightly component add rust-analyzer
     - name: Check if rust-analyzer encounters any errors parsing project
-      run: rustup run nightly rust-analyzer analysis-stats . 2>&1 | (! grep ERROR)
+      run: rustup run nightly rust-analyzer analysis-stats . 2>&1 | (! grep '^\[ERROR')
 
   build-and-test:
     strategy:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -70,6 +70,18 @@ jobs:
     - run: cargo hack --feature-powerset --exclude-features docs build --target ${{ matrix.sys.target }}
     - run: cargo hack --feature-powerset --ignore-unknown-features --features testutils --exclude-features docs test --target ${{ matrix.sys.target }}
 
+  build-fuzz:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: stellar/actions/rust-cache@main
+    - run: rustup install nightly
+    - uses: stellar/binaries@v15
+      with:
+        name: cargo-fuzz
+        version: 0.11.2
+    - run: make build-fuzz
+
   docs:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -47,7 +47,7 @@ jobs:
     - run: rustup update
     - run: rustup +nightly component add rust-analyzer
     - name: Check if rust-analyzer encounters any errors parsing project
-      run: rustup run nightly rust-analyzer analysis-stats . 2>&1 | (! grep '^\[ERROR')
+      run: rustup run nightly rust-analyzer analysis-stats . 2>&1 | (! grep ERROR)
 
   build-and-test:
     strategy:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -93,6 +93,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
+name = "bit-set"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
 name = "block-buffer"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -356,7 +377,7 @@ checksum = "c762bae6dcaf24c4c84667b8579785430908723d5c889f469d76a41d59cc7a9d"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
- "rand",
+ "rand 0.7.3",
  "serde",
  "sha2 0.9.9",
  "zeroize",
@@ -388,10 +409,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "errno"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a"
+dependencies = [
+ "errno-dragonfly",
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "errno-dragonfly"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
 name = "ethnum"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0198b9d0078e0f30dedc7acbb21c974e838fc8fae3ee170128658a98cb2c1c04"
+
+[[package]]
+name = "fastrand"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
+dependencies = [
+ "instant",
+]
 
 [[package]]
 name = "ff"
@@ -468,6 +519,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
+name = "hermit-abi"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -532,10 +589,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e04e2fd2b8188ea827b32ef11de88377086d690286ab35747ef7f9bf3ccb590"
 
 [[package]]
+name = "instant"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "intx"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6f38a50a899dc47a6d0ed5508e7f601a2e34c3a85303514b5d137f3c10a0c75"
+
+[[package]]
+name = "io-lifetimes"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys",
+]
 
 [[package]]
 name = "itertools"
@@ -585,6 +662,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+
+[[package]]
 name = "libc"
 version = "0.2.146"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -595,6 +678,12 @@ name = "libm"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7012b1bbb0719e1097c47611d3898568c546d597c2e74d66f6087edd5233ff4"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
 
 [[package]]
 name = "log"
@@ -656,6 +745,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -742,6 +832,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e35c06b98bf36aba164cc17cb25f7e232f5c4aeea73baa14b8a9f0d92dbfa65"
+dependencies = [
+ "bit-set",
+ "bitflags",
+ "byteorder",
+ "lazy_static",
+ "num-traits",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
+name = "proptest-arbitrary-interop"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1981e49bd2432249da8b0e11e5557099a8e74690d6b94e721f7dc0bb7f3555f"
+dependencies = [
+ "arbitrary",
+ "proptest",
+]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
 name = "quote"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -758,9 +884,20 @@ checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
 dependencies = [
  "getrandom 0.1.16",
  "libc",
- "rand_chacha",
+ "rand_chacha 0.2.2",
  "rand_core 0.5.1",
  "rand_hc",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -771,6 +908,16 @@ checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
 dependencies = [
  "ppv-lite86",
  "rand_core 0.5.1",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -801,6 +948,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_xorshift"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
+dependencies = [
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
+
+[[package]]
 name = "rfc6979"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -815,6 +986,32 @@ name = "rustc-demangle"
 version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
+
+[[package]]
+name = "rustix"
+version = "0.37.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b96e891d04aa506a6d1f318d2771bcb1c7dfda84e126660ace067c9b474bb2c0"
+dependencies = [
+ "bitflags",
+ "errno",
+ "io-lifetimes",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb3dcc6e454c328bb824492db107ab7c0ae8fcffe4ad210136ef014458c1bc4f"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "ryu"
@@ -990,8 +1187,8 @@ dependencies = [
  "num-derive",
  "num-integer",
  "num-traits",
- "rand",
- "rand_chacha",
+ "rand 0.7.3",
+ "rand_chacha 0.2.2",
  "sha2 0.9.9",
  "sha3",
  "soroban-env-common",
@@ -1047,7 +1244,9 @@ dependencies = [
  "bytes-lit",
  "ed25519-dalek",
  "hex",
- "rand",
+ "proptest",
+ "proptest-arbitrary-interop",
+ "rand 0.7.3",
  "soroban-env-guest",
  "soroban-env-host",
  "soroban-ledger-snapshot",
@@ -1209,6 +1408,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31c0432476357e58790aaa47a8efb0c5138f137343f3b5f23bd36a27e3b0a6d6"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "fastrand",
+ "redox_syscall",
+ "rustix",
+ "windows-sys",
+]
+
+[[package]]
 name = "test_add_i128"
 version = "0.8.4"
 dependencies = [
@@ -1360,6 +1573,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1370,6 +1589,15 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "wasi"
@@ -1487,6 +1715,15 @@ name = "windows"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
  "windows-targets",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1043,6 +1043,7 @@ dependencies = [
 name = "soroban-sdk"
 version = "0.8.4"
 dependencies = [
+ "arbitrary",
  "bytes-lit",
  "ed25519-dalek",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ members = [
     "tests/errors",
     "tests/alloc",
     "tests/auth",
+    "tests/fuzz",
 ]
 
 [workspace.package]

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,9 @@ check: build fmt
 	cargo hack --feature-powerset --exclude-features docs check
 	cargo hack check --release --target wasm32-unknown-unknown
 
+build-fuzz:
+	cd tests/fuzz/fuzz && cargo +nightly fuzz check
+
 readme:
 	cd soroban-sdk \
 		&& cargo +nightly rustdoc -- -Zunstable-options -wjson \

--- a/deny.toml
+++ b/deny.toml
@@ -249,6 +249,14 @@ deny = [
 # Certain crates/versions that will be skipped when doing duplicate detection.
 skip = [
     #{ name = "ansi_term", version = "=0.11.0" },
+
+    # ed25519-dalek and proptest have conflicting rand deps,
+    # where ed25519-dalek is on an older revision.
+    # proptest is only used as a dev-dependency,
+    # so this conflict should not cause extra bloat to contracts.
+    # Below are the newer version numbers required by proptest.
+    { name = "rand", version = "0.8" },
+    { name = "rand_chacha", version = "0.3" },
 ]
 # Similarly to `skip` allows you to skip certain crates during duplicate
 # detection. Unlike skip, it also includes the entire tree of transitive

--- a/soroban-sdk-macros/Cargo.toml
+++ b/soroban-sdk-macros/Cargo.toml
@@ -25,3 +25,6 @@ proc-macro2 = "1.0"
 itertools = "0.10.3"
 darling = "0.20.0"
 sha2 = "0.9.9"
+
+[features]
+testutils = []

--- a/soroban-sdk-macros/src/arbitrary.rs
+++ b/soroban-sdk-macros/src/arbitrary.rs
@@ -1,0 +1,341 @@
+use proc_macro2::TokenStream as TokenStream2;
+use quote::{format_ident, quote};
+use syn::{DataEnum, DataStruct, Ident, Path, Visibility};
+
+pub fn derive_arbitrary_struct(
+    path: &Path,
+    vis: &Visibility,
+    ident: &Ident,
+    data: &DataStruct,
+) -> TokenStream2 {
+    derive_arbitrary_struct_common(path, vis, ident, data, FieldType::Named)
+}
+
+pub fn derive_arbitrary_struct_tuple(
+    path: &Path,
+    vis: &Visibility,
+    ident: &Ident,
+    data: &DataStruct,
+) -> TokenStream2 {
+    derive_arbitrary_struct_common(path, vis, ident, data, FieldType::Unnamed)
+}
+
+enum FieldType {
+    Named,
+    Unnamed,
+}
+
+fn derive_arbitrary_struct_common(
+    path: &Path,
+    vis: &Visibility,
+    ident: &Ident,
+    data: &DataStruct,
+    field_type: FieldType,
+) -> TokenStream2 {
+    let arbitrary_type_ident = format_ident!("Arbitrary{}", ident);
+
+    let arbitrary_type_fields: Vec<TokenStream2> = data
+        .fields
+        .iter()
+        .map(|field| {
+            let field_type = &field.ty;
+            match &field.ident {
+                Some(ident) => {
+                    quote! {
+                        #ident: <#field_type as #path::arbitrary::SorobanArbitrary>::Prototype
+                    }
+                }
+                None => {
+                    quote! {
+                        <#field_type as #path::arbitrary::SorobanArbitrary>::Prototype
+                    }
+                }
+            }
+        })
+        .collect();
+
+    let field_conversions: Vec<TokenStream2> = data
+        .fields
+        .iter()
+        .enumerate()
+        .map(|(i, field)| match &field.ident {
+            Some(ident) => {
+                quote! {
+                    #ident: #path::IntoVal::into_val(&v.#ident, env)
+                }
+            }
+            None => {
+                let i = syn::Index::from(i);
+                quote! {
+                    #path::IntoVal::into_val(&v.#i, env)
+                }
+            }
+        })
+        .collect();
+
+    let arbitrary_type_decl = match field_type {
+        FieldType::Named => quote! {
+            struct #arbitrary_type_ident {
+                #(#arbitrary_type_fields,)*
+            }
+        },
+        FieldType::Unnamed => quote! {
+            struct #arbitrary_type_ident (
+                #(#arbitrary_type_fields,)*
+            );
+        },
+    };
+
+    let arbitrary_ctor = match field_type {
+        FieldType::Named => quote! {
+            #ident {
+                #(#field_conversions,)*
+            }
+        },
+        FieldType::Unnamed => quote! {
+            #ident (
+                #(#field_conversions,)*
+            )
+        },
+    };
+
+    quote_arbitrary(
+        path,
+        vis,
+        ident,
+        arbitrary_type_ident,
+        arbitrary_type_decl,
+        arbitrary_ctor,
+    )
+}
+
+pub fn derive_arbitrary_enum(
+    path: &Path,
+    vis: &Visibility,
+    ident: &Ident,
+    data: &DataEnum,
+) -> TokenStream2 {
+    let arbitrary_type_ident = format_ident!("Arbitrary{}", ident);
+
+    let arbitrary_type_variants: Vec<TokenStream2> = data
+        .variants
+        .iter()
+        .map(|variant| {
+            let mut field_types = None;
+            let variant_ident = &variant.ident;
+            let fields: Vec<TokenStream2> = variant
+                .fields
+                .iter()
+                .map(|field| {
+                    let field_type = &field.ty;
+                    match &field.ident {
+                        Some(ident) => {
+                            field_types = Some(FieldType::Named);
+                            quote! {
+                                #ident: <#field_type as #path::arbitrary::SorobanArbitrary>::Prototype
+                            }
+                        }
+                        None => {
+                            field_types = Some(FieldType::Unnamed);
+                            quote! {
+                                <#field_type as #path::arbitrary::SorobanArbitrary>::Prototype
+                            }
+                        }
+                    }
+                })
+                .collect();
+            match field_types {
+                None => {
+                    quote! {
+                        #variant_ident
+                    }
+                },
+                Some(FieldType::Named) => {
+                    quote! {
+                        #variant_ident { #(#fields,)* }
+                    }
+                }
+                Some(FieldType::Unnamed) => {
+                    quote! {
+                        #variant_ident ( #(#fields,)* )
+                    }
+                }
+            }
+        })
+        .collect();
+
+    let variant_conversions: Vec<TokenStream2> = data
+        .variants
+        .iter()
+        .map(|variant| {
+            let mut field_types = None;
+            let variant_ident = &variant.ident;
+            let fields: Vec<TokenStream2> = variant
+                .fields
+                .iter()
+                .enumerate()
+                .map(|(i, field)| {
+                    match &field.ident {
+                        Some(ident) => {
+                            quote! {
+                                #ident
+                            }
+                        }
+                        None => {
+                            let ident = format_ident!("field_{}", i);
+                            quote! {
+                                #ident
+                            }
+                        }
+                    }
+                })
+                .collect();
+            let field_conversions: Vec<TokenStream2> = variant
+                .fields
+                .iter()
+                .enumerate()
+                .map(|(i, field)| {
+                    match &field.ident {
+                       Some(ident) => {
+                            field_types = Some(FieldType::Named);
+                            quote! {
+                                #ident: #path::IntoVal::into_val(#ident, env)
+                            }
+                        }
+                        None => {
+                            field_types = Some(FieldType::Unnamed);
+                            let ident = format_ident!("field_{}", i);
+                            quote! {
+                                #path::IntoVal::into_val(#ident, env)
+                            }
+                        }
+                    }
+                })
+                .collect();
+            match field_types {
+                None => {
+                    quote! {
+                        #arbitrary_type_ident::#variant_ident => #ident::#variant_ident
+                    }
+                },
+                Some(FieldType::Named) => {
+                    quote! {
+                        #arbitrary_type_ident::#variant_ident { #(#fields,)* } => #ident::#variant_ident { #(#field_conversions,)* }
+                    }
+                }
+                Some(FieldType::Unnamed) => {
+                    quote! {
+                        #arbitrary_type_ident::#variant_ident ( #(#fields,)* ) => #ident::#variant_ident ( #(#field_conversions,)* )
+                    }
+                }
+            }
+        })
+        .collect();
+
+    let arbitrary_type_decl = quote! {
+        enum #arbitrary_type_ident {
+            #(#arbitrary_type_variants,)*
+        }
+    };
+    let arbitrary_ctor = quote! {
+        match v {
+            #(#variant_conversions,)*
+        }
+    };
+
+    quote_arbitrary(
+        path,
+        vis,
+        ident,
+        arbitrary_type_ident,
+        arbitrary_type_decl,
+        arbitrary_ctor,
+    )
+}
+
+pub fn derive_arbitrary_enum_int(
+    path: &Path,
+    vis: &Visibility,
+    ident: &Ident,
+    data: &DataEnum,
+) -> TokenStream2 {
+    let arbitrary_type_ident = format_ident!("Arbitrary{}", ident);
+
+    let arbitrary_type_variants: Vec<TokenStream2> = data
+        .variants
+        .iter()
+        .map(|variant| {
+            let variant_ident = &variant.ident;
+            quote! {
+                #variant_ident
+            }
+        })
+        .collect();
+
+    let variant_conversions: Vec<TokenStream2> = data
+        .variants
+        .iter()
+        .map(|variant| {
+            let variant_ident = &variant.ident;
+            quote! {
+                #arbitrary_type_ident::#variant_ident => #ident::#variant_ident
+            }
+        })
+        .collect();
+
+    let arbitrary_type_decl = quote! {
+        enum #arbitrary_type_ident {
+            #(#arbitrary_type_variants,)*
+        }
+    };
+    let arbitrary_ctor = quote! {
+        match v {
+            #(#variant_conversions,)*
+        }
+    };
+
+    quote_arbitrary(
+        path,
+        vis,
+        ident,
+        arbitrary_type_ident,
+        arbitrary_type_decl,
+        arbitrary_ctor,
+    )
+}
+
+fn quote_arbitrary(
+    path: &Path,
+    vis: &Visibility,
+    ident: &Ident,
+    arbitrary_type_ident: Ident,
+    arbitrary_type_decl: TokenStream2,
+    arbitrary_ctor: TokenStream2,
+) -> TokenStream2 {
+    quote! {
+        // This allows us to create a scope to import std and arbitrary, while
+        // also keeping everything from the current scope. This is better than a
+        // module because: modules inside functions have surprisingly
+        // inconsistent scoping rules and visibility management is harder.
+        #[cfg(feature = "testutils")]
+        const _: () = {
+            // derive(Arbitrary) expects these two to be in scope
+            use #path::arbitrary::std;
+            use #path::arbitrary::arbitrary;
+
+            #[derive(#path::arbitrary::arbitrary::Arbitrary, Debug)]
+            #vis #arbitrary_type_decl
+
+            impl #path::arbitrary::SorobanArbitrary for #ident {
+                type Prototype = #arbitrary_type_ident;
+            }
+
+            impl #path::TryFromVal<#path::Env, #arbitrary_type_ident> for #ident {
+                type Error = #path::ConversionError;
+                fn try_from_val(env: &#path::Env, v: &#arbitrary_type_ident) -> std::result::Result<Self, Self::Error> {
+                    Ok(#arbitrary_ctor)
+                }
+            }
+        };
+    }
+}

--- a/soroban-sdk-macros/src/arbitrary.rs
+++ b/soroban-sdk-macros/src/arbitrary.rs
@@ -312,6 +312,9 @@ fn quote_arbitrary(
     arbitrary_type_decl: TokenStream2,
     arbitrary_ctor: TokenStream2,
 ) -> TokenStream2 {
+    if !cfg!(any(test, feature = "testutils")) {
+        return quote!();
+    }
     quote! {
         // This allows us to create a scope to import std and arbitrary, while
         // also keeping everything from the current scope. This is better than a

--- a/soroban-sdk-macros/src/arbitrary.rs
+++ b/soroban-sdk-macros/src/arbitrary.rs
@@ -317,7 +317,7 @@ fn quote_arbitrary(
         // also keeping everything from the current scope. This is better than a
         // module because: modules inside functions have surprisingly
         // inconsistent scoping rules and visibility management is harder.
-        #[cfg(feature = "testutils")]
+        #[cfg(any(test, feature = "testutils"))]
         const _: () = {
             // derive(Arbitrary) expects these two to be in scope
             use #path::arbitrary::std;

--- a/soroban-sdk-macros/src/derive_enum.rs
+++ b/soroban-sdk-macros/src/derive_enum.rs
@@ -1,7 +1,7 @@
 use itertools::MultiUnzip;
 use proc_macro2::{Literal, TokenStream as TokenStream2};
 use quote::{format_ident, quote};
-use syn::{spanned::Spanned, Attribute, DataEnum, Error, Fields, Ident, Path};
+use syn::{spanned::Spanned, Attribute, DataEnum, Error, Fields, Ident, Path, Visibility};
 
 use stellar_xdr::{
     Error as XdrError, ScSpecEntry, ScSpecTypeDef, ScSpecUdtUnionCaseTupleV0, ScSpecUdtUnionCaseV0,
@@ -12,6 +12,7 @@ use crate::{doc::docs_from_attrs, map_type::map_type};
 
 pub fn derive_type_enum(
     path: &Path,
+    vis: &Visibility,
     enum_ident: &Ident,
     attrs: &[Attribute],
     data: &DataEnum,
@@ -160,6 +161,8 @@ pub fn derive_type_enum(
         None
     };
 
+    let arbitrary_tokens = crate::arbitrary::derive_arbitrary_enum(path, vis, enum_ident, data);
+
     // Output.
     quote! {
         #spec_gen
@@ -262,6 +265,8 @@ pub fn derive_type_enum(
                 (&val).try_into()
             }
         }
+
+        #arbitrary_tokens
     }
 }
 

--- a/soroban-sdk-macros/src/derive_enum_int.rs
+++ b/soroban-sdk-macros/src/derive_enum_int.rs
@@ -2,7 +2,7 @@ use itertools::MultiUnzip;
 use proc_macro2::TokenStream as TokenStream2;
 use quote::{format_ident, quote};
 use stellar_xdr::{ScSpecUdtEnumV0, StringM};
-use syn::{spanned::Spanned, Attribute, DataEnum, Error, ExprLit, Ident, Lit, Path};
+use syn::{spanned::Spanned, Attribute, DataEnum, Error, ExprLit, Ident, Lit, Path, Visibility};
 
 use stellar_xdr::{ScSpecEntry, ScSpecUdtEnumCaseV0, WriteXdr};
 
@@ -12,6 +12,7 @@ use crate::doc::docs_from_attrs;
 
 pub fn derive_type_enum_int(
     path: &Path,
+    vis: &Visibility,
     enum_ident: &Ident,
     attrs: &[Attribute],
     data: &DataEnum,
@@ -89,6 +90,8 @@ pub fn derive_type_enum_int(
         None
     };
 
+    let arbitrary_tokens = crate::arbitrary::derive_arbitrary_enum_int(path, vis, enum_ident, data);
+
     // Output.
     quote! {
         #spec_gen
@@ -149,5 +152,7 @@ pub fn derive_type_enum_int(
                 Ok((self as u32).into())
             }
         }
+
+        #arbitrary_tokens
     }
 }

--- a/soroban-sdk-macros/src/derive_struct.rs
+++ b/soroban-sdk-macros/src/derive_struct.rs
@@ -1,7 +1,7 @@
 use itertools::Itertools;
 use proc_macro2::{Literal, TokenStream as TokenStream2};
 use quote::{format_ident, quote};
-use syn::{Attribute, DataStruct, Error, Ident, Path};
+use syn::{Attribute, DataStruct, Error, Ident, Path, Visibility};
 
 use stellar_xdr::{
     ScSpecEntry, ScSpecTypeDef, ScSpecUdtStructFieldV0, ScSpecUdtStructV0, StringM, WriteXdr,
@@ -16,6 +16,7 @@ use crate::{doc::docs_from_attrs, map_type::map_type};
 
 pub fn derive_type_struct(
     path: &Path,
+    vis: &Visibility,
     ident: &Ident,
     attrs: &[Attribute],
     data: &DataStruct,
@@ -99,6 +100,8 @@ pub fn derive_type_struct(
     } else {
         None
     };
+
+    let arbitrary_tokens = crate::arbitrary::derive_arbitrary_struct(path, vis, ident, data);
 
     // Output.
     quote! {
@@ -200,5 +203,7 @@ pub fn derive_type_struct(
                 (&val).try_into()
             }
         }
+
+        #arbitrary_tokens
     }
 }

--- a/soroban-sdk-macros/src/derive_struct_tuple.rs
+++ b/soroban-sdk-macros/src/derive_struct_tuple.rs
@@ -1,7 +1,7 @@
 use itertools::MultiUnzip;
 use proc_macro2::{Literal, TokenStream as TokenStream2};
 use quote::{format_ident, quote};
-use syn::{Attribute, DataStruct, Error, Ident, Path};
+use syn::{Attribute, DataStruct, Error, Ident, Path, Visibility};
 
 use stellar_xdr::{
     ScSpecEntry, ScSpecTypeDef, ScSpecUdtStructFieldV0, ScSpecUdtStructV0, StringM, WriteXdr,
@@ -11,6 +11,7 @@ use crate::{doc::docs_from_attrs, map_type::map_type};
 
 pub fn derive_type_struct_tuple(
     path: &Path,
+    vis: &Visibility,
     ident: &Ident,
     attrs: &[Attribute],
     data: &DataStruct,
@@ -86,6 +87,8 @@ pub fn derive_type_struct_tuple(
     } else {
         None
     };
+
+    let arbitrary_tokens = crate::arbitrary::derive_arbitrary_struct_tuple(path, vis, ident, data);
 
     // Output.
     quote! {
@@ -186,5 +189,7 @@ pub fn derive_type_struct_tuple(
                 (&val).try_into()
             }
         }
+
+        #arbitrary_tokens
     }
 }

--- a/soroban-sdk-macros/src/lib.rs
+++ b/soroban-sdk-macros/src/lib.rs
@@ -1,5 +1,6 @@
 extern crate proc_macro;
 
+mod arbitrary;
 mod derive_client;
 mod derive_enum;
 mod derive_enum_int;
@@ -255,6 +256,7 @@ pub fn contracttype(metadata: TokenStream, input: TokenStream) -> TokenStream {
         Err(e) => return e.write_errors().into(),
     };
     let input = parse_macro_input!(input as DeriveInput);
+    let vis = &input.vis;
     let ident = &input.ident;
     let attrs = &input.attrs;
     // If the export argument has a value, do as it instructs regarding
@@ -267,11 +269,17 @@ pub fn contracttype(metadata: TokenStream, input: TokenStream) -> TokenStream {
     let derived = match &input.data {
         Data::Struct(s) => match s.fields {
             Fields::Named(_) => {
-                derive_type_struct(&args.crate_path, ident, attrs, s, gen_spec, &args.lib)
+                derive_type_struct(&args.crate_path, vis, ident, attrs, s, gen_spec, &args.lib)
             }
-            Fields::Unnamed(_) => {
-                derive_type_struct_tuple(&args.crate_path, ident, attrs, s, gen_spec, &args.lib)
-            }
+            Fields::Unnamed(_) => derive_type_struct_tuple(
+                &args.crate_path,
+                vis,
+                ident,
+                attrs,
+                s,
+                gen_spec,
+                &args.lib,
+            ),
             Fields::Unit => Error::new(
                 s.fields.span(),
                 "unit structs are not supported as contract types",
@@ -286,9 +294,9 @@ pub fn contracttype(metadata: TokenStream, input: TokenStream) -> TokenStream {
                 .filter(|v| v.discriminant.is_some())
                 .count();
             if count_of_int_variants == 0 {
-                derive_type_enum(&args.crate_path, ident, attrs, e, gen_spec, &args.lib)
+                derive_type_enum(&args.crate_path, vis, ident, attrs, e, gen_spec, &args.lib)
             } else if count_of_int_variants == count_of_variants {
-                derive_type_enum_int(&args.crate_path, ident, attrs, e, gen_spec, &args.lib)
+                derive_type_enum_int(&args.crate_path, vis, ident, attrs, e, gen_spec, &args.lib)
             } else {
                 Error::new(input.span(), "enums are supported as contract types only when all variants have an explicit integer literal, or when all variants are unit or single field")
                     .to_compile_error()

--- a/soroban-sdk/Cargo.toml
+++ b/soroban-sdk/Cargo.toml
@@ -16,6 +16,7 @@ doctest = false
 [dependencies]
 soroban-sdk-macros = { workspace = true }
 bytes-lit = "0.0.5"
+arbitrary = { version = "1.1.3", features = ["derive"], optional = true }
 
 [target.'cfg(target_family="wasm")'.dependencies]
 soroban-env-guest = { workspace = true }
@@ -38,7 +39,7 @@ hex = "0.4.3"
 
 [features]
 alloc = []
-testutils = ["soroban-env-host/testutils", "dep:ed25519-dalek"]
+testutils = ["soroban-env-host/testutils", "dep:ed25519-dalek", "dep:arbitrary"]
 docs = []
 
 [package.metadata.docs.rs]

--- a/soroban-sdk/Cargo.toml
+++ b/soroban-sdk/Cargo.toml
@@ -36,6 +36,8 @@ soroban-spec = { workspace = true }
 ed25519-dalek = "1.0.1"
 rand = "0.7.3"
 hex = "0.4.3"
+proptest  = "1.2.0"
+proptest-arbitrary-interop = "0.1.0"
 
 [features]
 alloc = []

--- a/soroban-sdk/Cargo.toml
+++ b/soroban-sdk/Cargo.toml
@@ -30,6 +30,7 @@ ed25519-dalek = { version = "1.0.1", optional = true }
 rand = "0.7.3"
 
 [dev-dependencies]
+soroban-sdk-macros = { workspace = true, features = ["testutils"] }
 soroban-env-host = { workspace = true, features = ["testutils"] }
 stellar-xdr = { workspace = true, features = ["next", "std"] }
 soroban-spec = { workspace = true }

--- a/soroban-sdk/Cargo.toml
+++ b/soroban-sdk/Cargo.toml
@@ -16,7 +16,6 @@ doctest = false
 [dependencies]
 soroban-sdk-macros = { workspace = true }
 bytes-lit = "0.0.5"
-arbitrary = { version = "1.1.3", features = ["derive"], optional = true }
 
 [target.'cfg(target_family="wasm")'.dependencies]
 soroban-env-guest = { workspace = true }
@@ -25,6 +24,7 @@ soroban-env-guest = { workspace = true }
 soroban-env-host = { workspace = true, features = [] }
 soroban-ledger-snapshot = { workspace = true }
 stellar-strkey = { workspace = true }
+arbitrary = { version = "1.1.3", features = ["derive"], optional = true }
 ed25519-dalek = { version = "1.0.1", optional = true }
 # match the version of rand used in dalek
 rand = "0.7.3"
@@ -36,6 +36,7 @@ soroban-spec = { workspace = true }
 ed25519-dalek = "1.0.1"
 rand = "0.7.3"
 hex = "0.4.3"
+arbitrary = { version = "1.1.3", features = ["derive"] }
 proptest  = "1.2.0"
 proptest-arbitrary-interop = "0.1.0"
 

--- a/soroban-sdk/Cargo.toml
+++ b/soroban-sdk/Cargo.toml
@@ -42,7 +42,7 @@ proptest-arbitrary-interop = "0.1.0"
 
 [features]
 alloc = []
-testutils = ["soroban-env-host/testutils", "dep:ed25519-dalek", "dep:arbitrary"]
+testutils = ["soroban-sdk-macros/testutils", "soroban-env-host/testutils", "dep:ed25519-dalek", "dep:arbitrary"]
 docs = []
 
 [package.metadata.docs.rs]

--- a/soroban-sdk/src/arbitrary.rs
+++ b/soroban-sdk/src/arbitrary.rs
@@ -167,7 +167,8 @@
 //! });
 //! ```
 
-#![cfg(feature = "testutils")]
+#![cfg(any(test, feature = "testutils"))]
+#![cfg_attr(feature = "docs", doc(cfg(feature = "testutils")))]
 
 /// A reexport of the `arbitrary` crate.
 ///

--- a/soroban-sdk/src/arbitrary.rs
+++ b/soroban-sdk/src/arbitrary.rs
@@ -1,0 +1,1232 @@
+//! Support for fuzzing Soroban contracts with [`cargo-fuzz`].
+//!
+//! This module provides a pattern for generating Soroban contract types for the
+//! purpose of fuzzing Soroban contracts. It is focused on implementing the
+//! [`Arbitrary`] trait that `cargo-fuzz` relies on to feed fuzzers with
+//! generated Rust values.
+//!
+//! [`cargo-fuzz`]: https://github.com/rust-fuzz/cargo-fuzz/
+//! [`Arbitrary`]: ::arbitrary::Arbitrary
+//!
+//! This module
+//!
+//! - defines the [`SorobanArbitrary`] trait,
+//! - defines the [`fuzz_catch_panic`] helper,
+//! - reexports the [`arbitrary`] crate and the [`Arbitrary`] type.
+//!
+//! This module is only available when the "testutils" Cargo feature is defined.
+//!
+//!
+//! ## About `cargo-fuzz` and `Arbitrary`
+//!
+//! In its basic operation `cargo-fuzz` fuzz generates raw bytes and feeds them
+//! to a program-dependent fuzzer designed to exercise a program, in our case a
+//! Soroban contract.
+//!
+//! `cargo-fuzz` programs declare their entry points with a macro:
+//!
+//! ```
+//! # macro_rules! fuzz_target {
+//! #     (|$data:ident: $dty: ty| $body:block) => { };
+//! # }
+//! fuzz_target!(|input: &[u8]| {
+//!     // feed bytes to the program
+//! });
+//! ```
+//!
+//! More sophisticated fuzzers accept not bytes but Rust types:
+//!
+//! ```
+//! # use arbitrary::Arbitrary;
+//! # macro_rules! fuzz_target {
+//! #     (|$data:ident: $dty: ty| $body:block) => { };
+//! # }
+//! #[derive(Arbitrary, Debug)]
+//! struct FuzzDeposit {
+//!     deposit_amount: i128,
+//! }
+//!
+//! fuzz_target!(|input: FuzzDeposit| {
+//!     // fuzz the program based on the input
+//! });
+//! ```
+//!
+//! Types accepted as input to `fuzz_target` must implement the `Arbitrary` trait,
+//! which transforms bytes to Rust types.
+//!
+//!
+//! ## The `SorobanArbitrary` trait
+//!
+//! Soroban types are managed by the host environment, and so must be created
+//! from an [`Env`] value; `Arbitrary` values though must be created from
+//! nothing but bytes. The [`SorobanArbitrary`] trait, implemented for all
+//! Soroban contract types, exists to bridge this gap: it defines a _prototype_
+//! pattern whereby the `fuzz_target` macro creates prototype values that the
+//! fuzz program can convert to contract values with the standard soroban
+//! conversion traits, [`FromVal`] or [`IntoVal`].
+//!
+//! [`Env`]: crate::Env
+//! [`FromVal`]: crate::FromVal
+//! [`IntoVal`]: crate::IntoVal
+//!
+//! The types of prototypes are identified by the associated type,
+//! [`SorobanArbitrary::Prototype`]:
+//!
+//! ```
+//! # use soroban_sdk::arbitrary::Arbitrary;
+//! # use soroban_sdk::{TryFromVal, IntoVal, Val, Env};
+//! pub trait SorobanArbitrary:
+//!     TryFromVal<Env, Self::Prototype> + IntoVal<Env, Val> + TryFromVal<Env, Val>
+//! {
+//!     type Prototype: for <'a> Arbitrary<'a>;
+//! }
+//! ```
+//!
+//! Types that implement `SorobanArbitrary` include:
+//!
+//! - `i32`, `u32`, `i64`, `u64`, `i128`, `u128`, `I256`, `U256`, `()`, and `bool`,
+//! - [`Error`],
+//! - [`Bytes`], [`BytesN`], [`Vec`], [`Map`],
+//! - [`Address`], [`Symbol`],
+//! - [`Val`],
+//!
+//! [`I256`]: crate::I256
+//! [`U256`]: crate::U256
+//! [`Error`]: crate::Error
+//! [`Bytes`]: crate::Bytes
+//! [`BytesN`]: crate::BytesN
+//! [`Vec`]: crate::Vec
+//! [`Map`]: crate::Map
+//! [`Address`]: crate::Address
+//! [`Symbol`]: crate::Symbol
+//! [`Val`]: crate::Val
+//!
+//! All user-defined contract types, those with the [`contracttype`] attribute,
+//! automatically derive `SorobanArbitrary`. Note that `SorobanArbitrary` is
+//! only derived when the "testutils" Cargo feature is active. This implies
+//! that, in general, to make a Soroban contract fuzzable, the contract crate
+//! must define a "testutils" Cargo feature, that feature should turn on the
+//! "soroban-sdk/testutils" feature, and the fuzz test, which is its own crate,
+//! must turn that feature on.
+//!
+//! [`contracttype`]: crate::contracttype
+//!
+//!
+//! ## Example: take a Soroban `Vec` of `Address` as fuzzer input
+//!
+//! ```
+//! # macro_rules! fuzz_target {
+//! #     (|$data:ident: $dty: ty| $body:block) => { };
+//! # }
+//! use soroban_sdk::{Address, Env, Vec};
+//! use soroban_sdk::arbitrary::SorobanArbitrary;
+//!
+//! fuzz_target!(|input: <Vec<Address> as SorobanArbitrary>::Prototype| {
+//!     let env = Env::default();
+//!     let addresses: Vec<Address> = input.into_val(&env);
+//!     // fuzz the program based on the input
+//! });
+//! ```
+//!
+//!
+//! ## Example: take a custom contract type as fuzzer input
+//!
+//! ```
+//! # macro_rules! fuzz_target {
+//! #     (|$data:ident: $dty: ty| $body:block) => { };
+//! # }
+//! use soroban_sdk::{Address, Env, Vec};
+//! use soroban_sdk::contracttype;
+//! use soroban_sdk::arbitrary::{Arbitrary, SorobanArbitrary};
+//! use std::vec::Vec as RustVec;
+//!
+//! #[derive(Arbitrary, Debug)]
+//! struct TestInput {
+//!     deposit_amount: i128,
+//!     claim_address: <Address as SorobanArbitrary>::Prototype,
+//!     time_bound: <TimeBound as SorobanArbitrary>::Prototype,
+//! }
+//!
+//! #[contracttype]
+//! pub struct TimeBound {
+//!     pub kind: TimeBoundKind,
+//!     pub timestamp: u64,
+//! }
+//!
+//! #[contracttype]
+//! pub enum TimeBoundKind {
+//!     Before,
+//!     After,
+//! }
+//!
+//! fuzz_target!(|input: TestInput| {
+//!     let env = Env::default();
+//!     let claim_address: Address = input.claim_address.into_val(&env);
+//!     let time_bound: TimeBound = input.time_bound.into_val(&env);
+//!     // fuzz the program based on the input
+//! });
+//! ```
+
+#![cfg(feature = "testutils")]
+
+/// A reexport of the `arbitrary` crate.
+///
+/// Used by the `contracttype` macro to derive `Arbitrary`.
+pub use arbitrary;
+
+// Used often enough in fuzz tests to want direct access to it.
+pub use arbitrary::Arbitrary;
+
+// Used by `contracttype`
+#[doc(hidden)]
+pub use std;
+
+pub use api::*;
+pub use fuzz_test_helpers::*;
+
+/// The traits that must be implemented on Soroban types to support fuzzing.
+///
+/// These allow for ergonomic conversion from a randomly-generated "prototype"
+/// that implements `Arbitrary` into `Env`-"hosted" values that are paired with an
+/// `Env`.
+///
+/// These traits are intended to be easy to automatically derive.
+mod api {
+    use crate::Env;
+    use crate::Val;
+    use crate::{IntoVal, TryFromVal};
+    use arbitrary::Arbitrary;
+
+    /// An `Env`-hosted contract value that can be randomly generated.
+    ///
+    /// Types that implement `SorabanArbitrary` have an associated "prototype"
+    /// type that implements [`Arbitrary`].
+    ///
+    /// This exists partly that the prototype can be named like
+    ///
+    /// ```ignore
+    /// fuzz_target!(|input: <Bytes as SorobanArbitrary>::Arbitrary| {
+    ///   ...
+    /// });
+    /// ```
+    // This also makes derivation of `SorobanArbitrary` for custom types easier
+    // since we depend on all fields also implementing `SorobanArbitrary`.
+    //
+    // The IntoVal<Env, Val> + TryFromVal<Env, Val> bounds are to satisfy
+    // the bounds of Vec and Map, so that collections of prototypes can be
+    // converted to contract types.
+    pub trait SorobanArbitrary:
+        TryFromVal<Env, Self::Prototype> + IntoVal<Env, Val> + TryFromVal<Env, Val>
+    {
+        /// A type that implements [`Arbitrary`] and can be converted to this
+        /// [`SorobanArbitrary`] type.
+        // NB: The `Arbitrary` bound here is not necessary for the correct use of
+        // `SorobanArbitrary`, but it makes the purpose clear.
+        type Prototype: for<'a> Arbitrary<'a>;
+    }
+}
+
+/// Implementations of `soroban_sdk::arbitrary::api` for Rust scalar types.
+///
+/// These types
+///
+/// - do not have a distinct `Arbitrary` prototype,
+///   i.e. they use themselves as the `SorobanArbitrary::Prototype` type,
+/// - implement `Arbitrary` in the `arbitrary` crate,
+/// - trivially implement `TryFromVal<Env, SorobanArbitrary::Prototype>`,
+///
+/// Examples:
+///
+/// - `u32`
+mod scalars {
+    use crate::arbitrary::api::*;
+
+    impl SorobanArbitrary for () {
+        type Prototype = ();
+    }
+
+    impl SorobanArbitrary for bool {
+        type Prototype = bool;
+    }
+
+    impl SorobanArbitrary for u32 {
+        type Prototype = u32;
+    }
+
+    impl SorobanArbitrary for i32 {
+        type Prototype = i32;
+    }
+
+    impl SorobanArbitrary for u64 {
+        type Prototype = u64;
+    }
+
+    impl SorobanArbitrary for i64 {
+        type Prototype = i64;
+    }
+
+    impl SorobanArbitrary for u128 {
+        type Prototype = u128;
+    }
+
+    impl SorobanArbitrary for i128 {
+        type Prototype = i128;
+    }
+}
+
+/// Implementations of `soroban_sdk::arbitrary::api` for Soroban types that do not
+/// need access to the Soroban host environment.
+///
+/// These types
+///
+/// - do not have a distinct `Arbitrary` prototype,
+///   i.e. they use themselves as the `SorobanArbitrary::Prototype` type,
+/// - implement `Arbitrary` in the `soroban-env-common` crate,
+/// - trivially implement `TryFromVal<Env, SorobanArbitrary::Prototype>`,
+///
+/// Examples:
+///
+/// - `Error`
+mod simple {
+    use crate::arbitrary::api::*;
+    pub use crate::Error;
+
+    impl SorobanArbitrary for Error {
+        type Prototype = Error;
+    }
+}
+
+/// Implementations of `soroban_sdk::arbitrary::api` for Soroban types that do
+/// need access to the Soroban host environment.
+///
+/// These types
+///
+/// - have a distinct `Arbitrary` prototype that derives `Arbitrary`,
+/// - require an `Env` to be converted to their actual contract type.
+///
+/// Examples:
+///
+/// - `Vec`
+mod objects {
+    use arbitrary::{Arbitrary, Result as ArbitraryResult, Unstructured};
+
+    use crate::arbitrary::api::*;
+    use crate::ConversionError;
+    use crate::{Env, IntoVal, TryFromVal};
+
+    use crate::xdr::{Int256Parts, ScVal, UInt256Parts};
+    use crate::{Address, Bytes, BytesN, Map, String, Symbol, Val, Vec, I256, U256};
+    use soroban_env_host::TryIntoVal;
+
+    use std::string::String as RustString;
+    use std::vec::Vec as RustVec;
+
+    //////////////////////////////////
+
+    #[derive(Arbitrary, Debug, Clone, Eq, PartialEq, Ord, PartialOrd)]
+    pub struct ArbitraryU256 {
+        parts: (u64, u64, u64, u64),
+    }
+
+    impl SorobanArbitrary for U256 {
+        type Prototype = ArbitraryU256;
+    }
+
+    impl TryFromVal<Env, ArbitraryU256> for U256 {
+        type Error = ConversionError;
+        fn try_from_val(env: &Env, v: &ArbitraryU256) -> Result<Self, Self::Error> {
+            let v = ScVal::U256(UInt256Parts {
+                hi_hi: v.parts.0,
+                hi_lo: v.parts.1,
+                lo_hi: v.parts.2,
+                lo_lo: v.parts.3,
+            });
+            let v = Val::try_from_val(env, &v)?;
+            v.try_into_val(env)
+        }
+    }
+
+    //////////////////////////////////
+
+    #[derive(Arbitrary, Debug, Clone, Eq, PartialEq, Ord, PartialOrd)]
+    pub struct ArbitraryI256 {
+        parts: (i64, u64, u64, u64),
+    }
+
+    impl SorobanArbitrary for I256 {
+        type Prototype = ArbitraryI256;
+    }
+
+    impl TryFromVal<Env, ArbitraryI256> for I256 {
+        type Error = ConversionError;
+        fn try_from_val(env: &Env, v: &ArbitraryI256) -> Result<Self, Self::Error> {
+            let v = ScVal::I256(Int256Parts {
+                hi_hi: v.parts.0,
+                hi_lo: v.parts.1,
+                lo_hi: v.parts.2,
+                lo_lo: v.parts.3,
+            });
+            let v = Val::try_from_val(env, &v)?;
+            v.try_into_val(env)
+        }
+    }
+
+    //////////////////////////////////
+
+    #[derive(Arbitrary, Debug, Clone, Eq, PartialEq, Ord, PartialOrd)]
+    pub struct ArbitraryBytes {
+        vec: RustVec<u8>,
+    }
+
+    impl SorobanArbitrary for Bytes {
+        type Prototype = ArbitraryBytes;
+    }
+
+    impl TryFromVal<Env, ArbitraryBytes> for Bytes {
+        type Error = ConversionError;
+        fn try_from_val(env: &Env, v: &ArbitraryBytes) -> Result<Self, Self::Error> {
+            Self::try_from_val(env, &v.vec.as_slice())
+        }
+    }
+
+    //////////////////////////////////
+
+    #[derive(Arbitrary, Debug, Clone, Eq, PartialEq, Ord, PartialOrd)]
+    pub struct ArbitraryString {
+        inner: RustString,
+    }
+
+    impl SorobanArbitrary for String {
+        type Prototype = ArbitraryString;
+    }
+
+    impl TryFromVal<Env, ArbitraryString> for String {
+        type Error = ConversionError;
+        fn try_from_val(env: &Env, v: &ArbitraryString) -> Result<Self, Self::Error> {
+            Self::try_from_val(env, &v.inner.as_str())
+        }
+    }
+
+    //////////////////////////////////
+
+    #[derive(Arbitrary, Debug, Clone, Eq, PartialEq, Ord, PartialOrd)]
+    pub struct ArbitraryBytesN<const N: usize> {
+        array: [u8; N],
+    }
+
+    impl<const N: usize> SorobanArbitrary for BytesN<N> {
+        type Prototype = ArbitraryBytesN<N>;
+    }
+
+    impl<const N: usize> TryFromVal<Env, ArbitraryBytesN<N>> for BytesN<N> {
+        type Error = ConversionError;
+        fn try_from_val(env: &Env, v: &ArbitraryBytesN<N>) -> Result<Self, Self::Error> {
+            Self::try_from_val(env, &v.array)
+        }
+    }
+
+    //////////////////////////////////
+
+    #[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd)]
+    pub struct ArbitrarySymbol {
+        s: RustString,
+    }
+
+    impl<'a> Arbitrary<'a> for ArbitrarySymbol {
+        fn arbitrary(u: &mut Unstructured<'a>) -> ArbitraryResult<ArbitrarySymbol> {
+            let valid_chars = "_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+            let valid_chars = valid_chars.as_bytes();
+            let mut chars = vec![];
+            let len = u.int_in_range(0..=32)?;
+            for _ in 0..len {
+                let ch = u.choose(valid_chars)?;
+                chars.push(*ch);
+            }
+            Ok(ArbitrarySymbol {
+                s: RustString::from_utf8(chars).expect("utf8"),
+            })
+        }
+    }
+
+    impl SorobanArbitrary for Symbol {
+        type Prototype = ArbitrarySymbol;
+    }
+
+    impl TryFromVal<Env, ArbitrarySymbol> for Symbol {
+        type Error = ConversionError;
+        fn try_from_val(env: &Env, v: &ArbitrarySymbol) -> Result<Self, Self::Error> {
+            Self::try_from_val(env, &v.s.as_str())
+        }
+    }
+
+    //////////////////////////////////
+
+    #[derive(Arbitrary, Debug, Clone, Eq, PartialEq, Ord, PartialOrd)]
+    pub struct ArbitraryVec<T> {
+        vec: RustVec<T>,
+    }
+
+    impl<T> SorobanArbitrary for Vec<T>
+    where
+        T: SorobanArbitrary,
+    {
+        type Prototype = ArbitraryVec<T::Prototype>;
+    }
+
+    impl<T> TryFromVal<Env, ArbitraryVec<T::Prototype>> for Vec<T>
+    where
+        T: SorobanArbitrary,
+    {
+        type Error = ConversionError;
+        fn try_from_val(env: &Env, v: &ArbitraryVec<T::Prototype>) -> Result<Self, Self::Error> {
+            let mut buf: Vec<T> = Vec::new(env);
+            for item in v.vec.iter() {
+                buf.push_back(item.into_val(env));
+            }
+            Ok(buf)
+        }
+    }
+
+    //////////////////////////////////
+
+    #[derive(Arbitrary, Debug, Clone, Eq, PartialEq, Ord, PartialOrd)]
+    pub struct ArbitraryMap<K, V> {
+        map: RustVec<(K, V)>,
+    }
+
+    impl<K, V> SorobanArbitrary for Map<K, V>
+    where
+        K: SorobanArbitrary,
+        V: SorobanArbitrary,
+    {
+        type Prototype = ArbitraryMap<K::Prototype, V::Prototype>;
+    }
+
+    impl<K, V> TryFromVal<Env, ArbitraryMap<K::Prototype, V::Prototype>> for Map<K, V>
+    where
+        K: SorobanArbitrary,
+        V: SorobanArbitrary,
+    {
+        type Error = ConversionError;
+        fn try_from_val(
+            env: &Env,
+            v: &ArbitraryMap<K::Prototype, V::Prototype>,
+        ) -> Result<Self, Self::Error> {
+            let mut map: Map<K, V> = Map::new(env);
+            for (k, v) in v.map.iter() {
+                map.set(k.into_val(env), v.into_val(env));
+            }
+            Ok(map)
+        }
+    }
+
+    //////////////////////////////////
+
+    #[derive(Arbitrary, Debug, Clone, Eq, PartialEq, Ord, PartialOrd)]
+    pub struct ArbitraryAddress {
+        inner: [u8; 32],
+    }
+
+    impl SorobanArbitrary for Address {
+        type Prototype = ArbitraryAddress;
+    }
+
+    impl TryFromVal<Env, ArbitraryAddress> for Address {
+        type Error = ConversionError;
+        fn try_from_val(env: &Env, v: &ArbitraryAddress) -> Result<Self, Self::Error> {
+            use crate::env::xdr::{Hash, ScAddress};
+
+            let sc_addr = ScVal::Address(ScAddress::Contract(Hash(v.inner)));
+            Ok(sc_addr.into_val(env))
+        }
+    }
+}
+
+/// Implementations of `soroban_sdk::arbitrary::api` for `Val`.
+mod composite {
+    use arbitrary::Arbitrary;
+
+    use crate::arbitrary::api::*;
+    use crate::ConversionError;
+    use crate::{Env, IntoVal, TryFromVal};
+
+    use super::objects::*;
+    use super::simple::*;
+    use crate::{Address, Bytes, Map, String, Symbol, Val, Vec, I256, U256};
+
+    #[derive(Arbitrary, Debug, Clone, Eq, PartialEq, Ord, PartialOrd)]
+    pub enum ArbitraryVal {
+        Void,
+        Bool(bool),
+        Error(Error),
+        U32(u32),
+        I32(i32),
+        U64(u64),
+        I64(i64),
+        U128(u128),
+        I128(i128),
+        U256(ArbitraryU256),
+        I256(ArbitraryI256),
+        Bytes(ArbitraryBytes),
+        String(ArbitraryString),
+        Symbol(ArbitrarySymbol),
+        Vec(ArbitraryValVec),
+        Map(ArbitraryValMap),
+        Address(<Address as SorobanArbitrary>::Prototype),
+    }
+
+    impl SorobanArbitrary for Val {
+        type Prototype = ArbitraryVal;
+    }
+
+    impl TryFromVal<Env, ArbitraryVal> for Val {
+        type Error = ConversionError;
+        fn try_from_val(env: &Env, v: &ArbitraryVal) -> Result<Self, Self::Error> {
+            Ok(match v {
+                ArbitraryVal::Void => Val::VOID.into(),
+                ArbitraryVal::Bool(v) => v.into_val(env),
+                ArbitraryVal::Error(v) => v.into_val(env),
+                ArbitraryVal::U32(v) => v.into_val(env),
+                ArbitraryVal::I32(v) => v.into_val(env),
+                ArbitraryVal::U64(v) => v.into_val(env),
+                ArbitraryVal::I64(v) => v.into_val(env),
+                ArbitraryVal::U256(v) => {
+                    let v: U256 = v.into_val(env);
+                    v.into_val(env)
+                }
+                ArbitraryVal::I256(v) => {
+                    let v: I256 = v.into_val(env);
+                    v.into_val(env)
+                }
+                ArbitraryVal::U128(v) => v.into_val(env),
+                ArbitraryVal::I128(v) => v.into_val(env),
+                ArbitraryVal::Bytes(v) => {
+                    let v: Bytes = v.into_val(env);
+                    v.into_val(env)
+                }
+                ArbitraryVal::String(v) => {
+                    let v: String = v.into_val(env);
+                    v.into_val(env)
+                }
+                ArbitraryVal::Symbol(v) => {
+                    let v: Symbol = v.into_val(env);
+                    v.into_val(env)
+                }
+                ArbitraryVal::Vec(v) => v.into_val(env),
+                ArbitraryVal::Map(v) => v.into_val(env),
+                ArbitraryVal::Address(v) => {
+                    let v: Address = v.into_val(env);
+                    v.into_val(env)
+                }
+            })
+        }
+    }
+
+    #[derive(Arbitrary, Debug, Clone, Eq, PartialEq, Ord, PartialOrd)]
+    pub enum ArbitraryValVec {
+        Void(<Vec<()> as SorobanArbitrary>::Prototype),
+        Bool(<Vec<bool> as SorobanArbitrary>::Prototype),
+        Error(<Vec<Error> as SorobanArbitrary>::Prototype),
+        U32(<Vec<u32> as SorobanArbitrary>::Prototype),
+        I32(<Vec<i32> as SorobanArbitrary>::Prototype),
+        U64(<Vec<u64> as SorobanArbitrary>::Prototype),
+        I64(<Vec<i64> as SorobanArbitrary>::Prototype),
+        U128(<Vec<u128> as SorobanArbitrary>::Prototype),
+        I128(<Vec<i128> as SorobanArbitrary>::Prototype),
+        U256(<Vec<U256> as SorobanArbitrary>::Prototype),
+        I256(<Vec<I256> as SorobanArbitrary>::Prototype),
+        Bytes(<Vec<Bytes> as SorobanArbitrary>::Prototype),
+        String(<Vec<String> as SorobanArbitrary>::Prototype),
+        Symbol(<Vec<Symbol> as SorobanArbitrary>::Prototype),
+        Vec(<Vec<Vec<u32>> as SorobanArbitrary>::Prototype),
+        Map(<Map<u32, u32> as SorobanArbitrary>::Prototype),
+        Address(<Vec<Address> as SorobanArbitrary>::Prototype),
+        Val(<Vec<Val> as SorobanArbitrary>::Prototype),
+    }
+
+    impl TryFromVal<Env, ArbitraryValVec> for Val {
+        type Error = ConversionError;
+        fn try_from_val(env: &Env, v: &ArbitraryValVec) -> Result<Self, Self::Error> {
+            Ok(match v {
+                ArbitraryValVec::Void(v) => {
+                    let v: Vec<()> = v.into_val(env);
+                    v.into_val(env)
+                }
+                ArbitraryValVec::Bool(v) => {
+                    let v: Vec<bool> = v.into_val(env);
+                    v.into_val(env)
+                }
+                ArbitraryValVec::Error(v) => {
+                    let v: Vec<Error> = v.into_val(env);
+                    v.into_val(env)
+                }
+                ArbitraryValVec::U32(v) => {
+                    let v: Vec<u32> = v.into_val(env);
+                    v.into_val(env)
+                }
+                ArbitraryValVec::I32(v) => {
+                    let v: Vec<i32> = v.into_val(env);
+                    v.into_val(env)
+                }
+                ArbitraryValVec::U64(v) => {
+                    let v: Vec<u64> = v.into_val(env);
+                    v.into_val(env)
+                }
+                ArbitraryValVec::I64(v) => {
+                    let v: Vec<i64> = v.into_val(env);
+                    v.into_val(env)
+                }
+                ArbitraryValVec::U128(v) => {
+                    let v: Vec<u128> = v.into_val(env);
+                    v.into_val(env)
+                }
+                ArbitraryValVec::I128(v) => {
+                    let v: Vec<i128> = v.into_val(env);
+                    v.into_val(env)
+                }
+                ArbitraryValVec::U256(v) => {
+                    let v: Vec<U256> = v.into_val(env);
+                    v.into_val(env)
+                }
+                ArbitraryValVec::I256(v) => {
+                    let v: Vec<I256> = v.into_val(env);
+                    v.into_val(env)
+                }
+                ArbitraryValVec::Bytes(v) => {
+                    let v: Vec<Bytes> = v.into_val(env);
+                    v.into_val(env)
+                }
+                ArbitraryValVec::String(v) => {
+                    let v: Vec<String> = v.into_val(env);
+                    v.into_val(env)
+                }
+                ArbitraryValVec::Symbol(v) => {
+                    let v: Vec<Symbol> = v.into_val(env);
+                    v.into_val(env)
+                }
+                ArbitraryValVec::Vec(v) => {
+                    let v: Vec<Vec<u32>> = v.into_val(env);
+                    v.into_val(env)
+                }
+                ArbitraryValVec::Map(v) => {
+                    let v: Map<u32, u32> = v.into_val(env);
+                    v.into_val(env)
+                }
+                ArbitraryValVec::Address(v) => {
+                    let v: Vec<Address> = v.into_val(env);
+                    v.into_val(env)
+                }
+                ArbitraryValVec::Val(v) => {
+                    let v: Vec<Val> = v.into_val(env);
+                    v.into_val(env)
+                }
+            })
+        }
+    }
+
+    #[derive(Arbitrary, Debug, Clone, Eq, PartialEq, Ord, PartialOrd)]
+    pub enum ArbitraryValMap {
+        VoidToVoid(<Map<(), ()> as SorobanArbitrary>::Prototype),
+        BoolToBool(<Map<bool, bool> as SorobanArbitrary>::Prototype),
+        ErrorToError(<Map<Error, Error> as SorobanArbitrary>::Prototype),
+        U32ToU32(<Map<u32, u32> as SorobanArbitrary>::Prototype),
+        I32ToI32(<Map<i32, i32> as SorobanArbitrary>::Prototype),
+        U64ToU64(<Map<u64, u64> as SorobanArbitrary>::Prototype),
+        I64ToI64(<Map<i64, i64> as SorobanArbitrary>::Prototype),
+        U128ToU128(<Map<u128, u128> as SorobanArbitrary>::Prototype),
+        I128ToI128(<Map<i128, i128> as SorobanArbitrary>::Prototype),
+        U256ToU256(<Map<U256, U256> as SorobanArbitrary>::Prototype),
+        I256ToI256(<Map<I256, I256> as SorobanArbitrary>::Prototype),
+        BytesToBytes(<Map<Bytes, Bytes> as SorobanArbitrary>::Prototype),
+        StringToString(<Map<String, String> as SorobanArbitrary>::Prototype),
+        SymbolToSymbol(<Map<Symbol, Symbol> as SorobanArbitrary>::Prototype),
+        VecToVec(<Map<Vec<u32>, Vec<u32>> as SorobanArbitrary>::Prototype),
+        MapToMap(<Map<Map<u32, u32>, Map<u32, u32>> as SorobanArbitrary>::Prototype),
+        AddressToAddress(<Map<Address, Address> as SorobanArbitrary>::Prototype),
+        ValToVal(<Map<Val, Val> as SorobanArbitrary>::Prototype),
+    }
+
+    impl TryFromVal<Env, ArbitraryValMap> for Val {
+        type Error = ConversionError;
+        fn try_from_val(env: &Env, v: &ArbitraryValMap) -> Result<Self, Self::Error> {
+            Ok(match v {
+                ArbitraryValMap::VoidToVoid(v) => {
+                    let v: Map<(), ()> = v.into_val(env);
+                    v.into_val(env)
+                }
+                ArbitraryValMap::BoolToBool(v) => {
+                    let v: Map<bool, bool> = v.into_val(env);
+                    v.into_val(env)
+                }
+                ArbitraryValMap::ErrorToError(v) => {
+                    let v: Map<Error, Error> = v.into_val(env);
+                    v.into_val(env)
+                }
+                ArbitraryValMap::U32ToU32(v) => {
+                    let v: Map<u32, u32> = v.into_val(env);
+                    v.into_val(env)
+                }
+                ArbitraryValMap::I32ToI32(v) => {
+                    let v: Map<i32, i32> = v.into_val(env);
+                    v.into_val(env)
+                }
+                ArbitraryValMap::U64ToU64(v) => {
+                    let v: Map<u64, u64> = v.into_val(env);
+                    v.into_val(env)
+                }
+                ArbitraryValMap::I64ToI64(v) => {
+                    let v: Map<i64, i64> = v.into_val(env);
+                    v.into_val(env)
+                }
+                ArbitraryValMap::U128ToU128(v) => {
+                    let v: Map<u128, u128> = v.into_val(env);
+                    v.into_val(env)
+                }
+                ArbitraryValMap::I128ToI128(v) => {
+                    let v: Map<i128, i128> = v.into_val(env);
+                    v.into_val(env)
+                }
+                ArbitraryValMap::U256ToU256(v) => {
+                    let v: Map<U256, U256> = v.into_val(env);
+                    v.into_val(env)
+                }
+                ArbitraryValMap::I256ToI256(v) => {
+                    let v: Map<I256, I256> = v.into_val(env);
+                    v.into_val(env)
+                }
+                ArbitraryValMap::BytesToBytes(v) => {
+                    let v: Map<Bytes, Bytes> = v.into_val(env);
+                    v.into_val(env)
+                }
+                ArbitraryValMap::StringToString(v) => {
+                    let v: Map<String, String> = v.into_val(env);
+                    v.into_val(env)
+                }
+                ArbitraryValMap::SymbolToSymbol(v) => {
+                    let v: Map<Symbol, Symbol> = v.into_val(env);
+                    v.into_val(env)
+                }
+                ArbitraryValMap::VecToVec(v) => {
+                    let v: Map<Vec<u32>, Vec<u32>> = v.into_val(env);
+                    v.into_val(env)
+                }
+                ArbitraryValMap::MapToMap(v) => {
+                    let v: Map<Map<u32, u32>, Map<u32, u32>> = v.into_val(env);
+                    v.into_val(env)
+                }
+                ArbitraryValMap::AddressToAddress(v) => {
+                    let v: Map<Address, Address> = v.into_val(env);
+                    v.into_val(env)
+                }
+                ArbitraryValMap::ValToVal(v) => {
+                    let v: Map<Val, Val> = v.into_val(env);
+                    v.into_val(env)
+                }
+            })
+        }
+    }
+}
+
+/// Additional tools for writing fuzz tests.
+mod fuzz_test_helpers {
+    use soroban_env_host::call_with_suppressed_panic_hook;
+
+    /// Catch panics within a fuzz test.
+    ///
+    /// The `cargo-fuzz` test harness turns panics into test failures,
+    /// immediately aborting the process.
+    ///
+    /// This function catches panics while temporarily disabling the
+    /// `cargo-fuzz` panic handler.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # macro_rules! fuzz_target {
+    /// #     (|$data:ident: $dty: ty| $body:block) => { };
+    /// # }
+    /// # struct ExampleContract;
+    /// # impl ExampleContract {
+    /// #   fn new(e: &soroban_sdk::Env, b: &soroban_sdk::BytesN<32>) { }
+    /// #   fn deposit(&self, a: soroban_sdk::Address, n: i128) { }
+    /// # }
+    /// use soroban_sdk::{Address, Env};
+    /// use soroban_sdk::arbitrary::{Arbitrary, SorobanArbitrary};
+    ///
+    /// #[derive(Arbitrary, Debug)]
+    /// struct FuzzDeposit {
+    ///     deposit_amount: i128,
+    ///     deposit_address: <Address as SorobanArbitrary>::Prototype,
+    /// }
+    ///
+    /// fuzz_target!(|input: FuzzDeposit| {
+    ///     let env = Env::default();
+    ///
+    ///     let contract = ExampleContract::new(env, &env.register_contract(None, ExampleContract {}));
+    ///
+    ///     let addresses: Address = input.deposit_address.into_val(&env);
+    ///     let r = fuzz_catch_panic(|| {
+    ///         contract.deposit(deposit_address, input.deposit_amount);
+    ///     });
+    /// });
+    /// ```
+    pub fn fuzz_catch_panic<F, R>(f: F) -> std::thread::Result<R>
+    where
+        F: FnOnce() -> R,
+    {
+        call_with_suppressed_panic_hook(std::panic::AssertUnwindSafe(f))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::arbitrary::*;
+    use crate::{Bytes, BytesN, Map, String, Symbol, Val, Vec, I256, U256};
+    use crate::{Env, IntoVal};
+    use arbitrary::{Arbitrary, Unstructured};
+    use rand::RngCore;
+
+    fn run_test<T>()
+    where
+        T: SorobanArbitrary,
+        T::Prototype: for<'a> Arbitrary<'a>,
+    {
+        let env = Env::default();
+        let mut rng = rand::thread_rng();
+        let mut rng_data = [0u8; 64];
+
+        for _ in 0..100 {
+            rng.fill_bytes(&mut rng_data);
+            let mut unstructured = Unstructured::new(&rng_data);
+            let input = T::Prototype::arbitrary(&mut unstructured).expect("SorobanArbitrary");
+            let _val: T = input.into_val(&env);
+        }
+    }
+
+    #[test]
+    fn test_u32() {
+        run_test::<u32>()
+    }
+
+    #[test]
+    fn test_i32() {
+        run_test::<i32>()
+    }
+
+    #[test]
+    fn test_u64() {
+        run_test::<u64>()
+    }
+
+    #[test]
+    fn test_i64() {
+        run_test::<i64>()
+    }
+
+    #[test]
+    fn test_u128() {
+        run_test::<u128>()
+    }
+
+    #[test]
+    fn test_i128() {
+        run_test::<i128>()
+    }
+
+    #[test]
+    fn test_u256() {
+        run_test::<U256>()
+    }
+
+    #[test]
+    fn test_i256() {
+        run_test::<I256>()
+    }
+
+    #[test]
+    fn test_bytes() {
+        run_test::<Bytes>()
+    }
+
+    #[test]
+    fn test_string() {
+        run_test::<String>()
+    }
+
+    #[test]
+    fn test_symbol() {
+        run_test::<Symbol>()
+    }
+
+    #[test]
+    fn test_bytes_n() {
+        run_test::<BytesN<64>>()
+    }
+
+    #[test]
+    fn test_vec_u32() {
+        run_test::<Vec<u32>>()
+    }
+
+    #[test]
+    fn test_vec_i32() {
+        run_test::<Vec<i32>>()
+    }
+
+    #[test]
+    fn test_vec_bytes() {
+        run_test::<Vec<Bytes>>()
+    }
+
+    #[test]
+    fn test_vec_bytes_n() {
+        run_test::<Vec<BytesN<32>>>()
+    }
+
+    #[test]
+    fn test_vec_vec_bytes() {
+        run_test::<Vec<Vec<Bytes>>>()
+    }
+
+    #[test]
+    fn test_map_u32() {
+        run_test::<Map<u32, Vec<u32>>>()
+    }
+
+    #[test]
+    fn test_map_i32() {
+        run_test::<Map<i32, Vec<i32>>>()
+    }
+
+    #[test]
+    fn test_map_bytes() {
+        run_test::<Map<Bytes, Bytes>>()
+    }
+
+    #[test]
+    fn test_map_bytes_n() {
+        run_test::<Map<BytesN<32>, Bytes>>()
+    }
+
+    #[test]
+    fn test_map_vec() {
+        run_test::<Map<Vec<Bytes>, Vec<Bytes>>>()
+    }
+
+    #[test]
+    fn test_raw_val() {
+        run_test::<Val>()
+    }
+
+    mod user_defined_types {
+        use crate as soroban_sdk;
+        use crate::arbitrary::tests::run_test;
+        use crate::{Address, Bytes, BytesN, Error, Map, Symbol, Vec, I256, U256};
+        use soroban_sdk::contracttype;
+
+        #[contracttype]
+        #[derive(Clone, Debug, Eq, PartialEq)]
+        struct PrivStruct {
+            count_u: u32,
+            count_i: i32,
+            bytes_n: BytesN<32>,
+            vec: Vec<Bytes>,
+            map: Map<Bytes, Vec<i32>>,
+            u256: U256,
+            i156: I256,
+            error: Error,
+            address: Address,
+            symbol: Symbol,
+        }
+
+        #[test]
+        fn test_user_defined_priv_struct() {
+            run_test::<PrivStruct>();
+        }
+
+        #[contracttype]
+        #[derive(Clone, Debug, Eq, PartialEq)]
+        struct PrivStructPubFields {
+            pub count_u: u32,
+            pub count_i: i32,
+            pub bytes_n: BytesN<32>,
+            pub vec: Vec<Bytes>,
+            pub map: Map<Bytes, Vec<i32>>,
+        }
+
+        #[test]
+        fn test_user_defined_priv_struct_pub_fields() {
+            run_test::<PrivStructPubFields>();
+        }
+
+        #[contracttype]
+        #[derive(Clone, Debug, Eq, PartialEq)]
+        pub struct PubStruct {
+            count_u: u32,
+            count_i: i32,
+            bytes_n: BytesN<32>,
+            vec: Vec<Bytes>,
+            map: Map<Bytes, Vec<i32>>,
+        }
+
+        #[test]
+        fn test_user_defined_pub_struct() {
+            run_test::<PubStruct>();
+        }
+
+        #[contracttype]
+        #[derive(Clone, Debug, Eq, PartialEq)]
+        pub struct PubStructPubFields {
+            pub count_u: u32,
+            pub count_i: i32,
+            pub bytes_n: BytesN<32>,
+            pub vec: Vec<Bytes>,
+            pub map: Map<Bytes, Vec<i32>>,
+        }
+
+        #[test]
+        fn test_user_defined_pubstruct_pub_fields() {
+            run_test::<PubStructPubFields>();
+        }
+
+        #[contracttype]
+        #[derive(Clone, Debug, Eq, PartialEq)]
+        struct PrivTupleStruct(u32, i32, BytesN<32>, Vec<Bytes>, Map<Bytes, Vec<i32>>);
+
+        #[test]
+        fn test_user_defined_priv_tuple_struct() {
+            run_test::<PrivTupleStruct>();
+        }
+
+        #[contracttype]
+        #[derive(Clone, Debug, Eq, PartialEq)]
+        struct PrivTupleStructPubFields(
+            pub u32,
+            pub i32,
+            pub BytesN<32>,
+            pub Vec<Bytes>,
+            pub Map<Bytes, Vec<i32>>,
+        );
+
+        #[test]
+        fn test_user_defined_priv_tuple_struct_pub_fields() {
+            run_test::<PrivTupleStructPubFields>();
+        }
+
+        #[contracttype]
+        #[derive(Clone, Debug, Eq, PartialEq)]
+        pub struct PubTupleStruct(u32, i32, BytesN<32>, Vec<Bytes>, Map<Bytes, Vec<i32>>);
+
+        #[test]
+        fn test_user_defined_pub_tuple_struct() {
+            run_test::<PubTupleStruct>();
+        }
+
+        #[contracttype]
+        #[derive(Clone, Debug, Eq, PartialEq)]
+        pub struct PubTupleStructPubFields(
+            pub u32,
+            pub i32,
+            pub BytesN<32>,
+            pub Vec<Bytes>,
+            pub Map<Bytes, Vec<i32>>,
+        );
+
+        #[test]
+        fn test_user_defined_pub_tuple_struct_pub_fields() {
+            run_test::<PubTupleStructPubFields>();
+        }
+
+        #[contracttype]
+        #[derive(Clone, Debug, Eq, PartialEq)]
+        pub(crate) struct PubCrateStruct(u32);
+
+        #[test]
+        fn test_user_defined_pub_crate_struct() {
+            run_test::<PubCrateStruct>();
+        }
+
+        #[contracttype]
+        #[derive(Clone, Debug, Eq, PartialEq)]
+        enum PrivEnum {
+            A(u32),
+            Aa(u32, u32),
+            C,
+            D,
+        }
+
+        #[test]
+        fn test_user_defined_priv_enum() {
+            run_test::<PrivEnum>();
+        }
+
+        #[contracttype]
+        #[derive(Clone, Debug, Eq, PartialEq)]
+        pub enum PubEnum {
+            A(u32),
+            C,
+            D,
+        }
+
+        #[test]
+        fn test_user_defined_pub_enum() {
+            run_test::<PubEnum>();
+        }
+
+        #[contracttype]
+        #[derive(Clone, Debug, Eq, PartialEq)]
+        pub(crate) enum PubCrateEnum {
+            A(u32),
+            C,
+            D,
+        }
+
+        #[test]
+        fn test_user_defined_pub_crate_enum() {
+            run_test::<PubCrateEnum>();
+        }
+
+        #[contracttype]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq)]
+        enum PrivEnumInt {
+            A = 1,
+            C = 2,
+            D = 3,
+        }
+
+        #[test]
+        fn test_user_defined_priv_enum_int() {
+            run_test::<PrivEnumInt>();
+        }
+
+        #[contracttype]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq)]
+        pub enum PubEnumInt {
+            A = 1,
+            C = 2,
+            D = 3,
+        }
+
+        #[test]
+        fn test_user_defined_pub_enum_int() {
+            run_test::<PubEnumInt>();
+        }
+
+        #[test]
+        fn test_declared_inside_a_fn() {
+            #[contracttype]
+            struct Foo {
+                a: u32,
+            }
+
+            #[contracttype]
+            enum Bar {
+                Baz,
+                Qux,
+            }
+
+            run_test::<Foo>();
+            run_test::<Bar>();
+        }
+    }
+}

--- a/soroban-sdk/src/arbitrary_extra.rs
+++ b/soroban-sdk/src/arbitrary_extra.rs
@@ -1,0 +1,71 @@
+//! Extra trait impls required by the bounds to `SorobanArbitrary`.
+//!
+//! These are in their own module so that they are defined even when "testutils"
+//! is not configured, making type inference consistent between configurations.
+
+use crate::ConversionError;
+use crate::Error;
+use crate::{Env, TryFromVal};
+
+impl TryFromVal<Env, u32> for u32 {
+    type Error = ConversionError;
+    fn try_from_val(_env: &Env, v: &u32) -> Result<Self, Self::Error> {
+        Ok(*v)
+    }
+}
+
+impl TryFromVal<Env, i32> for i32 {
+    type Error = ConversionError;
+    fn try_from_val(_env: &Env, v: &i32) -> Result<Self, Self::Error> {
+        Ok(*v)
+    }
+}
+
+impl TryFromVal<Env, u64> for u64 {
+    type Error = ConversionError;
+    fn try_from_val(_env: &Env, v: &u64) -> Result<Self, Self::Error> {
+        Ok(*v)
+    }
+}
+
+impl TryFromVal<Env, i64> for i64 {
+    type Error = ConversionError;
+    fn try_from_val(_env: &Env, v: &i64) -> Result<Self, Self::Error> {
+        Ok(*v)
+    }
+}
+
+impl TryFromVal<Env, u128> for u128 {
+    type Error = ConversionError;
+    fn try_from_val(_env: &Env, v: &u128) -> Result<Self, Self::Error> {
+        Ok(*v)
+    }
+}
+
+impl TryFromVal<Env, i128> for i128 {
+    type Error = ConversionError;
+    fn try_from_val(_env: &Env, v: &i128) -> Result<Self, Self::Error> {
+        Ok(*v)
+    }
+}
+
+impl TryFromVal<Env, bool> for bool {
+    type Error = ConversionError;
+    fn try_from_val(_env: &Env, v: &bool) -> Result<Self, Self::Error> {
+        Ok(*v)
+    }
+}
+
+impl TryFromVal<Env, ()> for () {
+    type Error = ConversionError;
+    fn try_from_val(_env: &Env, v: &()) -> Result<Self, Self::Error> {
+        Ok(*v)
+    }
+}
+
+impl TryFromVal<Env, Error> for Error {
+    type Error = ConversionError;
+    fn try_from_val(_env: &Env, v: &Error) -> Result<Self, Self::Error> {
+        Ok(*v)
+    }
+}

--- a/soroban-sdk/src/lib.rs
+++ b/soroban-sdk/src/lib.rs
@@ -686,4 +686,7 @@ pub mod xdr;
 
 pub mod testutils;
 
+pub mod arbitrary;
+mod arbitrary_extra;
+
 mod tests;

--- a/soroban-sdk/src/tests.rs
+++ b/soroban-sdk/src/tests.rs
@@ -18,5 +18,7 @@ mod contractimport;
 mod contractimport_with_error;
 mod contractimport_with_sha256;
 mod env;
+mod proptest_scval_cmp;
+mod proptest_val_cmp;
 mod token_client;
 mod token_spec;

--- a/soroban-sdk/src/tests/proptest_scval_cmp.rs
+++ b/soroban-sdk/src/tests/proptest_scval_cmp.rs
@@ -1,0 +1,123 @@
+//! Check that Val and ScVal can be converted between each other,
+//! and that their comparison functions are equivalent.
+
+#![cfg(feature = "testutils")]
+
+use crate::xdr::ScVal;
+use crate::Env;
+use crate::TryFromVal;
+use crate::Val;
+use core::cmp::Ordering;
+use proptest::prelude::*;
+use proptest_arbitrary_interop::arb;
+use soroban_env_host::Compare;
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(10000))]
+
+    #[test]
+    fn test(
+        scval_1 in arb::<ScVal>(),
+        scval_2 in arb::<ScVal>(),
+    ) {
+        let env = &Env::default();
+
+        // Compare Ord & PartialOrd
+        let scval_cmp = Ord::cmp(&scval_1, &scval_2);
+        let scval_cmp_partial = PartialOrd::partial_cmp(&scval_1, &scval_2);
+
+        prop_assert_eq!(Some(scval_cmp), scval_cmp_partial);
+
+        let rawval_1 = Val::try_from_val(env, &scval_1);
+        let rawval_1 = match rawval_1 {
+            Ok(rawval_1) => rawval_1,
+            Err(_) => {
+                // Many ScVal's are invalid:
+                //
+                // - LedgerKeyNonce
+                // - Vec(None), Map(None)
+                // - Symbol with invalid chars
+                // - Map with duplicate keys
+                // - Containers with the above
+                return Ok(());
+            }
+        };
+
+        let rawval_2 = Val::try_from_val(env, &scval_2);
+        let rawval_2 = match rawval_2 {
+            Ok(rawval_2) => rawval_2,
+            Err(_) => {
+                return Ok(());
+            }
+        };
+
+        let rawval_cmp = env.compare(&rawval_1, &rawval_2).expect("cmp");
+
+        if scval_cmp != rawval_cmp {
+            panic!(
+                "scval and rawval don't compare the same:\n\
+                 {scval_1:#?}\n\
+                 {scval_2:#?}\n\
+                 {scval_cmp:#?}\n\
+                 {rawval_1:#?}\n\
+                 {rawval_2:#?}\n\
+                 {rawval_cmp:#?}"
+            );
+        }
+
+        // Compare Eq
+        let scval_partial_eq = PartialEq::eq(&scval_1, &scval_2);
+        let rawval_cmp_is_eq = scval_cmp == Ordering::Equal;
+
+        prop_assert_eq!(scval_partial_eq, rawval_cmp_is_eq);
+
+        // Compare<ScVal> for Budget
+        let budget = env.budget().0;
+        let scval_budget_cmp = budget.compare(&scval_1, &scval_2).expect("cmp");
+
+        if scval_budget_cmp != scval_cmp {
+            panic!(
+                "scval (budget) and scval don't compare the same:\n\
+                 {scval_1:#?}\n\
+                 {scval_2:#?}\n\
+                 {scval_budget_cmp:#?}\n\
+                 {scval_cmp:#?}"
+            );
+        }
+
+        // Roundtrip checks
+        {
+            let scval_after_1 = ScVal::try_from_val(env, &rawval_1);
+            let scval_after_1 = match scval_after_1 {
+                Ok(scval_after_1) => scval_after_1,
+                Err(e) => {
+                    panic!(
+                        "couldn't convert rawval to scval:\n\
+                         {rawval_1:?},\n\
+                         {scval_1:?},\n\
+                         {e:#?}"
+                    );
+                }
+            };
+
+            let scval_cmp_before_after_1 = Ord::cmp(&scval_1, &scval_after_1);
+            prop_assert_eq!(scval_cmp_before_after_1, Ordering::Equal);
+
+            let scval_after_2 = ScVal::try_from_val(env, &rawval_2);
+            let scval_after_2 = match scval_after_2 {
+                Ok(scval_after_2) => scval_after_2,
+                Err(e) => {
+                    panic!(
+                        "couldn't convert rawval to scval:\n\
+                         {rawval_2:?},\n\
+                         {scval_2:?},\n\
+                         {e:#?}"
+                    );
+                }
+            };
+
+            let scval_cmp_before_after_2 = Ord::cmp(&scval_2, &scval_after_2);
+            prop_assert_eq!(scval_cmp_before_after_2, Ordering::Equal);
+        }
+    }
+}

--- a/soroban-sdk/src/tests/proptest_scval_cmp.rs
+++ b/soroban-sdk/src/tests/proptest_scval_cmp.rs
@@ -1,8 +1,6 @@
 //! Check that Val and ScVal can be converted between each other,
 //! and that their comparison functions are equivalent.
 
-#![cfg(feature = "testutils")]
-
 use crate::xdr::ScVal;
 use crate::Env;
 use crate::TryFromVal;

--- a/soroban-sdk/src/tests/proptest_val_cmp.rs
+++ b/soroban-sdk/src/tests/proptest_val_cmp.rs
@@ -1,0 +1,137 @@
+//! Check that Val and ScVal can be converted between each other,
+//! and that their comparison functions are equivalent.
+
+#![cfg(feature = "testutils")]
+
+use crate::arbitrary::SorobanArbitrary;
+use crate::xdr::ScVal;
+use crate::Env;
+use crate::Val;
+use crate::{FromVal, TryFromVal};
+use core::cmp::Ordering;
+use proptest::prelude::*;
+use proptest_arbitrary_interop::arb;
+use soroban_env_host::Compare;
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(10000))]
+
+    #[test]
+    fn test(
+        rawval_proto_1 in arb::<<Val as SorobanArbitrary>::Prototype>(),
+        rawval_proto_2 in arb::<<Val as SorobanArbitrary>::Prototype>(),
+    ) {
+        let env = &Env::default();
+        let budget = env.budget().0;
+
+        let rawval_1 = Val::from_val(env, &rawval_proto_1);
+        let rawval_2 = Val::from_val(env, &rawval_proto_2);
+
+        let (scval_1, scval_2) = {
+            let scval_1 = ScVal::try_from_val(env, &rawval_1);
+            let scval_2 = ScVal::try_from_val(env, &rawval_2);
+
+            let scval_1 = match scval_1 {
+                Ok(scval_1) => scval_1,
+                Err(e) => {
+                    panic!(
+                        "couldn't convert rawval to scval:\n\
+                         {rawval_1:?},\n\
+                         {e:#?}"
+                    );
+                }
+            };
+
+            let scval_2 = match scval_2 {
+                Ok(scval_2) => scval_2,
+                Err(e) => {
+                    panic!(
+                        "couldn't convert rawval to scval:\n\
+                         {rawval_2:?},\n\
+                         {e:#?}"
+                    );
+                }
+            };
+
+            (scval_1, scval_2)
+        };
+
+        // Check the comparison functions
+        {
+            let rawval_cmp = env.compare(&rawval_1, &rawval_2);
+            let rawval_cmp = rawval_cmp.expect("cmp");
+            let scval_cmp = Ord::cmp(&scval_1, &scval_2);
+
+            let rawval_cmp_is_eq = rawval_cmp == Ordering::Equal;
+
+            if rawval_cmp != scval_cmp {
+                panic!(
+                    "rawval and scval don't compare the same:\n\
+                     {rawval_1:#?}\n\
+                     {rawval_2:#?}\n\
+                     {rawval_cmp:#?}\n\
+                     {scval_1:#?}\n\
+                     {scval_2:#?}\n\
+                     {scval_cmp:#?}"
+                );
+            }
+
+            let scval_cmp_partial = PartialOrd::partial_cmp(&scval_1, &scval_2);
+
+            prop_assert_eq!(Some(scval_cmp), scval_cmp_partial);
+
+            let scval_partial_eq = PartialEq::eq(&scval_1, &scval_2);
+            prop_assert_eq!(rawval_cmp_is_eq, scval_partial_eq);
+
+            // Compare<ScVal> for Budget
+            let scval_budget_cmp = budget.compare(&scval_1, &scval_2);
+            let scval_budget_cmp = scval_budget_cmp.expect("cmp");
+            if rawval_cmp != scval_budget_cmp {
+                panic!(
+                    "rawval and scval (budget) don't compare the same:\n\
+                     {rawval_1:#?}\n\
+                     {rawval_2:#?}\n\
+                     {rawval_cmp:#?}\n\
+                     {scval_1:#?}\n\
+                     {scval_2:#?}\n\
+                     {scval_budget_cmp:#?}"
+                );
+            }
+        }
+
+        // Roundtrip checks
+        {
+            let rawval_after_1 = Val::try_from_val(env, &scval_1);
+            let rawval_after_1 = match rawval_after_1 {
+                Ok(rawval_after_1) => rawval_after_1,
+                Err(e) => {
+                    panic!(
+                        "couldn't convert scval to rawval:\n\
+                         {scval_1:?},\n\
+                         {e:#?}"
+                    );
+                }
+            };
+
+            let rawval_cmp_before_after_1 = env.compare(&rawval_1, &rawval_after_1).expect("compare");
+
+            prop_assert_eq!(rawval_cmp_before_after_1, Ordering::Equal);
+
+            let rawval_after_2 = Val::try_from_val(env, &scval_2);
+            let rawval_after_2 = match rawval_after_2 {
+                Ok(rawval_after_2) => rawval_after_2,
+                Err(e) => {
+                    panic!(
+                        "couldn't convert scval to rawval:\n\
+                         {scval_2:?},\n\
+                         {e:#?}"
+                    );
+                }
+            };
+
+            let rawval_cmp_before_after_2 = env.compare(&rawval_2, &rawval_after_2).expect("compare");
+
+            prop_assert_eq!(rawval_cmp_before_after_2, Ordering::Equal);
+        }
+    }
+}

--- a/soroban-sdk/src/tests/proptest_val_cmp.rs
+++ b/soroban-sdk/src/tests/proptest_val_cmp.rs
@@ -1,8 +1,6 @@
 //! Check that Val and ScVal can be converted between each other,
 //! and that their comparison functions are equivalent.
 
-#![cfg(feature = "testutils")]
-
 use crate::arbitrary::SorobanArbitrary;
 use crate::xdr::ScVal;
 use crate::Env;

--- a/soroban-sdk/src/testutils.rs
+++ b/soroban-sdk/src/testutils.rs
@@ -68,7 +68,7 @@ pub mod budget {
     /// # #[cfg(not(feature = "testutils"))]
     /// # fn main() { }
     /// ```
-    pub struct Budget(crate::env::internal::budget::Budget);
+    pub struct Budget(pub(crate) crate::env::internal::budget::Budget);
 
     impl Display for Budget {
         fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {

--- a/tests/fuzz/Cargo.toml
+++ b/tests/fuzz/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "test_fuzz"
+version.workspace = true
+authors = ["Stellar Development Foundation <info@stellar.org>"]
+license = "Apache-2.0"
+edition = "2021"
+publish = false
+rust-version = "1.70"
+
+[lib]
+# Adding rlib is required so that the test_fuzz crate can be imported as a
+# library into the fuzzing crate. However, having multiple crate types is a
+# problem, it'll cause LTO optimizations to be disabled for the cdylib build.
+# TODO: Figure out what to do about this.
+crate-type = ["cdylib", "rlib"]
+doctest = false
+
+[features]
+testutils = ["soroban-sdk/testutils"]
+
+[dependencies]
+soroban-sdk = {path = "../../soroban-sdk"}
+
+[dev-dependencies]
+soroban-sdk = {path = "../../soroban-sdk", features = ["testutils"]}

--- a/tests/fuzz/fuzz/.gitignore
+++ b/tests/fuzz/fuzz/.gitignore
@@ -1,0 +1,4 @@
+target
+corpus
+artifacts
+coverage

--- a/tests/fuzz/fuzz/Cargo.lock
+++ b/tests/fuzz/fuzz/Cargo.lock
@@ -1192,7 +1192,6 @@ dependencies = [
 name = "test_fuzz-fuzz"
 version = "0.0.0"
 dependencies = [
- "arbitrary",
  "libfuzzer-sys",
  "soroban-sdk",
  "test_fuzz",

--- a/tests/fuzz/fuzz/Cargo.lock
+++ b/tests/fuzz/fuzz/Cargo.lock
@@ -93,27 +93,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
-name = "bit-set"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
-dependencies = [
- "bit-vec",
-]
-
-[[package]]
-name = "bit-vec"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
-
-[[package]]
-name = "bitflags"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
-
-[[package]]
 name = "block-buffer"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -160,6 +139,9 @@ name = "cc"
 version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
+dependencies = [
+ "jobserver",
+]
 
 [[package]]
 name = "cfg-if"
@@ -235,16 +217,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ctor"
-version = "0.1.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d2301688392eb071b0bf1a37be05c469d3cc4dbbd95df672fe28ab021e6a096"
-dependencies = [
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "curve25519-dalek"
 version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -314,12 +286,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "diff"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
-
-[[package]]
 name = "digest"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -377,7 +343,7 @@ checksum = "c762bae6dcaf24c4c84667b8579785430908723d5c889f469d76a41d59cc7a9d"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
- "rand 0.7.3",
+ "rand",
  "serde",
  "sha2 0.9.9",
  "zeroize",
@@ -409,40 +375,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "errno"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a"
-dependencies = [
- "errno-dragonfly",
- "libc",
- "windows-sys",
-]
-
-[[package]]
-name = "errno-dragonfly"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
-dependencies = [
- "cc",
- "libc",
-]
-
-[[package]]
 name = "ethnum"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0198b9d0078e0f30dedc7acbb21c974e838fc8fae3ee170128658a98cb2c1c04"
-
-[[package]]
-name = "fastrand"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
-dependencies = [
- "instant",
-]
 
 [[package]]
 name = "ff"
@@ -519,12 +455,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
-name = "hermit-abi"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
-
-[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -589,30 +519,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e04e2fd2b8188ea827b32ef11de88377086d690286ab35747ef7f9bf3ccb590"
 
 [[package]]
-name = "instant"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "intx"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6f38a50a899dc47a6d0ed5508e7f601a2e34c3a85303514b5d137f3c10a0c75"
-
-[[package]]
-name = "io-lifetimes"
-version = "1.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
-dependencies = [
- "hermit-abi",
- "libc",
- "windows-sys",
-]
 
 [[package]]
 name = "itertools"
@@ -628,6 +538,15 @@ name = "itoa"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
+
+[[package]]
+name = "jobserver"
+version = "0.1.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "936cfd212a0155903bcbc060e316fb6cc7cbf2e1907329391ebadc1fe0ce77c2"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "js-sys"
@@ -662,28 +581,27 @@ dependencies = [
 ]
 
 [[package]]
-name = "lazy_static"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
-
-[[package]]
 name = "libc"
 version = "0.2.146"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f92be4933c13fd498862a9e02a3055f8a8d9c039ce33db97306fd5a6caa7f29b"
 
 [[package]]
+name = "libfuzzer-sys"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "beb09950ae85a0a94b27676cccf37da5ff13f27076aa1adbc6545dd0d0e1bd4e"
+dependencies = [
+ "arbitrary",
+ "cc",
+ "once_cell",
+]
+
+[[package]]
 name = "libm"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7012b1bbb0719e1097c47611d3898568c546d597c2e74d66f6087edd5233ff4"
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.3.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
 
 [[package]]
 name = "log"
@@ -745,7 +663,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
 dependencies = [
  "autocfg",
- "libm",
 ]
 
 [[package]]
@@ -770,15 +687,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
-name = "output_vt100"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "628223faebab4e3e40667ee0b2336d34a5b960ff60ea743ddfdbcf7770bcfb66"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "paste"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -801,22 +709,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
-name = "pretty_assertions"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a25e9bcb20aa780fd0bb16b72403a9064d6b3f22f026946029acb941a50af755"
-dependencies = [
- "ctor",
- "diff",
- "output_vt100",
- "yansi",
-]
-
-[[package]]
 name = "prettyplease"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43ded2b5b204571f065ab8540367d738dfe1b3606ab9eb669dcfb5e7a3a07501"
+checksum = "f2b0377b720bde721213a46cda1289b2f34abf0a436907cad91578c20de0454d"
 dependencies = [
  "proc-macro2",
  "syn 2.0.18",
@@ -830,42 +726,6 @@ checksum = "dec2b086b7a862cf4de201096214fa870344cf922b2b30c167badb3af3195406"
 dependencies = [
  "unicode-ident",
 ]
-
-[[package]]
-name = "proptest"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e35c06b98bf36aba164cc17cb25f7e232f5c4aeea73baa14b8a9f0d92dbfa65"
-dependencies = [
- "bit-set",
- "bitflags",
- "byteorder",
- "lazy_static",
- "num-traits",
- "rand 0.8.5",
- "rand_chacha 0.3.1",
- "rand_xorshift",
- "regex-syntax",
- "rusty-fork",
- "tempfile",
- "unarray",
-]
-
-[[package]]
-name = "proptest-arbitrary-interop"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1981e49bd2432249da8b0e11e5557099a8e74690d6b94e721f7dc0bb7f3555f"
-dependencies = [
- "arbitrary",
- "proptest",
-]
-
-[[package]]
-name = "quick-error"
-version = "1.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
@@ -884,20 +744,9 @@ checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
 dependencies = [
  "getrandom 0.1.16",
  "libc",
- "rand_chacha 0.2.2",
+ "rand_chacha",
  "rand_core 0.5.1",
  "rand_hc",
-]
-
-[[package]]
-name = "rand"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
-dependencies = [
- "libc",
- "rand_chacha 0.3.1",
- "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -908,16 +757,6 @@ checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
 dependencies = [
  "ppv-lite86",
  "rand_core 0.5.1",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -948,30 +787,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand_xorshift"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
-dependencies = [
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "redox_syscall"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
-dependencies = [
- "bitflags",
-]
-
-[[package]]
-name = "regex-syntax"
-version = "0.6.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
-
-[[package]]
 name = "rfc6979"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -986,32 +801,6 @@ name = "rustc-demangle"
 version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
-
-[[package]]
-name = "rustix"
-version = "0.37.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b96e891d04aa506a6d1f318d2771bcb1c7dfda84e126660ace067c9b474bb2c0"
-dependencies = [
- "bitflags",
- "errno",
- "io-lifetimes",
- "libc",
- "linux-raw-sys",
- "windows-sys",
-]
-
-[[package]]
-name = "rusty-fork"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb3dcc6e454c328bb824492db107ab7c0ae8fcffe4ad210136ef014458c1bc4f"
-dependencies = [
- "fnv",
- "quick-error",
- "tempfile",
- "wait-timeout",
-]
 
 [[package]]
 name = "ryu"
@@ -1187,8 +976,8 @@ dependencies = [
  "num-derive",
  "num-integer",
  "num-traits",
- "rand 0.7.3",
- "rand_chacha 0.2.2",
+ "rand",
+ "rand_chacha",
  "sha2 0.9.9",
  "sha3",
  "soroban-env-common",
@@ -1217,7 +1006,6 @@ dependencies = [
 name = "soroban-ledger-snapshot"
 version = "0.8.4"
 dependencies = [
- "pretty_assertions",
  "serde",
  "serde_json",
  "soroban-env-common",
@@ -1243,17 +1031,12 @@ dependencies = [
  "arbitrary",
  "bytes-lit",
  "ed25519-dalek",
- "hex",
- "proptest",
- "proptest-arbitrary-interop",
- "rand 0.7.3",
+ "rand",
  "soroban-env-guest",
  "soroban-env-host",
  "soroban-ledger-snapshot",
  "soroban-sdk-macros",
- "soroban-spec",
  "stellar-strkey",
- "stellar-xdr",
 ]
 
 [[package]]
@@ -1277,7 +1060,6 @@ name = "soroban-spec"
 version = "0.8.4"
 dependencies = [
  "base64 0.13.1",
- "pretty_assertions",
  "stellar-xdr",
  "thiserror",
  "wasmparser",
@@ -1287,7 +1069,6 @@ dependencies = [
 name = "soroban-spec-rust"
 version = "0.8.4"
 dependencies = [
- "pretty_assertions",
  "prettyplease",
  "proc-macro2",
  "quote",
@@ -1296,13 +1077,6 @@ dependencies = [
  "stellar-xdr",
  "syn 2.0.18",
  "thiserror",
-]
-
-[[package]]
-name = "soroban-token-sdk"
-version = "0.8.4"
-dependencies = [
- "soroban-sdk",
 ]
 
 [[package]]
@@ -1408,90 +1182,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tempfile"
-version = "3.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31c0432476357e58790aaa47a8efb0c5138f137343f3b5f23bd36a27e3b0a6d6"
-dependencies = [
- "autocfg",
- "cfg-if",
- "fastrand",
- "redox_syscall",
- "rustix",
- "windows-sys",
-]
-
-[[package]]
-name = "test_add_i128"
-version = "0.8.4"
-dependencies = [
- "soroban-sdk",
-]
-
-[[package]]
-name = "test_add_u128"
-version = "0.8.4"
-dependencies = [
- "soroban-sdk",
-]
-
-[[package]]
-name = "test_add_u64"
-version = "0.8.4"
-dependencies = [
- "soroban-sdk",
-]
-
-[[package]]
-name = "test_alloc"
-version = "0.8.4"
-dependencies = [
- "soroban-sdk",
-]
-
-[[package]]
-name = "test_auth"
-version = "0.8.4"
-dependencies = [
- "soroban-sdk",
-]
-
-[[package]]
-name = "test_contract_data"
-version = "0.8.4"
-dependencies = [
- "soroban-sdk",
-]
-
-[[package]]
-name = "test_empty"
-version = "0.8.4"
-dependencies = [
- "soroban-sdk",
-]
-
-[[package]]
-name = "test_empty2"
-version = "0.8.4"
-dependencies = [
- "soroban-sdk",
-]
-
-[[package]]
-name = "test_errors"
-version = "0.8.4"
-dependencies = [
- "soroban-sdk",
-]
-
-[[package]]
-name = "test_events"
-version = "0.8.4"
-dependencies = [
- "soroban-sdk",
-]
-
-[[package]]
 name = "test_fuzz"
 version = "0.8.4"
 dependencies = [
@@ -1499,31 +1189,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "test_import_contract"
-version = "0.8.4"
+name = "test_fuzz-fuzz"
+version = "0.0.0"
 dependencies = [
+ "libfuzzer-sys",
  "soroban-sdk",
-]
-
-[[package]]
-name = "test_invoke_contract"
-version = "0.8.4"
-dependencies = [
- "soroban-sdk",
-]
-
-[[package]]
-name = "test_logging"
-version = "0.8.4"
-dependencies = [
- "soroban-sdk",
-]
-
-[[package]]
-name = "test_udt"
-version = "0.8.4"
-dependencies = [
- "soroban-sdk",
+ "test_fuzz",
 ]
 
 [[package]]
@@ -1580,12 +1251,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
 
 [[package]]
-name = "unarray"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
-
-[[package]]
 name = "unicode-ident"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1596,15 +1261,6 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
-
-[[package]]
-name = "wait-timeout"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "wasi"
@@ -1727,15 +1383,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-sys"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
-dependencies = [
- "windows-targets",
-]
-
-[[package]]
 name = "windows-targets"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1791,12 +1438,6 @@ name = "windows_x86_64_msvc"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
-
-[[package]]
-name = "yansi"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
 
 [[package]]
 name = "zeroize"

--- a/tests/fuzz/fuzz/Cargo.lock
+++ b/tests/fuzz/fuzz/Cargo.lock
@@ -1192,6 +1192,7 @@ dependencies = [
 name = "test_fuzz-fuzz"
 version = "0.0.0"
 dependencies = [
+ "arbitrary",
  "libfuzzer-sys",
  "soroban-sdk",
  "test_fuzz",

--- a/tests/fuzz/fuzz/Cargo.toml
+++ b/tests/fuzz/fuzz/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "test_fuzz-fuzz"
+version = "0.0.0"
+publish = false
+edition = "2021"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.4"
+soroban-sdk = { path = "../../../soroban-sdk", features = [ "testutils" ]}
+test_fuzz = { path = "..", features = [ "testutils" ] }
+
+# Prevent this from interfering with workspaces
+[workspace]
+members = ["."]
+
+[profile.release]
+debug = 1
+
+[[bin]]
+name = "fuzz_target_1"
+path = "fuzz_targets/fuzz_target_1.rs"
+test = false
+doc = false

--- a/tests/fuzz/fuzz/Cargo.toml
+++ b/tests/fuzz/fuzz/Cargo.toml
@@ -8,6 +8,11 @@ edition = "2021"
 cargo-fuzz = true
 
 [dependencies]
+# The soroban-sdk re-exports arbitrary, so importing arbitrary shouldn't be
+# required.  However, I was getting a few compile errors without it.
+# TODO: Revisit the re-export to figure out what's missing so we don't need to
+# import arbitrary.
+arbitrary = "1.3.0"
 libfuzzer-sys = "0.4"
 soroban-sdk = { path = "../../../soroban-sdk", features = [ "testutils" ]}
 test_fuzz = { path = "..", features = [ "testutils" ] }

--- a/tests/fuzz/fuzz/Cargo.toml
+++ b/tests/fuzz/fuzz/Cargo.toml
@@ -8,11 +8,6 @@ edition = "2021"
 cargo-fuzz = true
 
 [dependencies]
-# The soroban-sdk re-exports arbitrary, so importing arbitrary shouldn't be
-# required.  However, I was getting a few compile errors without it.
-# TODO: Revisit the re-export to figure out what's missing so we don't need to
-# import arbitrary.
-arbitrary = "1.3.0"
 libfuzzer-sys = "0.4"
 soroban-sdk = { path = "../../../soroban-sdk", features = [ "testutils" ]}
 test_fuzz = { path = "..", features = [ "testutils" ] }

--- a/tests/fuzz/fuzz/fuzz_targets/fuzz_target_1.rs
+++ b/tests/fuzz/fuzz/fuzz_targets/fuzz_target_1.rs
@@ -71,11 +71,8 @@
 
 use libfuzzer_sys::fuzz_target;
 
+use arbitrary::Arbitrary;
 use soroban_sdk::{
-    // We need to import `arbitrary` because the `derive(Arbitrary)` code seems
-    // to need it. TODO: Is there a way to remove it from being imported?
-    arbitrary,
-    arbitrary::Arbitrary,
     arbitrary::SorobanArbitrary,
     Env,
     IntoVal,

--- a/tests/fuzz/fuzz/fuzz_targets/fuzz_target_1.rs
+++ b/tests/fuzz/fuzz/fuzz_targets/fuzz_target_1.rs
@@ -2,8 +2,7 @@
 
 use libfuzzer_sys::fuzz_target;
 
-use arbitrary::Arbitrary;
-use soroban_sdk::{arbitrary::SorobanArbitrary, Env, IntoVal, U256};
+use soroban_sdk::{arbitrary::{arbitrary,Arbitrary,SorobanArbitrary}, Env, IntoVal, U256};
 
 use test_fuzz::{Contract, ContractClient};
 

--- a/tests/fuzz/fuzz/fuzz_targets/fuzz_target_1.rs
+++ b/tests/fuzz/fuzz/fuzz_targets/fuzz_target_1.rs
@@ -1,83 +1,9 @@
 #![no_main]
 
-// TODO: HELP!
-// This contract sees the following build errors and I'm not sure what the right
-// way to fix them is:
-//
-// ❯ cargo +nightly fuzz build
-// Compiling test_fuzz v0.8.4 (/Users/leighmcculloch/Code/rs-soroban-sdk/tests/fuzz)
-// Compiling test_fuzz-fuzz v0.0.0 (/Users/leighmcculloch/Code/rs-soroban-sdk/tests/fuzz/fuzz)
-// error[E0433]: failed to resolve: could not find `size_hint` in `arbitrary`
-// --> fuzz_targets/fuzz_target_1.rs:18:10
-// |
-// 18 | #[derive(Arbitrary, Debug)]
-// |          ^^^^^^^^^ could not find `size_hint` in `arbitrary`
-// |
-// = note: this error originates in the derive macro `Arbitrary` (in Nightly builds, run with -Z macro-backtrace for more info)
-//
-// error[E0412]: cannot find type `Unstructured` in module `arbitrary`
-// --> fuzz_targets/fuzz_target_1.rs:18:10
-// |
-// 18 | #[derive(Arbitrary, Debug)]
-// |          ^^^^^^^^^ not found in `arbitrary`
-// |
-// = note: this error originates in the derive macro `Arbitrary` (in Nightly builds, run with -Z macro-backtrace for more info)
-//
-// error[E0412]: cannot find type `Result` in module `arbitrary`
-// --> fuzz_targets/fuzz_target_1.rs:18:10
-// |
-// 18 | #[derive(Arbitrary, Debug)]
-// |          ^^^^^^^^^ not found in `arbitrary`
-// |
-// = note: this error originates in the derive macro `Arbitrary` (in Nightly builds, run with -Z macro-backtrace for more info)
-// help: consider importing one of these items
-// |
-// 3  + use core::fmt::Result;
-// |
-// 3  + use core::result::Result;
-// |
-// 3  + use std::fmt::Result;
-// |
-// 3  + use std::io::Result;
-// |
-// and 2 other candidates
-// help: if you import `Result`, refer to it directly
-// |
-// 18 | #[derive(Arbitrary, Debug)]
-// |
-//
-// error[E0433]: failed to resolve: could not find `Error` in `arbitrary`
-// --> fuzz_targets/fuzz_target_1.rs:18:10
-// |
-// 18 | #[derive(Arbitrary, Debug)]
-// |          ^^^^^^^^^ could not find `Error` in `arbitrary`
-// |
-// = note: this error originates in the derive macro `Arbitrary` (in Nightly builds, run with -Z macro-backtrace for more info)
-// help: consider importing one of these items
-// |
-// 3  + use core::error::Error;
-// |
-// 3  + use core::fmt::Error;
-// |
-// 3  + use soroban_sdk::Error;
-// |
-// 3  + use soroban_sdk::testutils::ed25519::Error;
-// |
-// and 4 other candidates
-// help: if you import `Error`, refer to it directly
-// |
-// 18 | #[derive(Arbitrary, Debug)]
-// |
-
 use libfuzzer_sys::fuzz_target;
 
 use arbitrary::Arbitrary;
-use soroban_sdk::{
-    arbitrary::SorobanArbitrary,
-    Env,
-    IntoVal,
-    U256,
-};
+use soroban_sdk::{arbitrary::SorobanArbitrary, Env, IntoVal, U256};
 
 use test_fuzz::{Contract, ContractClient};
 
@@ -96,5 +22,5 @@ fuzz_target!(|input: Input| {
     let contract_id = env.register_contract(None, Contract);
     let client = ContractClient::new(&env, &contract_id);
 
-    let _ = client.add(&a, &b);
+    let _ = client.run(&a, &b);
 });

--- a/tests/fuzz/fuzz/fuzz_targets/fuzz_target_1.rs
+++ b/tests/fuzz/fuzz/fuzz_targets/fuzz_target_1.rs
@@ -1,0 +1,103 @@
+#![no_main]
+
+// TODO: HELP!
+// This contract sees the following build errors and I'm not sure what the right
+// way to fix them is:
+//
+// ❯ cargo +nightly fuzz build
+// Compiling test_fuzz v0.8.4 (/Users/leighmcculloch/Code/rs-soroban-sdk/tests/fuzz)
+// Compiling test_fuzz-fuzz v0.0.0 (/Users/leighmcculloch/Code/rs-soroban-sdk/tests/fuzz/fuzz)
+// error[E0433]: failed to resolve: could not find `size_hint` in `arbitrary`
+// --> fuzz_targets/fuzz_target_1.rs:18:10
+// |
+// 18 | #[derive(Arbitrary, Debug)]
+// |          ^^^^^^^^^ could not find `size_hint` in `arbitrary`
+// |
+// = note: this error originates in the derive macro `Arbitrary` (in Nightly builds, run with -Z macro-backtrace for more info)
+//
+// error[E0412]: cannot find type `Unstructured` in module `arbitrary`
+// --> fuzz_targets/fuzz_target_1.rs:18:10
+// |
+// 18 | #[derive(Arbitrary, Debug)]
+// |          ^^^^^^^^^ not found in `arbitrary`
+// |
+// = note: this error originates in the derive macro `Arbitrary` (in Nightly builds, run with -Z macro-backtrace for more info)
+//
+// error[E0412]: cannot find type `Result` in module `arbitrary`
+// --> fuzz_targets/fuzz_target_1.rs:18:10
+// |
+// 18 | #[derive(Arbitrary, Debug)]
+// |          ^^^^^^^^^ not found in `arbitrary`
+// |
+// = note: this error originates in the derive macro `Arbitrary` (in Nightly builds, run with -Z macro-backtrace for more info)
+// help: consider importing one of these items
+// |
+// 3  + use core::fmt::Result;
+// |
+// 3  + use core::result::Result;
+// |
+// 3  + use std::fmt::Result;
+// |
+// 3  + use std::io::Result;
+// |
+// and 2 other candidates
+// help: if you import `Result`, refer to it directly
+// |
+// 18 | #[derive(Arbitrary, Debug)]
+// |
+//
+// error[E0433]: failed to resolve: could not find `Error` in `arbitrary`
+// --> fuzz_targets/fuzz_target_1.rs:18:10
+// |
+// 18 | #[derive(Arbitrary, Debug)]
+// |          ^^^^^^^^^ could not find `Error` in `arbitrary`
+// |
+// = note: this error originates in the derive macro `Arbitrary` (in Nightly builds, run with -Z macro-backtrace for more info)
+// help: consider importing one of these items
+// |
+// 3  + use core::error::Error;
+// |
+// 3  + use core::fmt::Error;
+// |
+// 3  + use soroban_sdk::Error;
+// |
+// 3  + use soroban_sdk::testutils::ed25519::Error;
+// |
+// and 4 other candidates
+// help: if you import `Error`, refer to it directly
+// |
+// 18 | #[derive(Arbitrary, Debug)]
+// |
+
+use libfuzzer_sys::fuzz_target;
+
+use soroban_sdk::{
+    // We need to import `arbitrary` because the `derive(Arbitrary)` code seems
+    // to need it. TODO: Is there a way to remove it from being imported?
+    arbitrary,
+    arbitrary::Arbitrary,
+    arbitrary::SorobanArbitrary,
+    Env,
+    IntoVal,
+    U256,
+};
+
+use test_fuzz::{Contract, ContractClient};
+
+#[derive(Arbitrary, Debug)]
+struct Input {
+    a: <U256 as SorobanArbitrary>::Prototype,
+    b: <U256 as SorobanArbitrary>::Prototype,
+}
+
+fuzz_target!(|input: Input| {
+    let env = Env::default();
+
+    let a: U256 = input.a.into_val(&env);
+    let b: U256 = input.b.into_val(&env);
+
+    let contract_id = env.register_contract(None, Contract);
+    let client = ContractClient::new(&env, &contract_id);
+
+    let _ = client.add(&a, &b);
+});

--- a/tests/fuzz/src/lib.rs
+++ b/tests/fuzz/src/lib.rs
@@ -1,0 +1,30 @@
+#![no_std]
+use soroban_sdk::{contractimpl, U256};
+
+pub struct Contract;
+
+#[contractimpl]
+impl Contract {
+    pub fn add(a: U256, b: U256) -> bool {
+        a < b
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use soroban_sdk::Env;
+
+    use crate::{Contract, ContractClient};
+
+    #[test]
+    fn test_add() {
+        let e = Env::default();
+        let contract_id = e.register_contract(None, Contract);
+        let client = ContractClient::new(&e, &contract_id);
+
+        let x = 10u64;
+        let y = 12u64;
+        let z = client.add(&x, &y);
+        assert!(z == 22);
+    }
+}

--- a/tests/fuzz/src/lib.rs
+++ b/tests/fuzz/src/lib.rs
@@ -5,26 +5,9 @@ pub struct Contract;
 
 #[contractimpl]
 impl Contract {
-    pub fn add(a: U256, b: U256) -> bool {
-        a < b
-    }
-}
-
-#[cfg(test)]
-mod test {
-    use soroban_sdk::Env;
-
-    use crate::{Contract, ContractClient};
-
-    #[test]
-    fn test_add() {
-        let e = Env::default();
-        let contract_id = e.register_contract(None, Contract);
-        let client = ContractClient::new(&e, &contract_id);
-
-        let x = 10u64;
-        let y = 12u64;
-        let z = client.add(&x, &y);
-        assert!(z == 22);
+    pub fn run(a: U256, b: U256) {
+        if a < b {
+            panic!("unexpected")
+        }
     }
 }


### PR DESCRIPTION
### What

Preliminary support for fuzzing Soroban contracts with [cargo-fuzz](https://github.com/rust-fuzz/cargo-fuzz/). This patch is primarily concerned with introducing a pattern for implementing the [Arbitrary](https://docs.rs/arbitrary/latest/arbitrary/) trait, by which fuzz tests generate semi-random Rust values.

This is a new revision of previous pr https://github.com/stellar/rs-soroban-sdk/pull/878. Little has changed functionally since that pr.

This patch additionally uses the Arbitrary impls with [`proptest-arbitrary-interop` crate](https://github.com/graydon/proptest-arbitrary-interop) to add proptests that help ensure that:
RawVals and ScVals can be converted between each other and their their comparison functions are equivalent, which closes https://github.com/stellar/rs-soroban-env/issues/743.

This patch introduces the SorobanArbitrary trait which looks like this:

```rust
    pub trait SorobanArbitrary:
        TryFromVal<Env, Self::Prototype> + IntoVal<Env, RawVal> + TryFromVal<Env, RawVal>
    {
        type Prototype: for<'a> Arbitrary<'a>;
    }
```

Basically every type relevant to soroban contracts implements (or should) this trait, including i32, u32, i64, u64, i128, u128, (), bool, I256Val, U256Val, Error, Bytes, BytesN, Vec, Map, Address, Symbol, TimepointVal, DurationVal.

The `#[contracttype]` macro automatically derives an implementation, along with a type that implements `SorobanArbitrary::Prototype`.

In use the trait looks like

```rust
use soroban_sdk::{Address, Env, Vec};
use soroban_sdk::contracttype;
use soroban_sdk::arbitrary::{Arbitrary, SorobanArbitrary};
use std::vec::Vec as RustVec;

#[derive(Arbitrary, Debug)]
struct TestInput {
    deposit_amount: i128,
    claim_address: <Address as SorobanArbitrary>::Prototype,
    time_bound: <TimeBound as SorobanArbitrary>::Prototype,
}

#[contracttype]
pub struct TimeBound {
    pub kind: TimeBoundKind,
    pub timestamp: u64,
}

#[contracttype]
pub enum TimeBoundKind {
    Before,
    After,
}

fuzz_target!(|input: TestInput| {
    let env = Env::default();
    let claim_address: Address = input.claim_address.into_val(&env);
    let time_bound: TimeBound = input.time_bound.into_val(&env).
    // fuzz the program based on the input
});
```

A more complete example is at https://github.com/brson/rs-soroban-sdk/blob/val-fuzz/soroban-sdk/fuzz/fuzz_targets/fuzz_rawval_cmp.rs


### Why

This patch assumes it is desirable to fuzz Soroban contracts with cargo-fuzz.

Soroban reference types can only be constructed with an `Env`, but the `Arbitrary` trait constructs values from nothing but bytes. The `SorobanArbitrary` trait provides a pattern to bridge this gap, expecting fuzz tests to construct `SorobanArbitrary::Prototype` types, and then convert them to their final type with `FromVal`/`IntoVal`.

There are a lot of docs here and hopefully they explain what's going on well enough.

### fuzz_catch_panic

This patch also introduces a helper function, `fuzz_catch_panic`, which is built off of the `call_with_suppressed_panic_hook` function in soroban-env-host.

The `fuzz_target!` macro overrides the Rust panic hook to abort on panic, assuming all panics are bugs, but Soroban contracts fail by panicking, and I have found it desirable to fuzz failing contracts. `fuzz_catch_panic` temporarily prevents the fuzzer from aborting on panic.


### Known limitations

The introduction of SorobanArbitrary requires a bunch of extra documentation to explain why Soroban contracts can't just use the stock Arbitrary trait.

As an alternative to this approach, we could instead expect users to construct XDR types, not SorobanArbitrary::Prototype types, and convert those to RawVals. I have been assuming that contract authors should rather concern themselves with contract types, and not the serialization types; and presently there are a number of XDR types that have values which can't be converted to contract types. The SorobanArbitrary::Prototype approach does allow more flexibility in the generation of contract types, e.g. we can generate some adversarial types like invalid object references and bad tags.

Contracts must use `IntoVal` to create the final types, but these traits are under-constrained for this purpose and always require type hints:

```rust
fuzz_target!(|input: <Address as SorobanArbitrary>::Prototype| {
    let env = Env::default();
    let address: Address = input.into_val(&env);
    // fuzz the program based on the input
});
```

This is quite unfortunate because it means the real type must be named twice.

This patch introduces a new private module `arbitrary_extra` which simply defines a bunch of new conversions like

```rust
impl TryFromVal<Env, u32> for u32 {
    type Error = ConversionError;
    fn try_from_val(_env: &Env, v: &u32) -> Result<Self, Self::Error> {
        Ok(*v)
    }
}
```

These conversions are required by `SorobanArbitrary`, which is only defined when `cfg(feature = "testutils")`; the `arbitrary_extra` module defines these conversions for all cfgs to ensure type inference is always the same, but the impls are probably useless outside of the SorobanArbitrary prototype pattern.

Crates that use `#[contracttype]` need to define a "testutils" feature if they want to use Arbitrary.

This patch doesn't generate "adversarial" values, which might include:

- RawVals with bad tags
- objects that have invalid references
- objects that are reused multiple times
- deeply nested vecs and maps
- vecs and maps that contain heterogenous element types

The arbitrary module has unit tests, and these help especially ensure the macros for custom types are correct, but the tests are not exhaustive.