### PR TITLE
Revert "Revert "Bump rs-soroban-env dependency""

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1096,7 +1096,7 @@ checksum = "4dccd0940a2dcdf68d092b8cbab7dc0ad8fa938bf95787e1b916b0e3d0e8e970"
 [[package]]
 name = "soroban-builtin-sdk-macros"
 version = "20.1.0"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=c1b238b65bfd13666be4ac14e0e390c31b549caf#c1b238b65bfd13666be4ac14e0e390c31b549caf"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=36d33cb6c986c9a8a9200b7eb04cf02e2c3f0ef4#36d33cb6c986c9a8a9200b7eb04cf02e2c3f0ef4"
 dependencies = [
  "itertools",
  "proc-macro2",
@@ -1107,7 +1107,7 @@ dependencies = [
 [[package]]
 name = "soroban-env-common"
 version = "20.1.0"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=c1b238b65bfd13666be4ac14e0e390c31b549caf#c1b238b65bfd13666be4ac14e0e390c31b549caf"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=36d33cb6c986c9a8a9200b7eb04cf02e2c3f0ef4#36d33cb6c986c9a8a9200b7eb04cf02e2c3f0ef4"
 dependencies = [
  "arbitrary",
  "crate-git-revision",
@@ -1124,7 +1124,7 @@ dependencies = [
 [[package]]
 name = "soroban-env-guest"
 version = "20.1.0"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=c1b238b65bfd13666be4ac14e0e390c31b549caf#c1b238b65bfd13666be4ac14e0e390c31b549caf"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=36d33cb6c986c9a8a9200b7eb04cf02e2c3f0ef4#36d33cb6c986c9a8a9200b7eb04cf02e2c3f0ef4"
 dependencies = [
  "soroban-env-common",
  "static_assertions",
@@ -1133,7 +1133,7 @@ dependencies = [
 [[package]]
 name = "soroban-env-host"
 version = "20.1.0"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=c1b238b65bfd13666be4ac14e0e390c31b549caf#c1b238b65bfd13666be4ac14e0e390c31b549caf"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=36d33cb6c986c9a8a9200b7eb04cf02e2c3f0ef4#36d33cb6c986c9a8a9200b7eb04cf02e2c3f0ef4"
 dependencies = [
  "backtrace",
  "curve25519-dalek",
@@ -1159,7 +1159,7 @@ dependencies = [
 [[package]]
 name = "soroban-env-macros"
 version = "20.1.0"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=c1b238b65bfd13666be4ac14e0e390c31b549caf#c1b238b65bfd13666be4ac14e0e390c31b549caf"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=36d33cb6c986c9a8a9200b7eb04cf02e2c3f0ef4#36d33cb6c986c9a8a9200b7eb04cf02e2c3f0ef4"
 dependencies = [
  "itertools",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,17 +43,17 @@ soroban-token-sdk = { version = "20.2.0", path = "soroban-token-sdk" }
 [workspace.dependencies.soroban-env-common]
 version = "=20.1.0"
 git = "https://github.com/stellar/rs-soroban-env"
-rev = "c1b238b65bfd13666be4ac14e0e390c31b549caf"
+rev = "36d33cb6c986c9a8a9200b7eb04cf02e2c3f0ef4"
 
 [workspace.dependencies.soroban-env-guest]
 version = "=20.1.0"
 git = "https://github.com/stellar/rs-soroban-env"
-rev = "c1b238b65bfd13666be4ac14e0e390c31b549caf"
+rev = "36d33cb6c986c9a8a9200b7eb04cf02e2c3f0ef4"
 
 [workspace.dependencies.soroban-env-host]
 version = "=20.1.0"
 git = "https://github.com/stellar/rs-soroban-env"
-rev = "c1b238b65bfd13666be4ac14e0e390c31b549caf"
+rev = "36d33cb6c986c9a8a9200b7eb04cf02e2c3f0ef4"
 
 [workspace.dependencies.stellar-strkey]
 version = "=0.0.8"


### PR DESCRIPTION
### What

Reverts stellar/rs-soroban-sdk#1212

### Why

To undo the revert that undid the env upgrade. See the reverted PR for more info.

### Merging

This needs re-applying at the next time the CLI/RPC needs this change and the newer soroban-sdk, so it doesn't necessarily need merging immediately as we may do more small releases on the current env.