### PR TITLE
Refactor Prng functions

### DIFF
--- a/soroban-sdk/src/prng.rs
+++ b/soroban-sdk/src/prng.rs
@@ -126,7 +126,7 @@ impl Prng {
     /// ```
     pub fn fill<T>(&self, v: &mut T)
     where
-        T: Fill,
+        T: Fill + ?Sized,
     {
         v.fill(self);
     }

--- a/soroban-sdk/src/prng.rs
+++ b/soroban-sdk/src/prng.rs
@@ -95,6 +95,117 @@ impl Prng {
         internal::Env::prng_reseed(env, seed.into()).unwrap_infallible();
     }
 
+    /// Fills the type with a random value.
+    ///
+    /// # Warning
+    ///
+    /// **The PRNG is unsuitable for generating secrets or use in applications with
+    /// low risk tolerance, see the module-level comment.**
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use soroban_sdk::{Env, contract, contractimpl, symbol_short, Bytes};
+    /// #
+    /// # #[contract]
+    /// # pub struct Contract;
+    /// #
+    /// # #[cfg(feature = "testutils")]
+    /// # fn main() {
+    /// #     let env = Env::default();
+    /// #     let contract_id = env.register_contract(None, Contract);
+    /// #     env.as_contract(&contract_id, || {
+    /// #         env.prng().seed(Bytes::from_array(&env, &[1; 32]));
+    /// let mut value: u64 = 0;
+    /// env.prng().fill(&mut value);
+    /// assert_eq!(value, 14156542310752927490);
+    /// #     })
+    /// # }
+    /// # #[cfg(not(feature = "testutils"))]
+    /// # fn main() { }
+    /// ```
+    pub fn fill<T>(&self, v: &mut T)
+    where
+        T: Fill,
+    {
+        v.fill(self);
+    }
+
+    /// Returns a random value of the given type.
+    ///
+    /// # Warning
+    ///
+    /// **The PRNG is unsuitable for generating secrets or use in applications with
+    /// low risk tolerance, see the module-level comment.**
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use soroban_sdk::{Env, contract, contractimpl, symbol_short, Bytes};
+    /// #
+    /// # #[contract]
+    /// # pub struct Contract;
+    /// #
+    /// # #[cfg(feature = "testutils")]
+    /// # fn main() {
+    /// #     let env = Env::default();
+    /// #     let contract_id = env.register_contract(None, Contract);
+    /// #     env.as_contract(&contract_id, || {
+    /// #         env.prng().seed(Bytes::from_array(&env, &[1; 32]));
+    /// let value: u64 = env.prng().gen();
+    /// assert_eq!(value, 14156542310752927490);
+    /// #     })
+    /// # }
+    /// # #[cfg(not(feature = "testutils"))]
+    /// # fn main() { }
+    /// ```
+    pub fn gen<T>(&self) -> T
+    where
+        T: Gen,
+    {
+        T::gen(self)
+    }
+
+    /// Returns a random value of the given type in the range specified.
+    ///
+    /// # Panics
+    ///
+    /// If the start of the range is greater than the end.
+    ///
+    /// # Warning
+    ///
+    /// **The PRNG is unsuitable for generating secrets or use in applications with
+    /// low risk tolerance, see the module-level comment.**
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use soroban_sdk::{Env, contract, contractimpl, symbol_short, Bytes};
+    /// #
+    /// # #[contract]
+    /// # pub struct Contract;
+    /// #
+    /// # #[cfg(feature = "testutils")]
+    /// # fn main() {
+    /// #     let env = Env::default();
+    /// #     let contract_id = env.register_contract(None, Contract);
+    /// #     env.as_contract(&contract_id, || {
+    /// #         env.prng().seed(Bytes::from_array(&env, &[1; 32]));
+    /// // Get a value in the range of 1 to 100, inclusive.
+    /// let value: u64 = env.prng().gen_range(1..=100);
+    /// assert_eq!(value, 77);
+    /// #     })
+    /// # }
+    /// # #[cfg(not(feature = "testutils"))]
+    /// # fn main() { }
+    /// ```
+    pub fn gen_range<T>(&self, r: impl RangeBounds<T::RangeBound>) -> T
+    where
+        T: GenRange,
+    {
+        T::gen_range(self, r)
+    }
+
     /// Returns a random u64 in the range specified.
     ///
     /// # Panics
@@ -109,9 +220,7 @@ impl Prng {
     /// # Examples
     ///
     /// ```
-    /// use soroban_sdk::{Env};
-    ///
-    /// # use soroban_sdk::{contract, contractimpl, symbol_short, Bytes};
+    /// # use soroban_sdk::{Env, contract, contractimpl, symbol_short, Bytes};
     /// #
     /// # #[contract]
     /// # pub struct Contract;
@@ -122,33 +231,17 @@ impl Prng {
     /// #     let contract_id = env.register_contract(None, Contract);
     /// #     env.as_contract(&contract_id, || {
     /// #         env.prng().seed(Bytes::from_array(&env, &[1; 32]));
-    /// // Get values in the range of 1 to 100, inclusive.
+    /// // Get a value in the range of 1 to 100, inclusive.
     /// let value = env.prng().u64_in_range(1..=100);
     /// assert_eq!(value, 77);
-    /// let value = env.prng().u64_in_range(1..=100);
-    /// assert_eq!(value, 66);
-    /// let value = env.prng().u64_in_range(1..=100);
-    /// assert_eq!(value, 72);
     /// #     })
     /// # }
     /// # #[cfg(not(feature = "testutils"))]
     /// # fn main() { }
     /// ```
+    #[deprecated(note = "use env.prng().gen_range(...)")]
     pub fn u64_in_range(&self, r: impl RangeBounds<u64>) -> u64 {
-        let start_bound = match r.start_bound() {
-            Bound::Included(b) => *b,
-            Bound::Excluded(b) => *b + 1,
-            Bound::Unbounded => 0,
-        };
-        let end_bound = match r.end_bound() {
-            Bound::Included(b) => *b,
-            Bound::Excluded(b) => *b - 1,
-            Bound::Unbounded => u64::MAX,
-        };
-        let env = self.env();
-        internal::Env::prng_u64_in_inclusive_range(env, start_bound.into(), end_bound.into())
-            .unwrap_infallible()
-            .into()
+        self.gen_range(r)
     }
 
     /// Shuffles a given vector v using the Fisher-Yates algorithm.
@@ -168,5 +261,67 @@ impl Prng {
             .unwrap_infallible()
             .try_into_val(env)
             .unwrap_infallible()
+    }
+}
+
+/// Implemented by types that support being filled by a Prng.
+pub trait Fill {
+    /// Fills the given value with the Prng.
+    fn fill(&mut self, prng: &Prng);
+}
+
+/// Implemented by types that support being generated by a Prng.
+pub trait Gen {
+    /// Generates a value of the implementing type with the Prng.
+    fn gen(prng: &Prng) -> Self;
+}
+
+/// Implemented by types that support being generated in a specific range by a
+/// Prng.
+pub trait GenRange {
+    type RangeBound;
+
+    /// Generates a value of the implementing type with the Prng in the
+    /// specified range.
+    ///
+    /// # Panics
+    ///
+    /// If the range is empty.
+    fn gen_range(prng: &Prng, r: impl RangeBounds<Self::RangeBound>) -> Self;
+}
+
+impl Fill for u64 {
+    fn fill(&mut self, prng: &Prng) {
+        *self = Self::gen(prng);
+    }
+}
+
+impl Gen for u64 {
+    fn gen(prng: &Prng) -> Self {
+        let env = prng.env();
+        internal::Env::prng_u64_in_inclusive_range(env, u64::MIN.into(), u64::MAX.into())
+            .unwrap_infallible()
+            .into()
+    }
+}
+
+impl GenRange for u64 {
+    type RangeBound = u64;
+
+    fn gen_range(prng: &Prng, r: impl RangeBounds<Self::RangeBound>) -> Self {
+        let env = prng.env();
+        let start_bound = match r.start_bound() {
+            Bound::Included(b) => *b,
+            Bound::Excluded(b) => *b + 1,
+            Bound::Unbounded => u64::MIN,
+        };
+        let end_bound = match r.end_bound() {
+            Bound::Included(b) => *b,
+            Bound::Excluded(b) => *b - 1,
+            Bound::Unbounded => u64::MAX,
+        };
+        internal::Env::prng_u64_in_inclusive_range(env, start_bound.into(), end_bound.into())
+            .unwrap_infallible()
+            .into()
     }
 }

--- a/soroban-sdk/src/tests/prng.rs
+++ b/soroban-sdk/src/tests/prng.rs
@@ -87,7 +87,7 @@ fn test_prng_u64_in_range() {
 
 #[test]
 #[should_panic(expected = "low > high")]
-fn test_prng_u64_in_range_panic_on_empty_range() {
+fn test_prng_u64_in_range_panic_on_invalid_range() {
     let e = Env::default();
     let id = e.register_contract(None, TestPrngContract);
 

--- a/soroban-sdk/src/tests/prng.rs
+++ b/soroban-sdk/src/tests/prng.rs
@@ -15,7 +15,7 @@ fn test_prng_seed() {
             &e,
             0x0000000000000000000000000000000000000000000000000000000000000001
         ));
-        assert_eq!(e.prng().u64_in_range(0..=9), 5);
+        assert_eq!(e.prng().gen_range::<u64>(0..=9), 5);
     });
 
     let e = Env::default();
@@ -26,7 +26,7 @@ fn test_prng_seed() {
             &e,
             0x0000000000000000000000000000000000000000000000000000000000000001
         ));
-        assert_eq!(e.prng().u64_in_range(0..=9), 5);
+        assert_eq!(e.prng().gen_range::<u64>(0..=9), 5);
     });
 }
 
@@ -67,31 +67,56 @@ fn test_vec_shuffle() {
 }
 
 #[test]
-fn test_prng_u64_in_range() {
+fn test_prng_fill_u64() {
     let e = Env::default();
     let id = e.register_contract(None, TestPrngContract);
 
     e.as_contract(&id, || {
-        assert_eq!(e.prng().u64_in_range(..), 15905370036469238889);
-        assert_eq!(e.prng().u64_in_range(u64::MAX..), u64::MAX);
+        let mut v: u64 = 0;
+        e.prng().fill(&mut v);
+        assert_eq!(v, 15905370036469238889);
+        e.prng().fill(&mut v);
+        assert_eq!(v, 9820564573332354559);
+    });
+}
+
+#[test]
+fn test_prng_gen_u64() {
+    let e = Env::default();
+    let id = e.register_contract(None, TestPrngContract);
+
+    e.as_contract(&id, || {
+        assert_eq!(e.prng().gen::<u64>(), 15905370036469238889);
+        assert_eq!(e.prng().gen::<u64>(), 9820564573332354559);
+    });
+}
+
+#[test]
+fn test_prng_gen_range_u64() {
+    let e = Env::default();
+    let id = e.register_contract(None, TestPrngContract);
+
+    e.as_contract(&id, || {
+        assert_eq!(e.prng().gen_range::<u64>(..), 15905370036469238889);
+        assert_eq!(e.prng().gen_range::<u64>(u64::MAX..), u64::MAX);
         assert_eq!(
-            e.prng().u64_in_range(u64::MAX - 1..u64::MAX),
+            e.prng().gen_range::<u64>(u64::MAX - 1..u64::MAX),
             18446744073709551614
         );
-        assert_eq!(e.prng().u64_in_range(u64::MAX..=u64::MAX), u64::MAX);
-        assert_eq!(e.prng().u64_in_range(0..1), 0);
-        assert_eq!(e.prng().u64_in_range(0..=0), 0);
-        assert_eq!(e.prng().u64_in_range(..=0), 0);
+        assert_eq!(e.prng().gen_range::<u64>(u64::MAX..=u64::MAX), u64::MAX);
+        assert_eq!(e.prng().gen_range::<u64>(0..1), 0);
+        assert_eq!(e.prng().gen_range::<u64>(0..=0), 0);
+        assert_eq!(e.prng().gen_range::<u64>(..=0), 0);
     });
 }
 
 #[test]
 #[should_panic(expected = "low > high")]
-fn test_prng_u64_in_range_panic_on_invalid_range() {
+fn test_prng_gen_range_u64_panic_on_invalid_range() {
     let e = Env::default();
     let id = e.register_contract(None, TestPrngContract);
 
     e.as_contract(&id, || {
-        e.prng().u64_in_range(u64::MAX..u64::MAX);
+        e.prng().gen_range::<u64>(u64::MAX..u64::MAX);
     });
 }


### PR DESCRIPTION
### What
Refactor Prng u64_in_range fn into fill, gen, gen_range

### Why
To make it easier to add generation of random values for other types such as slices of bytes, u32, u16, etc.