### PR TITLE
Generate all types of addresses when fuzzing.

### DIFF
--- a/soroban-sdk/src/arbitrary.rs
+++ b/soroban-sdk/src/arbitrary.rs
@@ -532,7 +532,7 @@ mod objects {
 
     #[derive(Arbitrary, Debug, Clone, Eq, PartialEq, Ord, PartialOrd)]
     pub struct ArbitraryAddress {
-        inner: [u8; 32],
+        inner: crate::env::xdr::ScAddress,
     }
 
     impl SorobanArbitrary for Address {
@@ -542,10 +542,7 @@ mod objects {
     impl TryFromVal<Env, ArbitraryAddress> for Address {
         type Error = ConversionError;
         fn try_from_val(env: &Env, v: &ArbitraryAddress) -> Result<Self, Self::Error> {
-            use crate::env::xdr::{Hash, ScAddress};
-
-            let sc_addr = ScVal::Address(ScAddress::Contract(Hash(v.inner)));
-            Ok(sc_addr.into_val(env))
+            Ok(v.inner.into_val(env))
         }
     }
 


### PR DESCRIPTION
### What

Generate both ScAddress::Contract and ScAddress::Account when fuzzing.

### Why

Currently only ScAddress::Contract is generated.

Closes #1096

### Known limitations

I don't really understand the consequences for fuzz testers of making this change. Maybe there aren't any. I have tested that the fuzzer in soroban-examples continues to work.