### PR TITLE
Remove use of rand from generated addresses, nonces, salts, and issuer pks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1199,6 +1199,8 @@ dependencies = [
  "proptest",
  "proptest-arbitrary-interop",
  "rand",
+ "serde",
+ "serde_json",
  "soroban-env-guest",
  "soroban-env-host",
  "soroban-ledger-snapshot",

--- a/soroban-sdk/Cargo.toml
+++ b/soroban-sdk/Cargo.toml
@@ -25,6 +25,8 @@ soroban-env-host = { workspace = true, features = [] }
 soroban-ledger-snapshot = { workspace = true }
 stellar-strkey = { workspace = true }
 arbitrary = { version = "1.3.0", features = ["derive"], optional = true }
+serde = { version = "1.0.0", features = ["derive"] }
+serde_json = "1.0.0"
 ed25519-dalek = { version = "2.0.0", features = ["rand_core"], optional = true }
 # match the version of rand used in dalek
 rand = "0.8.5"

--- a/soroban-sdk/src/env.rs
+++ b/soroban-sdk/src/env.rs
@@ -131,9 +131,9 @@ use internal::{
 pub struct MaybeEnv {
     maybe_env_impl: internal::MaybeEnvImpl,
     #[cfg(any(test, feature = "testutils"))]
-    snapshot: Option<Rc<LedgerSnapshot>>,
-    #[cfg(any(test, feature = "testutils"))]
     generators: Option<Rc<RefCell<Generators>>>,
+    #[cfg(any(test, feature = "testutils"))]
+    snapshot: Option<Rc<LedgerSnapshot>>,
 }
 
 #[cfg(target_family = "wasm")]
@@ -144,9 +144,9 @@ impl TryFrom<MaybeEnv> for Env {
         Ok(Env {
             env_impl: internal::EnvImpl {},
             #[cfg(any(test, feature = "testutils"))]
-            snapshot: value.snapshot,
-            #[cfg(any(test, feature = "testutils"))]
             generators: value.generators,
+            #[cfg(any(test, feature = "testutils"))]
+            snapshot: value.snapshot,
         })
     }
 }
@@ -164,9 +164,9 @@ impl MaybeEnv {
         Self {
             maybe_env_impl: internal::EnvImpl {},
             #[cfg(any(test, feature = "testutils"))]
-            snapshot: None,
-            #[cfg(any(test, feature = "testutils"))]
             generators: None,
+            #[cfg(any(test, feature = "testutils"))]
+            snapshot: None,
         }
     }
 }
@@ -178,9 +178,9 @@ impl MaybeEnv {
         Self {
             maybe_env_impl: None,
             #[cfg(any(test, feature = "testutils"))]
-            snapshot: None,
-            #[cfg(any(test, feature = "testutils"))]
             generators: None,
+            #[cfg(any(test, feature = "testutils"))]
+            snapshot: None,
         }
     }
 }
@@ -191,9 +191,9 @@ impl From<Env> for MaybeEnv {
         MaybeEnv {
             maybe_env_impl: value.env_impl,
             #[cfg(any(test, feature = "testutils"))]
-            snapshot: value.snapshot,
-            #[cfg(any(test, feature = "testutils"))]
             generators: Some(value.generators),
+            #[cfg(any(test, feature = "testutils"))]
+            snapshot: value.snapshot,
         }
     }
 }
@@ -207,9 +207,9 @@ impl TryFrom<MaybeEnv> for Env {
             Ok(Env {
                 env_impl,
                 #[cfg(any(test, feature = "testutils"))]
-                snapshot: value.snapshot,
-                #[cfg(any(test, feature = "testutils"))]
                 generators: value.generators.unwrap_or_default(),
+                #[cfg(any(test, feature = "testutils"))]
+                snapshot: value.snapshot,
             })
         } else {
             Err(ConversionError)
@@ -223,9 +223,9 @@ impl From<Env> for MaybeEnv {
         MaybeEnv {
             maybe_env_impl: Some(value.env_impl),
             #[cfg(any(test, feature = "testutils"))]
-            snapshot: value.snapshot,
-            #[cfg(any(test, feature = "testutils"))]
             generators: Some(value.generators),
+            #[cfg(any(test, feature = "testutils"))]
+            snapshot: value.snapshot,
         }
     }
 }
@@ -242,9 +242,9 @@ impl From<Env> for MaybeEnv {
 pub struct Env {
     env_impl: internal::EnvImpl,
     #[cfg(any(test, feature = "testutils"))]
-    snapshot: Option<Rc<LedgerSnapshot>>,
-    #[cfg(any(test, feature = "testutils"))]
     generators: Rc<RefCell<Generators>>,
+    #[cfg(any(test, feature = "testutils"))]
+    snapshot: Option<Rc<LedgerSnapshot>>,
 }
 
 impl Default for Env {
@@ -500,9 +500,9 @@ impl Env {
     /// Used by multiple constructors to configure test environments consistently.
     fn new_for_testutils(
         recording_footprint: Rc<dyn internal::storage::SnapshotSource>,
+        generators: Option<Rc<RefCell<Generators>>>,
         ledger_info: internal::LedgerInfo,
         snapshot: Option<Rc<LedgerSnapshot>>,
-        generators: Option<Rc<RefCell<Generators>>>,
     ) -> Env {
         let storage = internal::storage::Storage::with_recording_footprint(recording_footprint);
         let budget = internal::budget::Budget::default();
@@ -518,8 +518,8 @@ impl Env {
         env_impl.set_base_prng_seed([0; 32]).unwrap();
         let env = Env {
             env_impl,
-            snapshot,
             generators: generators.unwrap_or_default(),
+            snapshot,
         };
 
         env.ledger().set(ledger_info);
@@ -1192,9 +1192,9 @@ impl Env {
     pub fn from_snapshot(s: Snapshot) -> Env {
         Env::new_for_testutils(
             Rc::new(s.ledger.clone()),
+            Some(Rc::new(RefCell::new(s.generators))),
             s.ledger.ledger_info(),
             Some(Rc::new(s.ledger.clone())),
-            Some(Rc::new(RefCell::new(s.generators))),
         )
     }
 
@@ -1210,8 +1210,8 @@ impl Env {
     /// Create a snapshot from the Env's current state.
     pub fn to_snapshot(&self) -> Snapshot {
         Snapshot {
-            ledger: self.to_ledger_snapshot(),
             generators: (*self.generators).borrow().clone(),
+            ledger: self.to_ledger_snapshot(),
         }
     }
 
@@ -1280,9 +1280,9 @@ impl Env {
         Env {
             env_impl,
             #[cfg(any(test, feature = "testutils"))]
-            snapshot: None,
-            #[cfg(any(test, feature = "testutils"))]
             generators: Default::default(),
+            #[cfg(any(test, feature = "testutils"))]
+            snapshot: None,
         }
     }
 }

--- a/soroban-sdk/src/env.rs
+++ b/soroban-sdk/src/env.rs
@@ -460,8 +460,7 @@ impl Env {
 
     #[doc(hidden)]
     pub(crate) fn with_generator<T>(&self, f: impl FnOnce(RefMut<'_, Generators>) -> T) -> T {
-        let g = (*self.generators).borrow_mut();
-        f(g)
+        f((*self.generators).borrow_mut())
     }
 
     fn default_with_testutils() -> Env {

--- a/soroban-sdk/src/env.rs
+++ b/soroban-sdk/src/env.rs
@@ -494,7 +494,7 @@ impl Env {
             max_entry_ttl: 6_312_000,
         };
 
-        Env::new_for_testutils(rf, info, None, None)
+        Env::new_for_testutils(rf, None, info, None)
     }
 
     /// Used by multiple constructors to configure test environments consistently.
@@ -1230,9 +1230,9 @@ impl Env {
     pub fn from_ledger_snapshot(s: LedgerSnapshot) -> Env {
         Env::new_for_testutils(
             Rc::new(s.clone()),
+            None,
             s.ledger_info(),
             Some(Rc::new(s.clone())),
-            None,
         )
     }
 

--- a/soroban-sdk/src/tests/auth/auth_10_one.rs
+++ b/soroban-sdk/src/tests/auth/auth_10_one.rs
@@ -25,7 +25,7 @@ fn test() {
     let contract_id = e.register_contract(None, Contract);
     let client = ContractClient::new(&e, &contract_id);
 
-    let a = Address::random(&e);
+    let a = Address::generate(&e);
 
     let c = client
         .mock_auths(&[MockAuth {

--- a/soroban-sdk/src/tests/auth/auth_15_one_repeat.rs
+++ b/soroban-sdk/src/tests/auth/auth_15_one_repeat.rs
@@ -29,7 +29,7 @@ fn test() {
     let contract_id = e.register_contract(None, Contract);
     let client = ContractClient::new(&e, &contract_id);
 
-    let a = Address::random(&e);
+    let a = Address::generate(&e);
 
     let c = client
         .mock_auths(&[

--- a/soroban-sdk/src/tests/auth/auth_17_no_consume_requirement.rs
+++ b/soroban-sdk/src/tests/auth/auth_17_no_consume_requirement.rs
@@ -34,7 +34,7 @@ fn test() {
     let contract_id = e.register_contract(None, Contract);
     let client = ContractClient::new(&e, &contract_id);
 
-    let a = Address::random(&e);
+    let a = Address::generate(&e);
 
     let c = client
         .mock_auths(&[

--- a/soroban-sdk/src/tests/auth/auth_20_deep_one_address.rs
+++ b/soroban-sdk/src/tests/auth/auth_20_deep_one_address.rs
@@ -35,7 +35,7 @@ fn test() {
     let contract_b_id = e.register_contract(None, ContractB);
     let client = ContractAClient::new(&e, &contract_a_id);
 
-    let a = Address::random(&e);
+    let a = Address::generate(&e);
 
     let c = client
         .mock_auths(&[MockAuth {
@@ -65,7 +65,7 @@ fn test_auth_tree() {
     let contract_b_id = e.register_contract(None, ContractB);
     let client = ContractAClient::new(&e, &contract_a_id);
 
-    let a = Address::random(&e);
+    let a = Address::generate(&e);
 
     let c = client
         .mock_auths(&[MockAuth {

--- a/soroban-sdk/src/tests/auth/auth_30_deep_one_address_repeat.rs
+++ b/soroban-sdk/src/tests/auth/auth_30_deep_one_address_repeat.rs
@@ -36,7 +36,7 @@ fn test() {
     let contract_b_id = e.register_contract(None, ContractB);
     let client = ContractAClient::new(&e, &contract_a_id);
 
-    let a = Address::random(&e);
+    let a = Address::generate(&e);
 
     let c = client
         .mock_auths(&[
@@ -80,7 +80,7 @@ fn test_auth_tree() {
     let contract_b_id = e.register_contract(None, ContractB);
     let client = ContractAClient::new(&e, &contract_a_id);
 
-    let a = Address::random(&e);
+    let a = Address::generate(&e);
 
     let c = client
         .mock_auths(&[MockAuth {

--- a/soroban-sdk/src/tests/auth/auth_35_deep_one_address_repeat_grouped.rs
+++ b/soroban-sdk/src/tests/auth/auth_35_deep_one_address_repeat_grouped.rs
@@ -36,7 +36,7 @@ fn test() {
     let contract_b_id = e.register_contract(None, ContractB);
     let client = ContractAClient::new(&e, &contract_a_id);
 
-    let a = Address::random(&e);
+    let a = Address::generate(&e);
 
     let c = client
         .mock_auths(&[
@@ -80,7 +80,7 @@ fn test_auth_tree() {
     let contract_b_id = e.register_contract(None, ContractB);
     let client = ContractAClient::new(&e, &contract_a_id);
 
-    let a = Address::random(&e);
+    let a = Address::generate(&e);
 
     let c = client
         .mock_auths(&[MockAuth {

--- a/soroban-sdk/src/tests/auth/auth_40_multi_one_address.rs
+++ b/soroban-sdk/src/tests/auth/auth_40_multi_one_address.rs
@@ -36,7 +36,7 @@ fn test_auth_not_allowed_with_separated_tree() {
     let contract_b_id = e.register_contract(None, ContractB);
     let client = ContractAClient::new(&e, &contract_a_id);
 
-    let a = Address::random(&e);
+    let a = Address::generate(&e);
 
     assert!(client
         .mock_auths(&[
@@ -70,7 +70,7 @@ fn test_auth_as_tree() {
     let contract_b_id = e.register_contract(None, ContractB);
     let client = ContractAClient::new(&e, &contract_a_id);
 
-    let a = Address::random(&e);
+    let a = Address::generate(&e);
 
     let c = client
         .mock_auths(&[MockAuth {

--- a/soroban-sdk/src/tests/contract_snapshot.rs
+++ b/soroban-sdk/src/tests/contract_snapshot.rs
@@ -24,9 +24,9 @@ fn test() {
     client.store(&2, &4);
     assert_eq!(client.get(&2), 4);
 
-    let snapshot = e.to_snapshot();
+    let snapshot = e.to_ledger_snapshot();
 
-    let e = Env::from_snapshot(snapshot);
+    let e = Env::from_ledger_snapshot(snapshot);
     let contract_id = Address::try_from_val(&e, &contract_id_xdr).unwrap();
     e.register_contract(&contract_id, Contract);
     let client = ContractClient::new(&e, &contract_id);

--- a/soroban-sdk/src/tests/env.rs
+++ b/soroban-sdk/src/tests/env.rs
@@ -72,8 +72,8 @@ fn default_and_from_snapshot_same_settings() {
 
     let logs1 = env1.logs().all();
     let logs2 = env2.logs().all();
-    assert!(!logs1.is_empty());
-    assert!(!logs2.is_empty());
+    assert_eq!(logs1, &["[Diagnostic Event] contract:0000000000000000000000000000000000000000000000000000000000000001, topics:[log], data:\"test\""]);
+    assert_eq!(logs2, &["[Diagnostic Event] contract:0000000000000000000000000000000000000000000000000000000000000001, topics:[log], data:\"test\""]);
 }
 
 #[test]

--- a/soroban-sdk/src/tests/env.rs
+++ b/soroban-sdk/src/tests/env.rs
@@ -75,3 +75,32 @@ fn default_and_from_snapshot_same_settings() {
     assert!(!logs1.is_empty());
     assert!(!logs2.is_empty());
 }
+
+#[test]
+fn register_contract_deploys_predictable_contract_ids() {
+    let env1 = Env::default();
+    let env2 = Env::from_snapshot(env1.to_snapshot());
+
+    let env1addr1 = env1.register_contract(None, Contract);
+    println!("env1 addr1 {:?}", env1addr1.contract_id());
+    let env1addr2 = env1.register_contract(None, Contract);
+    println!("env1 addr2 {:?}", env1addr2.contract_id());
+    let env2addr1 = env2.register_contract(None, Contract);
+    println!("env2 addr1 {:?}", env2addr1.contract_id());
+    let env2addr2 = env2.register_contract(None, Contract);
+    println!("env2 addr2 {:?}", env2addr2.contract_id());
+
+    let env3 = Env::from_snapshot(env1.to_snapshot());
+    let env1addr3 = env1.register_contract(None, Contract);
+    println!("env1 addr3 {:?}", env1addr3.contract_id());
+    let env2addr3 = env2.register_contract(None, Contract);
+    println!("env2 addr3 {:?}", env2addr3.contract_id());
+    let env3addr3 = env3.register_contract(None, Contract);
+    println!("env3 addr3 {:?}", env3addr3.contract_id());
+
+    // Check that contracts deployed in the envs are consistent and predictable.
+    assert_eq!(env2addr1.contract_id(), env1addr1.contract_id());
+    assert_eq!(env2addr2.contract_id(), env1addr2.contract_id());
+    assert_eq!(env2addr3.contract_id(), env1addr3.contract_id());
+    assert_eq!(env3addr3.contract_id(), env1addr3.contract_id());
+}

--- a/soroban-sdk/src/tests/token_client.rs
+++ b/soroban-sdk/src/tests/token_client.rs
@@ -47,7 +47,7 @@ fn test_mock_all_auth() {
 
     let env = Env::default();
 
-    let admin = Address::random(&env);
+    let admin = Address::generate(&env);
     let token_contract_id = env.register_stellar_asset_contract(admin);
 
     let contract_id = env.register_contract(None, TestContract);
@@ -56,8 +56,8 @@ fn test_mock_all_auth() {
 
     let token_client = TokenClient::new(&env, &client.get_token());
     assert_eq!(token_client.decimals(), 7);
-    let from = Address::random(&env);
-    let spender = Address::random(&env);
+    let from = Address::generate(&env);
+    let spender = Address::generate(&env);
 
     // `TestContract` doesn't call `require_auth` before calling into token,
     // thus we need to allow non-root auth and regular `mock_all_auths` will
@@ -94,7 +94,7 @@ fn test_mock_auth() {
 
     let env = Env::default();
 
-    let admin = Address::random(&env);
+    let admin = Address::generate(&env);
     let token_contract_id = env.register_stellar_asset_contract(admin);
 
     let contract_id = env.register_contract(None, TestContract);
@@ -103,8 +103,8 @@ fn test_mock_auth() {
 
     let token_client = TokenClient::new(&env, &client.get_token());
     assert_eq!(token_client.decimals(), 7);
-    let from = Address::random(&env);
-    let spender = Address::random(&env);
+    let from = Address::generate(&env);
+    let spender = Address::generate(&env);
 
     client
         .mock_auths(&[MockAuth {

--- a/soroban-sdk/src/testutils.rs
+++ b/soroban-sdk/src/testutils.rs
@@ -15,6 +15,46 @@ pub mod storage;
 
 use crate::{Env, Val, Vec};
 
+#[derive(Clone)]
+pub(crate) struct Generators {
+    address: u64,
+    salt: u64,
+    nonce: u64,
+}
+
+impl Generators {
+    pub const fn new() -> Generators {
+        Generators {
+            address: 0,
+            salt: 0,
+            nonce: 0,
+        }
+    }
+
+    pub fn address(&mut self) -> [u8; 32] {
+        self.address = self.address.checked_add(1).unwrap();
+        let b: [u8; 8] = self.address.to_be_bytes();
+        [
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, b[0], b[1],
+            b[2], b[3], b[4], b[5], b[6], b[7],
+        ]
+    }
+
+    pub fn salt(&mut self) -> [u8; 32] {
+        self.salt = self.salt.checked_add(1).unwrap();
+        let b: [u8; 8] = self.salt.to_be_bytes();
+        [
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, b[0], b[1],
+            b[2], b[3], b[4], b[5], b[6], b[7],
+        ]
+    }
+
+    pub fn nonce(&mut self) -> i64 {
+        self.nonce = self.nonce.checked_add(1).unwrap();
+        self.nonce as i64
+    }
+}
+
 #[doc(hidden)]
 pub trait ContractFunctionSet {
     fn call(&self, func: &str, env: Env, args: &[Val]) -> Option<Val>;
@@ -177,10 +217,10 @@ pub(crate) fn random<const N: usize>() -> [u8; N] {
 }
 
 pub trait Address {
-    /// Create a random Address.
+    /// Generate a new Address.
     ///
     /// Implementation note: this always builds the contract addresses now. This
     /// shouldn't normally matter though, as contracts should be agnostic to
     /// the underlying Address value.
-    fn random(env: &Env) -> crate::Address;
+    fn generate(env: &Env) -> crate::Address;
 }

--- a/soroban-sdk/src/testutils.rs
+++ b/soroban-sdk/src/testutils.rs
@@ -18,7 +18,6 @@ use crate::{Env, Val, Vec};
 #[derive(Clone)]
 pub(crate) struct Generators {
     address: u64,
-    salt: u64,
     nonce: u64,
 }
 
@@ -26,7 +25,6 @@ impl Generators {
     pub const fn new() -> Generators {
         Generators {
             address: 0,
-            salt: 0,
             nonce: 0,
         }
     }
@@ -34,15 +32,6 @@ impl Generators {
     pub fn address(&mut self) -> [u8; 32] {
         self.address = self.address.checked_add(1).unwrap();
         let b: [u8; 8] = self.address.to_be_bytes();
-        [
-            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, b[0], b[1],
-            b[2], b[3], b[4], b[5], b[6], b[7],
-        ]
-    }
-
-    pub fn salt(&mut self) -> [u8; 32] {
-        self.salt = self.salt.checked_add(1).unwrap();
-        let b: [u8; 8] = self.salt.to_be_bytes();
         [
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, b[0], b[1],
             b[2], b[3], b[4], b[5], b[6], b[7],

--- a/soroban-sdk/src/testutils.rs
+++ b/soroban-sdk/src/testutils.rs
@@ -14,21 +14,60 @@ pub use mock_auth::{
 pub mod storage;
 
 use crate::{Env, Val, Vec};
+use soroban_ledger_snapshot::LedgerSnapshot;
 
-#[derive(Clone)]
-pub(crate) struct Generators {
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct Snapshot {
+    pub generators: Generators,
+    pub ledger: LedgerSnapshot,
+}
+
+impl Snapshot {
+    // Read in a [`Snapshot`] from a reader.
+    pub fn read(r: impl std::io::Read) -> Result<Snapshot, std::io::Error> {
+        Ok(serde_json::from_reader::<_, Snapshot>(r)?)
+    }
+
+    // Read in a [`Snapshot`] from a file.
+    pub fn read_file(p: impl AsRef<std::path::Path>) -> Result<Snapshot, std::io::Error> {
+        Self::read(std::fs::File::open(p)?)
+    }
+
+    // Write a [`Snapshot`] to a writer.
+    pub fn write(&self, w: impl std::io::Write) -> Result<(), std::io::Error> {
+        Ok(serde_json::to_writer_pretty(w, self)?)
+    }
+
+    // Write a [`Snapshot`] to file.
+    pub fn write_file(&self, p: impl AsRef<std::path::Path>) -> Result<(), std::io::Error> {
+        let p = p.as_ref();
+        if let Some(dir) = p.parent() {
+            if !dir.exists() {
+                std::fs::create_dir_all(dir)?;
+            }
+        }
+        self.write(std::fs::File::create(p)?)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct Generators {
     address: u64,
     nonce: u64,
 }
 
-impl Generators {
-    pub const fn new() -> Generators {
+impl Default for Generators {
+    fn default() -> Generators {
         Generators {
             address: 0,
             nonce: 0,
         }
     }
+}
 
+impl Generators {
     pub fn address(&mut self) -> [u8; 32] {
         self.address = self.address.checked_add(1).unwrap();
         let b: [u8; 8] = self.address.to_be_bytes();

--- a/soroban-sdk/src/testutils/mock_auth.rs
+++ b/soroban-sdk/src/testutils/mock_auth.rs
@@ -1,7 +1,6 @@
 #![cfg(any(test, feature = "testutils"))]
 
 use crate::{contract, contractimpl, xdr, Address, Env, Symbol, TryFromVal, Val, Vec};
-use rand::{thread_rng, Rng};
 
 use super::Ledger;
 
@@ -38,7 +37,7 @@ impl<'a> From<&MockAuth<'a>> for xdr::SorobanAuthorizationEntry {
             root_invocation: value.invoke.into(),
             credentials: xdr::SorobanCredentials::Address(xdr::SorobanAddressCredentials {
                 address: value.address.try_into().unwrap(),
-                nonce: thread_rng().gen(),
+                nonce: env.with_generator(|mut g| g.nonce()),
                 signature_expiration_ledger: curr_ledger + max_entry_ttl - 1,
                 signature: xdr::ScVal::Void,
             }),

--- a/tests/auth/src/lib.rs
+++ b/tests/auth/src/lib.rs
@@ -36,7 +36,7 @@ mod test_a {
         let contract_id = e.register_contract(None, ContractA);
         let client = ContractAClient::new(&e, &contract_id);
 
-        let a = Address::random(&e);
+        let a = Address::generate(&e);
 
         let r = client.mock_all_auths().fn1(&a);
         assert_eq!(r, 2);
@@ -63,7 +63,7 @@ mod test_a {
         let contract_id = e.register_contract(None, ContractA);
         let client = ContractAClient::new(&e, &contract_id);
 
-        let a = Address::random(&e);
+        let a = Address::generate(&e);
 
         let r = client
             .mock_auths(&[MockAuth {
@@ -255,7 +255,7 @@ mod test_b {
         let contract_b_id = e.register_contract(None, ContractB);
         let client = ContractBClient::new(&e, &contract_b_id);
 
-        let a = Address::random(&e);
+        let a = Address::generate(&e);
 
         let r = client.mock_all_auths().fn2(&a, &contract_a_id);
         assert_eq!(r, 2);
@@ -290,7 +290,7 @@ mod test_b {
         let contract_b_id = e.register_contract(None, ContractB);
         let client = ContractBClient::new(&e, &contract_b_id);
 
-        let a = Address::random(&e);
+        let a = Address::generate(&e);
 
         let r = client
             .mock_auths(&[MockAuth {


### PR DESCRIPTION
### What
Remove use of rand from generated addresses, nonces, salts, and issuer pks, replace with sequential values instead.

### Why
The SDK generates random addresses, nonces, salts, and issuer pks. This randomness makes it near impossible to write any test that produces predictable and consistent total system state.

The SDK doesn't need to be using random values for these things. It just needs to produce values that don't matter and that are unique.

Predictable and consistent values make it easier to write tests that can be used over time to assess the consistency of a contract. This is an important attribute of tests so that folks can evaluate if their contract is consistent even with dependency upgrades, SDK upgrades, and protocol upgrades.

This change also introduces the concept of a `Snapshot`, which is a superset of the existing `LedgerSnapshot`. The `LedgerSnapshot` contains everything needed to load in a ledger from a network or other source. `Snapshot` contains everything needed to rehydrate the state of an SDK testutils backed Env.

Related discussion in Discord: https://discord.com/channels/897514728459468821/1171226885171191949

For #1082