### PR TITLE
Fix a few clippy warnings

### DIFF
--- a/soroban-ledger-snapshot/src/lib.rs
+++ b/soroban-ledger-snapshot/src/lib.rs
@@ -70,7 +70,7 @@ impl LedgerSnapshot {
             protocol_version: self.protocol_version,
             sequence_number: self.sequence_number,
             timestamp: self.timestamp,
-            network_id: self.network_id.clone(),
+            network_id: self.network_id,
             base_reserve: self.base_reserve,
             min_persistent_entry_expiration: self.min_persistent_entry_expiration,
             min_temp_entry_expiration: self.min_temp_entry_expiration,
@@ -170,7 +170,7 @@ impl Default for LedgerSnapshot {
 
 impl SnapshotSource for &LedgerSnapshot {
     fn get(&self, key: &Rc<LedgerKey>) -> Result<Rc<LedgerEntry>, HostError> {
-        match self.ledger_entries.iter().find(|(k, _)| &**k == &**key) {
+        match self.ledger_entries.iter().find(|(k, _)| **k == **key) {
             Some((_, v)) => Ok(Rc::new(*v.clone())),
             None => Err(ScError {
                 type_: ScErrorType::Storage,
@@ -180,7 +180,7 @@ impl SnapshotSource for &LedgerSnapshot {
         }
     }
     fn has(&self, key: &Rc<LedgerKey>) -> Result<bool, HostError> {
-        Ok(self.ledger_entries.iter().any(|(k, _)| &**k == &**key))
+        Ok(self.ledger_entries.iter().any(|(k, _)| **k == **key))
     }
 }
 

--- a/soroban-sdk-macros/src/derive_enum.rs
+++ b/soroban-sdk-macros/src/derive_enum.rs
@@ -43,7 +43,7 @@ pub fn derive_type_enum(
             // TODO: Use attributes tagged on variant to control whether field is included.
             let case_ident = &variant.ident;
             let case_name = &case_ident.to_string();
-            let case_name_str_lit = Literal::string(&case_name);
+            let case_name_str_lit = Literal::string(case_name);
             let case_num_lit = Literal::usize_unsuffixed(case_num);
             if case_name.len() > SCSYMBOL_LIMIT as usize {
                 errors.push(Error::new(

--- a/soroban-sdk/src/address.rs
+++ b/soroban-sdk/src/address.rs
@@ -205,7 +205,7 @@ impl Address {
     ///
     /// If the invocation is not authorized.
     pub fn require_auth_for_args(&self, args: Vec<RawVal>) {
-        self.env.require_auth_for_args(&self, args);
+        self.env.require_auth_for_args(self, args);
     }
 
     /// Ensures that this Address has authorized invocation of the current
@@ -221,9 +221,9 @@ impl Address {
     ///
     /// ### Panics
     ///
-    /// If the invocation is not authorized.    
+    /// If the invocation is not authorized.
     pub fn require_auth(&self) {
-        self.env.require_auth(&self);
+        self.env.require_auth(self);
     }
 
     /// Creates an `Address` corresponding to the provided contract identifier.

--- a/soroban-sdk/src/bytes.rs
+++ b/soroban-sdk/src/bytes.rs
@@ -268,7 +268,7 @@ impl TryFromVal<Env, &[u8]> for Bytes {
     type Error = ConversionError;
 
     fn try_from_val(env: &Env, v: &&[u8]) -> Result<Self, Self::Error> {
-        Ok(Bytes::from_slice(env, *v))
+        Ok(Bytes::from_slice(env, v))
     }
 }
 
@@ -1384,7 +1384,7 @@ mod test {
         let env = Env::default();
         let mut bin = bytes![&env, [1, 2, 3, 4]];
 
-        assert_eq!(bin.remove_unchecked(2), ());
+        bin.remove_unchecked(2);
         assert_eq!(bin, bytes![&env, [1, 2, 4]]);
         assert_eq!(bin.len(), 3);
     }

--- a/soroban-sdk/src/env.rs
+++ b/soroban-sdk/src/env.rs
@@ -98,7 +98,7 @@ pub use internal::TryIntoVal;
 pub use internal::VecObject;
 
 pub trait IntoVal<E: internal::Env, T> {
-    fn into_val(&self, e: &E) -> T;
+    fn into_val(self, e: &E) -> T;
 }
 
 pub trait FromVal<E: internal::Env, T> {
@@ -939,7 +939,7 @@ impl Env {
     ///                 )),
     ///                 sub_invocations: std::vec![]
     ///             }
-    ///         )]         
+    ///         )]
     ///     );
     /// }
     /// # #[cfg(not(feature = "testutils"))]

--- a/soroban-sdk/src/env.rs
+++ b/soroban-sdk/src/env.rs
@@ -98,7 +98,7 @@ pub use internal::TryIntoVal;
 pub use internal::VecObject;
 
 pub trait IntoVal<E: internal::Env, T> {
-    fn into_val(self, e: &E) -> T;
+    fn into_val(&self, e: &E) -> T;
 }
 
 pub trait FromVal<E: internal::Env, T> {


### PR DESCRIPTION
### What
Fix a few warnings from clippy about redundant code.

### Why
So that we write necessary code. Code with extra borrows, etc can be misleading to a reader.