### PR TITLE
Bug 1076 conversion error flattening 2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1095,8 +1095,8 @@ checksum = "4dccd0940a2dcdf68d092b8cbab7dc0ad8fa938bf95787e1b916b0e3d0e8e970"
 
 [[package]]
 name = "soroban-builtin-sdk-macros"
-version = "20.1.0"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=c1b238b65bfd13666be4ac14e0e390c31b549caf#c1b238b65bfd13666be4ac14e0e390c31b549caf"
+version = "20.1.1"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=096d4614299ac08c93d255a5482dd079873265dd#096d4614299ac08c93d255a5482dd079873265dd"
 dependencies = [
  "itertools",
  "proc-macro2",
@@ -1106,8 +1106,8 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-common"
-version = "20.1.0"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=c1b238b65bfd13666be4ac14e0e390c31b549caf#c1b238b65bfd13666be4ac14e0e390c31b549caf"
+version = "20.1.1"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=096d4614299ac08c93d255a5482dd079873265dd#096d4614299ac08c93d255a5482dd079873265dd"
 dependencies = [
  "arbitrary",
  "crate-git-revision",
@@ -1123,8 +1123,8 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-guest"
-version = "20.1.0"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=c1b238b65bfd13666be4ac14e0e390c31b549caf#c1b238b65bfd13666be4ac14e0e390c31b549caf"
+version = "20.1.1"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=096d4614299ac08c93d255a5482dd079873265dd#096d4614299ac08c93d255a5482dd079873265dd"
 dependencies = [
  "soroban-env-common",
  "static_assertions",
@@ -1132,8 +1132,8 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-host"
-version = "20.1.0"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=c1b238b65bfd13666be4ac14e0e390c31b549caf#c1b238b65bfd13666be4ac14e0e390c31b549caf"
+version = "20.1.1"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=096d4614299ac08c93d255a5482dd079873265dd#096d4614299ac08c93d255a5482dd079873265dd"
 dependencies = [
  "backtrace",
  "curve25519-dalek",
@@ -1158,8 +1158,8 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-macros"
-version = "20.1.0"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=c1b238b65bfd13666be4ac14e0e390c31b549caf#c1b238b65bfd13666be4ac14e0e390c31b549caf"
+version = "20.1.1"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=096d4614299ac08c93d255a5482dd079873265dd#096d4614299ac08c93d255a5482dd079873265dd"
 dependencies = [
  "itertools",
  "proc-macro2",
@@ -1259,8 +1259,8 @@ dependencies = [
 
 [[package]]
 name = "soroban-wasmi"
-version = "0.31.1-soroban.20.0.0"
-source = "git+https://github.com/stellar/wasmi?rev=ab29800224d85ee64d4ac127bac84cdbb0276721#ab29800224d85ee64d4ac127bac84cdbb0276721"
+version = "0.31.1-soroban.20.0.1"
+source = "git+https://github.com/stellar/wasmi?rev=0ed3f3dee30dc41ebe21972399e0a73a41944aa0#0ed3f3dee30dc41ebe21972399e0a73a41944aa0"
 dependencies = [
  "smallvec",
  "spin",
@@ -1626,12 +1626,12 @@ checksum = "7ab9b36309365056cd639da3134bf87fa8f3d86008abf99e612384a6eecd459f"
 [[package]]
 name = "wasmi_arena"
 version = "0.4.0"
-source = "git+https://github.com/stellar/wasmi?rev=ab29800224d85ee64d4ac127bac84cdbb0276721#ab29800224d85ee64d4ac127bac84cdbb0276721"
+source = "git+https://github.com/stellar/wasmi?rev=0ed3f3dee30dc41ebe21972399e0a73a41944aa0#0ed3f3dee30dc41ebe21972399e0a73a41944aa0"
 
 [[package]]
 name = "wasmi_core"
 version = "0.13.0"
-source = "git+https://github.com/stellar/wasmi?rev=ab29800224d85ee64d4ac127bac84cdbb0276721#ab29800224d85ee64d4ac127bac84cdbb0276721"
+source = "git+https://github.com/stellar/wasmi?rev=0ed3f3dee30dc41ebe21972399e0a73a41944aa0#0ed3f3dee30dc41ebe21972399e0a73a41944aa0"
 dependencies = [
  "downcast-rs",
  "libm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,19 +41,19 @@ soroban-ledger-snapshot = { version = "20.2.0", path = "soroban-ledger-snapshot"
 soroban-token-sdk = { version = "20.2.0", path = "soroban-token-sdk" }
 
 [workspace.dependencies.soroban-env-common]
-version = "=20.1.0"
+version = "=20.1.1"
 git = "https://github.com/stellar/rs-soroban-env"
-rev = "c1b238b65bfd13666be4ac14e0e390c31b549caf"
+rev = "096d4614299ac08c93d255a5482dd079873265dd"
 
 [workspace.dependencies.soroban-env-guest]
-version = "=20.1.0"
+version = "=20.1.1"
 git = "https://github.com/stellar/rs-soroban-env"
-rev = "c1b238b65bfd13666be4ac14e0e390c31b549caf"
+rev = "096d4614299ac08c93d255a5482dd079873265dd"
 
 [workspace.dependencies.soroban-env-host]
-version = "=20.1.0"
+version = "=20.1.1"
 git = "https://github.com/stellar/rs-soroban-env"
-rev = "c1b238b65bfd13666be4ac14e0e390c31b549caf"
+rev = "096d4614299ac08c93d255a5482dd079873265dd"
 
 [workspace.dependencies.stellar-strkey]
 version = "=0.0.8"

--- a/soroban-sdk/src/address.rs
+++ b/soroban-sdk/src/address.rs
@@ -125,23 +125,23 @@ impl TryFromVal<Env, &Address> for Val {
 
 #[cfg(not(target_family = "wasm"))]
 impl TryFrom<&Address> for ScVal {
-    type Error = ConversionError;
-    fn try_from(v: &Address) -> Result<Self, ConversionError> {
-        Ok(ScVal::try_from_val(&v.env, &v.obj.to_val())?)
+    type Error = super::env::Error;
+    fn try_from(v: &Address) -> Result<Self, super::env::Error> {
+        ScVal::try_from_val(&v.env, &v.obj.to_val())
     }
 }
 
 #[cfg(not(target_family = "wasm"))]
 impl TryFrom<Address> for ScVal {
-    type Error = ConversionError;
-    fn try_from(v: Address) -> Result<Self, ConversionError> {
+    type Error = super::env::Error;
+    fn try_from(v: Address) -> Result<Self, super::env::Error> {
         (&v).try_into()
     }
 }
 
 #[cfg(not(target_family = "wasm"))]
 impl TryFromVal<Env, ScVal> for Address {
-    type Error = ConversionError;
+    type Error = super::env::Error;
     fn try_from_val(env: &Env, val: &ScVal) -> Result<Self, Self::Error> {
         Ok(
             AddressObject::try_from_val(env, &Val::try_from_val(env, val)?)?
@@ -153,18 +153,18 @@ impl TryFromVal<Env, ScVal> for Address {
 
 #[cfg(not(target_family = "wasm"))]
 impl TryFrom<&Address> for ScAddress {
-    type Error = ConversionError;
+    type Error = super::env::Error;
     fn try_from(v: &Address) -> Result<Self, Self::Error> {
         match ScVal::try_from_val(&v.env, &v.obj.to_val())? {
             ScVal::Address(a) => Ok(a),
-            _ => Err(ConversionError),
+            _ => Err(ConversionError.into()),
         }
     }
 }
 
 #[cfg(not(target_family = "wasm"))]
 impl TryFrom<Address> for ScAddress {
-    type Error = ConversionError;
+    type Error = super::env::Error;
     fn try_from(v: Address) -> Result<Self, Self::Error> {
         (&v).try_into()
     }
@@ -172,7 +172,7 @@ impl TryFrom<Address> for ScAddress {
 
 #[cfg(not(target_family = "wasm"))]
 impl TryFromVal<Env, ScAddress> for Address {
-    type Error = ConversionError;
+    type Error = super::env::Error;
     fn try_from_val(env: &Env, val: &ScAddress) -> Result<Self, Self::Error> {
         Ok(AddressObject::try_from_val(
             env,

--- a/soroban-sdk/src/address.rs
+++ b/soroban-sdk/src/address.rs
@@ -127,7 +127,7 @@ impl TryFromVal<Env, &Address> for Val {
 impl TryFrom<&Address> for ScVal {
     type Error = ConversionError;
     fn try_from(v: &Address) -> Result<Self, ConversionError> {
-        ScVal::try_from_val(&v.env, &v.obj.to_val())
+        Ok(ScVal::try_from_val(&v.env, &v.obj.to_val())?)
     }
 }
 

--- a/soroban-sdk/src/bytes.rs
+++ b/soroban-sdk/src/bytes.rs
@@ -230,23 +230,23 @@ impl From<&Bytes> for Bytes {
 
 #[cfg(not(target_family = "wasm"))]
 impl TryFrom<&Bytes> for ScVal {
-    type Error = ConversionError;
-    fn try_from(v: &Bytes) -> Result<Self, ConversionError> {
-        Ok(ScVal::try_from_val(&v.env, &v.obj.to_val())?)
+    type Error = super::env::Error;
+    fn try_from(v: &Bytes) -> Result<Self, super::env::Error> {
+        ScVal::try_from_val(&v.env, &v.obj.to_val())
     }
 }
 
 #[cfg(not(target_family = "wasm"))]
 impl TryFrom<Bytes> for ScVal {
-    type Error = ConversionError;
-    fn try_from(v: Bytes) -> Result<Self, ConversionError> {
+    type Error = super::env::Error;
+    fn try_from(v: Bytes) -> Result<Self, super::env::Error> {
         (&v).try_into()
     }
 }
 
 #[cfg(not(target_family = "wasm"))]
 impl TryFromVal<Env, ScVal> for Bytes {
-    type Error = ConversionError;
+    type Error = super::env::Error;
     fn try_from_val(env: &Env, val: &ScVal) -> Result<Self, Self::Error> {
         Ok(
             BytesObject::try_from_val(env, &Val::try_from_val(env, val)?)?
@@ -892,25 +892,25 @@ impl<const N: usize> From<&BytesN<N>> for Bytes {
 
 #[cfg(not(target_family = "wasm"))]
 impl<const N: usize> TryFrom<&BytesN<N>> for ScVal {
-    type Error = ConversionError;
-    fn try_from(v: &BytesN<N>) -> Result<Self, ConversionError> {
-        Ok(ScVal::try_from_val(&v.0.env, &v.0.obj.to_val())?)
+    type Error = super::env::Error;
+    fn try_from(v: &BytesN<N>) -> Result<Self, super::env::Error> {
+        ScVal::try_from_val(&v.0.env, &v.0.obj.to_val())
     }
 }
 
 #[cfg(not(target_family = "wasm"))]
 impl<const N: usize> TryFrom<BytesN<N>> for ScVal {
-    type Error = ConversionError;
-    fn try_from(v: BytesN<N>) -> Result<Self, ConversionError> {
+    type Error = super::env::Error;
+    fn try_from(v: BytesN<N>) -> Result<Self, super::env::Error> {
         (&v).try_into()
     }
 }
 
 #[cfg(not(target_family = "wasm"))]
 impl<const N: usize> TryFromVal<Env, ScVal> for BytesN<N> {
-    type Error = ConversionError;
+    type Error = super::env::Error;
     fn try_from_val(env: &Env, val: &ScVal) -> Result<Self, Self::Error> {
-        Bytes::try_from_val(env, val)?.try_into()
+        Ok(Bytes::try_from_val(env, val)?.try_into()?)
     }
 }
 

--- a/soroban-sdk/src/bytes.rs
+++ b/soroban-sdk/src/bytes.rs
@@ -232,7 +232,7 @@ impl From<&Bytes> for Bytes {
 impl TryFrom<&Bytes> for ScVal {
     type Error = ConversionError;
     fn try_from(v: &Bytes) -> Result<Self, ConversionError> {
-        ScVal::try_from_val(&v.env, &v.obj.to_val())
+        Ok(ScVal::try_from_val(&v.env, &v.obj.to_val())?)
     }
 }
 
@@ -894,7 +894,7 @@ impl<const N: usize> From<&BytesN<N>> for Bytes {
 impl<const N: usize> TryFrom<&BytesN<N>> for ScVal {
     type Error = ConversionError;
     fn try_from(v: &BytesN<N>) -> Result<Self, ConversionError> {
-        ScVal::try_from_val(&v.0.env, &v.0.obj.to_val())
+        Ok(ScVal::try_from_val(&v.0.env, &v.0.obj.to_val())?)
     }
 }
 

--- a/soroban-sdk/src/map.rs
+++ b/soroban-sdk/src/map.rs
@@ -226,24 +226,24 @@ where
 
 #[cfg(not(target_family = "wasm"))]
 impl<K, V> TryFrom<&Map<K, V>> for ScVal {
-    type Error = ConversionError;
-    fn try_from(v: &Map<K, V>) -> Result<Self, ConversionError> {
-        Ok(ScVal::try_from_val(&v.env, &v.obj.to_val())?)
+    type Error = super::env::Error;
+    fn try_from(v: &Map<K, V>) -> Result<Self, super::env::Error> {
+        ScVal::try_from_val(&v.env, &v.obj.to_val())
     }
 }
 
 #[cfg(not(target_family = "wasm"))]
 impl<K, V> TryFrom<Map<K, V>> for ScVal {
-    type Error = ConversionError;
-    fn try_from(v: Map<K, V>) -> Result<Self, ConversionError> {
+    type Error = super::env::Error;
+    fn try_from(v: Map<K, V>) -> Result<Self, super::env::Error> {
         (&v).try_into()
     }
 }
 
 #[cfg(not(target_family = "wasm"))]
 impl<K, V> TryFromVal<Env, Map<K, V>> for ScVal {
-    type Error = ConversionError;
-    fn try_from_val(_e: &Env, v: &Map<K, V>) -> Result<Self, ConversionError> {
+    type Error = super::env::Error;
+    fn try_from_val(_e: &Env, v: &Map<K, V>) -> Result<Self, super::env::Error> {
         v.try_into()
     }
 }
@@ -254,7 +254,7 @@ where
     K: IntoVal<Env, Val> + TryFromVal<Env, Val>,
     V: IntoVal<Env, Val> + TryFromVal<Env, Val>,
 {
-    type Error = ConversionError;
+    type Error = super::env::Error;
     fn try_from_val(env: &Env, val: &ScVal) -> Result<Self, Self::Error> {
         Ok(MapObject::try_from_val(env, &Val::try_from_val(env, val)?)?
             .try_into_val(env)

--- a/soroban-sdk/src/map.rs
+++ b/soroban-sdk/src/map.rs
@@ -228,7 +228,7 @@ where
 impl<K, V> TryFrom<&Map<K, V>> for ScVal {
     type Error = ConversionError;
     fn try_from(v: &Map<K, V>) -> Result<Self, ConversionError> {
-        ScVal::try_from_val(&v.env, &v.obj.to_val())
+        Ok(ScVal::try_from_val(&v.env, &v.obj.to_val())?)
     }
 }
 

--- a/soroban-sdk/src/num.rs
+++ b/soroban-sdk/src/num.rs
@@ -90,27 +90,27 @@ macro_rules! impl_num_wrapping_val_type {
 
         #[cfg(not(target_family = "wasm"))]
         impl TryFrom<&$wrapper> for ScVal {
-            type Error = ConversionError;
-            fn try_from(v: &$wrapper) -> Result<Self, ConversionError> {
+            type Error = super::env::Error;
+            fn try_from(v: &$wrapper) -> Result<Self, super::env::Error> {
                 if let Ok(ss) = <$small>::try_from(v.val) {
-                    ScVal::try_from(ss)
+                    Ok(ScVal::try_from(ss)?)
                 } else {
-                    Ok(ScVal::try_from_val(&v.env, &v.to_val())?)
+                    ScVal::try_from_val(&v.env, &v.to_val())
                 }
             }
         }
 
         #[cfg(not(target_family = "wasm"))]
         impl TryFrom<$wrapper> for ScVal {
-            type Error = ConversionError;
-            fn try_from(v: $wrapper) -> Result<Self, ConversionError> {
+            type Error = super::env::Error;
+            fn try_from(v: $wrapper) -> Result<Self, super::env::Error> {
                 (&v).try_into()
             }
         }
 
         #[cfg(not(target_family = "wasm"))]
         impl TryFromVal<Env, ScVal> for $wrapper {
-            type Error = ConversionError;
+            type Error = super::env::Error;
             fn try_from_val(env: &Env, val: &ScVal) -> Result<Self, Self::Error> {
                 Ok(<$val>::try_from_val(env, &Val::try_from_val(env, val)?)?
                     .try_into_val(env)

--- a/soroban-sdk/src/num.rs
+++ b/soroban-sdk/src/num.rs
@@ -95,7 +95,7 @@ macro_rules! impl_num_wrapping_val_type {
                 if let Ok(ss) = <$small>::try_from(v.val) {
                     ScVal::try_from(ss)
                 } else {
-                    ScVal::try_from_val(&v.env, &v.to_val())
+                    Ok(ScVal::try_from_val(&v.env, &v.to_val())?)
                 }
             }
         }

--- a/soroban-sdk/src/string.rs
+++ b/soroban-sdk/src/string.rs
@@ -135,23 +135,23 @@ impl From<&String> for String {
 
 #[cfg(not(target_family = "wasm"))]
 impl TryFrom<&String> for ScVal {
-    type Error = ConversionError;
-    fn try_from(v: &String) -> Result<Self, ConversionError> {
-        Ok(ScVal::try_from_val(&v.env, &v.obj.to_val())?)
+    type Error = super::env::Error;
+    fn try_from(v: &String) -> Result<Self, super::env::Error> {
+        ScVal::try_from_val(&v.env, &v.obj.to_val())
     }
 }
 
 #[cfg(not(target_family = "wasm"))]
 impl TryFrom<String> for ScVal {
-    type Error = ConversionError;
-    fn try_from(v: String) -> Result<Self, ConversionError> {
+    type Error = super::env::Error;
+    fn try_from(v: String) -> Result<Self, super::env::Error> {
         (&v).try_into()
     }
 }
 
 #[cfg(not(target_family = "wasm"))]
 impl TryFromVal<Env, ScVal> for String {
-    type Error = ConversionError;
+    type Error = super::env::Error;
     fn try_from_val(env: &Env, val: &ScVal) -> Result<Self, Self::Error> {
         Ok(
             StringObject::try_from_val(env, &Val::try_from_val(env, val)?)?

--- a/soroban-sdk/src/string.rs
+++ b/soroban-sdk/src/string.rs
@@ -137,7 +137,7 @@ impl From<&String> for String {
 impl TryFrom<&String> for ScVal {
     type Error = ConversionError;
     fn try_from(v: &String) -> Result<Self, ConversionError> {
-        ScVal::try_from_val(&v.env, &v.obj.to_val())
+        Ok(ScVal::try_from_val(&v.env, &v.obj.to_val())?)
     }
 }
 

--- a/soroban-sdk/src/symbol.rs
+++ b/soroban-sdk/src/symbol.rs
@@ -143,7 +143,7 @@ impl TryFrom<&Symbol> for ScVal {
             Ok(ScVal::try_from(ss)?)
         } else {
             let e: Env = v.env.clone().try_into()?;
-            ScVal::try_from_val(&e, &v.to_val())
+            Ok(ScVal::try_from_val(&e, &v.to_val())?)
         }
     }
 }

--- a/soroban-sdk/src/symbol.rs
+++ b/soroban-sdk/src/symbol.rs
@@ -137,36 +137,36 @@ impl TryFromVal<Env, &str> for Symbol {
 
 #[cfg(not(target_family = "wasm"))]
 impl TryFrom<&Symbol> for ScVal {
-    type Error = ConversionError;
-    fn try_from(v: &Symbol) -> Result<Self, ConversionError> {
+    type Error = super::env::Error;
+    fn try_from(v: &Symbol) -> Result<Self, super::env::Error> {
         if let Ok(ss) = SymbolSmall::try_from(v.val) {
-            Ok(ScVal::try_from(ss)?)
+            ScVal::try_from(ss)
         } else {
             let e: Env = v.env.clone().try_into()?;
-            Ok(ScVal::try_from_val(&e, &v.to_val())?)
+            ScVal::try_from_val(&e, &v.to_val())
         }
     }
 }
 
 #[cfg(not(target_family = "wasm"))]
 impl TryFrom<Symbol> for ScVal {
-    type Error = ConversionError;
-    fn try_from(v: Symbol) -> Result<Self, ConversionError> {
+    type Error = super::env::Error;
+    fn try_from(v: Symbol) -> Result<Self, super::env::Error> {
         (&v).try_into()
     }
 }
 
 #[cfg(not(target_family = "wasm"))]
 impl TryFromVal<Env, Symbol> for ScVal {
-    type Error = ConversionError;
-    fn try_from_val(_e: &Env, v: &Symbol) -> Result<Self, ConversionError> {
+    type Error = super::env::Error;
+    fn try_from_val(_e: &Env, v: &Symbol) -> Result<Self, super::env::Error> {
         v.try_into()
     }
 }
 
 #[cfg(not(target_family = "wasm"))]
 impl TryFromVal<Env, ScVal> for Symbol {
-    type Error = ConversionError;
+    type Error = super::env::Error;
     fn try_from_val(env: &Env, val: &ScVal) -> Result<Self, Self::Error> {
         Ok(SymbolVal::try_from_val(env, &Val::try_from_val(env, val)?)?
             .try_into_val(env)
@@ -176,7 +176,7 @@ impl TryFromVal<Env, ScVal> for Symbol {
 
 #[cfg(not(target_family = "wasm"))]
 impl TryFromVal<Env, ScSymbol> for Symbol {
-    type Error = ConversionError;
+    type Error = super::env::Error;
     fn try_from_val(env: &Env, val: &ScSymbol) -> Result<Self, Self::Error> {
         Ok(SymbolVal::try_from_val(env, val)?
             .try_into_val(env)

--- a/soroban-sdk/src/tests/env.rs
+++ b/soroban-sdk/src/tests/env.rs
@@ -72,8 +72,8 @@ fn default_and_from_snapshot_same_settings() {
 
     let logs1 = env1.logs().all();
     let logs2 = env2.logs().all();
-    assert_eq!(logs1, &["[Diagnostic Event] contract:0000000000000000000000000000000000000000000000000000000000000001, topics:[log], data:\"test\""]);
-    assert_eq!(logs2, &["[Diagnostic Event] contract:0000000000000000000000000000000000000000000000000000000000000001, topics:[log], data:\"test\""]);
+    assert_eq!(logs1, &["[Diagnostic Event] contract:CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM, topics:[log], data:\"test\""]);
+    assert_eq!(logs2, &["[Diagnostic Event] contract:CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM, topics:[log], data:\"test\""]);
 }
 
 #[test]

--- a/soroban-sdk/src/vec.rs
+++ b/soroban-sdk/src/vec.rs
@@ -259,44 +259,44 @@ use super::xdr::{ScVal, ScVec, VecM};
 
 #[cfg(not(target_family = "wasm"))]
 impl<T> TryFrom<&Vec<T>> for ScVal {
-    type Error = ConversionError;
-    fn try_from(v: &Vec<T>) -> Result<Self, ConversionError> {
+    type Error = super::env::Error;
+    fn try_from(v: &Vec<T>) -> Result<Self, super::env::Error> {
         Ok(ScVal::try_from_val(&v.env, &v.obj.to_val())?)
     }
 }
 
 #[cfg(not(target_family = "wasm"))]
 impl<T> TryFrom<&Vec<T>> for ScVec {
-    type Error = ConversionError;
-    fn try_from(v: &Vec<T>) -> Result<Self, ConversionError> {
+    type Error = super::env::Error;
+    fn try_from(v: &Vec<T>) -> Result<Self, super::env::Error> {
         if let ScVal::Vec(Some(vec)) = ScVal::try_from(v)? {
             Ok(vec)
         } else {
-            Err(ConversionError)
+            Err(ConversionError.into())
         }
     }
 }
 
 #[cfg(not(target_family = "wasm"))]
 impl<T> TryFrom<Vec<T>> for VecM<ScVal> {
-    type Error = ConversionError;
-    fn try_from(v: Vec<T>) -> Result<Self, ConversionError> {
+    type Error = super::env::Error;
+    fn try_from(v: Vec<T>) -> Result<Self, super::env::Error> {
         Ok(ScVec::try_from(v)?.0)
     }
 }
 
 #[cfg(not(target_family = "wasm"))]
 impl<T> TryFrom<Vec<T>> for ScVal {
-    type Error = ConversionError;
-    fn try_from(v: Vec<T>) -> Result<Self, ConversionError> {
+    type Error = super::env::Error;
+    fn try_from(v: Vec<T>) -> Result<Self, super::env::Error> {
         (&v).try_into()
     }
 }
 
 #[cfg(not(target_family = "wasm"))]
 impl<T> TryFrom<Vec<T>> for ScVec {
-    type Error = ConversionError;
-    fn try_from(v: Vec<T>) -> Result<Self, ConversionError> {
+    type Error = super::env::Error;
+    fn try_from(v: Vec<T>) -> Result<Self, super::env::Error> {
         (&v).try_into()
     }
 }

--- a/soroban-sdk/src/vec.rs
+++ b/soroban-sdk/src/vec.rs
@@ -261,7 +261,7 @@ use super::xdr::{ScVal, ScVec, VecM};
 impl<T> TryFrom<&Vec<T>> for ScVal {
     type Error = ConversionError;
     fn try_from(v: &Vec<T>) -> Result<Self, ConversionError> {
-        ScVal::try_from_val(&v.env, &v.obj.to_val())
+        Ok(ScVal::try_from_val(&v.env, &v.obj.to_val())?)
     }
 }
 

--- a/soroban-sdk/test_snapshots/tests/token_client/test_mock_all_auth.1.json
+++ b/soroban-sdk/test_snapshots/tests/token_client/test_mock_all_auth.1.json
@@ -382,7 +382,7 @@
                                 "symbol": "symbol"
                               },
                               "val": {
-                                "string": "aaa\\0"
+                                "string": "aaa"
                               }
                             }
                           ]

--- a/soroban-sdk/test_snapshots/tests/token_client/test_mock_auth.1.json
+++ b/soroban-sdk/test_snapshots/tests/token_client/test_mock_auth.1.json
@@ -413,7 +413,7 @@
                                 "symbol": "symbol"
                               },
                               "val": {
-                                "string": "aaa\\0"
+                                "string": "aaa"
                               }
                             }
                           ]


### PR DESCRIPTION
This is an alternative approach to PR https://github.com/stellar/rs-soroban-sdk/pull/1216 where we plumb the `env::Error` code all the way up to the surface of the SDK's UI.

I don't feel strongly about doing this or the other one, they both seem to work, it's a question of UI complexity. Neither approach suffers the problem that motivated this change at the env level, where we went from `Error` to `ConversionError` and then _back_ to `Error` and thereby produced misleading `Error` codes.