### PR TITLE
fix: use uppercase const name

### DIFF
--- a/soroban-sdk-macros/src/lib.rs
+++ b/soroban-sdk-macros/src/lib.rs
@@ -58,8 +58,8 @@ fn _symbol_short(crate_path: &str, s: &LitStr) -> TokenStream {
     match Symbol::try_from_small_str(&s.value()) {
         Ok(_) => quote! {{
             #[allow(deprecated)]
-            const symbol: #crate_path::Symbol = #crate_path::Symbol::short(#s);
-            symbol
+            const SYMBOL: #crate_path::Symbol = #crate_path::Symbol::short(#s);
+            SYMBOL
         }}
         .into(),
         Err(e) => Error::new(s.span(), format!("{e}"))


### PR DESCRIPTION


### What

This fixes an issue where Rust Analyzer sometimes complains that:

    constant `symbol` should have UPPER_SNAKE_CASE name

### Why

When using `symbol_short!`, as recommended by the Getting Started → Hello World tutorial, I was getting confusing warnings from Rust Analyzer:

<img width="957" alt="image" src="https://github.com/stellar/rs-soroban-sdk/assets/221614/d7a29fcf-6683-4979-b68b-bab4627d7dd7">

### Known limitations

Why not use this instead?

```rs
Ok(_) => quote! {
    #crate_path::Symbol::short(#s)
}
```