### PR TITLE
Change Storage::get to pub(crate)

### DIFF
--- a/soroban-sdk/src/storage.rs
+++ b/soroban-sdk/src/storage.rs
@@ -158,7 +158,7 @@ impl Storage {
     /// converting the internal value representation to `V`, or will panic if
     /// the conversion to `V` fails.
     #[inline(always)]
-    pub fn get<K, V>(&self, key: &K, storage_type: StorageType) -> Option<V>
+    pub(crate) fn get<K, V>(&self, key: &K, storage_type: StorageType) -> Option<V>
     where
         K: IntoVal<Env, Val>,
         V: TryFromVal<Env, Val>,


### PR DESCRIPTION
### What
Change `Storage::get` from `pub` to `pub(crate)`.

### Why
The function is intended to be an internal function that the instance, temporary, and persistent types call into.

The `Storage::has` and `Storage::set` are marked as `pub(crate)`.

Looks like we accidentally marked it as `pub`.