### PR TITLE
Remove Result from Storage::get API

### DIFF
--- a/soroban-sdk/src/lib.rs
+++ b/soroban-sdk/src/lib.rs
@@ -395,8 +395,7 @@ pub use soroban_sdk_macros::contractmeta;
 ///     pub fn get_state(env: Env) -> State {
 ///         env.storage()
 ///             .get(&Symbol::short("STATE"))
-///             .unwrap_or_else(|| Ok(State::default())) // If no value set, assume 0.
-///             .unwrap() // Panic if the value of COUNTER is not a State.
+///             .unwrap_or_else(|| State::default()) // If no value set, assume 0.
 ///     }
 /// }
 ///
@@ -470,7 +469,6 @@ pub use soroban_sdk_macros::contractmeta;
 ///     pub fn get(env: Env) -> Option<Color> {
 ///         env.storage()
 ///             .get(&Symbol::short("COLOR"))
-///             .map(Result::unwrap) // Panic if the value of COLOR is not a Color.
 ///     }
 /// }
 ///

--- a/soroban-sdk/src/storage.rs
+++ b/soroban-sdk/src/storage.rs
@@ -3,7 +3,7 @@ use core::fmt::Debug;
 
 use crate::{
     env::internal::{self, RawVal},
-    unwrap::UnwrapInfallible,
+    unwrap::{UnwrapInfallible, UnwrapOptimized},
     Env, IntoVal, TryFromVal,
 };
 
@@ -85,41 +85,21 @@ impl Storage {
     /// Returns `None` when the value is missing.
     ///
     /// If the value is present, then the returned value will be a result of
-    /// converting the internal value representation to `V`.
+    /// converting the internal value representation to `V`, or will panic if
+    /// the conversion to `V` fails.
     #[inline(always)]
-    pub fn get<K, V>(&self, key: &K) -> Option<Result<V, V::Error>>
+    pub fn get<K, V>(&self, key: &K) -> Option<V>
     where
-        V::Error: Debug,
         K: IntoVal<Env, RawVal>,
         V: TryFromVal<Env, RawVal>,
     {
         let key = key.into_val(&self.env);
         if self.has_internal(key) {
             let rv = self.get_internal(key);
-            Some(V::try_from_val(&self.env, &rv))
+            Some(V::try_from_val(&self.env, &rv).unwrap_optimized())
         } else {
             None
         }
-    }
-
-    /// Returns the value there is a value stored for the given key in the
-    /// currently executing contract's storage.
-    ///
-    /// The returned value is a result of converting the internal value
-    /// representation to `V`.
-    ///
-    /// ### Panics
-    ///
-    /// When the key does not have a value stored.
-    #[inline(always)]
-    pub fn get_unchecked<K, V>(&self, key: &K) -> Result<V, V::Error>
-    where
-        V::Error: Debug,
-        K: IntoVal<Env, RawVal>,
-        V: TryFromVal<Env, RawVal>,
-    {
-        let rv = self.get_internal(key.into_val(&self.env));
-        V::try_from_val(&self.env, &rv)
     }
 
     /// Sets the value for the given key in the currently executing contract's

--- a/soroban-sdk/src/storage.rs
+++ b/soroban-sdk/src/storage.rs
@@ -39,7 +39,7 @@ use crate::{
 /// let key = Symbol::short("key");
 /// env.storage().set(&key, &1);
 /// assert_eq!(storage.has(&key), true);
-/// assert_eq!(storage.get::<_, i32>(&key), Some(Ok(1)));
+/// assert_eq!(storage.get::<_, i32>(&key), Some(1));
 /// #     }
 /// # }
 /// #

--- a/soroban-sdk/src/tests/contract_snapshot.rs
+++ b/soroban-sdk/src/tests/contract_snapshot.rs
@@ -9,7 +9,7 @@ impl Contract {
         env.storage().set(&k, &v)
     }
     pub fn get(env: Env, k: i32) -> i32 {
-        env.storage().get(&k).unwrap().unwrap()
+        env.storage().get(&k).unwrap()
     }
 }
 

--- a/soroban-sdk/src/tests/contract_store.rs
+++ b/soroban-sdk/src/tests/contract_store.rs
@@ -20,6 +20,6 @@ fn test_storage() {
 
     assert_eq!(
         e.as_contract(&contract_id, || e.storage().get::<_, i32>(&2)),
-        Some(Ok(4))
+        Some(4)
     );
 }

--- a/soroban-sdk/src/tests/token_client.rs
+++ b/soroban-sdk/src/tests/token_client.rs
@@ -13,7 +13,7 @@ pub enum DataKey {
 }
 
 fn get_token(e: &Env) -> Address {
-    e.storage().get_unchecked(&DataKey::Token).unwrap()
+    e.storage().get(&DataKey::Token).unwrap()
 }
 
 pub struct TestContract;

--- a/soroban-token-sdk/src/lib.rs
+++ b/soroban-token-sdk/src/lib.rs
@@ -1,6 +1,6 @@
 #![no_std]
 
-use soroban_sdk::{contracttype, Bytes, ConversionError, Env, Symbol};
+use soroban_sdk::{contracttype, unwrap::UnwrapOptimized, Bytes, Env, Symbol};
 
 const METADATA_KEY: Symbol = Symbol::short("METADATA");
 
@@ -27,7 +27,7 @@ impl TokenUtils {
     }
 
     #[inline(always)]
-    pub fn get_metadata_unchecked(&self) -> Result<TokenMetadata, ConversionError> {
-        self.0.storage().get_unchecked(&METADATA_KEY)
+    pub fn get_metadata(&self) -> TokenMetadata {
+        self.0.storage().get(&METADATA_KEY).unwrap_optimized()
     }
 }

--- a/tests/contract_data/src/lib.rs
+++ b/tests/contract_data/src/lib.rs
@@ -10,7 +10,7 @@ impl Contract {
     }
 
     pub fn get(e: Env, key: Symbol) -> Option<Symbol> {
-        e.storage().get(&key).map(|v| v.unwrap())
+        e.storage().get(&key)
     }
 
     pub fn del(e: Env, key: Symbol) {

--- a/tests/errors/src/lib.rs
+++ b/tests/errors/src/lib.rs
@@ -30,8 +30,7 @@ impl Contract {
     pub fn persisted(env: Env) -> bool {
         env.storage()
             .get(&Symbol::short("persisted"))
-            .unwrap_or(Ok(false))
-            .unwrap()
+            .unwrap_or(false)
     }
 }
 


### PR DESCRIPTION
### What
Remove Result from Storage::get API, and remove Storage::get_unchecked.

### Why
A contract is the only entity capable of writing data for a key to storage. Therefore a correctly written contract should always be able to accurate predict the type of the data written to storage.

While functions processing user data need to be able to handle unexpected data, storage functions do not because the data is predictable.

Related to https://github.com/stellar/rs-soroban-sdk/issues/379#issuecomment-1569273478