### PR TITLE
Use deterministic randomness in arbitrary tests

### DIFF
--- a/soroban-sdk/src/arbitrary.rs
+++ b/soroban-sdk/src/arbitrary.rs
@@ -975,7 +975,7 @@ mod tests {
     };
     use crate::{Env, IntoVal};
     use arbitrary::{Arbitrary, Unstructured};
-    use rand::RngCore;
+    use rand::{RngCore, SeedableRng};
 
     fn run_test<T>()
     where
@@ -983,7 +983,7 @@ mod tests {
         T::Prototype: for<'a> Arbitrary<'a>,
     {
         let env = Env::default();
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rngs::StdRng::seed_from_u64(0);
         let mut rng_data = [0u8; 64];
 
         for _ in 0..100 {


### PR DESCRIPTION
### What

Use a seeded StdRng instead of thread_rng in arbitrary tests.

### Why

Per https://github.com/stellar/rs-soroban-env/issues/810 randomized test cases should be deterministic.

### Known limitations

This is different from the approach in soroban-env-host from https://github.com/stellar/rs-soroban-env/pull/1124, where a test prng is attached to the env / host.

There are two more uses of thread_rng in this crate, but I don't know enough about that code to know how they should be removed, i.e. if they should follow a pattern similar to soroban-env-host. I am willing to replace all uses of thread_rng if given guidance about the preferred way to do it.

The implementation of StdRng is allowed to change in the future, so it's possible the exact numbers generated could change. I could import rand_chacha instead if desired.