### PR TITLE
Allow bumping other instances

### DIFF
--- a/soroban-sdk/src/deploy.rs
+++ b/soroban-sdk/src/deploy.rs
@@ -142,9 +142,11 @@ impl Deployer {
             .unwrap_infallible();
     }
 
-    /// If the TTL for the provided contract is below `threshold` ledgers,
-    /// extend the TTL such that TTL == `extend_to`, where TTL is defined as
-    /// (live_until_ledger_seq for the entry - current ledger).
+    /// Extend the TTL of the contract instance.
+    ///
+    /// Extends the TTL only if the TTL for the provided contract is below `threshold` ledgers.
+    ///
+    /// The TTL is the number of ledgers between the current ledger and the `live_until_ledger_seq` value for the ledger entry.
     pub fn extend_ttl(&self, contract_address: Address, threshold: u32, extend_to: u32) {
         self.env
             .extend_contract_instance_and_code(

--- a/soroban-sdk/src/deploy.rs
+++ b/soroban-sdk/src/deploy.rs
@@ -141,6 +141,19 @@ impl Deployer {
             .update_current_contract_wasm(wasm_hash.into_val(&self.env).to_object())
             .unwrap_infallible();
     }
+
+    /// If the TTL for the provided contract is below `threshold` ledgers,
+    /// extend the TTL such that TTL == `extend_to`, where TTL is defined as
+    /// (live_until_ledger_seq for the entry - current ledger).
+    pub fn extend_ttl(&self, contract_address: Address, threshold: u32, extend_to: u32) {
+        self.env
+            .extend_contract_instance_and_code(
+                contract_address.to_object(),
+                threshold.into(),
+                extend_to.into(),
+            )
+            .unwrap_infallible();
+    }
 }
 
 /// A deployer that deploys a contract that has its ID derived from the provided


### PR DESCRIPTION
### What

Add SDK function for `extend_contract_instance_and_code`. I think the existing `extend_ttl` function should be called `extend_current_ttl`, and this new SDK function would be `extend_ttl`, but I'm not sure if it's worth updating now.