### PR TITLE
Enable build workflow for merge groups

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [main, release/**]
   pull_request:
+  merge_group:
 
 env:
   RUSTFLAGS: -D warnings


### PR DESCRIPTION
### What
Enable build workflow for pull request merge groups.

### Why
So that the Rust build and test workflow will run on merge groups in the pull request merge queue.