### PR TITLE
Remove stellar-xdr as dep in soroban-sdk

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -869,7 +869,6 @@ dependencies = [
  "soroban-sdk-macros",
  "soroban-spec",
  "stellar-strkey",
- "stellar-xdr",
 ]
 
 [[package]]

--- a/soroban-sdk/Cargo.toml
+++ b/soroban-sdk/Cargo.toml
@@ -30,7 +30,6 @@ rand = "0.7.3"
 
 [dev-dependencies]
 soroban-env-host = { workspace = true, features = ["testutils"] }
-stellar-xdr = { workspace = true, features = ["next", "std"] }
 soroban-spec = { workspace = true }
 ed25519-dalek = "1.0.1"
 rand = "0.7.3"

--- a/soroban-sdk/src/tests/contract_add_i32.rs
+++ b/soroban-sdk/src/tests/contract_add_i32.rs
@@ -1,6 +1,9 @@
 use crate as soroban_sdk;
-use soroban_sdk::{contractimpl, Env};
-use stellar_xdr::{ReadXdr, ScSpecEntry, ScSpecFunctionInputV0, ScSpecFunctionV0, ScSpecTypeDef};
+use soroban_sdk::{
+    contractimpl,
+    xdr::{ReadXdr, ScSpecEntry, ScSpecFunctionInputV0, ScSpecFunctionV0, ScSpecTypeDef},
+    Env,
+};
 
 pub struct Contract;
 

--- a/soroban-sdk/src/tests/contract_docs.rs
+++ b/soroban-sdk/src/tests/contract_docs.rs
@@ -1,7 +1,10 @@
 mod fn_ {
     use crate as soroban_sdk;
-    use soroban_sdk::{contractimpl, Env};
-    use stellar_xdr::{ReadXdr, ScSpecEntry, ScSpecFunctionV0};
+    use soroban_sdk::{
+        contractimpl,
+        xdr::{ReadXdr, ScSpecEntry, ScSpecFunctionV0},
+        Env,
+    };
 
     pub struct Contract;
 
@@ -36,8 +39,10 @@ mod fn_ {
 
 mod struct_ {
     use crate as soroban_sdk;
-    use soroban_sdk::contracttype;
-    use stellar_xdr::{ReadXdr, ScSpecEntry, ScSpecUdtStructFieldV0, ScSpecUdtStructV0};
+    use soroban_sdk::{
+        contracttype,
+        xdr::{ReadXdr, ScSpecEntry, ScSpecTypeDef, ScSpecUdtStructFieldV0, ScSpecUdtStructV0},
+    };
 
     /// S holds a and
     // TODO: Implement.
@@ -62,12 +67,12 @@ mod struct_ {
                 ScSpecUdtStructFieldV0 {
                     doc: "a is\na".try_into().unwrap(),
                     name: "a".try_into().unwrap(),
-                    type_: stellar_xdr::ScSpecTypeDef::U64,
+                    type_: ScSpecTypeDef::U64,
                 },
                 ScSpecUdtStructFieldV0 {
                     doc: "b is b".try_into().unwrap(),
                     name: "b".try_into().unwrap(),
-                    type_: stellar_xdr::ScSpecTypeDef::U64,
+                    type_: ScSpecTypeDef::U64,
                 },
             ]
             .try_into()
@@ -79,8 +84,10 @@ mod struct_ {
 
 mod struct_tuple {
     use crate as soroban_sdk;
-    use soroban_sdk::contracttype;
-    use stellar_xdr::{ReadXdr, ScSpecEntry, ScSpecUdtStructFieldV0, ScSpecUdtStructV0};
+    use soroban_sdk::{
+        contracttype,
+        xdr::{ReadXdr, ScSpecEntry, ScSpecTypeDef, ScSpecUdtStructFieldV0, ScSpecUdtStructV0},
+    };
 
     /// S holds two u64s.
     #[contracttype]
@@ -103,12 +110,12 @@ mod struct_tuple {
                 ScSpecUdtStructFieldV0 {
                     doc: "first\nline".try_into().unwrap(),
                     name: "0".try_into().unwrap(),
-                    type_: stellar_xdr::ScSpecTypeDef::U64,
+                    type_: ScSpecTypeDef::U64,
                 },
                 ScSpecUdtStructFieldV0 {
                     doc: "second".try_into().unwrap(),
                     name: "1".try_into().unwrap(),
-                    type_: stellar_xdr::ScSpecTypeDef::U64,
+                    type_: ScSpecTypeDef::U64,
                 },
             ]
             .try_into()
@@ -120,10 +127,12 @@ mod struct_tuple {
 
 mod enum_ {
     use crate as soroban_sdk;
-    use soroban_sdk::contracttype;
-    use stellar_xdr::{
-        ReadXdr, ScSpecEntry, ScSpecUdtUnionCaseTupleV0, ScSpecUdtUnionCaseV0,
-        ScSpecUdtUnionCaseVoidV0, ScSpecUdtUnionV0,
+    use soroban_sdk::{
+        contracttype,
+        xdr::{
+            ReadXdr, ScSpecEntry, ScSpecTypeDef, ScSpecUdtUnionCaseTupleV0, ScSpecUdtUnionCaseV0,
+            ScSpecUdtUnionCaseVoidV0, ScSpecUdtUnionV0,
+        },
     };
 
     /// E has variants A and B.
@@ -155,8 +164,8 @@ mod enum_ {
                     name: "B".try_into().unwrap(),
                     type_: [
                         // TODO: Add docs for tuple values in union cases.
-                        stellar_xdr::ScSpecTypeDef::U64,
-                        stellar_xdr::ScSpecTypeDef::U64,
+                        ScSpecTypeDef::U64,
+                        ScSpecTypeDef::U64,
                     ]
                     .try_into()
                     .unwrap(),
@@ -171,8 +180,10 @@ mod enum_ {
 
 mod enum_int {
     use crate as soroban_sdk;
-    use soroban_sdk::contracttype;
-    use stellar_xdr::{ReadXdr, ScSpecEntry, ScSpecUdtEnumCaseV0, ScSpecUdtEnumV0};
+    use soroban_sdk::{
+        contracttype,
+        xdr::{ReadXdr, ScSpecEntry, ScSpecUdtEnumCaseV0, ScSpecUdtEnumV0},
+    };
 
     /// E has variants A and B.
     #[contracttype]
@@ -213,8 +224,10 @@ mod enum_int {
 
 mod enum_error_int {
     use crate as soroban_sdk;
-    use soroban_sdk::contracterror;
-    use stellar_xdr::{ReadXdr, ScSpecEntry, ScSpecUdtErrorEnumCaseV0, ScSpecUdtErrorEnumV0};
+    use soroban_sdk::{
+        contracterror,
+        xdr::{ReadXdr, ScSpecEntry, ScSpecUdtErrorEnumCaseV0, ScSpecUdtErrorEnumV0},
+    };
 
     /// E has variants A and B.
     #[contracterror]

--- a/soroban-sdk/src/tests/contract_invoke.rs
+++ b/soroban-sdk/src/tests/contract_invoke.rs
@@ -1,6 +1,9 @@
 use crate as soroban_sdk;
-use soroban_sdk::{contractimpl, Env};
-use stellar_xdr::{ScErrorCode, ScErrorType};
+use soroban_sdk::{
+    contractimpl,
+    xdr::{ScErrorCode, ScErrorType},
+    Env,
+};
 
 pub struct Contract;
 

--- a/soroban-sdk/src/tests/contract_udt_struct.rs
+++ b/soroban-sdk/src/tests/contract_udt_struct.rs
@@ -1,8 +1,11 @@
 use crate as soroban_sdk;
-use soroban_sdk::{contractimpl, contracttype, map, ConversionError, Env, Symbol, TryFromVal};
-use stellar_xdr::{
-    ReadXdr, ScSpecEntry, ScSpecFunctionInputV0, ScSpecFunctionV0, ScSpecTypeDef, ScSpecTypeTuple,
-    ScSpecTypeUdt,
+use soroban_sdk::{
+    contractimpl, contracttype, map,
+    xdr::{
+        ReadXdr, ScSpecEntry, ScSpecFunctionInputV0, ScSpecFunctionV0, ScSpecTypeDef,
+        ScSpecTypeTuple, ScSpecTypeUdt,
+    },
+    ConversionError, Env, Symbol, TryFromVal,
 };
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]

--- a/soroban-sdk/src/tests/contract_udt_struct_tuple.rs
+++ b/soroban-sdk/src/tests/contract_udt_struct_tuple.rs
@@ -1,11 +1,11 @@
 use crate as soroban_sdk;
 use soroban_sdk::{
-    contractimpl, contracttype, vec, ConversionError, Env, IntoVal, RawVal, TryFromVal, TryIntoVal,
-    Vec,
-};
-use stellar_xdr::{
-    ReadXdr, ScSpecEntry, ScSpecFunctionInputV0, ScSpecFunctionV0, ScSpecTypeDef, ScSpecTypeTuple,
-    ScSpecTypeUdt,
+    contractimpl, contracttype, vec,
+    xdr::{
+        ReadXdr, ScSpecEntry, ScSpecFunctionInputV0, ScSpecFunctionV0, ScSpecTypeDef,
+        ScSpecTypeTuple, ScSpecTypeUdt,
+    },
+    ConversionError, Env, IntoVal, RawVal, TryFromVal, TryIntoVal, Vec,
 };
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]

--- a/soroban-sdk/src/tests/contractimport.rs
+++ b/soroban-sdk/src/tests/contractimport.rs
@@ -1,6 +1,9 @@
 use crate as soroban_sdk;
-use soroban_sdk::{contractimpl, Address, BytesN, Env};
-use stellar_xdr::{ScSpecEntry, ScSpecFunctionInputV0, ScSpecFunctionV0, ScSpecTypeDef};
+use soroban_sdk::{
+    contractimpl,
+    xdr::{ScSpecEntry, ScSpecFunctionInputV0, ScSpecFunctionV0, ScSpecTypeDef},
+    Address, BytesN, Env,
+};
 
 mod addcontract {
     use crate as soroban_sdk;

--- a/soroban-sdk/src/tests/contractimport_with_sha256.rs
+++ b/soroban-sdk/src/tests/contractimport_with_sha256.rs
@@ -1,6 +1,9 @@
 use crate as soroban_sdk;
-use soroban_sdk::{contractimpl, Address, Env};
-use stellar_xdr::{ScSpecEntry, ScSpecFunctionInputV0, ScSpecFunctionV0, ScSpecTypeDef};
+use soroban_sdk::{
+    contractimpl,
+    xdr::{ScSpecEntry, ScSpecFunctionInputV0, ScSpecFunctionV0, ScSpecTypeDef},
+    Address, Env,
+};
 
 mod addcontract {
     use crate as soroban_sdk;


### PR DESCRIPTION
### What
Remove stellar-xdr as dep in soroban-sdk.

### Why
It isn't needed. The stellar-xdr is re-exported in the imported env.

The only places the SDK repo needs to import the XDR independent of an env is for contract specs. We should keep it that way, because when we need to experiment with new contract specs it's helpful to be able to update the version of the stellar-xdr lib for that purpose ahead of the version that is used by the env crate which is only possible if we're using the stellar-xdr lib for a disjoint purpose to the xdr in the sdk and from the env.

This also encourages others to do the best thing. Most of the uses are in test contracts. If folks look at the test contracts and follow their patterns, we're hopefully directing them to do things we want them to do in the real world. Using the re-exported xdr helps prevent xdr misalignment.