### PR TITLE
Arbitrary testutils

### DIFF
--- a/soroban-sdk-macros/src/arbitrary.rs
+++ b/soroban-sdk-macros/src/arbitrary.rs
@@ -42,12 +42,12 @@ fn derive_arbitrary_struct_common(
             match &field.ident {
                 Some(ident) => {
                     quote! {
-                        #ident: <#field_type as #path::arbitrary::SorobanArbitrary>::Prototype
+                        #ident: <#field_type as #path::testutils::arbitrary::SorobanArbitrary>::Prototype
                     }
                 }
                 None => {
                     quote! {
-                        <#field_type as #path::arbitrary::SorobanArbitrary>::Prototype
+                        <#field_type as #path::testutils::arbitrary::SorobanArbitrary>::Prototype
                     }
                 }
             }
@@ -132,13 +132,13 @@ pub fn derive_arbitrary_enum(
                         Some(ident) => {
                             field_types = Some(FieldType::Named);
                             quote! {
-                                #ident: <#field_type as #path::arbitrary::SorobanArbitrary>::Prototype
+                                #ident: <#field_type as #path::testutils::arbitrary::SorobanArbitrary>::Prototype
                             }
                         }
                         None => {
                             field_types = Some(FieldType::Unnamed);
                             quote! {
-                                <#field_type as #path::arbitrary::SorobanArbitrary>::Prototype
+                                <#field_type as #path::testutils::arbitrary::SorobanArbitrary>::Prototype
                             }
                         }
                     }
@@ -323,14 +323,14 @@ fn quote_arbitrary(
         #[cfg(any(test, feature = "testutils"))]
         const _: () = {
             // derive(Arbitrary) expects these two to be in scope
-            use #path::arbitrary::std;
-            use #path::arbitrary::arbitrary;
+            use #path::testutils::arbitrary::std;
+            use #path::testutils::arbitrary::arbitrary;
 
-            #[derive(#path::arbitrary::arbitrary::Arbitrary)]
+            #[derive(#path::testutils::arbitrary::arbitrary::Arbitrary)]
             #[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd)]
             #vis #arbitrary_type_decl
 
-            impl #path::arbitrary::SorobanArbitrary for #ident {
+            impl #path::testutils::arbitrary::SorobanArbitrary for #ident {
                 type Prototype = #arbitrary_type_ident;
             }
 

--- a/soroban-sdk/src/lib.rs
+++ b/soroban-sdk/src/lib.rs
@@ -786,7 +786,6 @@ pub mod xdr;
 
 pub mod testutils;
 
-pub mod arbitrary;
 mod arbitrary_extra;
 
 mod tests;

--- a/soroban-sdk/src/tests/proptest_val_cmp.rs
+++ b/soroban-sdk/src/tests/proptest_val_cmp.rs
@@ -1,7 +1,7 @@
 //! Check that Val and ScVal can be converted between each other,
 //! and that their comparison functions are equivalent.
 
-use crate::arbitrary::SorobanArbitrary;
+use crate::testutils::arbitrary::SorobanArbitrary;
 use crate::xdr::ScVal;
 use crate::Env;
 use crate::Val;

--- a/soroban-sdk/src/testutils.rs
+++ b/soroban-sdk/src/testutils.rs
@@ -3,6 +3,8 @@
 
 //! Utilities intended for use when testing.
 
+pub mod arbitrary;
+
 mod sign;
 pub use sign::ed25519;
 

--- a/soroban-sdk/src/testutils/arbitrary.rs
+++ b/soroban-sdk/src/testutils/arbitrary.rs
@@ -73,7 +73,7 @@
 //! [`SorobanArbitrary::Prototype`]:
 //!
 //! ```
-//! # use soroban_sdk::arbitrary::Arbitrary;
+//! # use soroban_sdk::testutils::arbitrary::Arbitrary;
 //! # use soroban_sdk::{TryFromVal, IntoVal, Val, Env};
 //! pub trait SorobanArbitrary:
 //!     TryFromVal<Env, Self::Prototype> + IntoVal<Env, Val> + TryFromVal<Env, Val>
@@ -119,7 +119,7 @@
 //! #     (|$data:ident: $dty: ty| $body:block) => { };
 //! # }
 //! use soroban_sdk::{Address, Env, Vec};
-//! use soroban_sdk::arbitrary::SorobanArbitrary;
+//! use soroban_sdk::testutils::arbitrary::SorobanArbitrary;
 //!
 //! fuzz_target!(|input: <Vec<Address> as SorobanArbitrary>::Prototype| {
 //!     let env = Env::default();
@@ -137,7 +137,7 @@
 //! # }
 //! use soroban_sdk::{Address, Env, Vec};
 //! use soroban_sdk::contracttype;
-//! use soroban_sdk::arbitrary::{Arbitrary, SorobanArbitrary};
+//! use soroban_sdk::testutils::arbitrary::{Arbitrary, SorobanArbitrary};
 //! use std::vec::Vec as RustVec;
 //!
 //! #[derive(Arbitrary, Debug)]
@@ -207,7 +207,7 @@ mod api {
     /// #     (|$data:ident: $dty: ty| $body:block) => { };
     /// # }
     /// # use soroban_sdk::{Address, Env, Vec, Bytes};
-    /// # use soroban_sdk::arbitrary::SorobanArbitrary;
+    /// # use soroban_sdk::testutils::arbitrary::SorobanArbitrary;
     /// fuzz_target!(|input: <Bytes as SorobanArbitrary>::Prototype| {
     ///     // ...
     /// });
@@ -229,7 +229,7 @@ mod api {
     }
 }
 
-/// Implementations of `soroban_sdk::arbitrary::api` for Rust scalar types.
+/// Implementations of `soroban_sdk::testutils::arbitrary::api` for Rust scalar types.
 ///
 /// These types
 ///
@@ -277,7 +277,7 @@ mod scalars {
     }
 }
 
-/// Implementations of `soroban_sdk::arbitrary::api` for Soroban types that do not
+/// Implementations of `soroban_sdk::testutils::arbitrary::api` for Soroban types that do not
 /// need access to the Soroban host environment.
 ///
 /// These types
@@ -299,7 +299,7 @@ mod simple {
     }
 }
 
-/// Implementations of `soroban_sdk::arbitrary::api` for Soroban types that do
+/// Implementations of `soroban_sdk::testutils::arbitrary::api` for Soroban types that do
 /// need access to the Soroban host environment.
 ///
 /// These types
@@ -655,7 +655,7 @@ mod objects {
     }
 }
 
-/// Implementations of `soroban_sdk::arbitrary::api` for tuples of Soroban types.
+/// Implementations of `soroban_sdk::testutils::arbitrary::api` for tuples of Soroban types.
 ///
 /// The implementation is similar to objects, but macroized.
 mod tuples {
@@ -732,7 +732,7 @@ mod tuples {
     );
 }
 
-/// Implementations of `soroban_sdk::arbitrary::api` for `Val`.
+/// Implementations of `soroban_sdk::testutils::arbitrary::api` for `Val`.
 mod composite {
     use arbitrary::Arbitrary;
 
@@ -1083,7 +1083,7 @@ mod fuzz_test_helpers {
     /// #   fn deposit(&self, a: soroban_sdk::Address, n: i128) { }
     /// # }
     /// use soroban_sdk::{Address, Env};
-    /// use soroban_sdk::arbitrary::{Arbitrary, SorobanArbitrary};
+    /// use soroban_sdk::testutils::arbitrary::{Arbitrary, SorobanArbitrary};
     ///
     /// #[derive(Arbitrary, Debug)]
     /// struct FuzzDeposit {

--- a/soroban-sdk/src/testutils/arbitrary.rs
+++ b/soroban-sdk/src/testutils/arbitrary.rs
@@ -167,9 +167,6 @@
 //! });
 //! ```
 
-#![cfg(any(test, feature = "testutils"))]
-#![cfg_attr(feature = "docs", doc(cfg(feature = "testutils")))]
-
 /// A reexport of the `arbitrary` crate.
 ///
 /// Used by the `contracttype` macro to derive `Arbitrary`.
@@ -245,7 +242,7 @@ mod api {
 ///
 /// - `u32`
 mod scalars {
-    use crate::arbitrary::api::*;
+    use super::api::*;
 
     impl SorobanArbitrary for () {
         type Prototype = ();
@@ -294,7 +291,7 @@ mod scalars {
 ///
 /// - `Error`
 mod simple {
-    use crate::arbitrary::api::*;
+    use super::api::*;
     pub use crate::Error;
 
     impl SorobanArbitrary for Error {
@@ -316,8 +313,8 @@ mod simple {
 mod objects {
     use arbitrary::{Arbitrary, Result as ArbitraryResult, Unstructured};
 
-    use crate::arbitrary::api::*;
-    use crate::arbitrary::composite::ArbitraryVal;
+    use super::api::*;
+    use super::composite::ArbitraryVal;
     use crate::env::FromVal;
     use crate::ConversionError;
     use crate::{Env, IntoVal, TryFromVal};
@@ -662,7 +659,7 @@ mod objects {
 ///
 /// The implementation is similar to objects, but macroized.
 mod tuples {
-    use crate::arbitrary::api::*;
+    use super::api::*;
     use crate::ConversionError;
     use crate::{Env, IntoVal, TryFromVal, TryIntoVal, Val};
     use arbitrary::Arbitrary;
@@ -739,7 +736,7 @@ mod tuples {
 mod composite {
     use arbitrary::Arbitrary;
 
-    use crate::arbitrary::api::*;
+    use super::api::*;
     use crate::ConversionError;
     use crate::{Env, IntoVal, TryFromVal};
 
@@ -1115,7 +1112,7 @@ mod fuzz_test_helpers {
 
 #[cfg(test)]
 mod tests {
-    use crate::arbitrary::*;
+    use super::*;
     use crate::{
         Address, Bytes, BytesN, Duration, Error, Map, String, Symbol, Timepoint, Val, Vec, I256,
         U256,
@@ -1564,8 +1561,8 @@ mod tests {
     }
 
     mod user_defined_types {
+        use super::run_test;
         use crate as soroban_sdk;
-        use crate::arbitrary::tests::run_test;
         use crate::{
             Address, Bytes, BytesN, Duration, Error, Map, Symbol, Timepoint, Vec, I256, U256,
         };

--- a/tests/fuzz/fuzz/Cargo.lock
+++ b/tests/fuzz/fuzz/Cargo.lock
@@ -94,15 +94,6 @@ checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
 name = "block-buffer"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
-name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
@@ -117,12 +108,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3e2c3daef883ecc1b5d58c15adae93470a91d425f3532ba1695849656af3fc1"
 
 [[package]]
-name = "byteorder"
-version = "1.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
-
-[[package]]
 name = "bytes-lit"
 version = "0.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -131,7 +116,7 @@ dependencies = [
  "num-bigint",
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn",
 ]
 
 [[package]]
@@ -185,9 +170,9 @@ dependencies = [
 
 [[package]]
 name = "crate-git-revision"
-version = "0.0.4"
+version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f998aef136a4e7833b0e4f0fc0939a59c40140b28e0ffbf524ad84fb2cc568c8"
+checksum = "c521bf1f43d31ed2f73441775ed31935d77901cb3451e44b38a1c1612fcbaf98"
 dependencies = [
  "serde",
  "serde_derive",
@@ -201,7 +186,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf4c2f4e1afd912bc40bfd6fed5d9dc1f288e0ba01bfcc835cc5bc3eb13efe15"
 dependencies = [
  "generic-array",
- "rand_core 0.6.4",
+ "rand_core",
  "subtle",
  "zeroize",
 ]
@@ -217,16 +202,41 @@ dependencies = [
 ]
 
 [[package]]
-name = "curve25519-dalek"
-version = "3.2.0"
+name = "ctor"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b9fdf9972b2bd6af2d913799d9ebc165ea4d2e65878e329d9c6b372c4491b61"
+checksum = "37e366bff8cd32dd8754b0991fb66b279dc48f598c3a18914852a6673deef583"
 dependencies = [
- "byteorder",
- "digest 0.9.0",
- "rand_core 0.5.1",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "4.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e89b8c6a2e4b1f45971ad09761aafb85514a84744b67a95e32c3cc1352d1f65c"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "curve25519-dalek-derive",
+ "digest",
+ "fiat-crypto",
+ "platforms",
+ "rustc_version",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -250,7 +260,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.18",
+ "syn",
 ]
 
 [[package]]
@@ -261,7 +271,7 @@ checksum = "29a358ff9f12ec09c3e61fef9b5a9902623a695a46a917b07f269bff1445611a"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.18",
+ "syn",
 ]
 
 [[package]]
@@ -282,16 +292,7 @@ checksum = "53e0efad4403bfc52dc201159c4b842a246a14b98c64b55dfd0f2d89729dfeb8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
-]
-
-[[package]]
-name = "digest"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
-dependencies = [
- "generic-array",
+ "syn",
 ]
 
 [[package]]
@@ -300,7 +301,7 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer 0.10.4",
+ "block-buffer",
  "const-oid",
  "crypto-common",
  "subtle",
@@ -319,33 +320,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0997c976637b606099b9985693efa3581e84e41f5c11ba5255f88711058ad428"
 dependencies = [
  "der",
- "digest 0.10.7",
+ "digest",
  "elliptic-curve",
  "rfc6979",
- "signature 2.1.0",
+ "signature",
  "spki",
 ]
 
 [[package]]
 name = "ed25519"
-version = "1.5.3"
+version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91cff35c70bba8a626e3185d8cd48cc11b5437e1a5bcd15b9b5fa3c64b6dfee7"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
 dependencies = [
- "signature 1.6.4",
+ "pkcs8",
+ "signature",
 ]
 
 [[package]]
 name = "ed25519-dalek"
-version = "1.0.1"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c762bae6dcaf24c4c84667b8579785430908723d5c889f469d76a41d59cc7a9d"
+checksum = "7277392b266383ef8396db7fdeb1e77b6c52fed775f5df15bb24f35b72156980"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
- "rand",
+ "rand_core",
  "serde",
- "sha2 0.9.9",
+ "sha2",
  "zeroize",
 ]
 
@@ -363,12 +365,12 @@ checksum = "968405c8fdc9b3bf4df0a6638858cc0b52462836ab6b1c87377785dd09cf1c0b"
 dependencies = [
  "base16ct",
  "crypto-bigint",
- "digest 0.10.7",
+ "digest",
  "ff",
  "generic-array",
  "group",
  "pkcs8",
- "rand_core 0.6.4",
+ "rand_core",
  "sec1",
  "subtle",
  "zeroize",
@@ -386,9 +388,15 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ded41244b729663b1e574f1b4fb731469f69f79c17667b5d776b16cda0479449"
 dependencies = [
- "rand_core 0.6.4",
+ "rand_core",
  "subtle",
 ]
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a481586acf778f1b1455424c343f71124b048ffa5f4fc3f8f6ae9dc432dcb3c7"
 
 [[package]]
 name = "fnv"
@@ -409,17 +417,6 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi 0.9.0+wasi-snapshot-preview1",
-]
-
-[[package]]
-name = "getrandom"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
@@ -427,7 +424,7 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
  "wasm-bindgen",
 ]
 
@@ -444,7 +441,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
  "ff",
- "rand_core 0.6.4",
+ "rand_core",
  "subtle",
 ]
 
@@ -469,7 +466,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest 0.10.7",
+ "digest",
 ]
 
 [[package]]
@@ -519,12 +516,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e04e2fd2b8188ea827b32ef11de88377086d690286ab35747ef7f9bf3ccb590"
 
 [[package]]
-name = "intx"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f38a50a899dc47a6d0ed5508e7f601a2e34c3a85303514b5d137f3c10a0c75"
-
-[[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -567,8 +558,8 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "once_cell",
- "sha2 0.10.7",
- "signature 2.1.0",
+ "sha2",
+ "signature",
 ]
 
 [[package]]
@@ -637,13 +628,13 @@ dependencies = [
 
 [[package]]
 name = "num-derive"
-version = "0.3.3"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "876a53fff98e03a936a674b29568b0e605f06b29372c2489ff4de23f1949743d"
+checksum = "cfb77679af88f8b125209d354a202862602672222e7f2313fdd6dc349bad4712"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn",
 ]
 
 [[package]]
@@ -681,12 +672,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
-name = "opaque-debug"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
-
-[[package]]
 name = "paste"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -703,6 +688,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "platforms"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14e6ab3f592e6fb464fc9712d8d6e6912de6473954635fd76a589d832cffcbb0"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -715,57 +706,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2b0377b720bde721213a46cda1289b2f34abf0a436907cad91578c20de0454d"
 dependencies = [
  "proc-macro2",
- "syn 2.0.18",
+ "syn",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.60"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dec2b086b7a862cf4de201096214fa870344cf922b2b30c167badb3af3195406"
+checksum = "134c189feb4956b20f6f547d2cf727d4c0fe06722b20a0eec87ed445a97f92da"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.28"
+version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9ab9c7eadfd8df19006f1cf1a4aed13540ed5cbc047010ece5826e10825488"
+checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "rand"
-version = "0.7.3"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
- "getrandom 0.1.16",
  "libc",
  "rand_chacha",
- "rand_core 0.5.1",
- "rand_hc",
+ "rand_core",
 ]
 
 [[package]]
 name = "rand_chacha"
-version = "0.2.2"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.5.1",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
-dependencies = [
- "getrandom 0.1.16",
+ "rand_core",
 ]
 
 [[package]]
@@ -774,16 +754,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.10",
-]
-
-[[package]]
-name = "rand_hc"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
-dependencies = [
- "rand_core 0.5.1",
+ "getrandom",
 ]
 
 [[package]]
@@ -801,6 +772,15 @@ name = "rustc-demangle"
 version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+dependencies = [
+ "semver",
+]
 
 [[package]]
 name = "ryu"
@@ -823,6 +803,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "semver"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "836fa6a3e1e547f9a2c4040802ec865b5d85f4014efe00555d7090a3dcaa1090"
+
+[[package]]
 name = "serde"
 version = "1.0.164"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -839,7 +825,7 @@ checksum = "d9735b638ccc51c28bf6914d90a2e9725b377144fc612c49a611fddd1b631d68"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn",
 ]
 
 [[package]]
@@ -878,20 +864,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.18",
-]
-
-[[package]]
-name = "sha2"
-version = "0.9.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
-dependencies = [
- "block-buffer 0.9.0",
- "cfg-if",
- "cpufeatures",
- "digest 0.9.0",
- "opaque-debug",
+ "syn",
 ]
 
 [[package]]
@@ -902,7 +875,7 @@ checksum = "479fb9d862239e610720565ca91403019f2f00410f1864c5aa7479b950a76ed8"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest 0.10.7",
+ "digest",
 ]
 
 [[package]]
@@ -911,15 +884,9 @@ version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
 dependencies = [
- "digest 0.10.7",
+ "digest",
  "keccak",
 ]
-
-[[package]]
-name = "signature"
-version = "1.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
 
 [[package]]
 name = "signature"
@@ -927,8 +894,8 @@ version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e1788eed21689f9cf370582dfc467ef36ed9c707f073528ddafa8d83e3b8500"
 dependencies = [
- "digest 0.10.7",
- "rand_core 0.6.4",
+ "digest",
+ "rand_core",
 ]
 
 [[package]]
@@ -938,13 +905,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
+name = "soroban-builtin-sdk-macros"
+version = "20.0.0-rc2"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=2674d867d7c6aa4212abab05ff30e5804ff1db90#2674d867d7c6aa4212abab05ff30e5804ff1db90"
+dependencies = [
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "soroban-env-common"
-version = "0.0.16"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=c43bbd47959dde2e39eeeb5b7207868a44e96c7d#c43bbd47959dde2e39eeeb5b7207868a44e96c7d"
+version = "20.0.0-rc2"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=2674d867d7c6aa4212abab05ff30e5804ff1db90#2674d867d7c6aa4212abab05ff30e5804ff1db90"
 dependencies = [
  "arbitrary",
  "crate-git-revision",
  "ethnum",
+ "num-derive",
+ "num-traits",
  "serde",
  "soroban-env-macros",
  "soroban-wasmi",
@@ -954,8 +934,8 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-guest"
-version = "0.0.16"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=c43bbd47959dde2e39eeeb5b7207868a44e96c7d#c43bbd47959dde2e39eeeb5b7207868a44e96c7d"
+version = "20.0.0-rc2"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=2674d867d7c6aa4212abab05ff30e5804ff1db90#2674d867d7c6aa4212abab05ff30e5804ff1db90"
 dependencies = [
  "soroban-env-common",
  "static_assertions",
@@ -963,25 +943,23 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-host"
-version = "0.0.16"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=c43bbd47959dde2e39eeeb5b7207868a44e96c7d#c43bbd47959dde2e39eeeb5b7207868a44e96c7d"
+version = "20.0.0-rc2"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=2674d867d7c6aa4212abab05ff30e5804ff1db90#2674d867d7c6aa4212abab05ff30e5804ff1db90"
 dependencies = [
  "backtrace",
  "curve25519-dalek",
  "ed25519-dalek",
- "getrandom 0.2.10",
- "hex",
+ "getrandom",
  "k256",
- "log",
  "num-derive",
  "num-integer",
  "num-traits",
  "rand",
  "rand_chacha",
- "sha2 0.9.9",
+ "sha2",
  "sha3",
+ "soroban-builtin-sdk-macros",
  "soroban-env-common",
- "soroban-native-sdk-macros",
  "soroban-wasmi",
  "static_assertions",
  "stellar-strkey",
@@ -989,8 +967,8 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-macros"
-version = "0.0.16"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=c43bbd47959dde2e39eeeb5b7207868a44e96c7d#c43bbd47959dde2e39eeeb5b7207868a44e96c7d"
+version = "20.0.0-rc2"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=2674d867d7c6aa4212abab05ff30e5804ff1db90#2674d867d7c6aa4212abab05ff30e5804ff1db90"
 dependencies = [
  "itertools",
  "proc-macro2",
@@ -998,13 +976,12 @@ dependencies = [
  "serde",
  "serde_json",
  "stellar-xdr",
- "syn 2.0.18",
- "thiserror",
+ "syn",
 ]
 
 [[package]]
 name = "soroban-ledger-snapshot"
-version = "0.8.4"
+version = "20.0.0-rc2"
 dependencies = [
  "serde",
  "serde_json",
@@ -1014,22 +991,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "soroban-native-sdk-macros"
-version = "0.0.16"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=c43bbd47959dde2e39eeeb5b7207868a44e96c7d#c43bbd47959dde2e39eeeb5b7207868a44e96c7d"
-dependencies = [
- "itertools",
- "proc-macro2",
- "quote",
- "syn 2.0.18",
-]
-
-[[package]]
 name = "soroban-sdk"
-version = "0.8.4"
+version = "20.0.0-rc2"
 dependencies = [
  "arbitrary",
  "bytes-lit",
+ "ctor",
  "ed25519-dalek",
  "rand",
  "soroban-env-guest",
@@ -1041,23 +1008,25 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk-macros"
-version = "0.8.4"
+version = "20.0.0-rc2"
 dependencies = [
+ "crate-git-revision",
  "darling",
  "itertools",
  "proc-macro2",
  "quote",
- "sha2 0.9.9",
+ "rustc_version",
+ "sha2",
  "soroban-env-common",
  "soroban-spec",
  "soroban-spec-rust",
  "stellar-xdr",
- "syn 2.0.18",
+ "syn",
 ]
 
 [[package]]
 name = "soroban-spec"
-version = "0.8.4"
+version = "20.0.0-rc2"
 dependencies = [
  "base64 0.13.1",
  "stellar-xdr",
@@ -1067,40 +1036,28 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec-rust"
-version = "0.8.4"
+version = "20.0.0-rc2"
 dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "sha2 0.9.9",
+ "sha2",
  "soroban-spec",
  "stellar-xdr",
- "syn 2.0.18",
+ "syn",
  "thiserror",
 ]
 
 [[package]]
 name = "soroban-wasmi"
-version = "0.30.0-soroban"
-source = "git+https://github.com/stellar/wasmi?rev=1a2bc7f#1a2bc7f3801c565c2dab22021255a164c05a7f76"
+version = "0.31.0-soroban1"
+source = "git+https://github.com/stellar/wasmi?rev=7e63b4c9e08c4163f417d118d81f7ea34789d0be#7e63b4c9e08c4163f417d118d81f7ea34789d0be"
 dependencies = [
- "intx",
  "smallvec",
- "soroban-wasmi_core",
  "spin",
  "wasmi_arena",
+ "wasmi_core",
  "wasmparser-nostd",
-]
-
-[[package]]
-name = "soroban-wasmi_core"
-version = "0.30.0-soroban"
-source = "git+https://github.com/stellar/wasmi?rev=1a2bc7f#1a2bc7f3801c565c2dab22021255a164c05a7f76"
-dependencies = [
- "downcast-rs",
- "libm",
- "num-traits",
- "paste",
 ]
 
 [[package]]
@@ -1136,8 +1093,8 @@ dependencies = [
 
 [[package]]
 name = "stellar-xdr"
-version = "0.0.16"
-source = "git+https://github.com/stellar/rs-stellar-xdr?rev=50c7a57e55603bc57719b1d096091b3239ea6859#50c7a57e55603bc57719b1d096091b3239ea6859"
+version = "20.0.0-rc1"
+source = "git+https://github.com/stellar/rs-stellar-xdr?rev=9c97e4fa909a0b6455547a4f4a95800696b2a69a#9c97e4fa909a0b6455547a4f4a95800696b2a69a"
 dependencies = [
  "arbitrary",
  "base64 0.13.1",
@@ -1161,20 +1118,9 @@ checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
 
 [[package]]
 name = "syn"
-version = "1.0.109"
+version = "2.0.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
-
-[[package]]
-name = "syn"
-version = "2.0.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32d41677bcbe24c20c52e7c70b0d8db04134c5d1066bf98662e2871ad200ea3e"
+checksum = "23e78b90f2fcf45d3e842032ce32e3f2d1545ba6636271dcbf24fa306d87be7a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1183,7 +1129,7 @@ dependencies = [
 
 [[package]]
 name = "test_fuzz"
-version = "0.8.4"
+version = "20.0.0-rc2"
 dependencies = [
  "soroban-sdk",
 ]
@@ -1214,7 +1160,7 @@ checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn",
 ]
 
 [[package]]
@@ -1264,12 +1210,6 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "wasi"
-version = "0.9.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
-
-[[package]]
-name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
@@ -1295,7 +1235,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn",
  "wasm-bindgen-shared",
 ]
 
@@ -1317,7 +1257,7 @@ checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -1331,7 +1271,18 @@ checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
 [[package]]
 name = "wasmi_arena"
 version = "0.4.0"
-source = "git+https://github.com/stellar/wasmi?rev=1a2bc7f#1a2bc7f3801c565c2dab22021255a164c05a7f76"
+source = "git+https://github.com/stellar/wasmi?rev=7e63b4c9e08c4163f417d118d81f7ea34789d0be#7e63b4c9e08c4163f417d118d81f7ea34789d0be"
+
+[[package]]
+name = "wasmi_core"
+version = "0.13.0"
+source = "git+https://github.com/stellar/wasmi?rev=7e63b4c9e08c4163f417d118d81f7ea34789d0be#7e63b4c9e08c4163f417d118d81f7ea34789d0be"
+dependencies = [
+ "downcast-rs",
+ "libm",
+ "num-traits",
+ "paste",
+]
 
 [[package]]
 name = "wasmparser"
@@ -1444,17 +1395,3 @@ name = "zeroize"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a0956f1ba7c7909bfb66c2e9e4124ab6f6482560f6628b5aaeba39207c9aad9"
-dependencies = [
- "zeroize_derive",
-]
-
-[[package]]
-name = "zeroize_derive"
-version = "1.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.18",
-]

--- a/tests/fuzz/fuzz/fuzz_targets/fuzz_target_1.rs
+++ b/tests/fuzz/fuzz/fuzz_targets/fuzz_target_1.rs
@@ -2,7 +2,7 @@
 
 use libfuzzer_sys::fuzz_target;
 
-use soroban_sdk::{arbitrary::{arbitrary,Arbitrary,SorobanArbitrary}, Env, IntoVal, U256};
+use soroban_sdk::{testutils::arbitrary::{arbitrary,Arbitrary,SorobanArbitrary}, Env, IntoVal, U256};
 
 use test_fuzz::{Contract, ContractClient};
 


### PR DESCRIPTION
### What

Move the arbitrary module under the testutils module.

FIxes https://github.com/stellar/rs-soroban-sdk/issues/1131

### Why

All other testutils features are under the testutils module.

### Known limitations

This does not leave a deprecated module of reexports in the old location, so fuzz users will experience breakage. The soroban-examples repo and the fuzzing tutorial will need to be updated.

There is other possible restructuring of the arbitrary module that could also be done, but is not, e.g. the contents of `arbitrary` could be reexported directly under `testutils`.

This leaves the private `arbitrary_extra` module in its current location.

`soroban-env-common` has a corresponding `arbitrary` module, but it is private. Now these two crates will have their corresponding modules located in different places.

---

I also updated the lockfile for tests/fuzz/fuzz, as Cargo seems to want it updated.