### PR TITLE
Revert to using nightly for rust-analyzer compat check

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -45,9 +45,9 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - run: rustup update
-    - run: rustup component add rust-analyzer
+    - run: rustup +nightly component add rust-analyzer
     - name: Check if rust-analyzer encounters any errors parsing project
-      run: rustup run stable rust-analyzer analysis-stats . 2>&1 | (! grep '^\[ERROR')
+      run: rustup run nightly rust-analyzer analysis-stats . 2>&1 | (! grep '^\[ERROR')
 
   build-and-test:
     strategy:


### PR DESCRIPTION
### What
Revert to using nightly for rust-analyzer compat check.

### Why
I changed the version of rust-analyzer to the stable version in https://github.com/stellar/rs-soroban-sdk/pull/994 however it seems to be much much slower for some reason.