### PR TITLE
Fix name of the Stellar Asset admin client

### DIFF
--- a/soroban-sdk/src/token.rs
+++ b/soroban-sdk/src/token.rs
@@ -163,7 +163,7 @@ pub trait Interface {
 /// Interface for admin capabilities for Token contracts, such as the Stellar
 /// Asset Contract.
 #[contractspecfn(name = "StellarAssetSpec", export = false)]
-#[contractclient(crate_path = "crate", name = "AdminClient")]
+#[contractclient(crate_path = "crate", name = "StellarAssetAdminClient")]
 pub trait StellarAssetAdminInterface {
     /// Sets the administrator to the specified address `new_admin`.
     ///


### PR DESCRIPTION
### What
Rename `token::AdminClient` to `token::StellarAssetAdminClient`.

### Why
The `token::StellarAssetAdminInterface` provides a client, but it was accidentally named `AdminClient`. When I added the client, multiple PRs were being merged at the same time and one PR changed the interface name, and the other introduced the client with the old name.