### PR TITLE
fix(ts-gen): use strict type-checking

### DIFF
--- a/soroban-spec/src/gen/typescript/project_template/src/convert.ts
+++ b/soroban-spec/src/gen/typescript/project_template/src/convert.ts
@@ -1,4 +1,4 @@
-import { Address, Contract, xdr } from 'soroban-client';
+import { Address, xdr } from 'soroban-client';
 import { Buffer } from "buffer";
 import { bufToBigint } from 'bigint-conversion';
 
@@ -75,13 +75,13 @@ export function scValToJs<T>(val: xdr.ScVal): T {
         }
         case xdr.ScValType.scvVec(): {
             type Element = ElementType<T>;
-            return val.vec().map(v => scValToJs<Element>(v)) as unknown as T;
+            return val.vec()!.map(v => scValToJs<Element>(v)) as unknown as T;
         }
         case xdr.ScValType.scvMap(): {
             type Key = KeyType<T>;
             type Value = ValueType<T>;
             let res: any = {};
-            val.map().forEach((e) => {
+            val.map()!.forEach((e) => {
                 let key = scValToJs<Key>(e.key());
                 let value;
                 let v: xdr.ScVal = e.val();
@@ -89,7 +89,7 @@ export function scValToJs<T>(val: xdr.ScVal): T {
                 switch (v?.switch()) {
                     case xdr.ScValType.scvMap(): {
                         let inner_map = new Map() as Map<any, any>;
-                        v.map().forEach((e) => {
+                        v.map()!.forEach((e) => {
                             let key = scValToJs<Key>(e.key());
                             let value = scValToJs<Value>(e.val());
                             inner_map.set(key, value);

--- a/soroban-spec/src/gen/typescript/project_template/tsconfig.json
+++ b/soroban-spec/src/gen/typescript/project_template/tsconfig.json
@@ -69,7 +69,7 @@
     // "preserveSymlinks": true,                         /* Disable resolving symlinks to their realpath. This correlates to the same flag in node. */
     // "forceConsistentCasingInFileNames": true, /* Ensure that casing is correct in imports. */
     /* Type Checking */
-    // "strict": true, /* Enable all strict type-checking options. */
+    "strict": true, /* Enable all strict type-checking options. */
     // "noImplicitAny": true,                            /* Enable error reporting for expressions and declarations with an implied 'any' type. */
     // "strictNullChecks": true,                         /* When type checking, take into account 'null' and 'undefined'. */
     // "strictFunctionTypes": true,                      /* When assigning functions, check to ensure parameters and the return values are subtype-compatible. */


### PR DESCRIPTION
### What


- the dapp-example uses strict type-checking
- it's probably a good idea to use it in these libs, too
- the `convert.ts` logic currently fails in strict mode; this fixes it

### Why

- make it easier to copy the `convert.ts` logic into other apps
- if other apps use strict type checking and also type-check the
  generated libraries (on purpose or by accident), it jush Just Work

### Known limitations

N/A