### PR TITLE
Bring back the symbol macro

### DIFF
--- a/soroban-sdk-macros/src/lib.rs
+++ b/soroban-sdk-macros/src/lib.rs
@@ -42,16 +42,27 @@ use stellar_xdr::{ScMetaEntry, ScMetaV0, StringM, WriteXdr};
 use soroban_env_common::Symbol;
 
 #[proc_macro]
+pub fn internal_symbol_short(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as LitStr);
+    _symbol_short("crate", &input)
+}
+
+#[proc_macro]
 pub fn symbol_short(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as LitStr);
-    match Symbol::try_from_small_str(&input.value()) {
+    _symbol_short("soroban_sdk", &input)
+}
+
+fn _symbol_short(crate_path: &str, s: &LitStr) -> TokenStream {
+    let crate_path = format_ident!("{crate_path}");
+    match Symbol::try_from_small_str(&s.value()) {
         Ok(_) => quote! {{
             #[allow(deprecated)]
-            const symbol: soroban_sdk::Symbol = soroban_sdk::Symbol::short(#input);
+            const symbol: #crate_path::Symbol = #crate_path::Symbol::short(#s);
             symbol
         }}
         .into(),
-        Err(e) => Error::new(input.span(), format!("{e}"))
+        Err(e) => Error::new(s.span(), format!("{e}"))
             .to_compile_error()
             .into(),
     }

--- a/soroban-sdk-macros/src/lib.rs
+++ b/soroban-sdk-macros/src/lib.rs
@@ -46,6 +46,7 @@ pub fn symbol_short(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as LitStr);
     match Symbol::try_from_small_str(&input.value()) {
         Ok(_) => quote! {{
+            #[allow(deprecated)]
             const symbol: soroban_sdk::Symbol = soroban_sdk::Symbol::short(#input);
             symbol
         }}

--- a/soroban-sdk/README.md
+++ b/soroban-sdk/README.md
@@ -15,7 +15,7 @@ pub struct HelloContract;
 #[contractimpl]
 impl HelloContract {
     pub fn hello(env: Env, to: Symbol) -> Vec<Symbol> {
-        vec![&env, Symbol::short("Hello"), to]
+        vec![&env, symbol_short!("Hello"), to]
     }
 }
 
@@ -25,9 +25,9 @@ fn test() {
     let contract_id = env.register_contract(None, HelloContract);
     let client = HelloContractClient::new(&env, &contract_id);
 
-    let words = client.hello(&Symbol::short("Dev"));
+    let words = client.hello(&symbol_short!("Dev"));
 
-    assert_eq!(words, vec![&env, Symbol::short("Hello"), Symbol::short("Dev"),]);
+    assert_eq!(words, vec![&env, symbol_short!("Hello"), symbol_short!("Dev"),]);
 }
 ```
 

--- a/soroban-sdk/src/env.rs
+++ b/soroban-sdk/src/env.rs
@@ -703,7 +703,7 @@ impl Env {
         self.env_impl.switch_to_recording_auth();
         self.invoke_contract::<()>(
             &token_id,
-            &crate::Symbol::short("set_admin"),
+            &crate::symbol_short!("set_admin"),
             (admin,).try_into_val(self).unwrap(),
         );
         self.env_impl.set_auth_manager(prev_auth_manager);
@@ -935,7 +935,7 @@ impl Env {
     ///             AuthorizedInvocation {
     ///                 function: AuthorizedFunction::Contract((
     ///                     client.address.clone(),
-    ///                     Symbol::short("transfer"),
+    ///                     symbol_short!("transfer"),
     ///                     (&address, 1000_i128,).into_val(&env)
     ///                 )),
     ///                 sub_invocations: std::vec![]
@@ -951,7 +951,7 @@ impl Env {
     ///             AuthorizedInvocation {
     ///                 function: AuthorizedFunction::Contract((
     ///                     client.address.clone(),
-    ///                     Symbol::short("transfer2"),
+    ///                     symbol_short!("transfer2"),
     ///                     // `transfer2` requires auth for (amount / 2) == (1000 / 2) == 500.
     ///                     (500_i128,).into_val(&env)
     ///                 )),

--- a/soroban-sdk/src/env.rs
+++ b/soroban-sdk/src/env.rs
@@ -703,7 +703,7 @@ impl Env {
         self.env_impl.switch_to_recording_auth();
         self.invoke_contract::<()>(
             &token_id,
-            &crate::symbol_short!("set_admin"),
+            &soroban_sdk_macros::internal_symbol_short!("set_admin"),
             (admin,).try_into_val(self).unwrap(),
         );
         self.env_impl.set_auth_manager(prev_auth_manager);
@@ -901,7 +901,7 @@ impl Env {
     ///
     /// ### Examples
     /// ```
-    /// use soroban_sdk::{contract, contractimpl, testutils::{Address as _, AuthorizedFunction, AuthorizedInvocation}, Address, Symbol, Env, IntoVal};
+    /// use soroban_sdk::{contract, contractimpl, testutils::{Address as _, AuthorizedFunction, AuthorizedInvocation}, symbol_short, Address, Symbol, Env, IntoVal};
     ///
     /// #[contract]
     /// pub struct Contract;

--- a/soroban-sdk/src/lib.rs
+++ b/soroban-sdk/src/lib.rs
@@ -16,7 +16,7 @@
 //! #[contractimpl]
 //! impl HelloContract {
 //!     pub fn hello(env: Env, to: Symbol) -> Vec<Symbol> {
-//!         vec![&env, Symbol::short("Hello"), to]
+//!         vec![&env, symbol_short!("Hello"), to]
 //!     }
 //! }
 //!
@@ -29,9 +29,9 @@
 //!     let contract_id = env.register_contract(None, HelloContract);
 //!     let client = HelloContractClient::new(&env, &contract_id);
 //!
-//!     let words = client.hello(&Symbol::short("Dev"));
+//!     let words = client.hello(&symbol_short!("Dev"));
 //!
-//!     assert_eq!(words, vec![&env, Symbol::short("Hello"), Symbol::short("Dev"),]);
+//!     assert_eq!(words, vec![&env, symbol_short!("Hello"), symbol_short!("Dev"),]);
 //! }
 //! # #[cfg(not(feature = "testutils"))]
 //! # fn main() { }
@@ -115,6 +115,25 @@ pub mod reexports_for_macros {
     #[cfg(any(test, feature = "testutils"))]
     pub use ::ctor;
 }
+
+/// Create a short [Symbol] constant with the given string.
+///
+/// A short symbol's maximum length is 9 characters. For longer symbols, use
+/// [Symbol::new] to create the symbol at runtime.
+///
+/// Valid characters are `a-zA-Z0-9_`.
+///
+/// The [Symbol] is generated at compile time and returned as a const.
+///
+/// ### Examples
+///
+/// ```
+/// use soroban_sdk::{symbol, Symbol};
+///
+/// let symbol = symbol_short!("a_str");
+/// assert_eq!(symbol, symbol_short!("a_str"));
+/// ```
+pub use soroban_sdk_macros::symbol_short;
 
 /// Generates conversions from the repr(u32) enum from/into an `Error`.
 ///
@@ -291,7 +310,7 @@ pub use soroban_sdk_macros::contractimport;
 /// #[contractimpl]
 /// impl HelloContract {
 ///     pub fn hello(env: Env, to: Symbol) -> Vec<Symbol> {
-///         vec![&env, Symbol::short("Hello"), to]
+///         vec![&env, symbol_short!("Hello"), to]
 ///     }
 /// }
 ///
@@ -304,9 +323,9 @@ pub use soroban_sdk_macros::contractimport;
 ///     let contract_id = env.register_contract(None, HelloContract);
 ///     let client = HelloContractClient::new(&env, &contract_id);
 ///
-///     let words = client.hello(&Symbol::short("Dev"));
+///     let words = client.hello(&symbol_short!("Dev"));
 ///
-///     assert_eq!(words, vec![&env, Symbol::short("Hello"), Symbol::short("Dev"),]);
+///     assert_eq!(words, vec![&env, symbol_short!("Hello"), symbol_short!("Dev"),]);
 /// }
 /// # #[cfg(not(feature = "testutils"))]
 /// # fn main() { }
@@ -332,7 +351,7 @@ pub use soroban_sdk_macros::contract;
 /// #[contractimpl]
 /// impl HelloContract {
 ///     pub fn hello(env: Env, to: Symbol) -> Vec<Symbol> {
-///         vec![&env, Symbol::short("Hello"), to]
+///         vec![&env, symbol_short!("Hello"), to]
 ///     }
 /// }
 ///
@@ -345,9 +364,9 @@ pub use soroban_sdk_macros::contract;
 ///     let contract_id = env.register_contract(None, HelloContract);
 ///     let client = HelloContractClient::new(&env, &contract_id);
 ///
-///     let words = client.hello(&Symbol::short("Dev"));
+///     let words = client.hello(&symbol_short!("Dev"));
 ///
-///     assert_eq!(words, vec![&env, Symbol::short("Hello"), Symbol::short("Dev"),]);
+///     assert_eq!(words, vec![&env, symbol_short!("Hello"), symbol_short!("Dev"),]);
 /// }
 /// # #[cfg(not(feature = "testutils"))]
 /// # fn main() { }
@@ -371,7 +390,7 @@ pub use soroban_sdk_macros::contractimpl;
 /// #[contractimpl]
 /// impl HelloContract {
 ///     pub fn hello(env: Env, to: Symbol) -> Vec<Symbol> {
-///         vec![&env, Symbol::short("Hello"), to]
+///         vec![&env, symbol_short!("Hello"), to]
 ///     }
 /// }
 ///
@@ -385,9 +404,9 @@ pub use soroban_sdk_macros::contractimpl;
 ///     let contract_id = env.register_contract(None, HelloContract);
 ///     let client = HelloContractClient::new(&env, &contract_id);
 ///
-///     let words = client.hello(&Symbol::short("Dev"));
+///     let words = client.hello(&symbol_short!("Dev"));
 ///
-///     assert_eq!(words, vec![&env, Symbol::short("Hello"), Symbol::short("Dev"),]);
+///     assert_eq!(words, vec![&env, symbol_short!("Hello"), symbol_short!("Dev"),]);
 /// }
 /// # #[cfg(not(feature = "testutils"))]
 /// # fn main() { }
@@ -442,7 +461,7 @@ pub use soroban_sdk_macros::contractmeta;
 ///         state.last_incr = incr;
 ///
 ///         // Save the count.
-///         env.storage().persistent().set(&Symbol::short("STATE"), &state, None);
+///         env.storage().persistent().set(&symbol_short!("STATE"), &state, None);
 ///
 ///         // Return the count to the caller.
 ///         state.count
@@ -451,7 +470,7 @@ pub use soroban_sdk_macros::contractmeta;
 ///     /// Return the current state.
 ///     pub fn get_state(env: Env) -> State {
 ///         env.storage().persistent()
-///             .get(&Symbol::short("STATE"))
+///             .get(&symbol_short!("STATE"))
 ///             .unwrap_or_else(|| State::default()) // If no value set, assume 0.
 ///     }
 /// }
@@ -520,13 +539,13 @@ pub use soroban_sdk_macros::contractmeta;
 /// impl Contract {
 ///     /// Set the color.
 ///     pub fn set(env: Env, c: Color) {
-///         env.storage().persistent().set(&Symbol::short("COLOR"), &c, None);
+///         env.storage().persistent().set(&symbol_short!("COLOR"), &c, None);
 ///     }
 ///
 ///     /// Get the color.
 ///     pub fn get(env: Env) -> Option<Color> {
 ///         env.storage().persistent()
-///             .get(&Symbol::short("COLOR"))
+///             .get(&symbol_short!("COLOR"))
 ///     }
 /// }
 ///
@@ -584,7 +603,7 @@ pub use soroban_sdk_macros::contracttype;
 /// #[contractimpl]
 /// impl HelloContract {
 ///     pub fn hello(env: Env, to: Symbol) -> Vec<Symbol> {
-///         vec![&env, Symbol::short("Hello"), to]
+///         vec![&env, symbol_short!("Hello"), to]
 ///     }
 /// }
 ///
@@ -602,9 +621,9 @@ pub use soroban_sdk_macros::contracttype;
 ///     // the trait.
 ///     let client = Client::new(&env, &contract_id);
 ///
-///     let words = client.hello(&Symbol::short("Dev"));
+///     let words = client.hello(&symbol_short!("Dev"));
 ///
-///     assert_eq!(words, vec![&env, Symbol::short("Hello"), Symbol::short("Dev"),]);
+///     assert_eq!(words, vec![&env, symbol_short!("Hello"), symbol_short!("Dev"),]);
 /// }
 /// # #[cfg(not(feature = "testutils"))]
 /// # fn main() { }

--- a/soroban-sdk/src/lib.rs
+++ b/soroban-sdk/src/lib.rs
@@ -8,7 +8,7 @@
 //! ### Examples
 //!
 //! ```rust
-//! use soroban_sdk::{contract, contractimpl, vec, BytesN, Env, Symbol, Vec};
+//! use soroban_sdk::{contract, contractimpl, vec, symbol_short, BytesN, Env, Symbol, Vec};
 //!
 //! #[contract]
 //! pub struct HelloContract;
@@ -128,7 +128,7 @@ pub mod reexports_for_macros {
 /// ### Examples
 ///
 /// ```
-/// use soroban_sdk::{symbol, Symbol};
+/// use soroban_sdk::{symbol_short, Symbol};
 ///
 /// let symbol = symbol_short!("a_str");
 /// assert_eq!(symbol, symbol_short!("a_str"));
@@ -302,7 +302,7 @@ pub use soroban_sdk_macros::contractimport;
 /// using the generated client.
 ///
 /// ```
-/// use soroban_sdk::{contract, contractimpl, vec, BytesN, Env, Symbol, Vec};
+/// use soroban_sdk::{contract, contractimpl, vec, symbol_short, BytesN, Env, Symbol, Vec};
 ///
 /// #[contract]
 /// pub struct HelloContract;
@@ -343,7 +343,7 @@ pub use soroban_sdk_macros::contract;
 /// using the generated client.
 ///
 /// ```
-/// use soroban_sdk::{contract, contractimpl, vec, BytesN, Env, Symbol, Vec};
+/// use soroban_sdk::{contract, contractimpl, vec, symbol_short, BytesN, Env, Symbol, Vec};
 ///
 /// #[contract]
 /// pub struct HelloContract;
@@ -380,7 +380,7 @@ pub use soroban_sdk_macros::contractimpl;
 /// ### Examples
 ///
 /// ```
-/// use soroban_sdk::{contract, contractimpl, contractmeta, vec, BytesN, Env, Symbol, Vec};
+/// use soroban_sdk::{contract, contractimpl, contractmeta, vec, symbol_short, BytesN, Env, Symbol, Vec};
 ///
 /// contractmeta!(key="desc", val="hello world contract");
 ///
@@ -437,7 +437,7 @@ pub use soroban_sdk_macros::contractmeta;
 ///
 /// ```
 /// #![no_std]
-/// use soroban_sdk::{contract, contractimpl, contracttype, Env, Symbol};
+/// use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, Env, Symbol};
 ///
 /// #[contracttype]
 /// #[derive(Clone, Default, Debug, Eq, PartialEq)]
@@ -503,7 +503,7 @@ pub use soroban_sdk_macros::contractmeta;
 ///
 /// ```
 /// #![no_std]
-/// use soroban_sdk::{contract, contractimpl, contracttype, Symbol, Env};
+/// use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, Symbol, Env};
 ///
 /// /// A tuple enum is stored as a two-element vector containing the name of
 /// /// the enum variant as a Symbol, then the value in the tuple.
@@ -590,7 +590,7 @@ pub use soroban_sdk_macros::contracttype;
 /// ### Examples
 ///
 /// ```
-/// use soroban_sdk::{contract, contractclient, contractimpl, vec, BytesN, Env, Symbol, Vec};
+/// use soroban_sdk::{contract, contractclient, contractimpl, vec, symbol_short, BytesN, Env, Symbol, Vec};
 ///
 /// #[contractclient(name = "Client")]
 /// pub trait HelloInteface {

--- a/soroban-sdk/src/logs.rs
+++ b/soroban-sdk/src/logs.rs
@@ -47,7 +47,7 @@ use crate::{env::internal::EnvBase, Env, Val};
 /// let env = Env::default();
 ///
 /// let value = 5;
-/// log!(&env, "a log entry", value, Symbol::short("another"));
+/// log!(&env, "a log entry", value, symbol_short!("another"));
 /// ```
 ///
 /// Assert on logs in tests:
@@ -60,7 +60,7 @@ use crate::{env::internal::EnvBase, Env, Val};
 /// let env = Env::default();
 ///
 /// let value = 5;
-/// log!(&env, "a log entry", value, Symbol::short("another"));
+/// log!(&env, "a log entry", value, symbol_short!("another"));
 ///
 /// use soroban_sdk::testutils::Logs;
 /// let logentry = env.logs().all().last().unwrap().clone();

--- a/soroban-sdk/src/logs.rs
+++ b/soroban-sdk/src/logs.rs
@@ -42,7 +42,7 @@ use crate::{env::internal::EnvBase, Env, Val};
 /// Log a string with values:
 ///
 /// ```
-/// use soroban_sdk::{log, Symbol, Env};
+/// use soroban_sdk::{log, symbol_short, Symbol, Env};
 ///
 /// let env = Env::default();
 ///
@@ -55,7 +55,7 @@ use crate::{env::internal::EnvBase, Env, Val};
 /// ```
 /// # #[cfg(feature = "testutils")]
 /// # {
-/// use soroban_sdk::{log, Symbol, Env};
+/// use soroban_sdk::{log, symbol_short, Symbol, Env};
 ///
 /// let env = Env::default();
 ///

--- a/soroban-sdk/src/storage.rs
+++ b/soroban-sdk/src/storage.rs
@@ -34,7 +34,7 @@ use crate::{
 /// ```
 /// use soroban_sdk::{Env, Symbol};
 ///
-/// # use soroban_sdk::{contract, contractimpl, BytesN};
+/// # use soroban_sdk::{contract, contractimpl, symbol_short, BytesN};
 /// #
 /// # #[contract]
 /// # pub struct Contract;

--- a/soroban-sdk/src/storage.rs
+++ b/soroban-sdk/src/storage.rs
@@ -43,7 +43,7 @@ use crate::{
 /// # impl Contract {
 /// #     pub fn f(env: Env) {
 /// let storage = env.storage();
-/// let key = Symbol::short("key");
+/// let key = symbol_short!("key");
 /// storage.persistent().set(&key, &1, None);
 /// assert_eq!(storage.persistent().has(&key), true);
 /// assert_eq!(storage.persistent().get::<_, i32>(&key), Some(1));

--- a/soroban-sdk/src/symbol.rs
+++ b/soroban-sdk/src/symbol.rs
@@ -213,6 +213,7 @@ impl Symbol {
     ///
     /// When the input string is not representable by Symbol.
     #[doc(hidden)]
+    #[deprecated(note = "use [symbol_short!()]")]
     pub const fn short(s: &str) -> Self {
         if let Ok(sym) = SymbolSmall::try_from_str(s) {
             Symbol {

--- a/soroban-sdk/src/symbol.rs
+++ b/soroban-sdk/src/symbol.rs
@@ -212,6 +212,7 @@ impl Symbol {
     /// ### Panics
     ///
     /// When the input string is not representable by Symbol.
+    #[doc(hidden)]
     pub const fn short(s: &str) -> Self {
         if let Ok(sym) = SymbolSmall::try_from_str(s) {
             Symbol {

--- a/soroban-sdk/src/symbol.rs
+++ b/soroban-sdk/src/symbol.rs
@@ -190,6 +190,8 @@ impl Symbol {
     /// Valid characters are `a-zA-Z0-9_` and maximum string length is 32
     /// characters.
     ///
+    /// Use `symbol_short!` for constant symbols that are 9 characters or less.
+    ///
     /// Use `Symbol::try_from_val(env, s)`/`s.try_into_val(env)` in case if
     /// failures need to be handled gracefully.
     ///

--- a/soroban-sdk/src/tests/contract_call_stack.rs
+++ b/soroban-sdk/src/tests/contract_call_stack.rs
@@ -1,5 +1,5 @@
-use crate::{self as soroban_sdk, Symbol};
-use soroban_sdk::{contract, contractimpl, Address, BytesN, Env};
+use crate::{self as soroban_sdk};
+use soroban_sdk::{contract, contractimpl, symbol_short, Address, BytesN, Env};
 
 #[contract]
 pub struct OuterContract;

--- a/soroban-sdk/src/tests/contract_call_stack.rs
+++ b/soroban-sdk/src/tests/contract_call_stack.rs
@@ -15,7 +15,7 @@ impl OuterContract {
                 outer.0,
                 Address::from_contract_id(&BytesN::from_array(&env, &[1u8; 32]))
             );
-            assert_eq!(outer.1, Symbol::short("outer"));
+            assert_eq!(outer.1, symbol_short!("outer"));
         };
 
         // Check before the inner call
@@ -43,14 +43,14 @@ impl InnerContract {
             outer.0,
             Address::from_contract_id(&BytesN::from_array(&env, &[1u8; 32]))
         );
-        assert_eq!(outer.1, Symbol::short("outer"));
+        assert_eq!(outer.1, symbol_short!("outer"));
 
         let inner = stack.get_unchecked(1);
         assert_eq!(
             inner.0,
             Address::from_contract_id(&BytesN::from_array(&env, &[0u8; 32]))
         );
-        assert_eq!(inner.1, Symbol::short("inner"));
+        assert_eq!(inner.1, symbol_short!("inner"));
     }
 }
 

--- a/soroban-sdk/src/tests/contract_udt_enum.rs
+++ b/soroban-sdk/src/tests/contract_udt_enum.rs
@@ -50,10 +50,10 @@ fn test_error_on_partial_decode() {
     // Success case, a vec will decode to a Udt if the first element is the
     // variant name as a Symbol, and following elements are tuple-like values
     // for the variant.
-    let vec: Vec<Val> = vec![&env, Symbol::short("Aaa").into_val(&env)];
+    let vec: Vec<Val> = vec![&env, symbol_short!("Aaa").into_val(&env)];
     let udt = Udt::try_from_val(&env, &vec.to_val());
     assert_eq!(udt, Ok(Udt::Aaa));
-    let vec: Vec<Val> = vec![&env, Symbol::short("Bbb").into_val(&env), 8.into()];
+    let vec: Vec<Val> = vec![&env, symbol_short!("Bbb").into_val(&env), 8.into()];
     let udt = Udt::try_from_val(&env, &vec.to_val());
     assert_eq!(udt, Ok(Udt::Bbb(8)));
 
@@ -61,12 +61,12 @@ fn test_error_on_partial_decode() {
     // multiple values, it is an error. It is an error because decoding and
     // encoding will not round trip the data, and therefore partial decoding is
     // relatively difficult to use safely.
-    let vec: Vec<Val> = vec![&env, Symbol::short("Aaa").into_val(&env), 8.into()];
+    let vec: Vec<Val> = vec![&env, symbol_short!("Aaa").into_val(&env), 8.into()];
     let udt = Udt::try_from_val(&env, &vec.to_val());
     assert_eq!(udt, Err(ConversionError));
     let vec: Vec<Val> = vec![
         &env,
-        Symbol::short("Bbb").into_val(&env),
+        symbol_short!("Bbb").into_val(&env),
         8.into(),
         9.into(),
     ];

--- a/soroban-sdk/src/tests/contract_udt_enum.rs
+++ b/soroban-sdk/src/tests/contract_udt_enum.rs
@@ -1,8 +1,8 @@
-use crate::{self as soroban_sdk, Symbol};
+use crate::{self as soroban_sdk};
 use soroban_sdk::xdr::ScVec;
 use soroban_sdk::{
-    contract, contractimpl, contracttype, vec, ConversionError, Env, IntoVal, TryFromVal,
-    TryIntoVal, Val, Vec,
+    contract, contractimpl, contracttype, symbol_short, vec, ConversionError, Env, IntoVal,
+    TryFromVal, TryIntoVal, Val, Vec,
 };
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]

--- a/soroban-sdk/src/tests/contract_udt_struct.rs
+++ b/soroban-sdk/src/tests/contract_udt_struct.rs
@@ -1,6 +1,6 @@
 use crate as soroban_sdk;
 use soroban_sdk::{
-    contract, contractimpl, contracttype, map, ConversionError, Env, Symbol, TryFromVal,
+    contract, contractimpl, contracttype, map, symbol_short, ConversionError, Env, TryFromVal,
 };
 use stellar_xdr::{
     ReadXdr, ScSpecEntry, ScSpecFunctionInputV0, ScSpecFunctionV0, ScSpecTypeDef, ScSpecTypeTuple,

--- a/soroban-sdk/src/tests/contract_udt_struct.rs
+++ b/soroban-sdk/src/tests/contract_udt_struct.rs
@@ -77,10 +77,10 @@ fn test_out_of_order_functional() {
 
     let map = map![
         &env,
-        (Symbol::short("a"), 5),
-        (Symbol::short("b"), 7),
-        (Symbol::short("ba"), 9),
-        (Symbol::short("bb"), 11)
+        (symbol_short!("a"), 5),
+        (symbol_short!("b"), 7),
+        (symbol_short!("ba"), 9),
+        (symbol_short!("bb"), 11)
     ]
     .to_val();
     let udt = UdtWithNonAlphabeticallyOrderedFields::try_from_val(&env, &map);
@@ -104,7 +104,7 @@ fn test_error_on_partial_decode() {
 
     // Success case, a map will decode to a Udt if the symbol keys match the
     // fields.
-    let map = map![&env, (Symbol::short("a"), 5), (Symbol::short("b"), 7)].to_val();
+    let map = map![&env, (symbol_short!("a"), 5), (symbol_short!("b"), 7)].to_val();
     let udt = Udt::try_from_val(&env, &map);
     assert_eq!(udt, Ok(Udt { a: 5, b: 7 }));
 
@@ -114,9 +114,9 @@ fn test_error_on_partial_decode() {
     // is relatively difficult to use safely.
     let map = map![
         &env,
-        (Symbol::short("a"), 5),
-        (Symbol::short("b"), 7),
-        (Symbol::short("c"), 9)
+        (symbol_short!("a"), 5),
+        (symbol_short!("b"), 7),
+        (symbol_short!("c"), 9)
     ]
     .to_val();
     let udt = Udt::try_from_val(&env, &map);

--- a/soroban-sdk/src/tests/contractimport_with_error.rs
+++ b/soroban-sdk/src/tests/contractimport_with_error.rs
@@ -1,5 +1,5 @@
 use crate as soroban_sdk;
-use soroban_sdk::{contract, contractimpl, Address, Env, Symbol};
+use soroban_sdk::{contract, contractimpl, symbol_short, Address, Env, Symbol};
 
 mod errcontract {
     use crate as soroban_sdk;

--- a/soroban-sdk/src/tests/contractimport_with_error.rs
+++ b/soroban-sdk/src/tests/contractimport_with_error.rs
@@ -28,5 +28,5 @@ fn test_functional() {
     let client = ContractClient::new(&e, &contract_id);
 
     let z = client.hello_with(&err_contract_id, &0);
-    assert!(z == Symbol::short("hello"));
+    assert!(z == symbol_short!("hello"));
 }

--- a/soroban-token-sdk/src/lib.rs
+++ b/soroban-token-sdk/src/lib.rs
@@ -1,8 +1,8 @@
 #![no_std]
 
-use soroban_sdk::{contracttype, unwrap::UnwrapOptimized, Env, String, Symbol};
+use soroban_sdk::{contracttype, symbol_short, unwrap::UnwrapOptimized, Env, String, Symbol};
 
-const METADATA_KEY: Symbol = Symbol::short("METADATA");
+const METADATA_KEY: Symbol = symbol_short!("METADATA");
 
 #[derive(Clone)]
 #[contracttype]

--- a/tests/auth/src/lib.rs
+++ b/tests/auth/src/lib.rs
@@ -240,7 +240,7 @@ impl ContractB {
 mod test_b {
     use super::*;
     use soroban_sdk::{
-        contracterror,
+        contracterror, symbol_short,
         testutils::{
             Address as _, AuthorizedFunction, AuthorizedInvocation, MockAuth, MockAuthInvoke,
         },
@@ -249,7 +249,7 @@ mod test_b {
             SorobanAuthorizationEntry, SorobanAuthorizedContractFunction,
             SorobanAuthorizedFunction, SorobanAuthorizedInvocation, SorobanCredentials, StringM,
         },
-        Address, Env, Error, Symbol, Val,
+        Address, Env, Error, Val,
     };
     extern crate std;
 

--- a/tests/auth/src/lib.rs
+++ b/tests/auth/src/lib.rs
@@ -272,13 +272,13 @@ mod test_b {
                 AuthorizedInvocation {
                     function: AuthorizedFunction::Contract((
                         contract_b_id.clone(),
-                        Symbol::short("fn2"),
+                        symbol_short!("fn2"),
                         (1, 2).into_val(&e),
                     )),
                     sub_invocations: std::vec![AuthorizedInvocation {
                         function: AuthorizedFunction::Contract((
                             contract_a_id.clone(),
-                            Symbol::short("fn1"),
+                            symbol_short!("fn1"),
                             (&a,).into_val(&e),
                         )),
                         sub_invocations: std::vec![]
@@ -322,13 +322,13 @@ mod test_b {
                 AuthorizedInvocation {
                     function: AuthorizedFunction::Contract((
                         contract_b_id.clone(),
-                        Symbol::short("fn2"),
+                        symbol_short!("fn2"),
                         (1, 2).into_val(&e),
                     )),
                     sub_invocations: std::vec![AuthorizedInvocation {
                         function: AuthorizedFunction::Contract((
                             contract_a_id.clone(),
-                            Symbol::short("fn1"),
+                            symbol_short!("fn1"),
                             (&a,).into_val(&e),
                         )),
                         sub_invocations: std::vec![]
@@ -389,13 +389,13 @@ mod test_b {
                 AuthorizedInvocation {
                     function: AuthorizedFunction::Contract((
                         contract_b_id.clone(),
-                        Symbol::short("fn2"),
+                        symbol_short!("fn2"),
                         (1, 2).into_val(&e),
                     )),
                     sub_invocations: std::vec![AuthorizedInvocation {
                         function: AuthorizedFunction::Contract((
                             contract_a_id.clone(),
-                            Symbol::short("fn1"),
+                            symbol_short!("fn1"),
                             (&a,).into_val(&e),
                         )),
                         sub_invocations: std::vec![]

--- a/tests/errors/src/lib.rs
+++ b/tests/errors/src/lib.rs
@@ -43,8 +43,9 @@ impl Contract {
 #[cfg(test)]
 mod test {
     use soroban_sdk::{
+        symbol_short,
         xdr::{ScErrorCode, ScErrorType},
-        Env, Symbol,
+        Env,
     };
 
     use crate::{Contract, ContractClient, Error};

--- a/tests/errors/src/lib.rs
+++ b/tests/errors/src/lib.rs
@@ -1,5 +1,7 @@
 #![no_std]
-use soroban_sdk::{contract, contracterror, contractimpl, panic_with_error, Env, Symbol};
+use soroban_sdk::{
+    contract, contracterror, contractimpl, panic_with_error, symbol_short, Env, Symbol,
+};
 
 #[contract]
 pub struct Contract;
@@ -15,9 +17,9 @@ impl Contract {
     pub fn hello(env: Env, flag: u32) -> Result<Symbol, Error> {
         env.storage()
             .persistent()
-            .set(&Symbol::short("persisted"), &true, None);
+            .set(&symbol_short!("persisted"), &true, None);
         if flag == 0 {
-            Ok(Symbol::short("hello"))
+            Ok(symbol_short!("hello"))
         } else if flag == 1 {
             Err(Error::AnError)
         } else if flag == 2 {
@@ -33,7 +35,7 @@ impl Contract {
     pub fn persisted(env: Env) -> bool {
         env.storage()
             .persistent()
-            .get(&Symbol::short("persisted"))
+            .get(&symbol_short!("persisted"))
             .unwrap_or(false)
     }
 }
@@ -54,7 +56,7 @@ mod test {
         let client = ContractClient::new(&e, &contract_id);
 
         let res = client.hello(&0);
-        assert_eq!(res, Symbol::short("hello"));
+        assert_eq!(res, symbol_short!("hello"));
         assert!(client.persisted());
     }
 
@@ -65,7 +67,7 @@ mod test {
         let client = ContractClient::new(&e, &contract_id);
 
         let res = client.try_hello(&0);
-        assert_eq!(res, Ok(Ok(Symbol::short("hello"))));
+        assert_eq!(res, Ok(Ok(symbol_short!("hello"))));
         assert!(client.persisted());
     }
 

--- a/tests/events/src/lib.rs
+++ b/tests/events/src/lib.rs
@@ -1,5 +1,5 @@
 #![no_std]
-use soroban_sdk::{contract, contractimpl, Env, Symbol};
+use soroban_sdk::{contract, contractimpl, symbol_short, Env};
 
 #[contract]
 pub struct Contract;
@@ -8,12 +8,12 @@ pub struct Contract;
 impl Contract {
     pub fn hello(env: Env) {
         env.events().publish(
-            (Symbol::short("greetings"), Symbol::short("topic2")),
-            Symbol::short("hello"),
+            (symbol_short!("greetings"), symbol_short!("topic2")),
+            symbol_short!("hello"),
         );
         env.events().publish(
-            (Symbol::short("farewells"), Symbol::short("topic2")),
-            Symbol::short("bye"),
+            (symbol_short!("farewells"), symbol_short!("topic2")),
+            symbol_short!("bye"),
         );
     }
 }
@@ -41,16 +41,16 @@ mod test {
                 (
                     contract_id.clone(),
                     // Expect these event topics.
-                    (Symbol::short("greetings"), Symbol::short("topic2")).into_val(&env),
+                    (symbol_short!("greetings"), symbol_short!("topic2")).into_val(&env),
                     // Expect this event body.
-                    Symbol::short("hello").into_val(&env)
+                    symbol_short!("hello").into_val(&env)
                 ),
                 (
                     contract_id,
                     // Expect these event topics.
-                    (Symbol::short("farewells"), Symbol::short("topic2")).into_val(&env),
+                    (symbol_short!("farewells"), symbol_short!("topic2")).into_val(&env),
                     // Expect this event body.
-                    Symbol::short("bye").into_val(&env)
+                    symbol_short!("bye").into_val(&env)
                 ),
             ],
         );

--- a/tests/events/src/lib.rs
+++ b/tests/events/src/lib.rs
@@ -21,7 +21,7 @@ impl Contract {
 #[cfg(test)]
 mod test {
     extern crate alloc;
-    use soroban_sdk::{testutils::Events, vec, Env, IntoVal, Symbol};
+    use soroban_sdk::{symbol_short, testutils::Events, vec, Env, IntoVal};
 
     use crate::{Contract, ContractClient};
 

--- a/tests/invoke_contract/src/lib.rs
+++ b/tests/invoke_contract/src/lib.rs
@@ -1,5 +1,5 @@
 #![no_std]
-use soroban_sdk::{contract, contractimpl, vec, Address, Env, IntoVal, Symbol};
+use soroban_sdk::{contract, contractimpl, symbol_short, vec, Address, Env, IntoVal};
 
 #[contract]
 pub struct Contract;
@@ -10,7 +10,7 @@ impl Contract {
     pub fn add_with(env: Env, x: i32, y: i32, contract_id: Address) -> i32 {
         env.invoke_contract(
             &contract_id,
-            &Symbol::short("add"),
+            &symbol_short!("add"),
             vec![&env, x.into_val(&env), y.into_val(&env)],
         )
     }

--- a/tests/logging/src/lib.rs
+++ b/tests/logging/src/lib.rs
@@ -1,5 +1,5 @@
 #![no_std]
-use soroban_sdk::{contract, contractimpl, log, Env, Symbol};
+use soroban_sdk::{contract, contractimpl, log, symbol_short, Env};
 
 #[contract]
 pub struct Contract;
@@ -9,19 +9,19 @@ impl Contract {
     pub fn hello(env: Env) {
         log!(&env, "none");
         log!(&env, "none",);
-        log!(&env, "one:", Symbol::short("one"));
-        log!(&env, "one:", Symbol::short("one"),);
+        log!(&env, "one:", symbol_short!("one"));
+        log!(&env, "one:", symbol_short!("one"),);
         log!(
             &env,
             "one and two:",
-            Symbol::short("one"),
-            Symbol::short("two")
+            symbol_short!("one"),
+            symbol_short!("two")
         );
         log!(
             &env,
             "one and two:",
-            Symbol::short("one"),
-            Symbol::short("two"),
+            symbol_short!("one"),
+            symbol_short!("two"),
         );
     }
 }


### PR DESCRIPTION
### What
Bring back the `symbol!` macro from the past, in the form of `symbol_short!`.

### Why
The symbol! macro existed to ensure that when short symbols were generated, they were entirely generated at compile time. The goal was that the string and the conversion code would never end up in the file wasm.

At some point we removed the macro and replaced it with a const function. However const functions are only const evaluated at compile time if they are called in a const context.

The impact is that anytime a short symbol is used without the macro it increases the size of the wasm by about 200 bytes, because both the original string and the conversion code are embedded into the wasm.

Close #927

### Perf Diff

```diff
--rwxr-xr-x  1 leighmcculloch  staff  858 Jun 23 20:33 test_errors.wasm
+-rwxr-xr-x  1 leighmcculloch  staff  658 Jun 23 20:36 test_errors.wasm
--rwxr-xr-x  1 leighmcculloch  staff  954 Jun 23 20:32 test_events.wasm
+-rwxr-xr-x  1 leighmcculloch  staff  667 Jun 23 20:36 test_events.wasm
--rwxr-xr-x  1 leighmcculloch  staff  1025 Jun 23 20:32 test_invoke_contract.wasm
+-rwxr-xr-x  1 leighmcculloch  staff  843 Jun 23 20:35 test_invoke_contract.wasm
```