### PR TITLE
Mark exported fns as extern

### DIFF
--- a/soroban-sdk-macros/src/derive_fn.rs
+++ b/soroban-sdk-macros/src/derive_fn.rs
@@ -113,7 +113,7 @@ pub fn derive_fn(
 
             #[deprecated(note = #deprecated_note)]
             #[cfg_attr(target_family = "wasm", export_name = #wrap_export_name)]
-            pub fn invoke_raw(env: #crate_path::Env, #(#wrap_args),*) -> #crate_path::Val {
+            pub extern fn invoke_raw(env: #crate_path::Env, #(#wrap_args),*) -> #crate_path::Val {
                 #use_trait;
                 <_ as #crate_path::IntoVal<#crate_path::Env, #crate_path::Val>>::into_val(
                     #[allow(deprecated)]


### PR DESCRIPTION
### What
Mark exported fns as `extern`, which by default causes them to be marked as `extern "C"`.

### Why
Technically the Rust ABI is an internal detail. For an ABI stability guarantee I think we need to use the C ABI, which we can do by specifying `extern`.

A quick test with test vectors in this repo show that the resulting binary is identical with and without extern, so it really doesn't seems like it is need today.

Still adding because technically it seems like the correct thing to do even if it has no material impact today.