### PR TITLE
Rename logger to logs

### DIFF
--- a/soroban-sdk/src/env.rs
+++ b/soroban-sdk/src/env.rs
@@ -126,8 +126,8 @@ use crate::auth::InvokerContractAuthEntry;
 use crate::unwrap::UnwrapInfallible;
 use crate::unwrap::UnwrapOptimized;
 use crate::{
-    crypto::Crypto, deploy::Deployer, events::Events, ledger::Ledger, logging::Logger,
-    storage::Storage, Address, Vec,
+    crypto::Crypto, deploy::Deployer, events::Events, ledger::Ledger, logs::Logs, storage::Storage,
+    Address, Vec,
 };
 use internal::{
     AddressObject, Bool, BytesObject, DurationObject, I128Object, I256Object, I64Object,
@@ -442,10 +442,18 @@ impl Env {
             .unwrap_infallible();
     }
 
-    /// Get the [Logger] for logging debug events.
+    /// Get the [Logs] for logging debug events.
     #[inline(always)]
-    pub fn logger(&self) -> Logger {
-        Logger::new(self)
+    #[deprecated(note = "use [Env::logs]")]
+    #[doc(hidden)]
+    pub fn logger(&self) -> Logs {
+        self.logs()
+    }
+
+    /// Get the [Logs] for logging debug events.
+    #[inline(always)]
+    pub fn logs(&self) -> Logs {
+        Logs::new(self)
     }
 }
 

--- a/soroban-sdk/src/lib.rs
+++ b/soroban-sdk/src/lib.rs
@@ -667,7 +667,7 @@ pub mod deploy;
 pub mod events;
 pub mod iter;
 pub mod ledger;
-pub mod logging;
+pub mod logs;
 mod map;
 pub mod storage;
 pub mod token;

--- a/soroban-sdk/src/logs.rs
+++ b/soroban-sdk/src/logs.rs
@@ -62,8 +62,8 @@ use crate::{env::internal::EnvBase, Env, Val};
 /// let value = 5;
 /// log!(&env, "a log entry", value, Symbol::short("another"));
 ///
-/// use soroban_sdk::testutils::Logger;
-/// let logentry = env.logger().all().last().unwrap().clone();
+/// use soroban_sdk::testutils::Logs;
+/// let logentry = env.logs().all().last().unwrap().clone();
 /// assert!(logentry.contains("[\"a log entry\", 5, another]"));
 /// # }
 /// ```
@@ -71,12 +71,12 @@ use crate::{env::internal::EnvBase, Env, Val};
 macro_rules! log {
     ($env:expr, $fmt:literal $(,)?) => {
         if cfg!(debug_assertions) {
-            $env.logger().log($fmt, &[]);
+            $env.logs().log($fmt, &[]);
         }
     };
     ($env:expr, $fmt:literal, $($args:expr),* $(,)?) => {
         if cfg!(debug_assertions) {
-            $env.logger().log($fmt, &[
+            $env.logs().log($fmt, &[
                 $(
                     <_ as $crate::IntoVal<Env, $crate::Val>>::into_val(&$args, $env)
                 ),*
@@ -85,27 +85,27 @@ macro_rules! log {
     };
 }
 
-/// Logger logs debug events.
+/// Logs logs debug events.
 ///
 /// See [`log`][crate::log] for how to conveniently log debug events.
 #[derive(Clone)]
-pub struct Logger(Env);
+pub struct Logs(Env);
 
-impl Debug for Logger {
+impl Debug for Logs {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        write!(f, "Logger")
+        write!(f, "Logs")
     }
 }
 
-impl Logger {
+impl Logs {
     #[inline(always)]
     pub(crate) fn env(&self) -> &Env {
         &self.0
     }
 
     #[inline(always)]
-    pub(crate) fn new(env: &Env) -> Logger {
-        Logger(env.clone())
+    pub(crate) fn new(env: &Env) -> Logs {
+        Logs(env.clone())
     }
 
     /// Log a debug event.
@@ -128,7 +128,7 @@ use crate::testutils;
 
 #[cfg(any(test, feature = "testutils"))]
 #[cfg_attr(feature = "docs", doc(cfg(feature = "testutils")))]
-impl testutils::Logger for Logger {
+impl testutils::Logs for Logs {
     fn all(&self) -> std::vec::Vec<String> {
         use crate::xdr::{
             ContractEventBody, ContractEventType, ScSymbol, ScVal, ScVec, StringM, VecM,

--- a/soroban-sdk/src/logs.rs
+++ b/soroban-sdk/src/logs.rs
@@ -71,12 +71,12 @@ use crate::{env::internal::EnvBase, Env, Val};
 macro_rules! log {
     ($env:expr, $fmt:literal $(,)?) => {
         if cfg!(debug_assertions) {
-            $env.logs().log($fmt, &[]);
+            $env.logs().add($fmt, &[]);
         }
     };
     ($env:expr, $fmt:literal, $($args:expr),* $(,)?) => {
         if cfg!(debug_assertions) {
-            $env.logs().log($fmt, &[
+            $env.logs().add($fmt, &[
                 $(
                     <_ as $crate::IntoVal<Env, $crate::Val>>::into_val(&$args, $env)
                 ),*
@@ -108,6 +108,12 @@ impl Logs {
         Logs(env.clone())
     }
 
+    #[deprecated(note = "use [Logs::add]")]
+    #[inline(always)]
+    pub fn log(&self, msg: &'static str, args: &[Val]) {
+        self.add(msg, args);
+    }
+
     /// Log a debug event.
     ///
     /// Takes a literal string and a sequence of trailing values to add
@@ -115,7 +121,7 @@ impl Logs {
     ///
     /// See [`log`][crate::log] for how to conveniently log debug events.
     #[inline(always)]
-    pub fn log(&self, msg: &'static str, args: &[Val]) {
+    pub fn add(&self, msg: &'static str, args: &[Val]) {
         if cfg!(debug_assertions) {
             let env = self.env();
             env.log_from_slice(msg, args).unwrap();

--- a/soroban-sdk/src/testutils.rs
+++ b/soroban-sdk/src/testutils.rs
@@ -148,8 +148,8 @@ pub trait Events {
     fn all(&self) -> Vec<(crate::Address, Vec<Val>, Val)>;
 }
 
-/// Test utilities for [`Logger`][crate::logging::Logger].
-pub trait Logger {
+/// Test utilities for [`Logs`][crate::logs::Logs].
+pub trait Logs {
     /// Returns all diagnostic events that have been logged.
     fn all(&self) -> std::vec::Vec<String>;
     /// Prints all diagnostic events to stdout.

--- a/tests/logging/src/lib.rs
+++ b/tests/logging/src/lib.rs
@@ -29,7 +29,7 @@ impl Contract {
 mod test {
     extern crate std;
 
-    use soroban_sdk::{testutils::Logger, Env};
+    use soroban_sdk::{testutils::Logs, Env};
 
     use crate::{Contract, ContractClient};
 
@@ -41,7 +41,7 @@ mod test {
 
         client.hello();
 
-        env.logger().print();
+        env.logs().print();
 
         if cfg!(debug_assertions) {
             let pats = std::vec![
@@ -52,11 +52,11 @@ mod test {
                 "[\"one and two:\", one, two]",
                 "[\"one and two:\", one, two]"
             ];
-            for (msg, pat) in env.logger().all().iter().zip(pats.iter()) {
+            for (msg, pat) in env.logs().all().iter().zip(pats.iter()) {
                 assert!(msg.contains(pat));
             }
         } else {
-            assert_eq!(env.logger().all(), std::vec![""; 0]);
+            assert_eq!(env.logs().all(), std::vec![""; 0]);
         }
     }
 }


### PR DESCRIPTION
### What
Rename env.logger() to env.logs().

### Why
The logger function is inconsistently named compared to the other functions for accessing resources. E.g. `events`, `storage`, `ledger`. I keep looking for logs and having to remember it is logger. The type is used not just for the act of logging, but also the act accessing logs in tests.

Note that the deploy functionality is under `deployer`, but it's not one that as easily renamed to `deploy` or `deploys`.

The rename is done backwards compatible with a deprecated notice, so folks will get a meaningful warning message and do not need to go hunting for the new function.