### PR TITLE
Bump version to 20.0.0-rc2.1 (and pin soroban/stellar deps)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1165,7 +1165,7 @@ dependencies = [
 
 [[package]]
 name = "soroban-ledger-snapshot"
-version = "20.0.0-rc2"
+version = "20.0.0-rc2.1"
 dependencies = [
  "pretty_assertions",
  "serde",
@@ -1188,7 +1188,7 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk"
-version = "20.0.0-rc2"
+version = "20.0.0-rc2.1"
 dependencies = [
  "arbitrary",
  "bytes-lit",
@@ -1209,7 +1209,7 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk-macros"
-version = "20.0.0-rc2"
+version = "20.0.0-rc2.1"
 dependencies = [
  "crate-git-revision",
  "darling",
@@ -1227,7 +1227,7 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec"
-version = "20.0.0-rc2"
+version = "20.0.0-rc2.1"
 dependencies = [
  "base64 0.13.1",
  "pretty_assertions",
@@ -1238,7 +1238,7 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec-rust"
-version = "20.0.0-rc2"
+version = "20.0.0-rc2.1"
 dependencies = [
  "pretty_assertions",
  "prettyplease",
@@ -1253,7 +1253,7 @@ dependencies = [
 
 [[package]]
 name = "soroban-token-sdk"
-version = "20.0.0-rc2"
+version = "20.0.0-rc2.1"
 dependencies = [
  "soroban-sdk",
 ]
@@ -1364,119 +1364,119 @@ dependencies = [
 
 [[package]]
 name = "test_add_i128"
-version = "20.0.0-rc2"
+version = "20.0.0-rc2.1"
 dependencies = [
  "soroban-sdk",
 ]
 
 [[package]]
 name = "test_add_u128"
-version = "20.0.0-rc2"
+version = "20.0.0-rc2.1"
 dependencies = [
  "soroban-sdk",
 ]
 
 [[package]]
 name = "test_add_u64"
-version = "20.0.0-rc2"
+version = "20.0.0-rc2.1"
 dependencies = [
  "soroban-sdk",
 ]
 
 [[package]]
 name = "test_alloc"
-version = "20.0.0-rc2"
+version = "20.0.0-rc2.1"
 dependencies = [
  "soroban-sdk",
 ]
 
 [[package]]
 name = "test_auth"
-version = "20.0.0-rc2"
+version = "20.0.0-rc2.1"
 dependencies = [
  "soroban-sdk",
 ]
 
 [[package]]
 name = "test_contract_data"
-version = "20.0.0-rc2"
+version = "20.0.0-rc2.1"
 dependencies = [
  "soroban-sdk",
 ]
 
 [[package]]
 name = "test_empty"
-version = "20.0.0-rc2"
+version = "20.0.0-rc2.1"
 dependencies = [
  "soroban-sdk",
 ]
 
 [[package]]
 name = "test_empty2"
-version = "20.0.0-rc2"
+version = "20.0.0-rc2.1"
 dependencies = [
  "soroban-sdk",
 ]
 
 [[package]]
 name = "test_errors"
-version = "20.0.0-rc2"
+version = "20.0.0-rc2.1"
 dependencies = [
  "soroban-sdk",
 ]
 
 [[package]]
 name = "test_events"
-version = "20.0.0-rc2"
+version = "20.0.0-rc2.1"
 dependencies = [
  "soroban-sdk",
 ]
 
 [[package]]
 name = "test_fuzz"
-version = "20.0.0-rc2"
+version = "20.0.0-rc2.1"
 dependencies = [
  "soroban-sdk",
 ]
 
 [[package]]
 name = "test_import_contract"
-version = "20.0.0-rc2"
+version = "20.0.0-rc2.1"
 dependencies = [
  "soroban-sdk",
 ]
 
 [[package]]
 name = "test_invoke_contract"
-version = "20.0.0-rc2"
+version = "20.0.0-rc2.1"
 dependencies = [
  "soroban-sdk",
 ]
 
 [[package]]
 name = "test_logging"
-version = "20.0.0-rc2"
+version = "20.0.0-rc2.1"
 dependencies = [
  "soroban-sdk",
 ]
 
 [[package]]
 name = "test_multiimpl"
-version = "20.0.0-rc2"
+version = "20.0.0-rc2.1"
 dependencies = [
  "soroban-sdk",
 ]
 
 [[package]]
 name = "test_udt"
-version = "20.0.0-rc2"
+version = "20.0.0-rc2.1"
 dependencies = [
  "soroban-sdk",
 ]
 
 [[package]]
 name = "test_workspace_contract"
-version = "20.0.0-rc2"
+version = "20.0.0-rc2.1"
 dependencies = [
  "soroban-sdk",
  "test_workspace_lib",
@@ -1484,7 +1484,7 @@ dependencies = [
 
 [[package]]
 name = "test_workspace_lib"
-version = "20.0.0-rc2"
+version = "20.0.0-rc2.1"
 dependencies = [
  "soroban-sdk",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,38 +29,38 @@ members = [
 ]
 
 [workspace.package]
-version = "20.0.0-rc2"
+version = "20.0.0-rc2.1"
 
 [workspace.dependencies]
-soroban-sdk = { version = "20.0.0-rc2", path = "soroban-sdk" }
-soroban-sdk-macros = { version = "20.0.0-rc2", path = "soroban-sdk-macros" }
-soroban-spec = { version = "20.0.0-rc2", path = "soroban-spec" }
-soroban-spec-rust = { version = "20.0.0-rc2", path = "soroban-spec-rust" }
-soroban-ledger-snapshot = { version = "20.0.0-rc2", path = "soroban-ledger-snapshot" }
-soroban-token-sdk = { version = "20.0.0-rc2", path = "soroban-token-sdk" }
+soroban-sdk = { version = "20.0.0-rc2.1", path = "soroban-sdk" }
+soroban-sdk-macros = { version = "20.0.0-rc2.1", path = "soroban-sdk-macros" }
+soroban-spec = { version = "20.0.0-rc2.1", path = "soroban-spec" }
+soroban-spec-rust = { version = "20.0.0-rc2.1", path = "soroban-spec-rust" }
+soroban-ledger-snapshot = { version = "20.0.0-rc2.1", path = "soroban-ledger-snapshot" }
+soroban-token-sdk = { version = "20.0.0-rc2.1", path = "soroban-token-sdk" }
 
 [workspace.dependencies.soroban-env-common]
-version = "20.0.0-rc2"
+version = "=20.0.0-rc2"
 git = "https://github.com/stellar/rs-soroban-env"
 rev = "8c63bff68a15d79aca3a705ee6916a68db57b7e6"
 
 [workspace.dependencies.soroban-env-guest]
-version = "20.0.0-rc2"
+version = "=20.0.0-rc2"
 git = "https://github.com/stellar/rs-soroban-env"
 rev = "8c63bff68a15d79aca3a705ee6916a68db57b7e6"
 
 [workspace.dependencies.soroban-env-host]
-version = "20.0.0-rc2"
+version = "=20.0.0-rc2"
 git = "https://github.com/stellar/rs-soroban-env"
 rev = "8c63bff68a15d79aca3a705ee6916a68db57b7e6"
 
 [workspace.dependencies.stellar-strkey]
-version = "0.0.7"
+version = "=0.0.7"
 git = "https://github.com/stellar/rs-stellar-strkey"
 rev = "e6ba45c60c16de28c7522586b80ed0150157df73"
 
 [workspace.dependencies.stellar-xdr]
-version = "20.0.0-rc1"
+version = "=20.0.0-rc1"
 git = "https://github.com/stellar/rs-stellar-xdr"
 rev = "d5ce0c9e7aa83461773a6e81662067f35d39e4c1"
 default-features = false


### PR DESCRIPTION
### What
Pin soroban/stellar deps and bump version to v20.0.0-rc2.1.

### Why
Yesterday we released the stable stellar-xdr v20.0.0, and users of soroban-sdk v20.0.0-rc2 which is dependent on stellar-xdr v20.0.0-rc1 started seeing new projects automatically pickup stellar-xdr v20.0.0.

The reason for this is because cargo sees pre-releases and stable releases as compatible, and so it thinks it's reasonable to pick v20.0.0 when v20.0.0-rc1 is requested.

This is a bug in cargo, but it's been known for a long time and efforts to address it are ongoing. See https://github.com/rust-lang/rfcs/pull/3263 
for more details.

This release is based on soroban-sdk v20.0.0-rc2, and makes no functional code changes. It merely pins the dependencies so that cargo will always pick those exact dependencies.

This PR is a patch release based on v20.0.0-rc2.