### PR TITLE
Change Vec iter to not create many Vecs

### DIFF
--- a/soroban-sdk/src/vec.rs
+++ b/soroban-sdk/src/vec.rs
@@ -895,15 +895,15 @@ where
 #[derive(Clone)]
 pub struct VecTryIter<T> {
     vec: Vec<T>,
-    start: u32,
-    len: u32,
+    start: u32, // inclusive
+    end: u32,   // exclusive
 }
 
 impl<T> VecTryIter<T> {
     fn new(vec: Vec<T>) -> Self {
         Self {
             start: 0,
-            len: vec.len(),
+            end: vec.len(),
             vec,
         }
     }
@@ -920,17 +920,17 @@ where
     type Item = Result<T, T::Error>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        if self.len == 0 {
-            None
-        } else {
+        if self.start < self.end {
             let val = self.vec.try_get_unchecked(self.start);
             self.start += 1;
             Some(val)
+        } else {
+            None
         }
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        let len = self.len as usize;
+        let len = (self.end - self.start) as usize;
         (len, Some(len))
     }
 
@@ -943,13 +943,12 @@ where
     T: IntoVal<Env, Val> + TryFromVal<Env, Val>,
 {
     fn next_back(&mut self) -> Option<Self::Item> {
-        let len = self.len;
-        if len == 0 {
-            None
-        } else {
-            let val = self.vec.try_get_unchecked(len - 1);
-            self.len -= 1;
+        if self.start < self.end {
+            let val = self.vec.try_get_unchecked(self.end - 1);
+            self.end -= 1;
             Some(val)
+        } else {
+            None
         }
     }
 
@@ -964,7 +963,7 @@ where
     T: IntoVal<Env, Val> + TryFromVal<Env, Val>,
 {
     fn len(&self) -> usize {
-        self.len as usize
+        (self.end - self.start) as usize
     }
 }
 

--- a/soroban-sdk/src/vec.rs
+++ b/soroban-sdk/src/vec.rs
@@ -1228,6 +1228,18 @@ mod test {
     }
 
     #[test]
+    fn test_vec_iter_into_vec() {
+        let env = Env::default();
+
+        let vec = vec![&env, 0, 1, 2, 3, 4];
+
+        let mut iter = vec.try_iter();
+        assert_eq!(iter.next(), Some(Ok(0)));
+        assert_eq!(iter.next(), Some(Ok(1)));
+        assert_eq!(iter.into_vec(), vec![&env, 2, 3, 4]);
+    }
+
+    #[test]
     fn test_contains() {
         let env = Env::default();
         let vec = vec![&env, 0, 3, 5, 7, 9, 5];

--- a/soroban-sdk/src/vec.rs
+++ b/soroban-sdk/src/vec.rs
@@ -460,18 +460,6 @@ where
         self.obj = env.vec_del(self.obj, i.into()).unwrap_infallible();
     }
 
-    /// Returns true if the vec is empty and contains no items.
-    #[inline(always)]
-    pub fn is_empty(&self) -> bool {
-        self.len() == 0
-    }
-
-    /// Returns the number of items in the vec.
-    #[inline(always)]
-    pub fn len(&self) -> u32 {
-        self.env.vec_len(self.obj).unwrap_infallible().into()
-    }
-
     /// Adds the item to the front.
     ///
     /// Increases the length by one, shifts all items up by one, and puts the
@@ -768,6 +756,20 @@ where
     }
 }
 
+impl<T> Vec<T> {
+    /// Returns true if the vec is empty and contains no items.
+    #[inline(always)]
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Returns the number of items in the vec.
+    #[inline(always)]
+    pub fn len(&self) -> u32 {
+        self.env.vec_len(self.obj).unwrap_infallible().into()
+    }
+}
+
 impl<T> Vec<T>
 where
     T: IntoVal<Env, Val>,
@@ -855,7 +857,7 @@ where
     type IntoIter = UnwrappedIter<VecTryIter<T>, T, T::Error>;
 
     fn into_iter(self) -> Self::IntoIter {
-        VecTryIter(self).unwrapped()
+        VecTryIter::new(self).unwrapped()
     }
 }
 
@@ -877,7 +879,7 @@ where
     where
         T: IntoVal<Env, Val> + TryFromVal<Env, Val> + Clone,
     {
-        VecTryIter(self.clone())
+        VecTryIter::new(self.clone())
     }
 
     #[inline(always)]
@@ -886,16 +888,28 @@ where
         T: IntoVal<Env, Val> + TryFromVal<Env, Val> + Clone,
         T::Error: Debug,
     {
-        VecTryIter(self.clone())
+        VecTryIter::new(self.clone())
     }
 }
 
 #[derive(Clone)]
-pub struct VecTryIter<T>(Vec<T>);
+pub struct VecTryIter<T> {
+    vec: Vec<T>,
+    start: u32,
+    len: u32,
+}
 
 impl<T> VecTryIter<T> {
+    fn new(vec: Vec<T>) -> Self {
+        Self {
+            start: 0,
+            len: vec.len(),
+            vec,
+        }
+    }
+
     fn into_vec(self) -> Vec<T> {
-        self.0
+        self.vec
     }
 }
 
@@ -906,18 +920,17 @@ where
     type Item = Result<T, T::Error>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        let len = self.0.len();
-        if len == 0 {
+        if self.len == 0 {
             None
         } else {
-            let val = self.0.env().vec_front(self.0.obj).unwrap_infallible();
-            self.0 = self.0.slice(1..);
-            Some(T::try_from_val(self.0.env(), &val))
+            let val = self.vec.try_get_unchecked(self.start);
+            self.start += 1;
+            Some(val)
         }
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        let len = self.0.len() as usize;
+        let len = self.len as usize;
         (len, Some(len))
     }
 
@@ -930,13 +943,13 @@ where
     T: IntoVal<Env, Val> + TryFromVal<Env, Val>,
 {
     fn next_back(&mut self) -> Option<Self::Item> {
-        let len = self.0.len();
+        let len = self.len;
         if len == 0 {
             None
         } else {
-            let val = self.0.env().vec_back(self.0.obj).unwrap_infallible();
-            self.0 = self.0.slice(..len - 1);
-            Some(T::try_from_val(self.0.env(), &val))
+            let val = self.vec.try_get_unchecked(len - 1);
+            self.len -= 1;
+            Some(val)
         }
     }
 
@@ -951,7 +964,7 @@ where
     T: IntoVal<Env, Val> + TryFromVal<Env, Val>,
 {
     fn len(&self) -> usize {
-        self.0.len() as usize
+        self.len as usize
     }
 }
 

--- a/soroban-sdk/src/vec.rs
+++ b/soroban-sdk/src/vec.rs
@@ -1123,26 +1123,39 @@ mod test {
 
         let vec: Vec<()> = vec![&env];
         let mut iter = vec.iter();
+        assert_eq!(iter.len(), 0);
         assert_eq!(iter.next(), None);
         assert_eq!(iter.next(), None);
 
         let vec = vec![&env, 0, 1, 2, 3, 4];
 
         let mut iter = vec.iter();
+        assert_eq!(iter.len(), 5);
         assert_eq!(iter.next(), Some(0));
+        assert_eq!(iter.len(), 4);
         assert_eq!(iter.next(), Some(1));
+        assert_eq!(iter.len(), 3);
         assert_eq!(iter.next(), Some(2));
+        assert_eq!(iter.len(), 2);
         assert_eq!(iter.next(), Some(3));
+        assert_eq!(iter.len(), 1);
         assert_eq!(iter.next(), Some(4));
+        assert_eq!(iter.len(), 0);
         assert_eq!(iter.next(), None);
         assert_eq!(iter.next(), None);
 
         let mut iter = vec.iter();
+        assert_eq!(iter.len(), 5);
         assert_eq!(iter.next(), Some(0));
+        assert_eq!(iter.len(), 4);
         assert_eq!(iter.next_back(), Some(4));
+        assert_eq!(iter.len(), 3);
         assert_eq!(iter.next_back(), Some(3));
+        assert_eq!(iter.len(), 2);
         assert_eq!(iter.next(), Some(1));
+        assert_eq!(iter.len(), 1);
         assert_eq!(iter.next(), Some(2));
+        assert_eq!(iter.len(), 0);
         assert_eq!(iter.next(), None);
         assert_eq!(iter.next(), None);
         assert_eq!(iter.next_back(), None);
@@ -1178,26 +1191,39 @@ mod test {
 
         let vec: Vec<()> = vec![&env];
         let mut iter = vec.try_iter();
+        assert_eq!(iter.len(), 0);
         assert_eq!(iter.next(), None);
         assert_eq!(iter.next(), None);
 
         let vec = vec![&env, 0, 1, 2, 3, 4];
 
         let mut iter = vec.try_iter();
+        assert_eq!(iter.len(), 5);
         assert_eq!(iter.next(), Some(Ok(0)));
+        assert_eq!(iter.len(), 4);
         assert_eq!(iter.next(), Some(Ok(1)));
+        assert_eq!(iter.len(), 3);
         assert_eq!(iter.next(), Some(Ok(2)));
+        assert_eq!(iter.len(), 2);
         assert_eq!(iter.next(), Some(Ok(3)));
+        assert_eq!(iter.len(), 1);
         assert_eq!(iter.next(), Some(Ok(4)));
+        assert_eq!(iter.len(), 0);
         assert_eq!(iter.next(), None);
         assert_eq!(iter.next(), None);
 
         let mut iter = vec.try_iter();
+        assert_eq!(iter.len(), 5);
         assert_eq!(iter.next(), Some(Ok(0)));
+        assert_eq!(iter.len(), 4);
         assert_eq!(iter.next_back(), Some(Ok(4)));
+        assert_eq!(iter.len(), 3);
         assert_eq!(iter.next_back(), Some(Ok(3)));
+        assert_eq!(iter.len(), 2);
         assert_eq!(iter.next(), Some(Ok(1)));
+        assert_eq!(iter.len(), 1);
         assert_eq!(iter.next(), Some(Ok(2)));
+        assert_eq!(iter.len(), 0);
         assert_eq!(iter.next(), None);
         assert_eq!(iter.next(), None);
         assert_eq!(iter.next_back(), None);

--- a/soroban-sdk/src/vec.rs
+++ b/soroban-sdk/src/vec.rs
@@ -729,7 +729,9 @@ where
             self.push_back(item.clone());
         }
     }
+}
 
+impl<T> Vec<T> {
     /// Returns a subset of the bytes as defined by the start and end bounds of
     /// the range.
     ///
@@ -754,9 +756,7 @@ where
             .unwrap_infallible();
         unsafe { Self::unchecked_new(env.clone(), obj) }
     }
-}
 
-impl<T> Vec<T> {
     /// Returns true if the vec is empty and contains no items.
     #[inline(always)]
     pub fn is_empty(&self) -> bool {
@@ -909,7 +909,7 @@ impl<T> VecTryIter<T> {
     }
 
     fn into_vec(self) -> Vec<T> {
-        self.vec
+        self.vec.slice(self.start..self.end)
     }
 }
 


### PR DESCRIPTION
### What
Change Vec iter to not create a new Vec on each step of the iteration.

### Why

The Vec iterator currently makes a host copy of the vec on every step of the iteration. This is because it uses the slice function to get a new vec with the first or last item removed. Even though it results in optimized guest code because the iterator is only a single u64 handle, those optimizations are outsized by the calls to the host that repeatedly duplicate the vec.

Close #189

### Alternatives

There might be some advantage in having the slice function not copy the vec on the host side. The host could lazily reuse the vec backing array for read, pop, and slice operations. I don't think the guest savings would be worth the host complexity though. Additionally every step of an iteration would get two host fn calls instead of one, so in the end it is difficult to know if it would actually be better.

### Perf Diff

#### Code

```rust
let env = Env::default();

let vec = vec![&env, 0, 1, 2, 3, 4];

let mut iter = vec.iter();
_ = iter.next();
_ = iter.next();
_ = iter.next();
_ = iter.next();
_ = iter.next();
_ = iter.next();
_ = iter.next();
_ = iter.next();
_ = iter.next();
_ = iter.next();

env.budget().print()
```

#### Code Size

```diff
@@ -1 +1 @@
--rwxr-xr-x  1 leighmcculloch  staff  1210 Jun 20 22:25 test_iter.wasm
+-rwxr-xr-x  1 leighmcculloch  staff  934 Jun 20 22:30 test_iter.wasm
```

#### Budget

```diff
@@ -1,15 +1,15 @@
 =======================================================
-Cpu limit: 40000000; used: 35996
-Mem limit: 52428800; used: 504
+Cpu limit: 40000000; used: 6835
+Mem limit: 52428800; used: 104
 =======================================================
 CostType                 cpu_insns      mem_bytes      
 WasmInsnExec             0              0              
 WasmMemAlloc             0              0              
-HostMemAlloc             28200          504            
-HostMemCpy               276            0              
+HostMemAlloc             4700           104            
+HostMemCpy               46             0              
 HostMemCmp               0              0              
 InvokeHostFunction       0              0              
-VisitObject              475            0              
+VisitObject              114            0              
 ValXdrConv               0              0              
 ValSer                   0              0              
 ValDeser                 0              0              
@@ -23,7 +23,7 @@ VmMemRead                0              0
 VmMemWrite               0              0              
 VmInstantiation          0              0              
 InvokeVmFunction         0              0              
-ChargeBudget             7020           0              
+ChargeBudget             1950           0              
 ComputeKeccak256Hash     0              0              
 ComputeEcdsaSecp256k1Key 0              0              
 ComputeEcdsaSecp256k1Sig 0              0              
```