### PR TITLE
Replace increase/decrease_allowance functions with approve

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1176,7 +1176,7 @@ checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 [[package]]
 name = "soroban-env-common"
 version = "0.0.16"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=aff56a8cbf5c2f3c23fb0174da6edeb070322028#aff56a8cbf5c2f3c23fb0174da6edeb070322028"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=298818b9a2ab9d52ff4681f5cd5aab63904057cc#298818b9a2ab9d52ff4681f5cd5aab63904057cc"
 dependencies = [
  "arbitrary",
  "crate-git-revision",
@@ -1194,7 +1194,7 @@ dependencies = [
 [[package]]
 name = "soroban-env-guest"
 version = "0.0.16"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=aff56a8cbf5c2f3c23fb0174da6edeb070322028#aff56a8cbf5c2f3c23fb0174da6edeb070322028"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=298818b9a2ab9d52ff4681f5cd5aab63904057cc#298818b9a2ab9d52ff4681f5cd5aab63904057cc"
 dependencies = [
  "soroban-env-common",
  "static_assertions",
@@ -1203,7 +1203,7 @@ dependencies = [
 [[package]]
 name = "soroban-env-host"
 version = "0.0.16"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=aff56a8cbf5c2f3c23fb0174da6edeb070322028#aff56a8cbf5c2f3c23fb0174da6edeb070322028"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=298818b9a2ab9d52ff4681f5cd5aab63904057cc#298818b9a2ab9d52ff4681f5cd5aab63904057cc"
 dependencies = [
  "backtrace",
  "curve25519-dalek",
@@ -1229,7 +1229,7 @@ dependencies = [
 [[package]]
 name = "soroban-env-macros"
 version = "0.0.16"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=aff56a8cbf5c2f3c23fb0174da6edeb070322028#aff56a8cbf5c2f3c23fb0174da6edeb070322028"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=298818b9a2ab9d52ff4681f5cd5aab63904057cc#298818b9a2ab9d52ff4681f5cd5aab63904057cc"
 dependencies = [
  "itertools",
  "proc-macro2",
@@ -1256,7 +1256,7 @@ dependencies = [
 [[package]]
 name = "soroban-native-sdk-macros"
 version = "0.0.16"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=aff56a8cbf5c2f3c23fb0174da6edeb070322028#aff56a8cbf5c2f3c23fb0174da6edeb070322028"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=298818b9a2ab9d52ff4681f5cd5aab63904057cc#298818b9a2ab9d52ff4681f5cd5aab63904057cc"
 dependencies = [
  "itertools",
  "proc-macro2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1176,7 +1176,7 @@ checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 [[package]]
 name = "soroban-env-common"
 version = "0.0.16"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=298818b9a2ab9d52ff4681f5cd5aab63904057cc#298818b9a2ab9d52ff4681f5cd5aab63904057cc"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=422ce4110f26097e94835e0a70a4ed8c10b5bc16#422ce4110f26097e94835e0a70a4ed8c10b5bc16"
 dependencies = [
  "arbitrary",
  "crate-git-revision",
@@ -1194,7 +1194,7 @@ dependencies = [
 [[package]]
 name = "soroban-env-guest"
 version = "0.0.16"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=298818b9a2ab9d52ff4681f5cd5aab63904057cc#298818b9a2ab9d52ff4681f5cd5aab63904057cc"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=422ce4110f26097e94835e0a70a4ed8c10b5bc16#422ce4110f26097e94835e0a70a4ed8c10b5bc16"
 dependencies = [
  "soroban-env-common",
  "static_assertions",
@@ -1203,7 +1203,7 @@ dependencies = [
 [[package]]
 name = "soroban-env-host"
 version = "0.0.16"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=298818b9a2ab9d52ff4681f5cd5aab63904057cc#298818b9a2ab9d52ff4681f5cd5aab63904057cc"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=422ce4110f26097e94835e0a70a4ed8c10b5bc16#422ce4110f26097e94835e0a70a4ed8c10b5bc16"
 dependencies = [
  "backtrace",
  "curve25519-dalek",
@@ -1229,7 +1229,7 @@ dependencies = [
 [[package]]
 name = "soroban-env-macros"
 version = "0.0.16"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=298818b9a2ab9d52ff4681f5cd5aab63904057cc#298818b9a2ab9d52ff4681f5cd5aab63904057cc"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=422ce4110f26097e94835e0a70a4ed8c10b5bc16#422ce4110f26097e94835e0a70a4ed8c10b5bc16"
 dependencies = [
  "itertools",
  "proc-macro2",
@@ -1256,7 +1256,7 @@ dependencies = [
 [[package]]
 name = "soroban-native-sdk-macros"
 version = "0.0.16"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=298818b9a2ab9d52ff4681f5cd5aab63904057cc#298818b9a2ab9d52ff4681f5cd5aab63904057cc"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=422ce4110f26097e94835e0a70a4ed8c10b5bc16#422ce4110f26097e94835e0a70a4ed8c10b5bc16"
 dependencies = [
  "itertools",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,17 +40,17 @@ soroban-token-sdk = { version = "0.8.4", path = "soroban-token-sdk" }
 [workspace.dependencies.soroban-env-common]
 version = "0.0.16"
 git = "https://github.com/stellar/rs-soroban-env"
-rev = "aff56a8cbf5c2f3c23fb0174da6edeb070322028"
+rev = "298818b9a2ab9d52ff4681f5cd5aab63904057cc"
 
 [workspace.dependencies.soroban-env-guest]
 version = "0.0.16"
 git = "https://github.com/stellar/rs-soroban-env"
-rev = "aff56a8cbf5c2f3c23fb0174da6edeb070322028"
+rev = "298818b9a2ab9d52ff4681f5cd5aab63904057cc"
 
 [workspace.dependencies.soroban-env-host]
 version = "0.0.16"
 git = "https://github.com/stellar/rs-soroban-env"
-rev = "aff56a8cbf5c2f3c23fb0174da6edeb070322028"
+rev = "298818b9a2ab9d52ff4681f5cd5aab63904057cc"
 
 [workspace.dependencies.stellar-strkey]
 version = "0.0.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,17 +40,17 @@ soroban-token-sdk = { version = "0.8.4", path = "soroban-token-sdk" }
 [workspace.dependencies.soroban-env-common]
 version = "0.0.16"
 git = "https://github.com/stellar/rs-soroban-env"
-rev = "298818b9a2ab9d52ff4681f5cd5aab63904057cc"
+rev = "422ce4110f26097e94835e0a70a4ed8c10b5bc16"
 
 [workspace.dependencies.soroban-env-guest]
 version = "0.0.16"
 git = "https://github.com/stellar/rs-soroban-env"
-rev = "298818b9a2ab9d52ff4681f5cd5aab63904057cc"
+rev = "422ce4110f26097e94835e0a70a4ed8c10b5bc16"
 
 [workspace.dependencies.soroban-env-host]
 version = "0.0.16"
 git = "https://github.com/stellar/rs-soroban-env"
-rev = "298818b9a2ab9d52ff4681f5cd5aab63904057cc"
+rev = "422ce4110f26097e94835e0a70a4ed8c10b5bc16"
 
 [workspace.dependencies.stellar-strkey]
 version = "0.0.7"

--- a/soroban-ledger-snapshot/src/lib.rs
+++ b/soroban-ledger-snapshot/src/lib.rs
@@ -32,6 +32,7 @@ pub struct LedgerSnapshot {
     pub base_reserve: u32,
     pub min_persistent_entry_expiration: u32,
     pub min_temp_entry_expiration: u32,
+    pub max_entry_expiration: u32,
     pub ledger_entries: Vec<(Box<LedgerKey>, Box<LedgerEntry>)>,
 }
 
@@ -74,6 +75,7 @@ impl LedgerSnapshot {
             base_reserve: self.base_reserve,
             min_persistent_entry_expiration: self.min_persistent_entry_expiration,
             min_temp_entry_expiration: self.min_temp_entry_expiration,
+            max_entry_expiration: self.max_entry_expiration,
         }
     }
 
@@ -164,6 +166,7 @@ impl Default for LedgerSnapshot {
             ledger_entries: Vec::default(),
             min_persistent_entry_expiration: Default::default(),
             min_temp_entry_expiration: Default::default(),
+            max_entry_expiration: Default::default(),
         }
     }
 }

--- a/soroban-sdk/src/env.rs
+++ b/soroban-sdk/src/env.rs
@@ -526,6 +526,7 @@ impl Env {
             base_reserve: 0,
             min_persistent_entry_expiration: 4096,
             min_temp_entry_expiration: 16,
+            max_entry_expiration: 6_312_000,
         });
 
         env

--- a/soroban-sdk/src/tests/token_client.rs
+++ b/soroban-sdk/src/tests/token_client.rs
@@ -34,8 +34,8 @@ impl TestContract {
         get_token(&e)
     }
 
-    pub fn increase_allowance(e: Env, from: Address, spender: Address, amount: i128) {
-        TokenClient::new(&e, &get_token(&e)).increase_allowance(&from, &spender, &amount);
+    pub fn approve(e: Env, from: Address, spender: Address, amount: i128, expiration_ledger: u32) {
+        TokenClient::new(&e, &get_token(&e)).approve(&from, &spender, &amount, &expiration_ledger);
     }
 
     pub fn allowance(e: Env, from: Address, spender: Address) -> i128 {
@@ -61,9 +61,7 @@ fn test_mock_all_auth() {
     let from = Address::random(&env);
     let spender = Address::random(&env);
 
-    client
-        .mock_all_auths()
-        .increase_allowance(&from, &spender, &20);
+    client.mock_all_auths().approve(&from, &spender, &20, &200);
 
     assert_eq!(
         env.auths(),
@@ -72,8 +70,8 @@ fn test_mock_all_auth() {
             AuthorizedInvocation {
                 function: AuthorizedFunction::Contract((
                     token_contract_id.clone(),
-                    Symbol::new(&env, "increase_allowance"),
-                    (&from, &spender, 20_i128).into_val(&env)
+                    Symbol::new(&env, "approve"),
+                    (&from, &spender, 20_i128, 200_u32).into_val(&env)
                 )),
                 sub_invocations: std::vec![]
             }
@@ -106,12 +104,12 @@ fn test_mock_auth() {
             address: &from,
             invoke: &MockAuthInvoke {
                 contract: &token_contract_id,
-                fn_name: "increase_allowance",
-                args: (&from, &spender, 20_i128).into_val(&env),
+                fn_name: "approve",
+                args: (&from, &spender, 20_i128, 200_u32).into_val(&env),
                 sub_invokes: &[],
             },
         }])
-        .increase_allowance(&from, &spender, &20);
+        .approve(&from, &spender, &20, &200);
 
     assert_eq!(client.allowance(&from, &spender), 20);
 }

--- a/soroban-sdk/src/token.rs
+++ b/soroban-sdk/src/token.rs
@@ -30,7 +30,7 @@ pub trait Interface {
     /// * `spender` - The address spending the tokens held by `from`.
     fn allowance(env: Env, from: Address, spender: Address) -> i128;
 
-    /// Increase the allowance by `amount` for `spender` to transfer/burn from
+    /// Set the allowance by `amount` for `spender` to transfer/burn from
     /// `from`.
     ///
     /// # Arguments
@@ -38,31 +38,17 @@ pub trait Interface {
     /// * `from` - The address holding the balance of tokens to be drawn from.
     /// * `spender` - The address being authorized to spend the tokens held by
     ///   `from`.
-    /// * `amount` - The additional tokens to be made availabe to `spender`.
+    /// * `amount` - The tokens to be made availabe to `spender`.
+    /// * `expiration_ledger` - The ledger number where this allowance expires. Cannot
+    ///    be less than the current ledger number unless the amount is being set to 0.
+    ///    An expired entry (where expiration_ledger < the current ledger number)
+    ///    should be treated as a 0 amount allowance.
     ///
     /// # Events
     ///
-    /// Emits an event with topics `["increase_allowance", from: Address,
-    /// spender: Address], data = [amount: i128]`
-    fn increase_allowance(env: Env, from: Address, spender: Address, amount: i128);
-
-    /// Decrease the allowance by `amount` for `spender` to transfer/burn from
-    /// `from`.
-    ///
-    /// # Arguments
-    ///
-    /// * `from` - The address holding the balance of tokens to be drawn from.
-    /// * `spender` - The address being (de-)authorized to spend the tokens held
-    ///   by `from`.
-    /// * `amount` - The tokens which are no longer availabe for use by
-    ///   `spender`. If `amount` is greater than the current allowance, set the
-    ///   allowance to 0.
-    ///
-    /// # Events
-    ///
-    /// Emits an event with topics `["decrease_allowance", from: Address,
-    /// spender: Address], data = [amount: i128]`
-    fn decrease_allowance(env: Env, from: Address, spender: Address, amount: i128);
+    /// Emits an event with topics `["approve", from: Address,
+    /// spender: Address], data = [amount: i128, expiration_ledger: u32]`
+    fn approve(env: Env, from: Address, spender: Address, amount: i128, expiration_ledger: u32);
 
     /// Returns the balance of `id`.
     ///
@@ -244,13 +230,12 @@ pub struct StellarAssetSpec;
 pub(crate) const SPEC_XDR_INPUT: &[&[u8]] = &[
     &StellarAssetSpec::spec_xdr_allowance(),
     &StellarAssetSpec::spec_xdr_authorized(),
+    &StellarAssetSpec::spec_xdr_approve(),
     &StellarAssetSpec::spec_xdr_balance(),
     &StellarAssetSpec::spec_xdr_burn(),
     &StellarAssetSpec::spec_xdr_burn_from(),
     &StellarAssetSpec::spec_xdr_clawback(),
     &StellarAssetSpec::spec_xdr_decimals(),
-    &StellarAssetSpec::spec_xdr_decrease_allowance(),
-    &StellarAssetSpec::spec_xdr_increase_allowance(),
     &StellarAssetSpec::spec_xdr_mint(),
     &StellarAssetSpec::spec_xdr_name(),
     &StellarAssetSpec::spec_xdr_set_admin(),
@@ -261,7 +246,7 @@ pub(crate) const SPEC_XDR_INPUT: &[&[u8]] = &[
     &StellarAssetSpec::spec_xdr_transfer_from(),
 ];
 
-pub(crate) const SPEC_XDR_LEN: usize = 5900;
+pub(crate) const SPEC_XDR_LEN: usize = 5572;
 
 impl StellarAssetSpec {
     /// Returns the XDR spec for the Token contract.


### PR DESCRIPTION
Update sdk to match SAC changes.

I tried to add the following documentation to the token interface for the approve function, but I was getting a `LengthExceedsMax` macro error. This should be added to our docs instead.

```
/// # A note on modifying allowances
///
/// The approve function overwrites the previous value with `amount`, so it's
/// possible for the previous allowance to be spent in an earlier transaction
/// before `amount` is written in a later transaction. The result of this is
/// that `spender` can spend more than intended. This issue can be avoided by
/// first setting the allowance to 0, verifying that the spender didn't spend
/// any portion of the previous allowance, and then setting the allowance to the
/// new desired amount. You can read more about this issue here - https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729.
```