### PR TITLE
Don't write test snapshot if no thread name

### DIFF
--- a/soroban-sdk/src/env.rs
+++ b/soroban-sdk/src/env.rs
@@ -1332,10 +1332,13 @@ impl Env {
     ///
     /// If there is any error writing the file.
     pub(crate) fn to_test_snapshot_file(&self) {
-        let test = std::thread::current();
-        let test_name = test
-            .name()
-            .expect("test name to be retrieved for use as the name of the test snapshot file");
+        let thread = std::thread::current();
+        let Some(test_name) = thread.name() else {
+            // The stock unit test runner sets a thread name.
+            // If there is no thread name, assume this is not running as
+            // part of a unit test, and do nothing.
+            return;
+        };
         let file_number = LAST_TEST_SNAPSHOT.with_borrow_mut(|l| {
             if test_name == l.name {
                 *l = LastTestSnapshot::default();


### PR DESCRIPTION
### What

When dropping `Env`, if there is no thread name, don't write a snapshot file (and don't panic).

### Why

The current code for writing test snapshots under `testutils` assumes the `Env` has been constructed as part of a unit test, but this is not the case for e.g. fuzz tests.

A fuzz test runs on the main thread and does not configure a thread name, but the test snapshot writer panics if there is no thread name.

This patch adds a (very crude) heuristic to decide that it is not running as part of a unit test and it is ok to not write the test snapshot. I looked for more reliable ways to determine if code was running as part of a unit test but did not find one.

### Known limitations

This heuristic may be inaccurate for other unanticipated scenarios.
