### PR TITLE
Split up the token interface trait

### DIFF
--- a/soroban-sdk/src/token.rs
+++ b/soroban-sdk/src/token.rs
@@ -21,6 +21,7 @@ use crate::{contractclient, contractspecfn, Address, Env, String};
 /// Spec contains the contract spec of Token contracts, including the general
 /// interface, as well as the admin interface, such as the Stellar Asset
 /// Contract.
+#[doc(hidden)]
 pub struct Spec;
 
 /// Interface for Token contracts, such as the Stellar Asset Contract.

--- a/soroban-sdk/src/token.rs
+++ b/soroban-sdk/src/token.rs
@@ -18,8 +18,9 @@ use crate::{contractclient, contractspecfn, Address, Env, String};
 // 2. The implementations have been replaced with a panic.
 // 3. &Host type usage are replaced with Env
 
-/// Spec contains the contract spec of Token contracts, such as the Stellar
-/// Asset Contract.
+/// Spec contains the contract spec of Token contracts, including the general
+/// interface, as well as the admin interface, such as the Stellar Asset
+/// Contract.
 pub struct Spec;
 
 /// Interface for Token contracts, such as the Stellar Asset Contract.
@@ -156,6 +157,46 @@ pub trait Interface {
     /// i128]`
     fn burn_from(env: Env, spender: Address, from: Address, amount: i128);
 
+    /// Returns the number of decimals used to represent amounts of this token.
+    ///
+    /// # Panics
+    ///
+    /// If the contract has not yet been initialized.
+    fn decimals(env: Env) -> u32;
+
+    /// Returns the name for this token.
+    ///
+    /// # Panics
+    ///
+    /// If the contract has not yet been initialized.
+    fn name(env: Env) -> String;
+
+    /// Returns the symbol for this token.
+    ///
+    /// # Panics
+    ///
+    /// If the contract has not yet been initialized.
+    fn symbol(env: Env) -> String;
+}
+
+/// Interface for admin capabilities for Token contracts, such as the Stellar
+/// Asset Contract.
+#[contractspecfn(name = "Spec", export = false)]
+#[contractclient(crate_path = "crate", name = "AdminClient")]
+pub trait AdminInterface {
+    /// Sets the administrator to the specified address `new_admin`.
+    ///
+    /// # Arguments
+    ///
+    /// * `new_admin` - The address which will henceforth be the administrator
+    ///   of this token contract.
+    ///
+    /// # Events
+    ///
+    /// Emits an event with topics `["set_admin", admin: Address], data =
+    /// [new_admin: Address]`
+    fn set_admin(env: Env, new_admin: Address);
+
     /// Sets whether the account is authorized to use its balance. If
     /// `authorized` is true, `id` should be able to use its balance.
     ///
@@ -197,40 +238,6 @@ pub trait Interface {
     /// Emits an event with topics `["clawback", admin: Address, to: Address],
     /// data = [amount: i128]`
     fn clawback(env: Env, from: Address, amount: i128);
-
-    /// Sets the administrator to the specified address `new_admin`.
-    ///
-    /// # Arguments
-    ///
-    /// * `new_admin` - The address which will henceforth be the administrator
-    ///   of this token contract.
-    ///
-    /// # Events
-    ///
-    /// Emits an event with topics `["set_admin", admin: Address], data =
-    /// [new_admin: Address]`
-    fn set_admin(env: Env, new_admin: Address);
-
-    /// Returns the number of decimals used to represent amounts of this token.
-    ///
-    /// # Panics
-    ///
-    /// If the contract has not yet been initialized.
-    fn decimals(env: Env) -> u32;
-
-    /// Returns the name for this token.
-    ///
-    /// # Panics
-    ///
-    /// If the contract has not yet been initialized.
-    fn name(env: Env) -> String;
-
-    /// Returns the symbol for this token.
-    ///
-    /// # Panics
-    ///
-    /// If the contract has not yet been initialized.
-    fn symbol(env: Env) -> String;
 }
 
 pub(crate) const SPEC_XDR_INPUT: &[&[u8]] = &[


### PR DESCRIPTION
### What
Separate admin functions in the token interface out to a separate trait.

### Why
The primary standard interface of tokens won't include the admin functions. Although many tokens on Soroban will have the admin functions because all Stellar Asset Contracts will have them.

We still want it to be convenient for folks to follow that same admin pattern if its a fit, but contracts shouldn't have to implement them if their follow a different pattern for admin operations.

This issue was discussed [on Discord](https://discord.com/channels/897514728459468821/1114325793926037605), and some folks suggested allowances should also be broken into a separate trait. However this seemed more controversial and there were also opinions that they shouldn't be separated, so I've kept them in for now.

Note that the Spec value in the SDK will continue to hold the entire token interface. It's not particularly useful to split that up, as the only user of it is the soroban-cli when interacting with Stellar Asset Contracts. I've hidden it from docs since it isn't routinely useful to most.

Close #965