### PR TITLE
Add doc comments about why symbol_short!

### DIFF
--- a/soroban-sdk/src/symbol.rs
+++ b/soroban-sdk/src/symbol.rs
@@ -213,6 +213,7 @@ impl Symbol {
     /// such as:
     ///
     /// ```rust
+    /// # use soroban_sdk::Symbol;
     /// const SYMBOL: Symbol = Symbol::short("abcde");
     /// ```
     ///
@@ -222,12 +223,14 @@ impl Symbol {
     /// avoided:
     ///
     /// ```rust
+    /// # use soroban_sdk::Symbol;
     /// let SYMBOL: Symbol = Symbol::short("abcde"); // AVOID!
     /// ```
     ///
     /// Instead use the `symbol_short!()` macro that will ensure the conversion always occurs in a const-context:
     ///
     /// ```rust
+    /// # use soroban_sdk::{symbol_short, Symbol};
     /// let SYMBOL: Symbol = symbol_short!("abcde"); // 👍
     /// ```
     ///

--- a/soroban-sdk/src/symbol.rs
+++ b/soroban-sdk/src/symbol.rs
@@ -209,7 +209,27 @@ impl Symbol {
     ///
     /// Valid characters are `a-zA-Z0-9_` and maximum length is 9 characters.
     ///
-    /// The conversion can happen at compile time.
+    /// The conversion can happen at compile time if called in a const context,
+    /// such as:
+    ///
+    /// ```rust
+    /// const SYMBOL: Symbol = Symbol::short("abcde");
+    /// ```
+    ///
+    /// Note that when called from a non-const context the conversion will occur
+    /// at runtime and the conversion logic will add considerable number of
+    /// bytes to built wasm file. For this reason the function should be generally
+    /// avoided:
+    ///
+    /// ```rust
+    /// let SYMBOL: Symbol = Symbol::short("abcde"); // AVOID!
+    /// ```
+    ///
+    /// Instead use the `symbol_short!()` macro that will ensure the conversion always occurs in a const-context:
+    ///
+    /// ```rust
+    /// let SYMBOL: Symbol = symbol_short!("abcde"); // 👍
+    /// ```
     ///
     /// ### Panics
     ///


### PR DESCRIPTION
### What
Add doc comments about why symbol_short! is preferred over Symbol::short.

### Why
The behavior of const functions when called in non-const-contexts is not well known, as has been evidenced by the many times folks have asked why we have symbol_short!, and the case where symbol_short! was removed with folks assuming it was of no use. For example: https://github.com/stellar/rs-soroban-sdk/pull/1043#discussion_r1276653494. Adding docs to knowledge share.