### PR TITLE
docs: Fixing a broken link in the SDK's `lib.rs` file

### DIFF
--- a/soroban-sdk/src/lib.rs
+++ b/soroban-sdk/src/lib.rs
@@ -37,7 +37,8 @@
 //! # fn main() { }
 //! ```
 //!
-//! More examples are available at <https://soroban.stellar.org/docs/category/how-to-guides>.
+//! More examples are available at <https://soroban.stellar.org/docs/category/basic-tutorials>
+//! and <https://soroban.stellar.org/docs/category/advanced-tutorials>.
 
 #![cfg_attr(target_family = "wasm", no_std)]
 #![cfg_attr(feature = "docs", feature(doc_cfg))]


### PR DESCRIPTION
### What

A link in the `lib.rs` file of the SDK previously directed users to the `how-to-guides` category on the website. I've changed that link to lead to the `basic-tutorials` page, and have added a link to the `advanced-tutorials` page.

### Why

The `how-to-guides` page no longer exists on the stellar/soroban-docs repo. We're seeing some 404 errors originating from `docs.rs` URLs.

### Known limitations

N/A