### PR TITLE
Upgrade env to v20.0.0-rc2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1102,8 +1102,8 @@ checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
 name = "soroban-env-common"
-version = "20.0.0-rc1"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=f19ef13363a1e0cbff7b100c0599a1d63dea88a6#f19ef13363a1e0cbff7b100c0599a1d63dea88a6"
+version = "20.0.0-rc2"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=8c63bff68a15d79aca3a705ee6916a68db57b7e6#8c63bff68a15d79aca3a705ee6916a68db57b7e6"
 dependencies = [
  "arbitrary",
  "crate-git-revision",
@@ -1119,8 +1119,8 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-guest"
-version = "20.0.0-rc1"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=f19ef13363a1e0cbff7b100c0599a1d63dea88a6#f19ef13363a1e0cbff7b100c0599a1d63dea88a6"
+version = "20.0.0-rc2"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=8c63bff68a15d79aca3a705ee6916a68db57b7e6#8c63bff68a15d79aca3a705ee6916a68db57b7e6"
 dependencies = [
  "soroban-env-common",
  "static_assertions",
@@ -1128,8 +1128,8 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-host"
-version = "20.0.0-rc1"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=f19ef13363a1e0cbff7b100c0599a1d63dea88a6#f19ef13363a1e0cbff7b100c0599a1d63dea88a6"
+version = "20.0.0-rc2"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=8c63bff68a15d79aca3a705ee6916a68db57b7e6#8c63bff68a15d79aca3a705ee6916a68db57b7e6"
 dependencies = [
  "backtrace",
  "ed25519-dalek",
@@ -1151,8 +1151,8 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-macros"
-version = "20.0.0-rc1"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=f19ef13363a1e0cbff7b100c0599a1d63dea88a6#f19ef13363a1e0cbff7b100c0599a1d63dea88a6"
+version = "20.0.0-rc2"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=8c63bff68a15d79aca3a705ee6916a68db57b7e6#8c63bff68a15d79aca3a705ee6916a68db57b7e6"
 dependencies = [
  "itertools",
  "proc-macro2",
@@ -1177,8 +1177,8 @@ dependencies = [
 
 [[package]]
 name = "soroban-native-sdk-macros"
-version = "20.0.0-rc1"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=f19ef13363a1e0cbff7b100c0599a1d63dea88a6#f19ef13363a1e0cbff7b100c0599a1d63dea88a6"
+version = "20.0.0-rc2"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=8c63bff68a15d79aca3a705ee6916a68db57b7e6#8c63bff68a15d79aca3a705ee6916a68db57b7e6"
 dependencies = [
  "itertools",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,19 +40,19 @@ soroban-ledger-snapshot = { version = "20.0.0-rc1", path = "soroban-ledger-snaps
 soroban-token-sdk = { version = "20.0.0-rc1", path = "soroban-token-sdk" }
 
 [workspace.dependencies.soroban-env-common]
-version = "20.0.0-rc1"
+version = "20.0.0-rc2"
 git = "https://github.com/stellar/rs-soroban-env"
-rev = "f19ef13363a1e0cbff7b100c0599a1d63dea88a6"
+rev = "8c63bff68a15d79aca3a705ee6916a68db57b7e6"
 
 [workspace.dependencies.soroban-env-guest]
-version = "20.0.0-rc1"
+version = "20.0.0-rc2"
 git = "https://github.com/stellar/rs-soroban-env"
-rev = "f19ef13363a1e0cbff7b100c0599a1d63dea88a6"
+rev = "8c63bff68a15d79aca3a705ee6916a68db57b7e6"
 
 [workspace.dependencies.soroban-env-host]
-version = "20.0.0-rc1"
+version = "20.0.0-rc2"
 git = "https://github.com/stellar/rs-soroban-env"
-rev = "f19ef13363a1e0cbff7b100c0599a1d63dea88a6"
+rev = "8c63bff68a15d79aca3a705ee6916a68db57b7e6"
 
 [workspace.dependencies.stellar-strkey]
 version = "0.0.7"


### PR DESCRIPTION
### What
Upgrade soroban-env-* dependencies to v20.0.0-rc2.

### Why
To get the stellar/rs-soroban-env#1074 bug fix into the SDK.