### PR TITLE
Correct comment on String::copy_into_slice

### DIFF
--- a/soroban-sdk/src/address.rs
+++ b/soroban-sdk/src/address.rs
@@ -265,7 +265,7 @@ impl Address {
     pub(crate) fn contract_id(&self) -> BytesN<32> {
         match self.try_contract_id() {
             Some(contract_id) => contract_id,
-            None => panic!("Address is not a Contract ID"),
+            None => sdk_panic!("Address is not a Contract ID"),
         }
     }
 

--- a/soroban-sdk/src/lib.rs
+++ b/soroban-sdk/src/lib.rs
@@ -672,6 +672,27 @@ macro_rules! panic_error {
     }};
 }
 
+/// An internal panic! variant that avoids including the string
+/// when building for wasm (since it's just pointless baggage).
+#[cfg(target_family = "wasm")]
+macro_rules! sdk_panic {
+    ($_msg:literal) => {
+        panic!()
+    };
+    () => {
+        panic!()
+    };
+}
+#[cfg(not(target_family = "wasm"))]
+macro_rules! sdk_panic {
+    ($msg:literal) => {
+        panic!($msg)
+    };
+    () => {
+        panic!()
+    };
+}
+
 /// Assert a condition and panic with the given error if it is false.
 ///
 /// The first argument in the list must be a reference to an [Env].

--- a/soroban-sdk/src/string.rs
+++ b/soroban-sdk/src/string.rs
@@ -211,11 +211,15 @@ impl String {
 
     /// Copy the bytes in [String] into the given slice.
     ///
-    /// The minimum number of bytes are copied to either exhaust [String] or fill
-    /// slice.
+    /// ### Panics
+    ///
+    /// If the output slice and string are of different lengths.
     #[inline(always)]
     pub fn copy_into_slice(&self, slice: &mut [u8]) {
         let env = self.env();
+        if self.len() as usize != slice.len() {
+            sdk_panic!("String::copy_into_slice with mismatched slice length")
+        }
         env.string_copy_to_slice(self.to_object(), Val::U32_ZERO, slice)
             .unwrap_optimized();
     }
@@ -234,5 +238,25 @@ mod test {
         let mut out = [0u8; 9];
         s.copy_into_slice(&mut out);
         assert_eq!(msg.as_bytes(), out)
+    }
+
+    #[test]
+    #[should_panic]
+    fn string_to_short_slice() {
+        let env = Env::default();
+        let msg = "a message";
+        let s = String::from_slice(&env, msg);
+        let mut out = [0u8; 8];
+        s.copy_into_slice(&mut out);
+    }
+
+    #[test]
+    #[should_panic]
+    fn string_to_long_slice() {
+        let env = Env::default();
+        let msg = "a message";
+        let s = String::from_slice(&env, msg);
+        let mut out = [0u8; 10];
+        s.copy_into_slice(&mut out);
     }
 }


### PR DESCRIPTION
The copy routine here actually traps if you pass an output slice larger than the string. I think this is correct, since the previously-documented not-actually-performed behaviour (taking the minimum size of the output or the string) is a potential footgun / attack vector if someone tricks a contract into "copying N bytes" out of a string much smaller than N -- they get to basically force the output to be whatever the buffer's content was. The newly documented (already existing) behaviour does less magic / is less surprising / fails under more abnormal circumstances.