### PR TITLE
Hide EnvBase and other internal types

### DIFF
--- a/soroban-sdk/src/lib.rs
+++ b/soroban-sdk/src/lib.rs
@@ -742,15 +742,17 @@ pub use env::TryFromVal;
 /// Used to do conversions between values in the Soroban environment.
 pub use env::TryIntoVal;
 
-mod envhidden {
-    pub use super::env::EnvBase;
-    pub use super::env::Error;
-    pub use super::env::MapObject;
-    pub use super::env::SymbolStr;
-    pub use super::env::VecObject;
-}
+// Used by generated code only.
 #[doc(hidden)]
-pub use envhidden::*;
+pub use env::EnvBase;
+#[doc(hidden)]
+pub use env::Error;
+#[doc(hidden)]
+pub use env::MapObject;
+#[doc(hidden)]
+pub use env::SymbolStr;
+#[doc(hidden)]
+pub use env::VecObject;
 
 #[doc(hidden)]
 #[deprecated(note = "use storage")]


### PR DESCRIPTION
### What
Hide EnvBase and other internal types in docs.

### Why
EnvBase is an implementation detail and not intended to be part of the Soroban SDKs public interface.

The intent was for it to be hidden, but the way we tried to hide it doesn't work for traits, even though it works for other types.

Close #1171