### PR TITLE
Compress contract specs with gzip and store in contractspecv0gzip

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -204,6 +204,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32fast"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "crypto-bigint"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -473,6 +482,16 @@ name = "fiat-crypto"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e825f6987101665dea6ec934c09ec6d721de7bc1bf92248e1d5810c8cd636b77"
+
+[[package]]
+name = "flate2"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8a2db397cb1c8772f31494cb8917e48cd1e64f0fa7efac59fbd741a0a8ce841"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "fnv"
@@ -1249,6 +1268,7 @@ version = "20.0.0-rc2"
 dependencies = [
  "crate-git-revision",
  "darling",
+ "flate2",
  "itertools",
  "proc-macro2",
  "quote",
@@ -1266,6 +1286,7 @@ name = "soroban-spec"
 version = "20.0.0-rc2"
 dependencies = [
  "base64 0.13.1",
+ "flate2",
  "pretty_assertions",
  "stellar-xdr",
  "thiserror",

--- a/soroban-sdk-macros/Cargo.toml
+++ b/soroban-sdk-macros/Cargo.toml
@@ -29,6 +29,7 @@ proc-macro2 = "1.0"
 itertools = "0.11.0"
 darling = "0.20.0"
 sha2 = "0.10.7"
+flate2 = "1.0.25"
 
 [features]
 testutils = []

--- a/soroban-sdk-macros/src/derive_error_enum_int.rs
+++ b/soroban-sdk-macros/src/derive_error_enum_int.rs
@@ -2,10 +2,10 @@ use itertools::MultiUnzip;
 use proc_macro2::TokenStream as TokenStream2;
 use quote::{format_ident, quote};
 use stellar_xdr::curr as stellar_xdr;
-use stellar_xdr::{ScSpecEntry, ScSpecUdtErrorEnumCaseV0, ScSpecUdtErrorEnumV0, StringM, WriteXdr};
+use stellar_xdr::{ScSpecEntry, ScSpecUdtErrorEnumCaseV0, ScSpecUdtErrorEnumV0, StringM};
 use syn::{spanned::Spanned, Attribute, DataEnum, Error, ExprLit, Ident, Lit, Path};
 
-use crate::{doc::docs_from_attrs, DEFAULT_XDR_RW_LIMITS};
+use crate::doc::docs_from_attrs;
 
 pub fn derive_type_error_enum_int(
     path: &Path,
@@ -71,12 +71,13 @@ pub fn derive_type_error_enum_int(
             name: enum_ident.to_string().try_into().unwrap(),
             cases: spec_cases.try_into().unwrap(),
         });
-        let spec_xdr = spec_entry.to_xdr(DEFAULT_XDR_RW_LIMITS).unwrap();
+        let spec_section_name = crate::spec::SECTION_NAME;
+        let spec_xdr = crate::spec::to_xdr_gzip(&spec_entry);
         let spec_xdr_lit = proc_macro2::Literal::byte_string(spec_xdr.as_slice());
         let spec_xdr_len = spec_xdr.len();
         let spec_ident = format_ident!("__SPEC_XDR_TYPE_{}", enum_ident.to_string().to_uppercase());
         Some(quote! {
-            #[cfg_attr(target_family = "wasm", link_section = "contractspecv0")]
+            #[cfg_attr(target_family = "wasm", link_section = #spec_section_name)]
             pub static #spec_ident: [u8; #spec_xdr_len] = #enum_ident::spec_xdr();
 
             impl #enum_ident {

--- a/soroban-sdk-macros/src/derive_struct.rs
+++ b/soroban-sdk-macros/src/derive_struct.rs
@@ -5,11 +5,10 @@ use syn::{Attribute, DataStruct, Error, Ident, Path, Visibility};
 
 use stellar_xdr::curr as stellar_xdr;
 use stellar_xdr::{
-    ScSpecEntry, ScSpecTypeDef, ScSpecUdtStructFieldV0, ScSpecUdtStructV0, StringM, WriteXdr,
-    SCSYMBOL_LIMIT,
+    ScSpecEntry, ScSpecTypeDef, ScSpecUdtStructFieldV0, ScSpecUdtStructV0, StringM, SCSYMBOL_LIMIT,
 };
 
-use crate::{doc::docs_from_attrs, map_type::map_type, DEFAULT_XDR_RW_LIMITS};
+use crate::{doc::docs_from_attrs, map_type::map_type};
 
 // TODO: Add field attribute for including/excluding fields in types.
 // TODO: Better handling of partial types and types without all their fields and
@@ -84,12 +83,13 @@ pub fn derive_type_struct(
             name: ident.to_string().try_into().unwrap(),
             fields: spec_fields.try_into().unwrap(),
         });
-        let spec_xdr = spec_entry.to_xdr(DEFAULT_XDR_RW_LIMITS).unwrap();
+        let spec_section_name = crate::spec::SECTION_NAME;
+        let spec_xdr = crate::spec::to_xdr_gzip(&spec_entry);
         let spec_xdr_lit = proc_macro2::Literal::byte_string(spec_xdr.as_slice());
         let spec_xdr_len = spec_xdr.len();
         let spec_ident = format_ident!("__SPEC_XDR_TYPE_{}", ident.to_string().to_uppercase());
         Some(quote! {
-            #[cfg_attr(target_family = "wasm", link_section = "contractspecv0")]
+            #[cfg_attr(target_family = "wasm", link_section = #spec_section_name)]
             pub static #spec_ident: [u8; #spec_xdr_len] = #ident::spec_xdr();
 
             impl #ident {

--- a/soroban-sdk-macros/src/derive_struct_tuple.rs
+++ b/soroban-sdk-macros/src/derive_struct_tuple.rs
@@ -4,11 +4,9 @@ use quote::{format_ident, quote};
 use syn::{Attribute, DataStruct, Error, Ident, Path, Visibility};
 
 use stellar_xdr::curr as stellar_xdr;
-use stellar_xdr::{
-    ScSpecEntry, ScSpecTypeDef, ScSpecUdtStructFieldV0, ScSpecUdtStructV0, StringM, WriteXdr,
-};
+use stellar_xdr::{ScSpecEntry, ScSpecTypeDef, ScSpecUdtStructFieldV0, ScSpecUdtStructV0, StringM};
 
-use crate::{doc::docs_from_attrs, map_type::map_type, DEFAULT_XDR_RW_LIMITS};
+use crate::{doc::docs_from_attrs, map_type::map_type};
 
 pub fn derive_type_struct_tuple(
     path: &Path,
@@ -71,12 +69,13 @@ pub fn derive_type_struct_tuple(
             name: ident.to_string().try_into().unwrap(),
             fields: field_specs.try_into().unwrap(),
         });
-        let spec_xdr = spec_entry.to_xdr(DEFAULT_XDR_RW_LIMITS).unwrap();
+        let spec_section_name = crate::spec::SECTION_NAME;
+        let spec_xdr = crate::spec::to_xdr_gzip(&spec_entry);
         let spec_xdr_lit = proc_macro2::Literal::byte_string(spec_xdr.as_slice());
         let spec_xdr_len = spec_xdr.len();
         let spec_ident = format_ident!("__SPEC_XDR_TYPE_{}", ident.to_string().to_uppercase());
         Some(quote! {
-            #[cfg_attr(target_family = "wasm", link_section = "contractspecv0")]
+            #[cfg_attr(target_family = "wasm", link_section = #spec_section_name)]
             pub static #spec_ident: [u8; #spec_xdr_len] = #ident::spec_xdr();
 
             impl #ident {

--- a/soroban-sdk-macros/src/lib.rs
+++ b/soroban-sdk-macros/src/lib.rs
@@ -12,6 +12,7 @@ mod derive_struct_tuple;
 mod doc;
 mod map_type;
 mod path;
+mod spec;
 mod syn_ext;
 
 use derive_client::{derive_client_impl, derive_client_type};

--- a/soroban-sdk-macros/src/spec.rs
+++ b/soroban-sdk-macros/src/spec.rs
@@ -1,0 +1,15 @@
+use crate::DEFAULT_XDR_RW_LIMITS;
+use flate2::write::GzEncoder;
+
+use stellar_xdr::curr as stellar_xdr;
+use stellar_xdr::{Limited, ScSpecEntry, WriteXdr as _};
+
+pub const SECTION_NAME: &str = "contractspecv0gzip";
+
+pub fn to_xdr_gzip(entry: &ScSpecEntry) -> Vec<u8> {
+    let mut compressor = GzEncoder::new(Vec::new(), flate2::Compression::best());
+    entry
+        .write_xdr(&mut Limited::new(&mut compressor, DEFAULT_XDR_RW_LIMITS))
+        .unwrap();
+    compressor.finish().unwrap()
+}

--- a/soroban-sdk/src/token.rs
+++ b/soroban-sdk/src/token.rs
@@ -251,7 +251,7 @@ pub(crate) const SPEC_XDR_INPUT: &[&[u8]] = &[
     &StellarAssetSpec::spec_xdr_transfer_from(),
 ];
 
-pub(crate) const SPEC_XDR_LEN: usize = 5336;
+pub(crate) const SPEC_XDR_LEN: usize = 3473;
 
 impl StellarAssetSpec {
     /// Returns the XDR spec for the Token contract.

--- a/soroban-spec/Cargo.toml
+++ b/soroban-spec/Cargo.toml
@@ -15,6 +15,7 @@ stellar-xdr = { workspace = true, features = ["curr", "std", "serde"] }
 base64 = "0.13.0"
 thiserror = "1.0.32"
 wasmparser = "0.88.0"
+flate2 = "1.0.25"
 
 [dev_dependencies]
 pretty_assertions = "1.2.1"


### PR DESCRIPTION
### What
Compress contract specs with gzip and store in contractspecv0gzip.

### Why
This is an experiment to see if compressing contracts specs would sufficiently address concerns of contract spec size. I used gzip out of convenience. Xz/lmza would be better, but I had problems building the libs for it which is a good signal it'd be too hard to adopt everywhere contract specs need decoding.

The results were underwhelming.

Most of the test vector contracts size in this repo canged by tiny amounts, less than 40 bytes.

The token contract interface size was over 5000 bytes to start. Gzipping reduced it into the 3000s. However, when I removed the doc comments from the contract spec, the 5000+ byte spec was reduced to 1004 bytes, and then when I gzipped that it was reduced to only 963, a 41 byte saving without doc comments.

This is pretty good signal that doc comments are a large cost and simply not using them is a massive saving. And also that gzipping isn't a win without doc comments.

I'm not convinced compression is worth adding, but interested in hearing peoples thoughts.