### PR TITLE
Do not record test snapshots for doc tests

### DIFF
--- a/soroban-sdk/src/env.rs
+++ b/soroban-sdk/src/env.rs
@@ -1339,6 +1339,13 @@ impl Env {
             // part of a unit test, and do nothing.
             return;
         };
+        if test_name == "main" {
+            // When doc tests are running they're all run with the thread name
+            // main. There's no way to detect which doc test is being run and
+            // there's little value in writing and overwriting a single file for
+            // all doc tests.
+            return;
+        }
         let file_number = LAST_TEST_SNAPSHOT.with_borrow_mut(|l| {
             if test_name == l.name {
                 *l = LastTestSnapshot::default();


### PR DESCRIPTION
### What
Do not record test snapshots for doc tests.

### Why
There's no way to differentiate different doc tests as they all run under a thread named `main`.