### PR TITLE
fix(ts): fail on ts build errors

### DIFF
--- a/soroban-spec/src/gen/typescript/project_template/scripts/build.mjs
+++ b/soroban-spec/src/gen/typescript/project_template/scripts/build.mjs
@@ -4,8 +4,13 @@ import path from "node:path"
 
 const buildDir = "./dist"
 
-spawnSync("rm", ["-rf", buildDir], { stdio: "inherit" })
-spawnSync("tsc", ["-b", "./scripts/tsconfig.cjs.json", "./scripts/tsconfig.esm.json", "./scripts/tsconfig.types.json"], { stdio: "inherit" })
+const { error, stderr } = spawnSync("tsc", ["-b", "./scripts/tsconfig.cjs.json", "./scripts/tsconfig.esm.json", "./scripts/tsconfig.types.json"], { stdio: "inherit" })
+
+if (error) {
+  console.error(stderr)
+  console.error(error)
+  throw error
+}
 
 function createEsmModulePackageJson() {
   fs.readdir(buildDir, function (err, dirs) {


### PR DESCRIPTION
### What

Report `tsc` errors when building the JS client.


### Why

Previously, if the `tsc` step failed, the `build` script continued and failed with a confusing error further down.

### Known limitations

N/A