### PR TITLE
Display `String` contents in `Debug` implementation.

### DIFF
--- a/soroban-sdk/src/string.rs
+++ b/soroban-sdk/src/string.rs
@@ -41,7 +41,10 @@ pub struct String {
 
 impl Debug for String {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        write!(f, "String()")?;
+        #[cfg(target_family = "wasm")]
+        write!(f, "String(..)")?;
+        #[cfg(not(target_family = "wasm"))]
+        write!(f, "String({})", self.to_string())?;
         Ok(())
     }
 }


### PR DESCRIPTION
### What

Display `String` contents in `Debug` implementation.

### Why

Improve testing/debugging UX

### Known limitations

N/A
