### PR TITLE
Don't block merges on rust-analyzer compat check

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,7 +17,7 @@ jobs:
 
   complete:
     if: always()
-    needs: [fmt, check-git-rev-deps, rust-analyzer-compat, build-and-test, docs]
+    needs: [fmt, check-git-rev-deps, build-and-test, docs]
     runs-on: ubuntu-latest
     steps:
     - if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')


### PR DESCRIPTION
### What
Don't block merges on rust-analyzer compat check.

### Why
It's been more than 6 months I think since we broke this compat check. We might not need it anymore. We just don't seem to be stumbling upon limitations in rust-analyzer, we might mean the things we were stumbling on in the past have been fixed. We could remove it. Simply stopping it from blocking merges is a step towards doing that.

Related:
- https://github.com/stellar/rs-soroban-env/pull/1204