### PR TITLE
Remove unused CI step

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -98,8 +98,6 @@ jobs:
     - run: cargo version
     - run: rustup target add ${{ matrix.sys.target }}
     - run: rustup target add wasm32-unknown-unknown
-    - if: matrix.target == 'aarch64-unknown-linux-gnu'
-      run: sudo apt-get update && sudo apt-get -y install gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
     - uses: stellar/binaries@v18
       with:
         name: cargo-hack


### PR DESCRIPTION
### What
Remove CI step that installs gcc/g++ for aarch64 on Linux.

### Why
It doesn't appear to be needed. The step has an error in it's `if` clause that causes it to never be triggered. The if checks `matrix.target` but should be checking `matrix.sys.target`. All the CI tests are passing so it seems like it is not needed.