### PR TITLE
Remove unused export

### DIFF
--- a/soroban-sdk/src/env.rs
+++ b/soroban-sdk/src/env.rs
@@ -76,7 +76,6 @@ pub mod internal {
 }
 
 pub use internal::xdr;
-pub use internal::Compare;
 pub use internal::ConversionError;
 pub use internal::EnvBase;
 pub use internal::Error;


### PR DESCRIPTION
### What
Remove unused export.

### Why
It creates a warning with Rust v1.75.