### PR TITLE
Adapt to removal of ConversionError from number type conversions.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1103,7 +1103,7 @@ checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 [[package]]
 name = "soroban-env-common"
 version = "0.0.17"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=3d6c35d1308fc36a05d30d257756e42fc928b537#3d6c35d1308fc36a05d30d257756e42fc928b537"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=66a3c504387da5bb5bb0b1cc4b0beb22c74fb252#66a3c504387da5bb5bb0b1cc4b0beb22c74fb252"
 dependencies = [
  "arbitrary",
  "crate-git-revision",
@@ -1120,7 +1120,7 @@ dependencies = [
 [[package]]
 name = "soroban-env-guest"
 version = "0.0.17"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=3d6c35d1308fc36a05d30d257756e42fc928b537#3d6c35d1308fc36a05d30d257756e42fc928b537"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=66a3c504387da5bb5bb0b1cc4b0beb22c74fb252#66a3c504387da5bb5bb0b1cc4b0beb22c74fb252"
 dependencies = [
  "soroban-env-common",
  "static_assertions",
@@ -1129,7 +1129,7 @@ dependencies = [
 [[package]]
 name = "soroban-env-host"
 version = "0.0.17"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=3d6c35d1308fc36a05d30d257756e42fc928b537#3d6c35d1308fc36a05d30d257756e42fc928b537"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=66a3c504387da5bb5bb0b1cc4b0beb22c74fb252#66a3c504387da5bb5bb0b1cc4b0beb22c74fb252"
 dependencies = [
  "backtrace",
  "ed25519-dalek",
@@ -1152,7 +1152,7 @@ dependencies = [
 [[package]]
 name = "soroban-env-macros"
 version = "0.0.17"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=3d6c35d1308fc36a05d30d257756e42fc928b537#3d6c35d1308fc36a05d30d257756e42fc928b537"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=66a3c504387da5bb5bb0b1cc4b0beb22c74fb252#66a3c504387da5bb5bb0b1cc4b0beb22c74fb252"
 dependencies = [
  "itertools",
  "proc-macro2",
@@ -1178,7 +1178,7 @@ dependencies = [
 [[package]]
 name = "soroban-native-sdk-macros"
 version = "0.0.17"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=3d6c35d1308fc36a05d30d257756e42fc928b537#3d6c35d1308fc36a05d30d257756e42fc928b537"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=66a3c504387da5bb5bb0b1cc4b0beb22c74fb252#66a3c504387da5bb5bb0b1cc4b0beb22c74fb252"
 dependencies = [
  "itertools",
  "proc-macro2",
@@ -1304,7 +1304,7 @@ dependencies = [
 [[package]]
 name = "stellar-xdr"
 version = "0.0.17"
-source = "git+https://github.com/stellar/rs-stellar-xdr?rev=39904e09941046dab61e6e35fc89e31bf2dea1cd#39904e09941046dab61e6e35fc89e31bf2dea1cd"
+source = "git+https://github.com/stellar/rs-stellar-xdr?rev=84d4d01f739b4f2c3f445f41bc7464a5621ba58c#84d4d01f739b4f2c3f445f41bc7464a5621ba58c"
 dependencies = [
  "arbitrary",
  "base64 0.13.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,17 +42,17 @@ soroban-token-sdk = { version = "0.9.2", path = "soroban-token-sdk" }
 [workspace.dependencies.soroban-env-common]
 version = "0.0.17"
 git = "https://github.com/stellar/rs-soroban-env"
-rev = "3d6c35d1308fc36a05d30d257756e42fc928b537"
+rev = "66a3c504387da5bb5bb0b1cc4b0beb22c74fb252"
 
 [workspace.dependencies.soroban-env-guest]
 version = "0.0.17"
 git = "https://github.com/stellar/rs-soroban-env"
-rev = "3d6c35d1308fc36a05d30d257756e42fc928b537"
+rev = "66a3c504387da5bb5bb0b1cc4b0beb22c74fb252"
 
 [workspace.dependencies.soroban-env-host]
 version = "0.0.17"
 git = "https://github.com/stellar/rs-soroban-env"
-rev = "3d6c35d1308fc36a05d30d257756e42fc928b537"
+rev = "66a3c504387da5bb5bb0b1cc4b0beb22c74fb252"
 
 [workspace.dependencies.stellar-strkey]
 version = "0.0.7"
@@ -62,8 +62,9 @@ rev = "e6ba45c60c16de28c7522586b80ed0150157df73"
 [workspace.dependencies.stellar-xdr]
 version = "0.0.17"
 git = "https://github.com/stellar/rs-stellar-xdr"
-rev = "39904e09941046dab61e6e35fc89e31bf2dea1cd"
+rev = "84d4d01f739b4f2c3f445f41bc7464a5621ba58c"
 default-features = false
+features = ["curr"]
 
 #[patch."https://github.com/stellar/rs-soroban-env"]
 #soroban-env-common = { path = "../rs-soroban-env/soroban-env-common" }

--- a/soroban-sdk-macros/Cargo.toml
+++ b/soroban-sdk-macros/Cargo.toml
@@ -22,7 +22,7 @@ crate-git-revision = "0.0.6"
 soroban-spec = { workspace = true }
 soroban-spec-rust = { workspace = true }
 soroban-env-common = { workspace = true }
-stellar-xdr = { workspace = true, features = ["next", "std"] }
+stellar-xdr = { workspace = true, features = ["curr", "std"] }
 syn = {version="2.0",features=["full"]}
 quote = "1.0"
 proc-macro2 = "1.0"

--- a/soroban-sdk-macros/src/derive_enum.rs
+++ b/soroban-sdk-macros/src/derive_enum.rs
@@ -302,7 +302,7 @@ fn map_empty_variant(
     let try_into = quote! {
         #enum_ident::#case_ident => {
             let tup: (#path::Val,) = (#path::Symbol::try_from_val(env, &#case_name_str_lit)?.to_val(),);
-            tup.try_into_val(env)
+            tup.try_into_val(env).map_err(Into::into)
         }
     };
     let try_from_xdr = quote! {
@@ -414,7 +414,7 @@ fn map_tuple_variant(
         quote! {
             #enum_ident::#case_ident(#(ref #binding_names,)* ) => {
                 let tup: (#path::Val, #(#tup_elem_types,)* ) = (#path::Symbol::try_from_val(env, &#case_name_str_lit)?.to_val(), #(#field_convs,)* );
-                tup.try_into_val(env)
+                tup.try_into_val(env).map_err(Into::into)
             }
         }
     };

--- a/soroban-sdk/Cargo.toml
+++ b/soroban-sdk/Cargo.toml
@@ -33,7 +33,7 @@ ctor = { version = "0.2.1", optional = true }
 [dev-dependencies]
 soroban-sdk-macros = { workspace = true, features = ["testutils"] }
 soroban-env-host = { workspace = true, features = ["testutils"] }
-stellar-xdr = { workspace = true, features = ["next", "std"] }
+stellar-xdr = { workspace = true, features = ["curr", "std"] }
 soroban-spec = { workspace = true }
 ed25519-dalek = "2.0.0"
 rand = "0.8.5"

--- a/soroban-sdk/src/symbol.rs
+++ b/soroban-sdk/src/symbol.rs
@@ -140,7 +140,7 @@ impl TryFrom<&Symbol> for ScVal {
     type Error = ConversionError;
     fn try_from(v: &Symbol) -> Result<Self, ConversionError> {
         if let Ok(ss) = SymbolSmall::try_from(v.val) {
-            ScVal::try_from(ss)
+            Ok(ScVal::try_from(ss)?)
         } else {
             let e: Env = v.env.clone().try_into()?;
             ScVal::try_from_val(&e, &v.to_val())

--- a/soroban-sdk/src/vec.rs
+++ b/soroban-sdk/src/vec.rs
@@ -1193,7 +1193,7 @@ mod test {
     }
 
     #[test]
-    #[should_panic(expected = "ConversionError")]
+    #[should_panic(expected = "Error(Value, UnexpectedType)")]
     fn test_vec_iter_panic_on_conversion() {
         let env = Env::default();
 
@@ -1269,7 +1269,7 @@ mod test {
 
         let mut iter = vec.try_iter();
         assert_eq!(iter.next(), Some(Ok(1)));
-        assert_eq!(iter.next(), Some(Err(ConversionError)));
+        assert_eq!(iter.next(), Some(Err(ConversionError.into())));
     }
 
     #[test]
@@ -1409,7 +1409,7 @@ mod test {
     }
 
     #[test]
-    #[should_panic(expected = "ConversionError")]
+    #[should_panic(expected = "Error(Value, UnexpectedType)")]
     fn test_pop_front_panics_on_conversion() {
         let env = Env::default();
 
@@ -1427,11 +1427,11 @@ mod test {
         let mut v: Vec<i64> = v.try_into_val(&env).unwrap();
 
         assert_eq!(v.try_pop_front(), Ok(Some(1)));
-        assert_eq!(v.try_pop_front(), Err(ConversionError));
+        assert_eq!(v.try_pop_front(), Err(ConversionError.into()));
     }
 
     #[test]
-    #[should_panic(expected = "ConversionError")]
+    #[should_panic(expected = "Error(Value, UnexpectedType)")]
     fn test_pop_front_unchecked_panics_on_conversion() {
         let env = Env::default();
 
@@ -1459,7 +1459,7 @@ mod test {
         let mut v: Vec<i64> = v.try_into_val(&env).unwrap();
 
         assert_eq!(v.try_pop_front_unchecked(), Ok(1));
-        assert_eq!(v.try_pop_front_unchecked(), Err(ConversionError));
+        assert_eq!(v.try_pop_front_unchecked(), Err(ConversionError.into()));
     }
 
     #[test]
@@ -1506,7 +1506,7 @@ mod test {
     }
 
     #[test]
-    #[should_panic(expected = "ConversionError")]
+    #[should_panic(expected = "Error(Value, UnexpectedType)")]
     fn test_pop_back_panics_on_conversion() {
         let env = Env::default();
 
@@ -1524,11 +1524,11 @@ mod test {
         let mut v: Vec<i64> = v.try_into_val(&env).unwrap();
 
         assert_eq!(v.try_pop_back(), Ok(Some(2)));
-        assert_eq!(v.try_pop_back(), Err(ConversionError));
+        assert_eq!(v.try_pop_back(), Err(ConversionError.into()));
     }
 
     #[test]
-    #[should_panic(expected = "ConversionError")]
+    #[should_panic(expected = "Error(Value, UnexpectedType)")]
     fn test_pop_back_unchecked_panics_on_conversion() {
         let env = Env::default();
 
@@ -1556,7 +1556,7 @@ mod test {
         let mut v: Vec<i64> = v.try_into_val(&env).unwrap();
 
         assert_eq!(v.try_pop_back_unchecked(), Ok(2));
-        assert_eq!(v.try_pop_back_unchecked(), Err(ConversionError));
+        assert_eq!(v.try_pop_back_unchecked(), Err(ConversionError.into()));
     }
 
     #[test]
@@ -1596,7 +1596,7 @@ mod test {
     }
 
     #[test]
-    #[should_panic(expected = "ConversionError")]
+    #[should_panic(expected = "Error(Value, UnexpectedType)")]
     fn test_get_panics_on_conversion() {
         let env = Env::default();
 
@@ -1636,7 +1636,7 @@ mod test {
         let v: Val = (1i64, 2i32).try_into_val(&env).unwrap();
         let v: Vec<i64> = v.try_into_val(&env).unwrap();
         assert_eq!(v.try_get(0), Ok(Some(1)));
-        assert_eq!(v.try_get(1), Err(ConversionError));
+        assert_eq!(v.try_get(1), Err(ConversionError.into()));
     }
 
     #[test]
@@ -1655,7 +1655,7 @@ mod test {
     }
 
     #[test]
-    #[should_panic(expected = "ConversionError")]
+    #[should_panic(expected = "Error(Value, UnexpectedType)")]
     fn test_get_unchecked_panics_on_conversion() {
         let env = Env::default();
 
@@ -1693,7 +1693,7 @@ mod test {
         let v: Val = (1i64, 2i32).try_into_val(&env).unwrap();
         let v: Vec<i64> = v.try_into_val(&env).unwrap();
         assert_eq!(v.try_get_unchecked(0), Ok(1));
-        assert_eq!(v.try_get_unchecked(1), Err(ConversionError));
+        assert_eq!(v.try_get_unchecked(1), Err(ConversionError.into()));
     }
 
     #[test]

--- a/soroban-spec-rust/Cargo.toml
+++ b/soroban-spec-rust/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2021"
 rust-version = "1.72"
 
 [dependencies]
-stellar-xdr = { workspace = true, features = ["next", "std", "serde"] }
+stellar-xdr = { workspace = true, features = ["curr", "std", "serde"] }
 soroban-spec = { workspace = true }
 thiserror = "1.0.32"
 syn = {version="2.0",features=["full"]}

--- a/soroban-spec/Cargo.toml
+++ b/soroban-spec/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2021"
 rust-version = "1.72"
 
 [dependencies]
-stellar-xdr = { workspace = true, features = ["next", "std", "serde"] }
+stellar-xdr = { workspace = true, features = ["curr", "std", "serde"] }
 base64 = "0.13.0"
 thiserror = "1.0.32"
 wasmparser = "0.88.0"


### PR DESCRIPTION
This contains small fixes to adapt to [changes to the env found during code review](https://github.com/stellar/rs-soroban-env/pull/1044) to eliminate easy-to-adapt-to uses of ConversionError (as described in bug https://github.com/stellar/rs-soroban-env/issues/1046) where we can do better and pass a full Error.