### PR TITLE
Handle errors in Events::all, Logs::all

### DIFF
--- a/soroban-sdk/src/testutils.rs
+++ b/soroban-sdk/src/testutils.rs
@@ -145,13 +145,13 @@ pub trait Events {
     /// - Contract ID
     /// - Event Topics as a [`Vec<Val>`]
     /// - Event Data as a [`Val`]
-    fn all(&self) -> Vec<(crate::Address, Vec<Val>, Val)>;
+    fn all(&self) -> Result<Vec<(crate::Address, Vec<Val>, Val)>, soroban_env_host::HostError>;
 }
 
 /// Test utilities for [`Logs`][crate::logs::Logs].
 pub trait Logs {
     /// Returns all diagnostic events that have been logged.
-    fn all(&self) -> std::vec::Vec<String>;
+    fn all(&self) -> Result<std::vec::Vec<String>, soroban_env_host::HostError>;
     /// Prints all diagnostic events to stdout.
     fn print(&self);
 }

--- a/tests/events/src/lib.rs
+++ b/tests/events/src/lib.rs
@@ -34,7 +34,7 @@ mod test {
         client.hello();
 
         assert_eq!(
-            env.events().all(),
+            env.events().all().unwrap(),
             vec![
                 &env,
                 // Expect 2 events.

--- a/tests/logging/src/lib.rs
+++ b/tests/logging/src/lib.rs
@@ -53,11 +53,11 @@ mod test {
                 "[\"one and two:\", one, two]",
                 "[\"one and two:\", one, two]"
             ];
-            for (msg, pat) in env.logs().all().iter().zip(pats.iter()) {
+            for (msg, pat) in env.logs().all().unwrap().iter().zip(pats.iter()) {
                 assert!(msg.contains(pat));
             }
         } else {
-            assert_eq!(env.logs().all(), std::vec![""; 0]);
+            assert_eq!(env.logs().all().unwrap(), std::vec![""; 0]);
         }
     }
 }


### PR DESCRIPTION
### What

Change the testutils functions `Events::all` and `Logs::all` to return `Result`.

### Why

I am not sure this is the correct resolution, or if this is worth fixing at all.

These functions call `Host::get_events`, which returns `Result`. That function may return an error, in which case `Events::all` and `Logs::all` panic.

This patch avoids the panic, but doesn't necessarily improve the debugging experience, since calling these functions will still fail to retrieve useful event information.

`Host::get_events` calls `Events::externalize`, and that function may fail if any single event fails to serialize to XDR. It's not clear to me what the consequences of `externalize` failing are.

I have seen these functions fail after calling a contract while passing objects with invalid references (intentionally adversarial). Because those objects can't be visited by the host, serialization fails.

From a debugging standpoint, it would be more useful to return partial event lists, perhaps with the non-externalizable events replaced with a placeholder. But I also see that these events are externalized by the `Host::try_finish` method, which seems to be a step in finalizing a transaction, though I don't understand how it's used.

### Known limitations

These functions still fail to return any events if just one event can't be externalized.
