### PR TITLE
Remove authorized from standard token interface

### DIFF
--- a/soroban-sdk/src/token.rs
+++ b/soroban-sdk/src/token.rs
@@ -68,13 +68,6 @@ pub trait Interface {
     ///   reserves/liabilities.
     fn spendable_balance(env: Env, id: Address) -> i128;
 
-    /// Returns true if `id` is authorized to use its balance.
-    ///
-    /// # Arguments
-    ///
-    /// * `id` - The address for which token authorization is being checked.
-    fn authorized(env: Env, id: Address) -> bool;
-
     /// Transfer `amount` from `from` to `to`.
     ///
     /// # Arguments
@@ -163,8 +156,8 @@ pub trait Interface {
 /// Interface for admin capabilities for Token contracts, such as the Stellar
 /// Asset Contract.
 #[contractspecfn(name = "StellarAssetSpec", export = false)]
-#[contractclient(crate_path = "crate", name = "StellarAssetAdminClient")]
-pub trait StellarAssetAdminInterface {
+#[contractclient(crate_path = "crate", name = "StellarAssetClient")]
+pub trait StellarAssetInterface {
     /// Sets the administrator to the specified address `new_admin`.
     ///
     /// # Arguments
@@ -198,6 +191,13 @@ pub trait StellarAssetAdminInterface {
     /// Emits an event with topics `["set_authorized", id: Address], data =
     /// [authorize: bool]`
     fn set_authorized(env: Env, id: Address, authorize: bool);
+
+    /// Returns true if `id` is authorized to use its balance.
+    ///
+    /// # Arguments
+    ///
+    /// * `id` - The address for which token authorization is being checked.
+    fn authorized(env: Env, id: Address) -> bool;
 
     /// Mints `amount` to `to`.
     ///


### PR DESCRIPTION
### What

Removed the `authorized` function from the standard token interface.

Add the `authorized` function to the `StellarAssetInterface`, which is renamed from `StellarAssetAdminInterface`.

### Why

I think we might have accidentally included the `authorized` function in the token interface, or failed to move it out when we moved out the other functions. 

An `authorized` function makes assumptions about how a token operates and it's heavily influenced by the Stellar Asset.  It makes an assumption that authorization is static, when it could be dynamic. For a specialized token a user may be authorized to hold up to a certain amount, but not greater, and a binary flag for authorization may be harmful.

For contracts that do have a concept of "authorization," or any similar concept where someone has to authorize an address to be able to participate with the token, an `authorization` function isn't even necessarily required. This is because these contracts are, in any case, going to reject calls to other functions for users who aren't authorized.

Removing the function doesn't preclude contracts and the ecosystem from adding it and creating standards around authorization.

The `StellarAssetAdminInterface` is renamed to `StellarAssetInterface` because with this change the trait contains non-admin style functions. The trait contains a subset of functions the contract exposes. While that's a trade-off, I think the gain of it being clear what functions are not part of the standard token interface is a bigger win than we lose.

### Known limitations

It's pretty late in the game to make this change. However, this is a relatively light change to make.

### Merging

@tomerweller @sisuresh It would be ideal if you both could review, and if you agree with the change, approve the change prior to merging.

### Follow-up

The actual standard token interface is defined in [CAP-46-6](https://github.com/stellar/stellar-protocol/blob/c42f6939b8a079dffad6f17cd3036fae8a2e1a11/core/cap-0046-06.md) and also needs updating if this change goes ahead.