### PR TITLE
fix(snapshot): set entry expiration info in `set_ledger_info`

### DIFF
--- a/soroban-ledger-snapshot/src/lib.rs
+++ b/soroban-ledger-snapshot/src/lib.rs
@@ -85,6 +85,9 @@ impl LedgerSnapshot {
         self.timestamp = info.timestamp;
         self.network_id = info.network_id;
         self.base_reserve = info.base_reserve;
+        self.min_persistent_entry_expiration = info.min_persistent_entry_expiration;
+        self.min_temp_entry_expiration = info.min_temp_entry_expiration;
+        self.max_entry_expiration = info.max_entry_expiration;
     }
 
     /// Get the entries in the snapshot.


### PR DESCRIPTION
I've noticed some inconsistencies with snapshot creation and use where the various `*_entry_expiration` values are not set properly when create an `Env` from a snapshot that did have those values set.

This could possibly be related to #1101, but I'm not sure, since Leigh seemed more focused on prng.

Refs: #1101

### What

This commit updates the ledger-snapshot crate to also set the various ledger entry expiration values, if they are set on the snapshot being set in the environment.

### Why

When trying to load a ledger snapshot that I've created from an `Env` with valid entry expiration values, the new Env uses the defaults (which turn out to be `0`) for those expiration values.

I noticed trouble trying to run `env.register_contract()` or `env.register_stellar_asset_contract()` in a test file after loading a previously valid snapshot, and receive the error: `trying to bump past max expiration ledger`. (That expiration ledger, being `0` ledgers from now.)

### Known limitations

It's possible this is deliberate, and I'm misunderstanding how to use snapshots. If that's the case, we should probably bolster documentation around ledger snapshots to communicate that.