### PR TITLE
Add prng generation for slices and arrays

### DIFF
--- a/soroban-sdk/src/prng.rs
+++ b/soroban-sdk/src/prng.rs
@@ -126,7 +126,7 @@ impl Prng {
     /// ```
     pub fn fill<T>(&self, v: &mut T)
     where
-        T: Fill,
+        T: Fill + ?Sized,
     {
         v.fill(self);
     }

--- a/soroban-sdk/src/prng.rs
+++ b/soroban-sdk/src/prng.rs
@@ -108,7 +108,7 @@ impl Prng {
     ///
     /// # Examples
     ///
-    /// ## u64
+    /// ## `u64`
     ///
     /// ```
     /// # use soroban_sdk::{Env, contract, contractimpl, symbol_short, Bytes};
@@ -130,6 +130,35 @@ impl Prng {
     /// # #[cfg(not(feature = "testutils"))]
     /// # fn main() { }
     /// ```
+    ///
+    /// ## `[u8]`
+    ///
+    /// ```
+    /// # use soroban_sdk::{Env, contract, contractimpl, symbol_short, Bytes};
+    /// #
+    /// # #[contract]
+    /// # pub struct Contract;
+    /// #
+    /// # #[cfg(feature = "testutils")]
+    /// # fn main() {
+    /// #     let env = Env::default();
+    /// #     let contract_id = env.register_contract(None, Contract);
+    /// #     env.as_contract(&contract_id, || {
+    /// #         env.prng().seed(Bytes::from_array(&env, &[1; 32]));
+    /// let mut value = [0u8; 32];
+    /// env.prng().fill(&mut value);
+    /// assert_eq!(
+    ///   value,
+    ///   [
+    ///     2, 63, 55, 32, 58, 36, 118, 196, 37, 102, 166, 28, 197, 92, 60, 168, 117, 219,
+    ///     180, 204, 65, 192, 222, 183, 137, 248, 231, 191, 136, 24, 54, 56
+    ///   ],
+    /// );
+    /// #     })
+    /// # }
+    /// # #[cfg(not(feature = "testutils"))]
+    /// # fn main() { }
+    /// ```
     pub fn fill<T>(&self, v: &mut T)
     where
         T: Fill + ?Sized,
@@ -146,6 +175,8 @@ impl Prng {
     ///
     /// # Examples
     ///
+    /// ## `u64`
+    ///
     /// ```
     /// # use soroban_sdk::{Env, contract, contractimpl, symbol_short, Bytes};
     /// #
@@ -160,6 +191,34 @@ impl Prng {
     /// #         env.prng().seed(Bytes::from_array(&env, &[1; 32]));
     /// let value: u64 = env.prng().gen();
     /// assert_eq!(value, 14156542310752927490);
+    /// #     })
+    /// # }
+    /// # #[cfg(not(feature = "testutils"))]
+    /// # fn main() { }
+    /// ```
+    ///
+    /// ## `[u8; N]`
+    ///
+    /// ```
+    /// # use soroban_sdk::{Env, contract, contractimpl, symbol_short, Bytes};
+    /// #
+    /// # #[contract]
+    /// # pub struct Contract;
+    /// #
+    /// # #[cfg(feature = "testutils")]
+    /// # fn main() {
+    /// #     let env = Env::default();
+    /// #     let contract_id = env.register_contract(None, Contract);
+    /// #     env.as_contract(&contract_id, || {
+    /// #         env.prng().seed(Bytes::from_array(&env, &[1; 32]));
+    /// let value: [u8; 32] = env.prng().gen();
+    /// assert_eq!(
+    ///   value,
+    ///   [
+    ///     2, 63, 55, 32, 58, 36, 118, 196, 37, 102, 166, 28, 197, 92, 60, 168, 117, 219,
+    ///     180, 204, 65, 192, 222, 183, 137, 248, 231, 191, 136, 24, 54, 56
+    ///   ],
+    /// );
     /// #     })
     /// # }
     /// # #[cfg(not(feature = "testutils"))]
@@ -184,6 +243,8 @@ impl Prng {
     /// low risk tolerance, see the module-level comment.**
     ///
     /// # Examples
+    ///
+    /// ## `Bytes`
     ///
     /// ```
     /// # use soroban_sdk::{Env, contract, contractimpl, symbol_short, Bytes};
@@ -230,6 +291,8 @@ impl Prng {
     /// low risk tolerance, see the module-level comment.**
     ///
     /// # Examples
+    ///
+    /// ## `u64`
     ///
     /// ```
     /// # use soroban_sdk::{Env, contract, contractimpl, symbol_short, Bytes};

--- a/soroban-sdk/src/prng.rs
+++ b/soroban-sdk/src/prng.rs
@@ -95,6 +95,117 @@ impl Prng {
         internal::Env::prng_reseed(env, seed.into()).unwrap_infallible();
     }
 
+    /// Fills the type with a random value.
+    ///
+    /// # Warning
+    ///
+    /// **The PRNG is unsuitable for generating secrets or use in applications with
+    /// low risk tolerance, see the module-level comment.**
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use soroban_sdk::{Env, contract, contractimpl, symbol_short, Bytes};
+    /// #
+    /// # #[contract]
+    /// # pub struct Contract;
+    /// #
+    /// # #[cfg(feature = "testutils")]
+    /// # fn main() {
+    /// #     let env = Env::default();
+    /// #     let contract_id = env.register_contract(None, Contract);
+    /// #     env.as_contract(&contract_id, || {
+    /// #         env.prng().seed(Bytes::from_array(&env, &[1; 32]));
+    /// let mut value: u64 = 0;
+    /// env.prng().fill(&mut value);
+    /// assert_eq!(value, 14156542310752927490);
+    /// #     })
+    /// # }
+    /// # #[cfg(not(feature = "testutils"))]
+    /// # fn main() { }
+    /// ```
+    pub fn fill<T>(&self, v: &mut T)
+    where
+        T: Fill,
+    {
+        v.fill(self);
+    }
+
+    /// Returns a random value of the given type.
+    ///
+    /// # Warning
+    ///
+    /// **The PRNG is unsuitable for generating secrets or use in applications with
+    /// low risk tolerance, see the module-level comment.**
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use soroban_sdk::{Env, contract, contractimpl, symbol_short, Bytes};
+    /// #
+    /// # #[contract]
+    /// # pub struct Contract;
+    /// #
+    /// # #[cfg(feature = "testutils")]
+    /// # fn main() {
+    /// #     let env = Env::default();
+    /// #     let contract_id = env.register_contract(None, Contract);
+    /// #     env.as_contract(&contract_id, || {
+    /// #         env.prng().seed(Bytes::from_array(&env, &[1; 32]));
+    /// let value: u64 = env.prng().gen();
+    /// assert_eq!(value, 14156542310752927490);
+    /// #     })
+    /// # }
+    /// # #[cfg(not(feature = "testutils"))]
+    /// # fn main() { }
+    /// ```
+    pub fn gen<T>(&self) -> T
+    where
+        T: Gen,
+    {
+        T::gen(self)
+    }
+
+    /// Returns a random value of the given type in the range specified.
+    ///
+    /// # Panics
+    ///
+    /// If the start of the range is greater than the end.
+    ///
+    /// # Warning
+    ///
+    /// **The PRNG is unsuitable for generating secrets or use in applications with
+    /// low risk tolerance, see the module-level comment.**
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use soroban_sdk::{Env, contract, contractimpl, symbol_short, Bytes};
+    /// #
+    /// # #[contract]
+    /// # pub struct Contract;
+    /// #
+    /// # #[cfg(feature = "testutils")]
+    /// # fn main() {
+    /// #     let env = Env::default();
+    /// #     let contract_id = env.register_contract(None, Contract);
+    /// #     env.as_contract(&contract_id, || {
+    /// #         env.prng().seed(Bytes::from_array(&env, &[1; 32]));
+    /// // Get a value in the range of 1 to 100, inclusive.
+    /// let value: u64 = env.prng().gen_range(1..=100);
+    /// assert_eq!(value, 77);
+    /// #     })
+    /// # }
+    /// # #[cfg(not(feature = "testutils"))]
+    /// # fn main() { }
+    /// ```
+    pub fn gen_range<T>(&self, r: impl RangeBounds<T::RangeBound>) -> T
+    where
+        T: GenRange,
+    {
+        T::gen_range(self, r)
+    }
+
     /// Returns a random u64 in the range specified.
     ///
     /// # Panics
@@ -109,9 +220,7 @@ impl Prng {
     /// # Examples
     ///
     /// ```
-    /// use soroban_sdk::{Env};
-    ///
-    /// # use soroban_sdk::{contract, contractimpl, symbol_short, Bytes};
+    /// # use soroban_sdk::{Env, contract, contractimpl, symbol_short, Bytes};
     /// #
     /// # #[contract]
     /// # pub struct Contract;
@@ -122,33 +231,17 @@ impl Prng {
     /// #     let contract_id = env.register_contract(None, Contract);
     /// #     env.as_contract(&contract_id, || {
     /// #         env.prng().seed(Bytes::from_array(&env, &[1; 32]));
-    /// // Get values in the range of 1 to 100, inclusive.
+    /// // Get a value in the range of 1 to 100, inclusive.
     /// let value = env.prng().u64_in_range(1..=100);
     /// assert_eq!(value, 77);
-    /// let value = env.prng().u64_in_range(1..=100);
-    /// assert_eq!(value, 66);
-    /// let value = env.prng().u64_in_range(1..=100);
-    /// assert_eq!(value, 72);
     /// #     })
     /// # }
     /// # #[cfg(not(feature = "testutils"))]
     /// # fn main() { }
     /// ```
+    #[deprecated(note = "use env.prng().gen_range(...)")]
     pub fn u64_in_range(&self, r: impl RangeBounds<u64>) -> u64 {
-        let start_bound = match r.start_bound() {
-            Bound::Included(b) => *b,
-            Bound::Excluded(b) => *b + 1,
-            Bound::Unbounded => 0,
-        };
-        let end_bound = match r.end_bound() {
-            Bound::Included(b) => *b,
-            Bound::Excluded(b) => *b - 1,
-            Bound::Unbounded => u64::MAX,
-        };
-        let env = self.env();
-        internal::Env::prng_u64_in_inclusive_range(env, start_bound.into(), end_bound.into())
-            .unwrap_infallible()
-            .into()
+        self.gen_range(r)
     }
 
     /// Shuffles a given vector v using the Fisher-Yates algorithm.
@@ -168,5 +261,67 @@ impl Prng {
             .unwrap_infallible()
             .try_into_val(env)
             .unwrap_infallible()
+    }
+}
+
+/// Implemented by types that support being filled by a Prng.
+pub trait Fill {
+    /// Fills the given value with the Prng.
+    fn fill(&mut self, prng: &Prng);
+}
+
+/// Implemented by types that support being generated by a Prng.
+pub trait Gen {
+    /// Generates a value of the implementing type with the Prng.
+    fn gen(prng: &Prng) -> Self;
+}
+
+/// Implemented by types that support being generated in a specific range by a
+/// Prng.
+pub trait GenRange {
+    type RangeBound;
+
+    /// Generates a value of the implementing type with the Prng in the
+    /// specified range.
+    ///
+    /// # Panics
+    ///
+    /// If the range is empty.
+    fn gen_range(prng: &Prng, r: impl RangeBounds<Self::RangeBound>) -> Self;
+}
+
+impl Fill for u64 {
+    fn fill(&mut self, prng: &Prng) {
+        *self = Self::gen(prng);
+    }
+}
+
+impl Gen for u64 {
+    fn gen(prng: &Prng) -> Self {
+        let env = prng.env();
+        internal::Env::prng_u64_in_inclusive_range(env, u64::MIN.into(), u64::MAX.into())
+            .unwrap_infallible()
+            .into()
+    }
+}
+
+impl GenRange for u64 {
+    type RangeBound = u64;
+
+    fn gen_range(prng: &Prng, r: impl RangeBounds<Self::RangeBound>) -> Self {
+        let env = prng.env();
+        let start_bound = match r.start_bound() {
+            Bound::Included(b) => *b,
+            Bound::Excluded(b) => *b + 1,
+            Bound::Unbounded => u64::MIN,
+        };
+        let end_bound = match r.end_bound() {
+            Bound::Included(b) => *b,
+            Bound::Excluded(b) => *b - 1,
+            Bound::Unbounded => u64::MAX,
+        };
+        internal::Env::prng_u64_in_inclusive_range(env, start_bound.into(), end_bound.into())
+            .unwrap_infallible()
+            .into()
     }
 }

--- a/soroban-sdk/src/prng.rs
+++ b/soroban-sdk/src/prng.rs
@@ -63,7 +63,11 @@
 //! output from the local PRNG.
 use core::ops::{Bound, RangeBounds};
 
-use crate::{env::internal, unwrap::UnwrapInfallible, Bytes, Env, IntoVal, TryIntoVal, Val, Vec};
+use crate::{
+    env::internal,
+    unwrap::{UnwrapInfallible, UnwrapOptimized},
+    Bytes, BytesN, Env, IntoVal, TryIntoVal, Val, Vec,
+};
 
 /// Prng is a pseudo-random generator.
 ///
@@ -103,6 +107,8 @@ impl Prng {
     /// low risk tolerance, see the module-level comment.**
     ///
     /// # Examples
+    ///
+    /// ## u64
     ///
     /// ```
     /// # use soroban_sdk::{Env, contract, contractimpl, symbol_short, Bytes};
@@ -164,6 +170,52 @@ impl Prng {
         T: Gen,
     {
         T::gen(self)
+    }
+
+    /// Returns a random value of the given type with the given length.
+    ///
+    /// # Panics
+    ///
+    /// If the length is greater than u32::MAX.
+    ///
+    /// # Warning
+    ///
+    /// **The PRNG is unsuitable for generating secrets or use in applications with
+    /// low risk tolerance, see the module-level comment.**
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use soroban_sdk::{Env, contract, contractimpl, symbol_short, Bytes};
+    /// #
+    /// # #[contract]
+    /// # pub struct Contract;
+    /// #
+    /// # #[cfg(feature = "testutils")]
+    /// # fn main() {
+    /// #     let env = Env::default();
+    /// #     let contract_id = env.register_contract(None, Contract);
+    /// #     env.as_contract(&contract_id, || {
+    /// #         env.prng().seed(Bytes::from_array(&env, &[1; 32]));
+    /// // Get a value of length 32 bytes.
+    /// let value: Bytes = env.prng().gen_len(32);
+    /// assert_eq!(value, Bytes::from_slice(
+    ///   &env,
+    ///   &[
+    ///     2, 63, 55, 32, 58, 36, 118, 196, 37, 102, 166, 28, 197, 92, 60, 168, 117, 219,
+    ///     180, 204, 65, 192, 222, 183, 137, 248, 231, 191, 136, 24, 54, 56
+    ///   ],
+    /// ));
+    /// #     })
+    /// # }
+    /// # #[cfg(not(feature = "testutils"))]
+    /// # fn main() { }
+    /// ```
+    pub fn gen_len<T>(&self, len: T::Len) -> T
+    where
+        T: GenLen,
+    {
+        T::gen_len(self, len)
     }
 
     /// Returns a random value of the given type in the range specified.
@@ -276,6 +328,20 @@ pub trait Gen {
     fn gen(prng: &Prng) -> Self;
 }
 
+/// Implemented by types that support being generated of specific length by a
+/// Prng.
+pub trait GenLen {
+    type Len;
+
+    /// Generates a value of the given implementing type with length with the
+    /// Prng.
+    ///
+    /// # Panics
+    ///
+    /// If the length is greater than u32::MAX.
+    fn gen_len(prng: &Prng, len: Self::Len) -> Self;
+}
+
 /// Implemented by types that support being generated in a specific range by a
 /// Prng.
 pub trait GenRange {
@@ -323,5 +389,100 @@ impl GenRange for u64 {
         internal::Env::prng_u64_in_inclusive_range(env, start_bound.into(), end_bound.into())
             .unwrap_infallible()
             .into()
+    }
+}
+
+impl Fill for Bytes {
+    /// Fills the Bytes with the Prng.
+    ///
+    /// # Panics
+    ///
+    /// If the length of Bytes is greater than u32::MAX in length.
+    fn fill(&mut self, prng: &Prng) {
+        let env = prng.env();
+        let len: u32 = self.len().try_into().unwrap_optimized();
+        let obj = internal::Env::prng_bytes_new(env, len.into()).unwrap_infallible();
+        *self = unsafe { Bytes::unchecked_new(env.clone(), obj) };
+    }
+}
+
+impl GenLen for Bytes {
+    type Len = u32;
+    /// Generates the Bytes with the Prng of the given length.
+    fn gen_len(prng: &Prng, len: u32) -> Self {
+        let env = prng.env();
+        let obj = internal::Env::prng_bytes_new(env, len.into()).unwrap_infallible();
+        unsafe { Bytes::unchecked_new(env.clone(), obj) }
+    }
+}
+
+impl<const N: usize> Fill for BytesN<N> {
+    /// Fills the BytesN with the Prng.
+    ///
+    /// # Panics
+    ///
+    /// If the length of BytesN is greater than u32::MAX in length.
+    fn fill(&mut self, prng: &Prng) {
+        let bytesn = Self::gen(prng);
+        *self = bytesn;
+    }
+}
+
+impl<const N: usize> Gen for BytesN<N> {
+    /// Generates the BytesN with the Prng.
+    ///
+    /// # Panics
+    ///
+    /// If the length of BytesN is greater than u32::MAX in length.
+    fn gen(prng: &Prng) -> Self {
+        let env = prng.env();
+        let len: u32 = N.try_into().unwrap_optimized();
+        let obj = internal::Env::prng_bytes_new(env, len.into()).unwrap_infallible();
+        unsafe { BytesN::unchecked_new(env.clone(), obj) }
+    }
+}
+
+impl Fill for [u8] {
+    /// Fills the slice with the Prng.
+    ///
+    /// # Panics
+    ///
+    /// If the slice is greater than u32::MAX in length.
+    fn fill(&mut self, prng: &Prng) {
+        let env = prng.env();
+        let len: u32 = self.len().try_into().unwrap_optimized();
+        let bytes: Bytes = internal::Env::prng_bytes_new(env, len.into())
+            .unwrap_infallible()
+            .into_val(env);
+        bytes.copy_into_slice(self);
+    }
+}
+
+impl<const N: usize> Fill for [u8; N] {
+    /// Fills the array with the Prng.
+    ///
+    /// # Panics
+    ///
+    /// If the array is greater than u32::MAX in length.
+    fn fill(&mut self, prng: &Prng) {
+        let env = prng.env();
+        let len: u32 = N.try_into().unwrap_optimized();
+        let bytes: Bytes = internal::Env::prng_bytes_new(env, len.into())
+            .unwrap_infallible()
+            .into_val(env);
+        bytes.copy_into_slice(self);
+    }
+}
+
+impl<const N: usize> Gen for [u8; N] {
+    /// Generates the array with the Prng.
+    ///
+    /// # Panics
+    ///
+    /// If the array is greater than u32::MAX in length.
+    fn gen(prng: &Prng) -> Self {
+        let mut v = [0u8; N];
+        v.fill(prng);
+        v
     }
 }

--- a/soroban-sdk/src/tests/prng.rs
+++ b/soroban-sdk/src/tests/prng.rs
@@ -1,4 +1,4 @@
-use crate::{self as soroban_sdk};
+use crate::{self as soroban_sdk, Bytes, BytesN};
 use crate::{bytes, vec, Env, Val, Vec};
 use soroban_sdk::contract;
 
@@ -118,5 +118,203 @@ fn test_prng_gen_range_u64_panic_on_invalid_range() {
 
     e.as_contract(&id, || {
         e.prng().gen_range::<u64>(u64::MAX..u64::MAX);
+    });
+}
+
+#[test]
+fn test_prng_fill_bytes() {
+    let e = Env::default();
+    let id = e.register_contract(None, TestPrngContract);
+
+    e.as_contract(&id, || {
+        let mut v = Bytes::from_array(&e, &[0u8; 32]);
+        e.prng().fill(&mut v);
+        assert_eq!(
+            v,
+            Bytes::from_array(
+                &e,
+                &[
+                    105, 12, 228, 36, 199, 57, 187, 220, 255, 181, 66, 167, 114, 167, 73, 136, 126,
+                    229, 99, 124, 156, 9, 231, 42, 211, 148, 110, 234, 189, 179, 224, 119
+                ]
+            )
+        );
+        e.prng().fill(&mut v);
+        assert_eq!(
+            v,
+            Bytes::from_array(
+                &e,
+                &[
+                    12, 120, 166, 125, 4, 130, 72, 67, 232, 216, 155, 171, 240, 65, 91, 25, 149,
+                    135, 147, 217, 131, 98, 2, 123, 78, 144, 194, 14, 36, 113, 79, 193
+                ]
+            )
+        );
+    });
+}
+
+#[test]
+fn test_prng_gen_len_bytes() {
+    let e = Env::default();
+    let id = e.register_contract(None, TestPrngContract);
+
+    e.as_contract(&id, || {
+        assert_eq!(
+            e.prng().gen_len::<Bytes>(32),
+            Bytes::from_array(
+                &e,
+                &[
+                    105, 12, 228, 36, 199, 57, 187, 220, 255, 181, 66, 167, 114, 167, 73, 136, 126,
+                    229, 99, 124, 156, 9, 231, 42, 211, 148, 110, 234, 189, 179, 224, 119
+                ]
+            )
+        );
+        assert_eq!(
+            e.prng().gen_len::<Bytes>(32),
+            Bytes::from_array(
+                &e,
+                &[
+                    12, 120, 166, 125, 4, 130, 72, 67, 232, 216, 155, 171, 240, 65, 91, 25, 149,
+                    135, 147, 217, 131, 98, 2, 123, 78, 144, 194, 14, 36, 113, 79, 193
+                ]
+            )
+        );
+    });
+}
+
+#[test]
+fn test_prng_fill_bytesn() {
+    let e = Env::default();
+    let id = e.register_contract(None, TestPrngContract);
+
+    e.as_contract(&id, || {
+        let mut v = BytesN::from_array(&e, &[0u8; 32]);
+        e.prng().fill(&mut v);
+        assert_eq!(
+            v,
+            BytesN::from_array(
+                &e,
+                &[
+                    105, 12, 228, 36, 199, 57, 187, 220, 255, 181, 66, 167, 114, 167, 73, 136, 126,
+                    229, 99, 124, 156, 9, 231, 42, 211, 148, 110, 234, 189, 179, 224, 119
+                ]
+            )
+        );
+        e.prng().fill(&mut v);
+        assert_eq!(
+            v,
+            BytesN::from_array(
+                &e,
+                &[
+                    12, 120, 166, 125, 4, 130, 72, 67, 232, 216, 155, 171, 240, 65, 91, 25, 149,
+                    135, 147, 217, 131, 98, 2, 123, 78, 144, 194, 14, 36, 113, 79, 193
+                ]
+            )
+        );
+    });
+}
+
+#[test]
+fn test_prng_gen_bytesn() {
+    let e = Env::default();
+    let id = e.register_contract(None, TestPrngContract);
+
+    e.as_contract(&id, || {
+        assert_eq!(
+            e.prng().gen::<BytesN<32>>(),
+            BytesN::from_array(
+                &e,
+                &[
+                    105, 12, 228, 36, 199, 57, 187, 220, 255, 181, 66, 167, 114, 167, 73, 136, 126,
+                    229, 99, 124, 156, 9, 231, 42, 211, 148, 110, 234, 189, 179, 224, 119
+                ]
+            )
+        );
+        assert_eq!(
+            e.prng().gen::<BytesN<32>>(),
+            BytesN::from_array(
+                &e,
+                &[
+                    12, 120, 166, 125, 4, 130, 72, 67, 232, 216, 155, 171, 240, 65, 91, 25, 149,
+                    135, 147, 217, 131, 98, 2, 123, 78, 144, 194, 14, 36, 113, 79, 193
+                ]
+            )
+        );
+    });
+}
+
+#[test]
+fn test_prng_fill_slice() {
+    let e = Env::default();
+    let id = e.register_contract(None, TestPrngContract);
+
+    e.as_contract(&id, || {
+        let mut buf = [0u8; 32];
+        let v: &mut [u8] = &mut buf;
+        e.prng().fill(v);
+        assert_eq!(
+            v,
+            [
+                105, 12, 228, 36, 199, 57, 187, 220, 255, 181, 66, 167, 114, 167, 73, 136, 126,
+                229, 99, 124, 156, 9, 231, 42, 211, 148, 110, 234, 189, 179, 224, 119
+            ]
+        );
+        e.prng().fill(v);
+        assert_eq!(
+            v,
+            [
+                12, 120, 166, 125, 4, 130, 72, 67, 232, 216, 155, 171, 240, 65, 91, 25, 149, 135,
+                147, 217, 131, 98, 2, 123, 78, 144, 194, 14, 36, 113, 79, 193
+            ]
+        );
+    });
+}
+
+#[test]
+fn test_prng_fill_array() {
+    let e = Env::default();
+    let id = e.register_contract(None, TestPrngContract);
+
+    e.as_contract(&id, || {
+        let mut v = [0u8; 32];
+        e.prng().fill(&mut v);
+        assert_eq!(
+            v,
+            [
+                105, 12, 228, 36, 199, 57, 187, 220, 255, 181, 66, 167, 114, 167, 73, 136, 126,
+                229, 99, 124, 156, 9, 231, 42, 211, 148, 110, 234, 189, 179, 224, 119
+            ]
+        );
+        e.prng().fill(&mut v);
+        assert_eq!(
+            v,
+            [
+                12, 120, 166, 125, 4, 130, 72, 67, 232, 216, 155, 171, 240, 65, 91, 25, 149, 135,
+                147, 217, 131, 98, 2, 123, 78, 144, 194, 14, 36, 113, 79, 193
+            ]
+        );
+    });
+}
+
+#[test]
+fn test_prng_gen_array() {
+    let e = Env::default();
+    let id = e.register_contract(None, TestPrngContract);
+
+    e.as_contract(&id, || {
+        assert_eq!(
+            e.prng().gen::<[u8; 32]>(),
+            [
+                105, 12, 228, 36, 199, 57, 187, 220, 255, 181, 66, 167, 114, 167, 73, 136, 126,
+                229, 99, 124, 156, 9, 231, 42, 211, 148, 110, 234, 189, 179, 224, 119
+            ]
+        );
+        assert_eq!(
+            e.prng().gen::<[u8; 32]>(),
+            [
+                12, 120, 166, 125, 4, 130, 72, 67, 232, 216, 155, 171, 240, 65, 91, 25, 149, 135,
+                147, 217, 131, 98, 2, 123, 78, 144, 194, 14, 36, 113, 79, 193
+            ]
+        );
     });
 }

--- a/soroban-sdk/src/tests/prng.rs
+++ b/soroban-sdk/src/tests/prng.rs
@@ -87,7 +87,7 @@ fn test_prng_u64_in_range() {
 
 #[test]
 #[should_panic(expected = "low > high")]
-fn test_prng_u64_in_range_panic_on_empty_range() {
+fn test_prng_u64_in_range_panic_on_invalid_range() {
     let e = Env::default();
     let id = e.register_contract(None, TestPrngContract);
 

--- a/soroban-sdk/src/tests/prng.rs
+++ b/soroban-sdk/src/tests/prng.rs
@@ -15,7 +15,7 @@ fn test_prng_seed() {
             &e,
             0x0000000000000000000000000000000000000000000000000000000000000001
         ));
-        assert_eq!(e.prng().u64_in_range(0..=9), 5);
+        assert_eq!(e.prng().gen_range::<u64>(0..=9), 5);
     });
 
     let e = Env::default();
@@ -26,7 +26,7 @@ fn test_prng_seed() {
             &e,
             0x0000000000000000000000000000000000000000000000000000000000000001
         ));
-        assert_eq!(e.prng().u64_in_range(0..=9), 5);
+        assert_eq!(e.prng().gen_range::<u64>(0..=9), 5);
     });
 }
 
@@ -67,31 +67,56 @@ fn test_vec_shuffle() {
 }
 
 #[test]
-fn test_prng_u64_in_range() {
+fn test_prng_fill_u64() {
     let e = Env::default();
     let id = e.register_contract(None, TestPrngContract);
 
     e.as_contract(&id, || {
-        assert_eq!(e.prng().u64_in_range(..), 15905370036469238889);
-        assert_eq!(e.prng().u64_in_range(u64::MAX..), u64::MAX);
+        let mut v: u64 = 0;
+        e.prng().fill(&mut v);
+        assert_eq!(v, 15905370036469238889);
+        e.prng().fill(&mut v);
+        assert_eq!(v, 9820564573332354559);
+    });
+}
+
+#[test]
+fn test_prng_gen_u64() {
+    let e = Env::default();
+    let id = e.register_contract(None, TestPrngContract);
+
+    e.as_contract(&id, || {
+        assert_eq!(e.prng().gen::<u64>(), 15905370036469238889);
+        assert_eq!(e.prng().gen::<u64>(), 9820564573332354559);
+    });
+}
+
+#[test]
+fn test_prng_gen_range_u64() {
+    let e = Env::default();
+    let id = e.register_contract(None, TestPrngContract);
+
+    e.as_contract(&id, || {
+        assert_eq!(e.prng().gen_range::<u64>(..), 15905370036469238889);
+        assert_eq!(e.prng().gen_range::<u64>(u64::MAX..), u64::MAX);
         assert_eq!(
-            e.prng().u64_in_range(u64::MAX - 1..u64::MAX),
+            e.prng().gen_range::<u64>(u64::MAX - 1..u64::MAX),
             18446744073709551614
         );
-        assert_eq!(e.prng().u64_in_range(u64::MAX..=u64::MAX), u64::MAX);
-        assert_eq!(e.prng().u64_in_range(0..1), 0);
-        assert_eq!(e.prng().u64_in_range(0..=0), 0);
-        assert_eq!(e.prng().u64_in_range(..=0), 0);
+        assert_eq!(e.prng().gen_range::<u64>(u64::MAX..=u64::MAX), u64::MAX);
+        assert_eq!(e.prng().gen_range::<u64>(0..1), 0);
+        assert_eq!(e.prng().gen_range::<u64>(0..=0), 0);
+        assert_eq!(e.prng().gen_range::<u64>(..=0), 0);
     });
 }
 
 #[test]
 #[should_panic(expected = "low > high")]
-fn test_prng_u64_in_range_panic_on_invalid_range() {
+fn test_prng_gen_range_u64_panic_on_invalid_range() {
     let e = Env::default();
     let id = e.register_contract(None, TestPrngContract);
 
     e.as_contract(&id, || {
-        e.prng().u64_in_range(u64::MAX..u64::MAX);
+        e.prng().gen_range::<u64>(u64::MAX..u64::MAX);
     });
 }


### PR DESCRIPTION
### What
Add prng generation for slices and arrays

### Why
The host function exists supporting it, but looks like we missed it.

### Merging

This PR is intended to be merged to `main` after #1129.