### PR TITLE
Add #[contract] macro

### DIFF
--- a/soroban-sdk-macros/src/derive_client.rs
+++ b/soroban-sdk-macros/src/derive_client.rs
@@ -27,6 +27,71 @@ pub fn derive_client_type(crate_path: &Path, ty: &str, name: &str) -> TokenStrea
             #[cfg(any(test, feature = "testutils"))]
             mock_all_auths: bool,
         }
+
+        impl<'a> #client_ident<'a> {
+            pub fn new(env: &#crate_path::Env, address: &#crate_path::Address) -> Self {
+                Self {
+                    env: env.clone(),
+                    address: address.clone(),
+                    #[cfg(not(any(test, feature = "testutils")))]
+                    _phantom: core::marker::PhantomData,
+                    #[cfg(any(test, feature = "testutils"))]
+                    set_auths: None,
+                    #[cfg(any(test, feature = "testutils"))]
+                    mock_auths: None,
+                    #[cfg(any(test, feature = "testutils"))]
+                    mock_all_auths: false,
+                }
+            }
+
+            /// Set authorizations in the environment which will be consumed by
+            /// contracts when they invoke `Address::require_auth` or
+            /// `Address::require_auth_for_args` functions.
+            ///
+            /// See `soroban_sdk::Env::set_auths` for more details and examples.
+            #[cfg(any(test, feature = "testutils"))]
+            pub fn set_auths(&self, auths: &'a [#crate_path::xdr::SorobanAuthorizationEntry]) -> Self {
+                Self {
+                    env: self.env.clone(),
+                    address: self.address.clone(),
+                    set_auths: Some(auths),
+                    mock_auths: self.mock_auths.clone(),
+                    mock_all_auths: false,
+                }
+            }
+
+            /// Mock authorizations in the environment which will cause matching invokes
+            /// of `Address::require_auth` and `Address::require_auth_for_args` to
+            /// pass.
+            ///
+            /// See `soroban_sdk::Env::set_auths` for more details and examples.
+            #[cfg(any(test, feature = "testutils"))]
+            pub fn mock_auths(&self, mock_auths: &'a [#crate_path::testutils::MockAuth<'a>]) -> Self {
+                Self {
+                    env: self.env.clone(),
+                    address: self.address.clone(),
+                    set_auths: self.set_auths.clone(),
+                    mock_auths: Some(mock_auths),
+                    mock_all_auths: false,
+                }
+            }
+
+            /// Mock all calls to the `Address::require_auth` and
+            /// `Address::require_auth_for_args` functions in invoked contracts,
+            /// having them succeed as if authorization was provided.
+            ///
+            /// See `soroban_sdk::Env::set_auths` for more details and examples.
+            #[cfg(any(test, feature = "testutils"))]
+            pub fn mock_all_auths(&self) -> Self {
+                Self {
+                    env: self.env.clone(),
+                    address: self.address.clone(),
+                    set_auths: None,
+                    mock_auths: None,
+                    mock_all_auths: true,
+                }
+            }
+        }
     }
 }
 
@@ -145,69 +210,6 @@ pub fn derive_client_impl(crate_path: &Path, name: &str, fns: &[syn_ext::Fn]) ->
     let client_ident = format_ident!("{}", name);
     quote! {
         impl<'a> #client_ident<'a> {
-            pub fn new(env: &#crate_path::Env, address: &#crate_path::Address) -> Self {
-                Self {
-                    env: env.clone(),
-                    address: address.clone(),
-                    #[cfg(not(any(test, feature = "testutils")))]
-                    _phantom: core::marker::PhantomData,
-                    #[cfg(any(test, feature = "testutils"))]
-                    set_auths: None,
-                    #[cfg(any(test, feature = "testutils"))]
-                    mock_auths: None,
-                    #[cfg(any(test, feature = "testutils"))]
-                    mock_all_auths: false,
-                }
-            }
-
-            /// Set authorizations in the environment which will be consumed by
-            /// contracts when they invoke `Address::require_auth` or
-            /// `Address::require_auth_for_args` functions.
-            ///
-            /// See `soroban_sdk::Env::set_auths` for more details and examples.
-            #[cfg(any(test, feature = "testutils"))]
-            pub fn set_auths(&self, auths: &'a [#crate_path::xdr::SorobanAuthorizationEntry]) -> Self {
-                Self {
-                    env: self.env.clone(),
-                    address: self.address.clone(),
-                    set_auths: Some(auths),
-                    mock_auths: self.mock_auths.clone(),
-                    mock_all_auths: false,
-                }
-            }
-
-            /// Mock authorizations in the environment which will cause matching invokes
-            /// of `Address::require_auth` and `Address::require_auth_for_args` to
-            /// pass.
-            ///
-            /// See `soroban_sdk::Env::set_auths` for more details and examples.
-            #[cfg(any(test, feature = "testutils"))]
-            pub fn mock_auths(&self, mock_auths: &'a [#crate_path::testutils::MockAuth<'a>]) -> Self {
-                Self {
-                    env: self.env.clone(),
-                    address: self.address.clone(),
-                    set_auths: self.set_auths.clone(),
-                    mock_auths: Some(mock_auths),
-                    mock_all_auths: false,
-                }
-            }
-
-            /// Mock all calls to the `Address::require_auth` and
-            /// `Address::require_auth_for_args` functions in invoked contracts,
-            /// having them succeed as if authorization was provided.
-            ///
-            /// See `soroban_sdk::Env::set_auths` for more details and examples.
-            #[cfg(any(test, feature = "testutils"))]
-            pub fn mock_all_auths(&self) -> Self {
-                Self {
-                    env: self.env.clone(),
-                    address: self.address.clone(),
-                    set_auths: None,
-                    mock_auths: None,
-                    mock_all_auths: true,
-                }
-            }
-
             #(#fns)*
         }
     }

--- a/soroban-sdk/src/deploy.rs
+++ b/soroban-sdk/src/deploy.rs
@@ -12,8 +12,9 @@
 //! ### Examples
 //!
 //! ```
-//! # use soroban_sdk::{contractimpl, BytesN, Env, Symbol};
+//! # use soroban_sdk::{contract, contractimpl, BytesN, Env, Symbol};
 //! #
+//! # #[contract]
 //! # pub struct Contract;
 //! #
 //! # #[contractimpl]

--- a/soroban-sdk/src/env.rs
+++ b/soroban-sdk/src/env.rs
@@ -318,8 +318,9 @@ impl Env {
     ///
     /// ### Examples
     /// ```
-    /// use soroban_sdk::{contractimpl, log, Env, Symbol};
+    /// use soroban_sdk::{contract, contractimpl, log, Env, Symbol};
     ///
+    /// #[contract]
     /// pub struct Contract;
     ///
     /// #[contractimpl]
@@ -530,8 +531,9 @@ impl Env {
     ///
     /// ### Examples
     /// ```
-    /// use soroban_sdk::{contractimpl, BytesN, Env, Symbol};
+    /// use soroban_sdk::{contract, contractimpl, BytesN, Env, Symbol};
     ///
+    /// #[contract]
     /// pub struct HelloContract;
     ///
     /// #[contractimpl]
@@ -764,8 +766,9 @@ impl Env {
     ///
     /// ### Examples
     /// ```
-    /// use soroban_sdk::{contractimpl, Env, Address, testutils::{Address as _, MockAuth, MockAuthInvoke}, IntoVal};
+    /// use soroban_sdk::{contract, contractimpl, Env, Address, testutils::{Address as _, MockAuth, MockAuthInvoke}, IntoVal};
     ///
+    /// #[contract]
     /// pub struct HelloContract;
     ///
     /// #[contractimpl]
@@ -832,8 +835,9 @@ impl Env {
     ///
     /// ### Examples
     /// ```
-    /// use soroban_sdk::{contractimpl, Env, Address, testutils::Address as _};
+    /// use soroban_sdk::{contract, contractimpl, Env, Address, testutils::Address as _};
     ///
+    /// #[contract]
     /// pub struct HelloContract;
     ///
     /// #[contractimpl]
@@ -886,8 +890,9 @@ impl Env {
     ///
     /// ### Examples
     /// ```
-    /// use soroban_sdk::{contractimpl, testutils::{Address as _, AuthorizedFunction, AuthorizedInvocation}, Address, Symbol, Env, IntoVal};
+    /// use soroban_sdk::{contract, contractimpl, testutils::{Address as _, AuthorizedFunction, AuthorizedInvocation}, Address, Symbol, Env, IntoVal};
     ///
+    /// #[contract]
     /// pub struct Contract;
     ///
     /// #[contractimpl]
@@ -975,7 +980,7 @@ impl Env {
     ///
     /// ### Examples
     /// ```
-    /// use soroban_sdk::{contracterror, contractimpl, testutils::{Address as _, BytesN as _}, vec, auth::Context, BytesN, Env, Vec, Val};
+    /// use soroban_sdk::{contract, contracterror, contractimpl, testutils::{Address as _, BytesN as _}, vec, auth::Context, BytesN, Env, Vec, Val};
     ///
     /// #[contracterror]
     /// #[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
@@ -983,6 +988,7 @@ impl Env {
     /// pub enum NoopAccountError {
     ///     SomeError = 1,
     /// }
+    /// #[contract]
     /// struct NoopAccountContract;
     /// #[contractimpl]
     /// impl NoopAccountContract {

--- a/soroban-sdk/src/events.rs
+++ b/soroban-sdk/src/events.rs
@@ -15,8 +15,9 @@ const TOPIC_BYTES_LENGTH_LIMIT: u32 = 32;
 /// ```
 /// use soroban_sdk::Env;
 ///
-/// # use soroban_sdk::{contractimpl, vec, map, Val, BytesN};
+/// # use soroban_sdk::{contract, contractimpl, vec, map, Val, BytesN};
 /// #
+/// # #[contract]
 /// # pub struct Contract;
 /// #
 /// # #[contractimpl]

--- a/soroban-sdk/src/ledger.rs
+++ b/soroban-sdk/src/ledger.rs
@@ -8,8 +8,9 @@ use crate::{env::internal, unwrap::UnwrapInfallible, BytesN, Env, TryIntoVal};
 /// ```
 /// use soroban_sdk::Env;
 ///
-/// # use soroban_sdk::{contractimpl, BytesN};
+/// # use soroban_sdk::{contract, contractimpl, BytesN};
 /// #
+/// # #[contract]
 /// # pub struct Contract;
 /// #
 /// # #[contractimpl]

--- a/soroban-sdk/src/lib.rs
+++ b/soroban-sdk/src/lib.rs
@@ -126,7 +126,7 @@ pub use bytes_lit::bytesmin as __bytes_lit_bytesmin;
 /// Defining an error and capturing errors using the `try_` variant.
 ///
 /// ```
-/// use soroban_sdk::{contracterror, contractimpl, Env};
+/// use soroban_sdk::{contract, contracterror, contractimpl, Env};
 ///
 /// #[contracterror]
 /// #[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
@@ -136,6 +136,7 @@ pub use bytes_lit::bytesmin as __bytes_lit_bytesmin;
 ///     AnotherError = 2,
 /// }
 ///
+/// #[contract]
 /// pub struct Contract;
 ///
 /// #[contractimpl]
@@ -170,7 +171,7 @@ pub use bytes_lit::bytesmin as __bytes_lit_bytesmin;
 /// Testing invocations that cause errors with `should_panic` instead of `try_`.
 ///
 /// ```should_panic
-/// # use soroban_sdk::{contracterror, contractimpl, Env};
+/// # use soroban_sdk::{contract, contracterror, contractimpl, Env};
 /// #
 /// # #[contracterror]
 /// # #[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
@@ -180,6 +181,7 @@ pub use bytes_lit::bytesmin as __bytes_lit_bytesmin;
 /// #     AnotherError = 2,
 /// # }
 /// #
+/// # #[contract]
 /// # pub struct Contract;
 /// #
 /// # #[contractimpl]
@@ -276,7 +278,7 @@ pub use soroban_sdk_macros::contractimport;
 /// using the generated client.
 ///
 /// ```
-/// use soroban_sdk::{contractimpl, vec, BytesN, Env, Symbol, Vec};
+/// use soroban_sdk::{contract, contractimpl, vec, BytesN, Env, Symbol, Vec};
 ///
 /// #[contract]
 /// pub struct HelloContract;

--- a/soroban-sdk/src/lib.rs
+++ b/soroban-sdk/src/lib.rs
@@ -8,8 +8,9 @@
 //! ### Examples
 //!
 //! ```rust
-//! use soroban_sdk::{contractimpl, vec, BytesN, Env, Symbol, Vec};
+//! use soroban_sdk::{contract, contractimpl, vec, BytesN, Env, Symbol, Vec};
 //!
+//! #[contract]
 //! pub struct HelloContract;
 //!
 //! #[contractimpl]
@@ -259,6 +260,52 @@ pub use soroban_sdk_macros::contracterror;
 /// ```
 pub use soroban_sdk_macros::contractimport;
 
+/// Marks a type as being the type that contract functions are attached for.
+///
+/// Use `#[contractimpl]` on impl blocks of this type to make those functions
+/// contract functions.
+///
+/// Note that a crate only ever exports a single contract. While there can be
+/// multiple types in a crate with `#[contract]`, when built as a wasm file and
+/// deployed the combination of all contract functions and all contracts within
+/// a crate will be seen as a single contract.
+///
+/// ### Examples
+///
+/// Define a contract with one function, `hello`, and call it from within a test
+/// using the generated client.
+///
+/// ```
+/// use soroban_sdk::{contractimpl, vec, BytesN, Env, Symbol, Vec};
+///
+/// #[contract]
+/// pub struct HelloContract;
+///
+/// #[contractimpl]
+/// impl HelloContract {
+///     pub fn hello(env: Env, to: Symbol) -> Vec<Symbol> {
+///         vec![&env, Symbol::short("Hello"), to]
+///     }
+/// }
+///
+/// #[test]
+/// fn test() {
+/// # }
+/// # #[cfg(feature = "testutils")]
+/// # fn main() {
+///     let env = Env::default();
+///     let contract_id = env.register_contract(None, HelloContract);
+///     let client = HelloContractClient::new(&env, &contract_id);
+///
+///     let words = client.hello(&Symbol::short("Dev"));
+///
+///     assert_eq!(words, vec![&env, Symbol::short("Hello"), Symbol::short("Dev"),]);
+/// }
+/// # #[cfg(not(feature = "testutils"))]
+/// # fn main() { }
+/// ```
+pub use soroban_sdk_macros::contract;
+
 /// Exports the publicly accessible functions to the Soroban environment.
 ///
 /// Functions that are publicly accessible in the implementation are invocable
@@ -270,8 +317,9 @@ pub use soroban_sdk_macros::contractimport;
 /// using the generated client.
 ///
 /// ```
-/// use soroban_sdk::{contractimpl, vec, BytesN, Env, Symbol, Vec};
+/// use soroban_sdk::{contract, contractimpl, vec, BytesN, Env, Symbol, Vec};
 ///
+/// #[contract]
 /// pub struct HelloContract;
 ///
 /// #[contractimpl]
@@ -306,10 +354,11 @@ pub use soroban_sdk_macros::contractimpl;
 /// ### Examples
 ///
 /// ```
-/// use soroban_sdk::{contractimpl, contractmeta, vec, BytesN, Env, Symbol, Vec};
+/// use soroban_sdk::{contract, contractimpl, contractmeta, vec, BytesN, Env, Symbol, Vec};
 ///
 /// contractmeta!(key="desc", val="hello world contract");
 ///
+/// #[contract]
 /// pub struct HelloContract;
 ///
 /// #[contractimpl]
@@ -362,7 +411,7 @@ pub use soroban_sdk_macros::contractmeta;
 ///
 /// ```
 /// #![no_std]
-/// use soroban_sdk::{contractimpl, contracttype, Env, Symbol};
+/// use soroban_sdk::{contract, contractimpl, contracttype, Env, Symbol};
 ///
 /// #[contracttype]
 /// #[derive(Clone, Default, Debug, Eq, PartialEq)]
@@ -371,6 +420,7 @@ pub use soroban_sdk_macros::contractmeta;
 ///     pub last_incr: u32,
 /// }
 ///
+/// #[contract]
 /// pub struct Contract;
 ///
 /// #[contractimpl]
@@ -427,7 +477,7 @@ pub use soroban_sdk_macros::contractmeta;
 ///
 /// ```
 /// #![no_std]
-/// use soroban_sdk::{contractimpl, contracttype, Symbol, Env};
+/// use soroban_sdk::{contract, contractimpl, contracttype, Symbol, Env};
 ///
 /// /// A tuple enum is stored as a two-element vector containing the name of
 /// /// the enum variant as a Symbol, then the value in the tuple.
@@ -456,6 +506,7 @@ pub use soroban_sdk_macros::contractmeta;
 ///     High = 2,
 /// }
 ///
+/// #[contract]
 /// pub struct Contract;
 ///
 /// #[contractimpl]
@@ -513,13 +564,14 @@ pub use soroban_sdk_macros::contracttype;
 /// ### Examples
 ///
 /// ```
-/// use soroban_sdk::{contractclient, contractimpl, vec, BytesN, Env, Symbol, Vec};
+/// use soroban_sdk::{contract, contractclient, contractimpl, vec, BytesN, Env, Symbol, Vec};
 ///
 /// #[contractclient(name = "Client")]
 /// pub trait HelloInteface {
 ///     fn hello(env: Env, to: Symbol) -> Vec<Symbol>;
 /// }
 ///
+/// #[contract]
 /// pub struct HelloContract;
 ///
 /// #[contractimpl]

--- a/soroban-sdk/src/storage.rs
+++ b/soroban-sdk/src/storage.rs
@@ -34,8 +34,9 @@ use crate::{
 /// ```
 /// use soroban_sdk::{Env, Symbol};
 ///
-/// # use soroban_sdk::{contractimpl, BytesN};
+/// # use soroban_sdk::{contract, contractimpl, BytesN};
 /// #
+/// # #[contract]
 /// # pub struct Contract;
 /// #
 /// # #[contractimpl]

--- a/soroban-sdk/src/tests/budget.rs
+++ b/soroban-sdk/src/tests/budget.rs
@@ -1,6 +1,7 @@
 use crate as soroban_sdk;
-use soroban_sdk::{contractimpl, map, xdr::ContractCostType, Env, Map};
+use soroban_sdk::{contract, contractimpl, map, xdr::ContractCostType, Env, Map};
 
+#[contract]
 pub struct Contract;
 
 #[contractimpl]

--- a/soroban-sdk/src/tests/contract_add_i32.rs
+++ b/soroban-sdk/src/tests/contract_add_i32.rs
@@ -1,7 +1,8 @@
 use crate as soroban_sdk;
-use soroban_sdk::{contractimpl, Env};
+use soroban_sdk::{contract, contractimpl, Env};
 use stellar_xdr::{ReadXdr, ScSpecEntry, ScSpecFunctionInputV0, ScSpecFunctionV0, ScSpecTypeDef};
 
+#[contract]
 pub struct Contract;
 
 #[contractimpl]

--- a/soroban-sdk/src/tests/contract_assert.rs
+++ b/soroban-sdk/src/tests/contract_assert.rs
@@ -1,7 +1,7 @@
 use crate as soroban_sdk;
-use soroban_sdk::{contractimpl, Env};
-use soroban_sdk_macros::contracterror;
+use soroban_sdk::{contract, contracterror, contractimpl, Env};
 
+#[contract]
 pub struct Contract;
 
 #[contracterror]

--- a/soroban-sdk/src/tests/contract_call_stack.rs
+++ b/soroban-sdk/src/tests/contract_call_stack.rs
@@ -1,6 +1,7 @@
 use crate::{self as soroban_sdk, Symbol};
-use soroban_sdk::{contractimpl, Address, BytesN, Env};
+use soroban_sdk::{contract, contractimpl, Address, BytesN, Env};
 
+#[contract]
 pub struct OuterContract;
 
 #[contractimpl]
@@ -28,6 +29,7 @@ impl OuterContract {
     }
 }
 
+#[contract]
 pub struct InnerContract;
 
 #[contractimpl]

--- a/soroban-sdk/src/tests/contract_docs.rs
+++ b/soroban-sdk/src/tests/contract_docs.rs
@@ -1,8 +1,9 @@
 mod fn_ {
     use crate as soroban_sdk;
-    use soroban_sdk::{contractimpl, Env};
+    use soroban_sdk::{contract, contractimpl, Env};
     use stellar_xdr::{ReadXdr, ScSpecEntry, ScSpecFunctionV0};
 
+    #[contract]
     pub struct Contract;
 
     #[contractimpl]

--- a/soroban-sdk/src/tests/contract_invoke.rs
+++ b/soroban-sdk/src/tests/contract_invoke.rs
@@ -1,6 +1,7 @@
 use crate as soroban_sdk;
-use soroban_sdk::{contractimpl, Env};
+use soroban_sdk::{contract, contractimpl, Env};
 
+#[contract]
 pub struct Contract;
 
 #[contractimpl]

--- a/soroban-sdk/src/tests/contract_overlapping_type_fn_names.rs
+++ b/soroban-sdk/src/tests/contract_overlapping_type_fn_names.rs
@@ -1,5 +1,5 @@
 use crate as soroban_sdk;
-use soroban_sdk::{contractimpl, contracttype, Env};
+use soroban_sdk::{contract, contractimpl, contracttype, Env};
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 #[contracttype]
@@ -7,6 +7,7 @@ pub struct State {
     pub a: i32,
 }
 
+#[contract]
 pub struct Contract;
 
 #[contractimpl]

--- a/soroban-sdk/src/tests/contract_snapshot.rs
+++ b/soroban-sdk/src/tests/contract_snapshot.rs
@@ -1,6 +1,7 @@
 use crate::{self as soroban_sdk};
-use soroban_sdk::{contractimpl, xdr, Address, Env, TryFromVal};
+use soroban_sdk::{contract, contractimpl, xdr, Address, Env, TryFromVal};
 
+#[contract]
 pub struct Contract;
 
 #[contractimpl]

--- a/soroban-sdk/src/tests/contract_store.rs
+++ b/soroban-sdk/src/tests/contract_store.rs
@@ -1,6 +1,7 @@
 use crate::{self as soroban_sdk};
-use soroban_sdk::{contractimpl, Env};
+use soroban_sdk::{contract, contractimpl, Env};
 
+#[contract]
 pub struct Contract;
 
 #[contractimpl]

--- a/soroban-sdk/src/tests/contract_udt_enum.rs
+++ b/soroban-sdk/src/tests/contract_udt_enum.rs
@@ -1,8 +1,8 @@
 use crate::{self as soroban_sdk, Symbol};
 use soroban_sdk::xdr::ScVec;
 use soroban_sdk::{
-    contractimpl, contracttype, vec, ConversionError, Env, IntoVal, TryFromVal, TryIntoVal, Val,
-    Vec,
+    contract, contractimpl, contracttype, vec, ConversionError, Env, IntoVal, TryFromVal,
+    TryIntoVal, Val, Vec,
 };
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
@@ -21,6 +21,7 @@ pub struct Udt2 {
     a: u32,
 }
 
+#[contract]
 pub struct Contract;
 
 #[contractimpl]

--- a/soroban-sdk/src/tests/contract_udt_struct.rs
+++ b/soroban-sdk/src/tests/contract_udt_struct.rs
@@ -1,5 +1,7 @@
 use crate as soroban_sdk;
-use soroban_sdk::{contractimpl, contracttype, map, ConversionError, Env, Symbol, TryFromVal};
+use soroban_sdk::{
+    contract, contractimpl, contracttype, map, ConversionError, Env, Symbol, TryFromVal,
+};
 use stellar_xdr::{
     ReadXdr, ScSpecEntry, ScSpecFunctionInputV0, ScSpecFunctionV0, ScSpecTypeDef, ScSpecTypeTuple,
     ScSpecTypeUdt,
@@ -27,6 +29,7 @@ pub struct UdtWithNonAlphabeticallyOrderedFields {
     pub a: i32,
 }
 
+#[contract]
 pub struct Contract;
 
 #[contractimpl]

--- a/soroban-sdk/src/tests/contract_udt_struct_tuple.rs
+++ b/soroban-sdk/src/tests/contract_udt_struct_tuple.rs
@@ -1,7 +1,7 @@
 use crate as soroban_sdk;
 use soroban_sdk::{
-    contractimpl, contracttype, vec, ConversionError, Env, IntoVal, TryFromVal, TryIntoVal, Val,
-    Vec,
+    contract, contractimpl, contracttype, vec, ConversionError, Env, IntoVal, TryFromVal,
+    TryIntoVal, Val, Vec,
 };
 use stellar_xdr::{
     ReadXdr, ScSpecEntry, ScSpecFunctionInputV0, ScSpecFunctionV0, ScSpecTypeDef, ScSpecTypeTuple,
@@ -12,6 +12,7 @@ use stellar_xdr::{
 #[contracttype]
 pub struct Udt(pub i32, pub i32);
 
+#[contract]
 pub struct Contract;
 
 #[contractimpl]

--- a/soroban-sdk/src/tests/contractimport.rs
+++ b/soroban-sdk/src/tests/contractimport.rs
@@ -1,5 +1,5 @@
 use crate as soroban_sdk;
-use soroban_sdk::{contractimpl, Address, BytesN, Env};
+use soroban_sdk::{contract, contractimpl, Address, BytesN, Env};
 use stellar_xdr::{ScSpecEntry, ScSpecFunctionInputV0, ScSpecFunctionV0, ScSpecTypeDef};
 
 mod addcontract {
@@ -11,6 +11,7 @@ mod addcontract {
 
 mod subcontract {
     use crate as soroban_sdk;
+    #[soroban_sdk::contract]
     pub struct Contract;
     #[soroban_sdk::contractimpl]
     impl Contract {
@@ -20,6 +21,7 @@ mod subcontract {
     }
 }
 
+#[contract]
 pub struct Contract;
 
 #[contractimpl(crate_path = "crate")]

--- a/soroban-sdk/src/tests/contractimport_with_error.rs
+++ b/soroban-sdk/src/tests/contractimport_with_error.rs
@@ -1,5 +1,5 @@
 use crate as soroban_sdk;
-use soroban_sdk::{contractimpl, Address, Env, Symbol};
+use soroban_sdk::{contract, contractimpl, Address, Env, Symbol};
 
 mod errcontract {
     use crate as soroban_sdk;
@@ -8,6 +8,7 @@ mod errcontract {
     );
 }
 
+#[contract]
 pub struct Contract;
 
 #[contractimpl]

--- a/soroban-sdk/src/tests/contractimport_with_sha256.rs
+++ b/soroban-sdk/src/tests/contractimport_with_sha256.rs
@@ -1,5 +1,5 @@
 use crate as soroban_sdk;
-use soroban_sdk::{contractimpl, Address, Env};
+use soroban_sdk::{contract, contractimpl, Address, Env};
 use stellar_xdr::{ScSpecEntry, ScSpecFunctionInputV0, ScSpecFunctionV0, ScSpecTypeDef};
 
 mod addcontract {
@@ -10,6 +10,7 @@ mod addcontract {
     );
 }
 
+#[contract]
 pub struct Contract;
 
 #[contractimpl]

--- a/soroban-sdk/src/tests/token_client.rs
+++ b/soroban-sdk/src/tests/token_client.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 
 use soroban_sdk::{
-    contractimpl, contracttype,
+    contract, contractimpl, contracttype,
     testutils::{Address as _, MockAuth, MockAuthInvoke},
     token::Client as TokenClient,
     Address, Env, IntoVal, Symbol,
@@ -19,6 +19,7 @@ fn get_token(e: &Env) -> Address {
     e.storage().persistent().get(&DataKey::Token).unwrap()
 }
 
+#[contract]
 pub struct TestContract;
 
 #[contractimpl]

--- a/soroban-sdk/src/testutils/mock_auth.rs
+++ b/soroban-sdk/src/testutils/mock_auth.rs
@@ -1,10 +1,10 @@
 #![cfg(any(test, feature = "testutils"))]
 
-use crate::{contractimpl, xdr, Address, Env, Symbol, Val, Vec};
+use crate::{contract, contractimpl, xdr, Address, Env, Symbol, TryFromVal, Val, Vec};
 use rand::{thread_rng, Rng};
-use soroban_env_host::TryFromVal;
 
 #[doc(hidden)]
+#[contract(crate_path = "crate")]
 pub struct MockAuthContract;
 
 #[contractimpl(crate_path = "crate")]

--- a/tests/add_i128/src/lib.rs
+++ b/tests/add_i128/src/lib.rs
@@ -1,6 +1,7 @@
 #![no_std]
-use soroban_sdk::contractimpl;
+use soroban_sdk::{contract, contractimpl};
 
+#[contract]
 pub struct Contract;
 
 #[contractimpl]

--- a/tests/add_u128/src/lib.rs
+++ b/tests/add_u128/src/lib.rs
@@ -1,6 +1,7 @@
 #![no_std]
-use soroban_sdk::contractimpl;
+use soroban_sdk::{contract, contractimpl};
 
+#[contract]
 pub struct Contract;
 
 #[contractimpl]

--- a/tests/add_u64/src/lib.rs
+++ b/tests/add_u64/src/lib.rs
@@ -1,6 +1,7 @@
 #![no_std]
-use soroban_sdk::contractimpl;
+use soroban_sdk::{contract, contractimpl};
 
+#[contract]
 pub struct Contract;
 
 #[contractimpl]

--- a/tests/alloc/src/lib.rs
+++ b/tests/alloc/src/lib.rs
@@ -1,8 +1,9 @@
 #![no_std]
-use soroban_sdk::{contractimpl, Env};
+use soroban_sdk::{contract, contractimpl, Env};
 
 extern crate alloc;
 
+#[contract]
 pub struct Contract;
 
 #[contractimpl]

--- a/tests/auth/src/lib.rs
+++ b/tests/auth/src/lib.rs
@@ -1,6 +1,7 @@
 #![no_std]
-use soroban_sdk::{contractimpl, Address, Env, IntoVal};
+use soroban_sdk::{contract, contractimpl, Address, Env, IntoVal};
 
+#[contract]
 pub struct ContractA;
 
 #[contractimpl]
@@ -186,6 +187,7 @@ mod test_a {
     mod auth_approve {
         use super::*;
 
+        #[contract]
         pub struct Contract;
 
         #[contractimpl]
@@ -198,6 +200,7 @@ mod test_a {
     mod auth_decline {
         use super::*;
 
+        #[contract]
         pub struct Contract;
 
         #[contracterror]
@@ -221,6 +224,7 @@ mod test_a {
     }
 }
 
+#[contract]
 pub struct ContractB;
 
 #[contractimpl]
@@ -458,6 +462,7 @@ mod test_b {
     mod auth_approve {
         use super::*;
 
+        #[contract]
         pub struct Contract;
 
         #[contractimpl]
@@ -470,6 +475,7 @@ mod test_b {
     mod auth_decline {
         use super::*;
 
+        #[contract]
         pub struct Contract;
 
         #[contracterror]

--- a/tests/contract_data/src/lib.rs
+++ b/tests/contract_data/src/lib.rs
@@ -1,6 +1,7 @@
 #![no_std]
-use soroban_sdk::{contractimpl, Env, Symbol};
+use soroban_sdk::{contract, contractimpl, Env, Symbol};
 
+#[contract]
 pub struct Contract;
 
 #[contractimpl]

--- a/tests/empty/src/lib.rs
+++ b/tests/empty/src/lib.rs
@@ -1,6 +1,7 @@
 #![no_std]
-use soroban_sdk::contractimpl;
+use soroban_sdk::{contract, contractimpl};
 
+#[contract]
 pub struct Contract;
 
 #[contractimpl]

--- a/tests/empty2/src/lib.rs
+++ b/tests/empty2/src/lib.rs
@@ -1,6 +1,7 @@
 #![no_std]
-use soroban_sdk::contractimpl;
+use soroban_sdk::{contract, contractimpl};
 
+#[contract]
 pub struct Contract;
 
 #[contractimpl]

--- a/tests/errors/src/lib.rs
+++ b/tests/errors/src/lib.rs
@@ -1,6 +1,7 @@
 #![no_std]
-use soroban_sdk::{contracterror, contractimpl, panic_with_error, Env, Symbol};
+use soroban_sdk::{contract, contracterror, contractimpl, panic_with_error, Env, Symbol};
 
+#[contract]
 pub struct Contract;
 
 #[contracterror]

--- a/tests/events/src/lib.rs
+++ b/tests/events/src/lib.rs
@@ -1,6 +1,7 @@
 #![no_std]
-use soroban_sdk::{contractimpl, Env, Symbol};
+use soroban_sdk::{contract, contractimpl, Env, Symbol};
 
+#[contract]
 pub struct Contract;
 
 #[contractimpl]

--- a/tests/fuzz/src/lib.rs
+++ b/tests/fuzz/src/lib.rs
@@ -1,6 +1,7 @@
 #![no_std]
-use soroban_sdk::{contractimpl, U256};
+use soroban_sdk::{contract, contractimpl, U256};
 
+#[contract]
 pub struct Contract;
 
 #[contractimpl]

--- a/tests/import_contract/src/lib.rs
+++ b/tests/import_contract/src/lib.rs
@@ -1,5 +1,5 @@
 #![no_std]
-use soroban_sdk::{contractimpl, Address, Env};
+use soroban_sdk::{contract, contractimpl, Address, Env};
 
 mod addcontract {
     soroban_sdk::contractimport!(
@@ -7,6 +7,7 @@ mod addcontract {
     );
 }
 
+#[contract]
 pub struct Contract;
 
 #[contractimpl]

--- a/tests/invoke_contract/src/lib.rs
+++ b/tests/invoke_contract/src/lib.rs
@@ -1,6 +1,7 @@
 #![no_std]
-use soroban_sdk::{contractimpl, vec, Address, Env, IntoVal, Symbol};
+use soroban_sdk::{contract, contractimpl, vec, Address, Env, IntoVal, Symbol};
 
+#[contract]
 pub struct Contract;
 
 #[contractimpl]
@@ -15,6 +16,7 @@ impl Contract {
     }
 }
 
+#[contract]
 pub struct AddContract;
 
 #[contractimpl]

--- a/tests/logging/src/lib.rs
+++ b/tests/logging/src/lib.rs
@@ -1,6 +1,7 @@
 #![no_std]
-use soroban_sdk::{contractimpl, log, Env, Symbol};
+use soroban_sdk::{contract, contractimpl, log, Env, Symbol};
 
+#[contract]
 pub struct Contract;
 
 #[contractimpl]

--- a/tests/udt/src/lib.rs
+++ b/tests/udt/src/lib.rs
@@ -1,5 +1,5 @@
 #![no_std]
-use soroban_sdk::{contractimpl, contracttype, Vec};
+use soroban_sdk::{contract, contractimpl, contracttype, Vec};
 
 #[contracttype]
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
@@ -29,6 +29,7 @@ pub struct UdtStruct {
     pub c: Vec<i64>,
 }
 
+#[contract]
 pub struct Contract;
 
 #[contractimpl]


### PR DESCRIPTION
### What
Add `#[contract]` macro that generates a contract client for the contract, and make #[contractimpl] only add functions to the existing contract client.

### Why
To support multiple `#[contractimpl]` per contract.

For contracts that have multiple impls, it is not ideal if there are multiple clients for that one contract. Ideally clients appear in the same way everywhere, and anyone importing the contract will see a single flat client.

Since macros cannot coordinate, there's no way for the first contractimpl to output the client struct and others to skip it. Today what happens is a compile error is shown because there are multiple clients generated.

Unblocks:
- #952 
- #965 
- And general better interoperability through trait sharing.

Close #268