### PR TITLE
Rename token::Interface/Client to TokenInterface/Client

### DIFF
--- a/soroban-sdk/src/token.rs
+++ b/soroban-sdk/src/token.rs
@@ -18,9 +18,11 @@ use crate::{contractclient, contractspecfn, Address, Env, String};
 // 2. The implementations have been replaced with a panic.
 // 3. &Host type usage are replaced with Env
 
+#[doc(hidden)]
 #[deprecated(note = "use TokenInterface")]
 pub use TokenInterface as Interface;
 
+#[doc(hidden)]
 #[deprecated(note = "use TokenClient")]
 pub use TokenClient as Client;
 

--- a/soroban-sdk/src/token.rs
+++ b/soroban-sdk/src/token.rs
@@ -1,10 +1,10 @@
 //! Token contains types for calling and accessing token contracts, including
 //! the Stellar Asset Contract.
 //!
-//! See [`Interface`] for the interface of token contracts such as the Stellar
-//! Asset Contract.
+//! See [`TokenInterface`] for the interface of token contracts such as the
+//! Stellar Asset Contract.
 //!
-//! Use [`Client`] for calling token contracts such as the Stellar Asset
+//! Use [`TokenClient`] for calling token contracts such as the Stellar Asset
 //! Contract.
 
 use crate::{contractclient, contractspecfn, Address, Env, String};
@@ -18,10 +18,16 @@ use crate::{contractclient, contractspecfn, Address, Env, String};
 // 2. The implementations have been replaced with a panic.
 // 3. &Host type usage are replaced with Env
 
+#[deprecated(note = "use TokenInterface")]
+pub use TokenInterface as Interface;
+
+#[deprecated(note = "use TokenClient")]
+pub use TokenClient as Client;
+
 /// Interface for Token contracts, such as the Stellar Asset Contract.
 #[contractspecfn(name = "StellarAssetSpec", export = false)]
-#[contractclient(crate_path = "crate", name = "Client")]
-pub trait Interface {
+#[contractclient(crate_path = "crate", name = "TokenClient")]
+pub trait TokenInterface {
     /// Returns the allowance for `spender` to transfer from `from`.
     ///
     /// # Arguments


### PR DESCRIPTION
### What
Rename token::Interface/Client to TokenInterface/Client.

### Why
When I've used the token::Interface it ends up with less than readable code because I end up with this generic "Interface" identifier in my code. If other interfaces follow suit it gets even worse when implementing multiple interfaces.

The rename happens in a backwards compatible way. The types are reexported as their old names, and the old names are hidden from docs, and have deprecated notices. The deprecated notice informs a developer what they need to change to update to the change. The hidden doc is helpful for the upcoming release that will be a first release and would be odd to display deprecated fns in the docs given any fns were release candidates anyway and the deprecated notice is a courtesy and convenience.