### PR TITLE
Run builds on ci for mac and windows

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -6,7 +6,11 @@ on:
   pull_request:
 
 env:
-  RUSTFLAGS: -D warnings
+  RUSTFLAGS: -D warning
+
+defaults:
+  run:
+    shell: bashs
 
 jobs:
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -55,6 +55,14 @@ jobs:
         sys:
         - os: ubuntu-latest
           target: x86_64-unknown-linux-gnu
+        - os: ubuntu-latest
+          target: aarch64-unknown-linux-gnu
+        - os: macos-latest
+          target: x86_64-apple-darwin
+        - os: macos-latest
+          target: aarch64-apple-darwin
+        - os: windows-latest
+          target: x86_64-pc-windows-msvc
     runs-on: ${{ matrix.sys.os }}
     steps:
     - uses: actions/checkout@v3
@@ -68,7 +76,8 @@ jobs:
         version: 0.5.16
     - run: cargo hack build --target wasm32-unknown-unknown --profile release
     - run: cargo hack --feature-powerset --exclude-features docs build --target ${{ matrix.sys.target }}
-    - run: cargo hack --feature-powerset --ignore-unknown-features --features testutils --exclude-features docs test --target ${{ matrix.sys.target }}
+    - if: startsWith(matrix.sys.target, 'x86_64')
+      run: cargo hack --feature-powerset --ignore-unknown-features --features testutils --exclude-features docs test --target ${{ matrix.sys.target }}
 
   build-fuzz:
     runs-on: ubuntu-latest

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -73,7 +73,9 @@ jobs:
     - uses: stellar/actions/rust-cache@main
     - run: rustup update
     - run: rustup target add ${{ matrix.sys.target }}
-    - run: rustup target add wasm32-unknown-unknown
+    - run: rustup target add wasm32-unknown-unknow
+    - if: matrix.target == 'aarch64-unknown-linux-gnu'
+      run: sudo apt-get update && sudo apt-get -y install gcc-aarch64-linux-gnu g++-aarch64-linux-gnun
     - uses: stellar/binaries@v12
       with:
         name: cargo-hack

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -55,6 +55,7 @@ jobs:
 
   build-and-test:
     strategy:
+      fail-fast: false
       matrix:
         sys:
         - os: ubuntu-latest

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -73,9 +73,9 @@ jobs:
     - uses: stellar/actions/rust-cache@main
     - run: rustup update
     - run: rustup target add ${{ matrix.sys.target }}
-    - run: rustup target add wasm32-unknown-unknow
+    - run: rustup target add wasm32-unknown-unknown
     - if: matrix.target == 'aarch64-unknown-linux-gnu'
-      run: sudo apt-get update && sudo apt-get -y install gcc-aarch64-linux-gnu g++-aarch64-linux-gnun
+      run: sudo apt-get update && sudo apt-get -y install gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
     - uses: stellar/binaries@v12
       with:
         name: cargo-hack

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
 
 env:
-  RUSTFLAGS: -D warning
+  RUSTFLAGS: -D warnings
 
 defaults:
   run:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -74,10 +74,10 @@ jobs:
       with:
         name: cargo-hack
         version: 0.5.16
-    - run: cargo hack build --target wasm32-unknown-unknown --profile release
-    - run: cargo hack --feature-powerset --exclude-features docs build --target ${{ matrix.sys.target }}
+    - run: cargo-hack hack build --target wasm32-unknown-unknown --profile release
+    - run: cargo-hack hack --feature-powerset --exclude-features docs build --target ${{ matrix.sys.target }}
     - if: startsWith(matrix.sys.target, 'x86_64')
-      run: cargo hack --feature-powerset --ignore-unknown-features --features testutils --exclude-features docs test --target ${{ matrix.sys.target }}
+      run: cargo-hack hack --feature-powerset --ignore-unknown-features --features testutils --exclude-features docs test --target ${{ matrix.sys.target }}
 
   build-fuzz:
     runs-on: ubuntu-latest

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -60,8 +60,10 @@ jobs:
         sys:
         - os: ubuntu-latest
           target: x86_64-unknown-linux-gnu
-        - os: ubuntu-latest
-          target: aarch64-unknown-linux-gnu
+        # TODO: Figure out why builds are broken for linux arm64 and reenable.
+        # https://github.com/stellar/rs-soroban-sdk/issues/1011
+        # - os: ubuntu-latest
+        #   target: aarch64-unknown-linux-gnu
         - os: macos-latest
           target: x86_64-apple-darwin
         - os: macos-latest

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -10,7 +10,7 @@ env:
 
 defaults:
   run:
-    shell: bashs
+    shell: bash
 
 jobs:
 


### PR DESCRIPTION
### What
Run builds on ci for mac and windows

### Why
To ensure that developers on these other platforms can build and test contracts.