### PR TITLE
Remove flags from storage interface for now

### DIFF
--- a/soroban-sdk/src/lib.rs
+++ b/soroban-sdk/src/lib.rs
@@ -461,7 +461,7 @@ pub use soroban_sdk_macros::contractmeta;
 ///         state.last_incr = incr;
 ///
 ///         // Save the count.
-///         env.storage().persistent().set(&symbol_short!("STATE"), &state, None);
+///         env.storage().persistent().set(&symbol_short!("STATE"), &state);
 ///
 ///         // Return the count to the caller.
 ///         state.count
@@ -539,7 +539,7 @@ pub use soroban_sdk_macros::contractmeta;
 /// impl Contract {
 ///     /// Set the color.
 ///     pub fn set(env: Env, c: Color) {
-///         env.storage().persistent().set(&symbol_short!("COLOR"), &c, None);
+///         env.storage().persistent().set(&symbol_short!("COLOR"), &c);
 ///     }
 ///
 ///     /// Get the color.

--- a/soroban-sdk/src/storage.rs
+++ b/soroban-sdk/src/storage.rs
@@ -44,7 +44,7 @@ use crate::{
 /// #     pub fn f(env: Env) {
 /// let storage = env.storage();
 /// let key = symbol_short!("key");
-/// storage.persistent().set(&key, &1, None);
+/// storage.persistent().set(&key, &1);
 /// assert_eq!(storage.persistent().has(&key), true);
 /// assert_eq!(storage.persistent().get::<_, i32>(&key), Some(1));
 /// #     }

--- a/soroban-sdk/src/storage.rs
+++ b/soroban-sdk/src/storage.rs
@@ -255,12 +255,12 @@ impl Persistent {
         self.storage.get(key, StorageType::Persistent)
     }
 
-    pub fn set<K, V>(&self, key: &K, val: &V, flags: Option<u32>)
+    pub fn set<K, V>(&self, key: &K, val: &V)
     where
         K: IntoVal<Env, Val>,
         V: IntoVal<Env, Val>,
     {
-        self.storage.set(key, val, StorageType::Persistent, flags)
+        self.storage.set(key, val, StorageType::Persistent, None)
     }
 
     pub fn bump<K>(&self, key: &K, min_ledgers_to_live: u32)
@@ -301,12 +301,12 @@ impl Temporary {
         self.storage.get(key, StorageType::Temporary)
     }
 
-    pub fn set<K, V>(&self, key: &K, val: &V, flags: Option<u32>)
+    pub fn set<K, V>(&self, key: &K, val: &V)
     where
         K: IntoVal<Env, Val>,
         V: IntoVal<Env, Val>,
     {
-        self.storage.set(key, val, StorageType::Temporary, flags)
+        self.storage.set(key, val, StorageType::Temporary, None)
     }
 
     pub fn bump<K>(&self, key: &K, min_ledgers_to_live: u32)
@@ -347,12 +347,12 @@ impl Instance {
         self.storage.get(key, StorageType::Instance)
     }
 
-    pub fn set<K, V>(&self, key: &K, val: &V, flags: Option<u32>)
+    pub fn set<K, V>(&self, key: &K, val: &V)
     where
         K: IntoVal<Env, Val>,
         V: IntoVal<Env, Val>,
     {
-        self.storage.set(key, val, StorageType::Instance, flags)
+        self.storage.set(key, val, StorageType::Instance, None)
     }
 
     #[inline(always)]

--- a/soroban-sdk/src/tests/contract_snapshot.rs
+++ b/soroban-sdk/src/tests/contract_snapshot.rs
@@ -7,7 +7,7 @@ pub struct Contract;
 #[contractimpl]
 impl Contract {
     pub fn store(env: Env, k: i32, v: i32) {
-        env.storage().persistent().set(&k, &v, None)
+        env.storage().persistent().set(&k, &v)
     }
     pub fn get(env: Env, k: i32) -> i32 {
         env.storage().persistent().get(&k).unwrap()

--- a/soroban-sdk/src/tests/contract_store.rs
+++ b/soroban-sdk/src/tests/contract_store.rs
@@ -7,7 +7,7 @@ pub struct Contract;
 #[contractimpl]
 impl Contract {
     pub fn store(env: Env, k: i32, v: i32) {
-        env.storage().persistent().set(&k, &v, None)
+        env.storage().persistent().set(&k, &v)
     }
 }
 

--- a/soroban-sdk/src/tests/token_client.rs
+++ b/soroban-sdk/src/tests/token_client.rs
@@ -25,9 +25,7 @@ pub struct TestContract;
 #[contractimpl]
 impl TestContract {
     pub fn init(e: Env, contract: Address) {
-        e.storage()
-            .persistent()
-            .set(&DataKey::Token, &contract, None);
+        e.storage().persistent().set(&DataKey::Token, &contract);
     }
 
     pub fn get_token(e: Env) -> Address {

--- a/soroban-token-sdk/src/lib.rs
+++ b/soroban-token-sdk/src/lib.rs
@@ -23,10 +23,7 @@ impl TokenUtils {
 
     #[inline(always)]
     pub fn set_metadata(&self, metadata: &TokenMetadata) {
-        self.0
-            .storage()
-            .persistent()
-            .set(&METADATA_KEY, metadata, None);
+        self.0.storage().persistent().set(&METADATA_KEY, metadata);
     }
 
     #[inline(always)]

--- a/tests/contract_data/src/lib.rs
+++ b/tests/contract_data/src/lib.rs
@@ -7,7 +7,7 @@ pub struct Contract;
 #[contractimpl]
 impl Contract {
     pub fn put(e: Env, key: Symbol, val: Symbol) {
-        e.storage().persistent().set(&key, &val, None)
+        e.storage().persistent().set(&key, &val)
     }
 
     pub fn get(e: Env, key: Symbol) -> Option<Symbol> {

--- a/tests/errors/src/lib.rs
+++ b/tests/errors/src/lib.rs
@@ -17,7 +17,7 @@ impl Contract {
     pub fn hello(env: Env, flag: u32) -> Result<Symbol, Error> {
         env.storage()
             .persistent()
-            .set(&symbol_short!("persisted"), &true, None);
+            .set(&symbol_short!("persisted"), &true);
         if flag == 0 {
             Ok(symbol_short!("hello"))
         } else if flag == 1 {


### PR DESCRIPTION
### What

The current interface is annoying to use since the common case is no change to flags. The only flag is NO_AUTOBUMP, so we can add support for this at any time. 