### PR TITLE
Fix type of signature in auth

### DIFF
--- a/soroban-sdk/src/auth.rs
+++ b/soroban-sdk/src/auth.rs
@@ -76,7 +76,7 @@ pub trait CustomAccountInterface {
     fn __check_auth(
         env: Env,
         signature_payload: BytesN<32>,
-        signatures: Vec<Self::Signature>,
+        signatures: Self::Signature,
         auth_contexts: Vec<Context>,
     ) -> Result<(), Self::Error>;
 }

--- a/soroban-sdk/src/env.rs
+++ b/soroban-sdk/src/env.rs
@@ -1085,11 +1085,7 @@ impl Env {
     ) -> Result<(), Result<E, E::Error>> {
         let args = Vec::from_array(
             self,
-            [
-                signature_payload.to_val(),
-                signature,
-                auth_context.to_val(),
-            ],
+            [signature_payload.to_val(), signature, auth_context.to_val()],
         );
         let res = self
             .host()

--- a/soroban-sdk/src/env.rs
+++ b/soroban-sdk/src/env.rs
@@ -1080,14 +1080,14 @@ impl Env {
         &self,
         contract: &BytesN<32>,
         signature_payload: &BytesN<32>,
-        signatures: &Vec<Val>,
+        signature: Val,
         auth_context: &Vec<auth::Context>,
     ) -> Result<(), Result<E, E::Error>> {
         let args = Vec::from_array(
             self,
             [
                 signature_payload.to_val(),
-                signatures.to_val(),
+                signature,
                 auth_context.to_val(),
             ],
         );

--- a/soroban-sdk/src/env.rs
+++ b/soroban-sdk/src/env.rs
@@ -1035,10 +1035,10 @@ impl Env {
     ///     pub fn __check_auth(
     ///         _env: Env,
     ///         _signature_payload: BytesN<32>,
-    ///         signatures: Vec<Val>,
+    ///         signature: Val,
     ///         _auth_context: Vec<Context>,
     ///     ) -> Result<(), NoopAccountError> {
-    ///         if signatures.is_empty() {
+    ///         if signature.is_void() {
     ///             Err(NoopAccountError::SomeError)
     ///         } else {
     ///             Ok(())
@@ -1056,7 +1056,7 @@ impl Env {
     ///         e.try_invoke_contract_check_auth::<NoopAccountError>(
     ///             &account_contract.address.contract_id(),
     ///             &BytesN::random(&e),
-    ///             &vec![&e],
+    ///             ().into(),
     ///             &vec![&e],
     ///         ),
     ///         // The inner `Result` is for conversion error and will be Ok
@@ -1069,7 +1069,7 @@ impl Env {
     ///         e.try_invoke_contract_check_auth::<soroban_sdk::Error>(
     ///             &account_contract.address.contract_id(),
     ///             &BytesN::random(&e),
-    ///             &vec![&e, 0_i32.into()],
+    ///             0_i32.into(),
     ///             &vec![&e],
     ///         ),
     ///         Ok(())


### PR DESCRIPTION
### What
Change the type of the signature in custom auth from Vec<Val> to Val.

### Why
The protocol and env don't actually require it to be a Vec anymore, and so the SDK is limiting the type unnecessarily.