### PR TITLE
Fix docs about prng seed

### DIFF
--- a/soroban-sdk/src/prng.rs
+++ b/soroban-sdk/src/prng.rs
@@ -86,8 +86,6 @@ impl Prng {
 
     /// Reseeds the PRNG with the provided value.
     ///
-    /// The seed is combined with the seed assigned to the contract invocation.
-    ///
     /// # Warning
     ///
     /// **The PRNG is unsuitable for generating secrets or use in applications with

--- a/soroban-sdk/src/tests/prng.rs
+++ b/soroban-sdk/src/tests/prng.rs
@@ -8,10 +8,20 @@ pub struct TestPrngContract;
 #[test]
 fn test_prng_seed() {
     let e = Env::default();
+    e.host().set_base_prng_seed([0; 32]).unwrap();
     let id = e.register_contract(None, TestPrngContract);
-
     e.as_contract(&id, || {
-        assert_eq!(e.prng().u64_in_range(0..=9), 8);
+        e.prng().seed(bytes!(
+            &e,
+            0x0000000000000000000000000000000000000000000000000000000000000001
+        ));
+        assert_eq!(e.prng().u64_in_range(0..=9), 5);
+    });
+
+    let e = Env::default();
+    let id = e.register_contract(None, TestPrngContract);
+    e.host().set_base_prng_seed([2; 32]).unwrap();
+    e.as_contract(&id, || {
         e.prng().seed(bytes!(
             &e,
             0x0000000000000000000000000000000000000000000000000000000000000001


### PR DESCRIPTION
### What
Remove the statement from the prng seed function docs that states that the base and local seed are combined.

### Why
They are not combined. Calling seed does what it sounds like it would do with any prng, it sets a new seed replacing the base seed set.

Possibly we should stop using the term "base seed" as it makes it sound like there's some relationship. But at the least we should remove this incorrect comment about seed interaction.