### PR TITLE
Make Address::from_contract_id pub

### DIFF
--- a/soroban-sdk/src/address.rs
+++ b/soroban-sdk/src/address.rs
@@ -231,7 +231,7 @@ impl Address {
     /// Prefer using the `Address` directly as input or output argument. Only
     /// use this in special cases, for example to get an Address of a freshly
     /// deployed contract.
-    pub(crate) fn from_contract_id(contract_id: &BytesN<32>) -> Self {
+    pub fn from_contract_id(contract_id: &BytesN<32>) -> Self {
         let env = contract_id.env();
         unsafe {
             Self::unchecked_new(
@@ -303,10 +303,6 @@ impl crate::testutils::Address for Address {
     fn random(env: &Env) -> Self {
         let sc_addr = ScVal::Address(ScAddress::Contract(Hash(random())));
         Self::try_from_val(env, &sc_addr).unwrap()
-    }
-
-    fn from_contract_id(contract_id: &crate::BytesN<32>) -> crate::Address {
-        Self::from_contract_id(contract_id)
     }
 
     fn contract_id(&self) -> crate::BytesN<32> {

--- a/soroban-sdk/src/address.rs
+++ b/soroban-sdk/src/address.rs
@@ -233,7 +233,7 @@ impl Address {
     /// deployed contract.
     ///
     /// TODO: Replace this function in its pub form with a function that accepts
-    /// a strkey instead.
+    /// a strkey instead. Dependent on https://github.com/stellar/rs-stellar-strkey/issues/56.
     pub fn from_contract_id(contract_id: &BytesN<32>) -> Self {
         let env = contract_id.env();
         unsafe {

--- a/soroban-sdk/src/address.rs
+++ b/soroban-sdk/src/address.rs
@@ -231,6 +231,9 @@ impl Address {
     /// Prefer using the `Address` directly as input or output argument. Only
     /// use this in special cases, for example to get an Address of a freshly
     /// deployed contract.
+    ///
+    /// TODO: Replace this function in its pub form with a function that accepts
+    /// a strkey instead.
     pub fn from_contract_id(contract_id: &BytesN<32>) -> Self {
         let env = contract_id.env();
         unsafe {

--- a/soroban-sdk/src/testutils.rs
+++ b/soroban-sdk/src/testutils.rs
@@ -182,9 +182,6 @@ pub trait Address {
     /// the underlying Address value.
     fn random(env: &Env) -> crate::Address;
 
-    /// Creates an `Address` corresponding to the provided contract identifier.
-    fn from_contract_id(contract_id: &crate::BytesN<32>) -> crate::Address;
-
     /// Get the contract ID of an Address as a BytesN<32>.
     ///
     /// ### Panics


### PR DESCRIPTION
### What
Make Address::from_contract_id public and accessible to contracts.

### Why
I recently hid the function because it presents some problems and constraints if used in contracts. From an portability point-of-view to be able to run a contract already built on multiple networks contracts would not have any hardcoded global state.

However @orbitlens pointed out that from an optimization standpoint it may be preferred to have global state hardcoded even if that means recompiling the contract for each network it is deployed on, or for each specific deployment. The why is because no rent payments are required on the additional data entries, and that there may be some savings in not having to load a storage ledger entry.

We haven't yet done the work to confirm if it is indeed cheaper, but it seems reasonable not to block developers from trying out different workflows. The SDK doesn't need to be strongly opinionated on everything, and this is an area where it feels like the SDK might be being too parental.

Discussion about this occurred on Discord at:
https://discord.com/channels/897514728459468821/1118888566349631561/1119051351528321054

### Merging

This change is intended to be merged to `main`, and then backported into a patch release based on the most recent release so that it can be enjoyed today.