### PR TITLE
Bug 1076 conversion error flattening

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1095,8 +1095,8 @@ checksum = "4dccd0940a2dcdf68d092b8cbab7dc0ad8fa938bf95787e1b916b0e3d0e8e970"
 
 [[package]]
 name = "soroban-builtin-sdk-macros"
-version = "20.1.0"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=c1b238b65bfd13666be4ac14e0e390c31b549caf#c1b238b65bfd13666be4ac14e0e390c31b549caf"
+version = "20.1.1"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=096d4614299ac08c93d255a5482dd079873265dd#096d4614299ac08c93d255a5482dd079873265dd"
 dependencies = [
  "itertools",
  "proc-macro2",
@@ -1106,8 +1106,8 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-common"
-version = "20.1.0"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=c1b238b65bfd13666be4ac14e0e390c31b549caf#c1b238b65bfd13666be4ac14e0e390c31b549caf"
+version = "20.1.1"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=096d4614299ac08c93d255a5482dd079873265dd#096d4614299ac08c93d255a5482dd079873265dd"
 dependencies = [
  "arbitrary",
  "crate-git-revision",
@@ -1123,8 +1123,8 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-guest"
-version = "20.1.0"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=c1b238b65bfd13666be4ac14e0e390c31b549caf#c1b238b65bfd13666be4ac14e0e390c31b549caf"
+version = "20.1.1"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=096d4614299ac08c93d255a5482dd079873265dd#096d4614299ac08c93d255a5482dd079873265dd"
 dependencies = [
  "soroban-env-common",
  "static_assertions",
@@ -1132,8 +1132,8 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-host"
-version = "20.1.0"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=c1b238b65bfd13666be4ac14e0e390c31b549caf#c1b238b65bfd13666be4ac14e0e390c31b549caf"
+version = "20.1.1"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=096d4614299ac08c93d255a5482dd079873265dd#096d4614299ac08c93d255a5482dd079873265dd"
 dependencies = [
  "backtrace",
  "curve25519-dalek",
@@ -1158,8 +1158,8 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-macros"
-version = "20.1.0"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=c1b238b65bfd13666be4ac14e0e390c31b549caf#c1b238b65bfd13666be4ac14e0e390c31b549caf"
+version = "20.1.1"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=096d4614299ac08c93d255a5482dd079873265dd#096d4614299ac08c93d255a5482dd079873265dd"
 dependencies = [
  "itertools",
  "proc-macro2",
@@ -1259,8 +1259,8 @@ dependencies = [
 
 [[package]]
 name = "soroban-wasmi"
-version = "0.31.1-soroban.20.0.0"
-source = "git+https://github.com/stellar/wasmi?rev=ab29800224d85ee64d4ac127bac84cdbb0276721#ab29800224d85ee64d4ac127bac84cdbb0276721"
+version = "0.31.1-soroban.20.0.1"
+source = "git+https://github.com/stellar/wasmi?rev=0ed3f3dee30dc41ebe21972399e0a73a41944aa0#0ed3f3dee30dc41ebe21972399e0a73a41944aa0"
 dependencies = [
  "smallvec",
  "spin",
@@ -1626,12 +1626,12 @@ checksum = "7ab9b36309365056cd639da3134bf87fa8f3d86008abf99e612384a6eecd459f"
 [[package]]
 name = "wasmi_arena"
 version = "0.4.0"
-source = "git+https://github.com/stellar/wasmi?rev=ab29800224d85ee64d4ac127bac84cdbb0276721#ab29800224d85ee64d4ac127bac84cdbb0276721"
+source = "git+https://github.com/stellar/wasmi?rev=0ed3f3dee30dc41ebe21972399e0a73a41944aa0#0ed3f3dee30dc41ebe21972399e0a73a41944aa0"
 
 [[package]]
 name = "wasmi_core"
 version = "0.13.0"
-source = "git+https://github.com/stellar/wasmi?rev=ab29800224d85ee64d4ac127bac84cdbb0276721#ab29800224d85ee64d4ac127bac84cdbb0276721"
+source = "git+https://github.com/stellar/wasmi?rev=0ed3f3dee30dc41ebe21972399e0a73a41944aa0#0ed3f3dee30dc41ebe21972399e0a73a41944aa0"
 dependencies = [
  "downcast-rs",
  "libm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,19 +41,19 @@ soroban-ledger-snapshot = { version = "20.2.0", path = "soroban-ledger-snapshot"
 soroban-token-sdk = { version = "20.2.0", path = "soroban-token-sdk" }
 
 [workspace.dependencies.soroban-env-common]
-version = "=20.1.0"
+version = "=20.1.1"
 git = "https://github.com/stellar/rs-soroban-env"
-rev = "c1b238b65bfd13666be4ac14e0e390c31b549caf"
+rev = "096d4614299ac08c93d255a5482dd079873265dd"
 
 [workspace.dependencies.soroban-env-guest]
-version = "=20.1.0"
+version = "=20.1.1"
 git = "https://github.com/stellar/rs-soroban-env"
-rev = "c1b238b65bfd13666be4ac14e0e390c31b549caf"
+rev = "096d4614299ac08c93d255a5482dd079873265dd"
 
 [workspace.dependencies.soroban-env-host]
-version = "=20.1.0"
+version = "=20.1.1"
 git = "https://github.com/stellar/rs-soroban-env"
-rev = "c1b238b65bfd13666be4ac14e0e390c31b549caf"
+rev = "096d4614299ac08c93d255a5482dd079873265dd"
 
 [workspace.dependencies.stellar-strkey]
 version = "=0.0.8"

--- a/soroban-sdk/src/address.rs
+++ b/soroban-sdk/src/address.rs
@@ -127,7 +127,7 @@ impl TryFromVal<Env, &Address> for Val {
 impl TryFrom<&Address> for ScVal {
     type Error = ConversionError;
     fn try_from(v: &Address) -> Result<Self, ConversionError> {
-        ScVal::try_from_val(&v.env, &v.obj.to_val())
+        Ok(ScVal::try_from_val(&v.env, &v.obj.to_val())?)
     }
 }
 

--- a/soroban-sdk/src/bytes.rs
+++ b/soroban-sdk/src/bytes.rs
@@ -232,7 +232,7 @@ impl From<&Bytes> for Bytes {
 impl TryFrom<&Bytes> for ScVal {
     type Error = ConversionError;
     fn try_from(v: &Bytes) -> Result<Self, ConversionError> {
-        ScVal::try_from_val(&v.env, &v.obj.to_val())
+        Ok(ScVal::try_from_val(&v.env, &v.obj.to_val())?)
     }
 }
 
@@ -894,7 +894,7 @@ impl<const N: usize> From<&BytesN<N>> for Bytes {
 impl<const N: usize> TryFrom<&BytesN<N>> for ScVal {
     type Error = ConversionError;
     fn try_from(v: &BytesN<N>) -> Result<Self, ConversionError> {
-        ScVal::try_from_val(&v.0.env, &v.0.obj.to_val())
+        Ok(ScVal::try_from_val(&v.0.env, &v.0.obj.to_val())?)
     }
 }
 

--- a/soroban-sdk/src/map.rs
+++ b/soroban-sdk/src/map.rs
@@ -228,7 +228,7 @@ where
 impl<K, V> TryFrom<&Map<K, V>> for ScVal {
     type Error = ConversionError;
     fn try_from(v: &Map<K, V>) -> Result<Self, ConversionError> {
-        ScVal::try_from_val(&v.env, &v.obj.to_val())
+        Ok(ScVal::try_from_val(&v.env, &v.obj.to_val())?)
     }
 }
 

--- a/soroban-sdk/src/num.rs
+++ b/soroban-sdk/src/num.rs
@@ -95,7 +95,7 @@ macro_rules! impl_num_wrapping_val_type {
                 if let Ok(ss) = <$small>::try_from(v.val) {
                     ScVal::try_from(ss)
                 } else {
-                    ScVal::try_from_val(&v.env, &v.to_val())
+                    Ok(ScVal::try_from_val(&v.env, &v.to_val())?)
                 }
             }
         }

--- a/soroban-sdk/src/string.rs
+++ b/soroban-sdk/src/string.rs
@@ -137,7 +137,7 @@ impl From<&String> for String {
 impl TryFrom<&String> for ScVal {
     type Error = ConversionError;
     fn try_from(v: &String) -> Result<Self, ConversionError> {
-        ScVal::try_from_val(&v.env, &v.obj.to_val())
+        Ok(ScVal::try_from_val(&v.env, &v.obj.to_val())?)
     }
 }
 

--- a/soroban-sdk/src/symbol.rs
+++ b/soroban-sdk/src/symbol.rs
@@ -143,7 +143,7 @@ impl TryFrom<&Symbol> for ScVal {
             Ok(ScVal::try_from(ss)?)
         } else {
             let e: Env = v.env.clone().try_into()?;
-            ScVal::try_from_val(&e, &v.to_val())
+            Ok(ScVal::try_from_val(&e, &v.to_val())?)
         }
     }
 }

--- a/soroban-sdk/src/tests/env.rs
+++ b/soroban-sdk/src/tests/env.rs
@@ -72,8 +72,8 @@ fn default_and_from_snapshot_same_settings() {
 
     let logs1 = env1.logs().all();
     let logs2 = env2.logs().all();
-    assert_eq!(logs1, &["[Diagnostic Event] contract:0000000000000000000000000000000000000000000000000000000000000001, topics:[log], data:\"test\""]);
-    assert_eq!(logs2, &["[Diagnostic Event] contract:0000000000000000000000000000000000000000000000000000000000000001, topics:[log], data:\"test\""]);
+    assert_eq!(logs1, &["[Diagnostic Event] contract:CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM, topics:[log], data:\"test\""]);
+    assert_eq!(logs2, &["[Diagnostic Event] contract:CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM, topics:[log], data:\"test\""]);
 }
 
 #[test]

--- a/soroban-sdk/src/vec.rs
+++ b/soroban-sdk/src/vec.rs
@@ -261,7 +261,7 @@ use super::xdr::{ScVal, ScVec, VecM};
 impl<T> TryFrom<&Vec<T>> for ScVal {
     type Error = ConversionError;
     fn try_from(v: &Vec<T>) -> Result<Self, ConversionError> {
-        ScVal::try_from_val(&v.env, &v.obj.to_val())
+        Ok(ScVal::try_from_val(&v.env, &v.obj.to_val())?)
     }
 }
 

--- a/soroban-sdk/test_snapshots/tests/token_client/test_mock_all_auth.1.json
+++ b/soroban-sdk/test_snapshots/tests/token_client/test_mock_all_auth.1.json
@@ -382,7 +382,7 @@
                                 "symbol": "symbol"
                               },
                               "val": {
-                                "string": "aaa\\0"
+                                "string": "aaa"
                               }
                             }
                           ]

--- a/soroban-sdk/test_snapshots/tests/token_client/test_mock_auth.1.json
+++ b/soroban-sdk/test_snapshots/tests/token_client/test_mock_auth.1.json
@@ -413,7 +413,7 @@
                                 "symbol": "symbol"
                               },
                               "val": {
-                                "string": "aaa\\0"
+                                "string": "aaa"
                               }
                             }
                           ]


### PR DESCRIPTION
This is the SDK companion to https://github.com/stellar/rs-soroban-env/pull/1339 -- it won't work until that change has landed and its refs have updated to point to it.

There's an explanation of the change over there, but briefly: we were discarding meaningful errors when passing through the `TryFromVal<ScVal> for Val` and `TryFromVal<Val> for ScVal` impls in env-common, and now (or at least if 1339 lands) we're not. Instead of returning `ConversionError` we'd be returning `Error`.

The SDK happens to _also_ have conversions with `ConversionError` signatures, and I've opted in this PR to _not_ go a step further and actually change those to `Error`, instead re-burying the `Error` into `ConversionError` in the SDK, keeping the SDK APIs as they are. I could also change them. But I figured that could be left to @leighmcculloch's choice; he might want to keep the SDK's error repertoire simpler, I'm not sure.