### PR TITLE
Provide a way to allow non-root auth in recording mode.

### DIFF
--- a/soroban-sdk/src/tests/token_client.rs
+++ b/soroban-sdk/src/tests/token_client.rs
@@ -42,7 +42,6 @@ impl TestContract {
 }
 
 #[test]
-#[should_panic] // FIXME: this is not supposed to panic; it does due to auth failure, dmkoz to fix.
 fn test_mock_all_auth() {
     extern crate std;
 
@@ -60,7 +59,16 @@ fn test_mock_all_auth() {
     let from = Address::random(&env);
     let spender = Address::random(&env);
 
-    client.mock_all_auths().approve(&from, &spender, &20, &200);
+    // `TestContract` doesn't call `require_auth` before calling into token,
+    // thus we need to allow non-root auth and regular `mock_all_auths` will
+    // fail.
+    assert!(client
+        .mock_all_auths()
+        .try_approve(&from, &spender, &20, &200)
+        .is_err());
+    client
+        .mock_all_auths_allowing_non_root_auth()
+        .approve(&from, &spender, &20, &200);
 
     assert_eq!(
         env.auths(),


### PR DESCRIPTION
### What

Provide a way to allow non-root auth in recording mode.

This is intentionally done via a separate helper with lengthy name and not a `mock_all_auths` argument - this is intended to be an option for a few 'exotic' contracts that do non-atomic bundling and majority of the users shouldn't ever need that.

Resolves https://github.com/stellar/rs-soroban-sdk/issues/1058

### Why

Recording auth now doesn't allow non-root `require_auth` by default in order to prevent the potential user footguns. This PR brings back the old behavior where non-root auth is allowed.

### Known limitations

N/A
