### PR TITLE
Move the Env testutil internal types into a single type

### DIFF
--- a/soroban-sdk/src/env.rs
+++ b/soroban-sdk/src/env.rs
@@ -131,11 +131,7 @@ use internal::{
 pub struct MaybeEnv {
     maybe_env_impl: internal::MaybeEnvImpl,
     #[cfg(any(test, feature = "testutils"))]
-    generators: Option<Rc<RefCell<Generators>>>,
-    #[cfg(any(test, feature = "testutils"))]
-    auth_snapshot: Option<Rc<RefCell<AuthSnapshot>>>,
-    #[cfg(any(test, feature = "testutils"))]
-    snapshot: Option<Rc<LedgerSnapshot>>,
+    internals: Option<EnvInternals>,
 }
 
 #[cfg(target_family = "wasm")]
@@ -145,10 +141,6 @@ impl TryFrom<MaybeEnv> for Env {
     fn try_from(_value: MaybeEnv) -> Result<Self, Self::Error> {
         Ok(Env {
             env_impl: internal::EnvImpl {},
-            #[cfg(any(test, feature = "testutils"))]
-            generators: value.generators,
-            #[cfg(any(test, feature = "testutils"))]
-            snapshot: value.snapshot,
         })
     }
 }
@@ -165,10 +157,6 @@ impl MaybeEnv {
     pub const fn none() -> Self {
         Self {
             maybe_env_impl: internal::EnvImpl {},
-            #[cfg(any(test, feature = "testutils"))]
-            generators: None,
-            #[cfg(any(test, feature = "testutils"))]
-            snapshot: None,
         }
     }
 }
@@ -180,11 +168,7 @@ impl MaybeEnv {
         Self {
             maybe_env_impl: None,
             #[cfg(any(test, feature = "testutils"))]
-            generators: None,
-            #[cfg(any(test, feature = "testutils"))]
-            auth_snapshot: None,
-            #[cfg(any(test, feature = "testutils"))]
-            snapshot: None,
+            internals: None,
         }
     }
 }
@@ -194,10 +178,6 @@ impl From<Env> for MaybeEnv {
     fn from(value: Env) -> Self {
         MaybeEnv {
             maybe_env_impl: value.env_impl,
-            #[cfg(any(test, feature = "testutils"))]
-            generators: Some(value.generators),
-            #[cfg(any(test, feature = "testutils"))]
-            snapshot: value.snapshot,
         }
     }
 }
@@ -211,11 +191,7 @@ impl TryFrom<MaybeEnv> for Env {
             Ok(Env {
                 env_impl,
                 #[cfg(any(test, feature = "testutils"))]
-                generators: value.generators.unwrap_or_default(),
-                #[cfg(any(test, feature = "testutils"))]
-                auth_snapshot: value.auth_snapshot.unwrap_or_default(),
-                #[cfg(any(test, feature = "testutils"))]
-                snapshot: value.snapshot,
+                internals: value.internals.unwrap_or_default(),
             })
         } else {
             Err(ConversionError)
@@ -229,11 +205,7 @@ impl From<Env> for MaybeEnv {
         MaybeEnv {
             maybe_env_impl: Some(value.env_impl.clone()),
             #[cfg(any(test, feature = "testutils"))]
-            generators: Some(value.generators.clone()),
-            #[cfg(any(test, feature = "testutils"))]
-            auth_snapshot: Some(value.auth_snapshot.clone()),
-            #[cfg(any(test, feature = "testutils"))]
-            snapshot: value.snapshot.clone(),
+            internals: Some(value.internals.clone()),
         }
     }
 }
@@ -250,11 +222,7 @@ impl From<Env> for MaybeEnv {
 pub struct Env {
     env_impl: internal::EnvImpl,
     #[cfg(any(test, feature = "testutils"))]
-    generators: Rc<RefCell<Generators>>,
-    #[cfg(any(test, feature = "testutils"))]
-    auth_snapshot: Rc<RefCell<AuthSnapshot>>,
-    #[cfg(any(test, feature = "testutils"))]
-    snapshot: Option<Rc<LedgerSnapshot>>,
+    internals: EnvInternals,
 }
 
 impl Default for Env {
@@ -269,6 +237,14 @@ impl Default for Env {
     fn default() -> Self {
         Self::default_with_testutils()
     }
+}
+
+#[cfg(any(test, feature = "testutils"))]
+#[derive(Clone, Default)]
+struct EnvInternals {
+    generators: Rc<RefCell<Generators>>,
+    auth_snapshot: Rc<RefCell<AuthSnapshot>>,
+    snapshot: Option<Rc<LedgerSnapshot>>,
 }
 
 impl Env {
@@ -478,7 +454,7 @@ impl Env {
 
     #[doc(hidden)]
     pub(crate) fn with_generator<T>(&self, f: impl FnOnce(RefMut<'_, Generators>) -> T) -> T {
-        f((*self.generators).borrow_mut())
+        f((*self.internals.generators).borrow_mut())
     }
 
     fn default_with_testutils() -> Env {
@@ -554,9 +530,11 @@ impl Env {
 
         let env = Env {
             env_impl,
-            generators: generators.unwrap_or_default(),
-            snapshot,
-            auth_snapshot,
+            internals: EnvInternals {
+                generators: generators.unwrap_or_default(),
+                snapshot,
+                auth_snapshot,
+            },
         };
 
         env.ledger().set(ledger_info);
@@ -611,9 +589,7 @@ impl Env {
             ) -> Option<Val> {
                 let env = Env {
                     env_impl: env_impl.clone(),
-                    generators: Default::default(),
-                    auth_snapshot: Default::default(),
-                    snapshot: None,
+                    internals: Default::default(),
                 };
                 self.0.call(
                     crate::Symbol::try_from_val(&env, func)
@@ -1064,7 +1040,7 @@ impl Env {
     /// # fn main() { }
     /// ```
     pub fn auths(&self) -> std::vec::Vec<(Address, AuthorizedInvocation)> {
-        (*self.auth_snapshot)
+        (*self.internals.auth_snapshot)
             .borrow()
             .0
             .last()
@@ -1266,8 +1242,8 @@ impl Env {
     /// Create a snapshot from the Env's current state.
     pub fn to_snapshot(&self) -> Snapshot {
         Snapshot {
-            generators: (*self.generators).borrow().clone(),
-            auth: (*self.auth_snapshot).borrow().clone(),
+            generators: (*self.internals.generators).borrow().clone(),
+            auth: (*self.internals.auth_snapshot).borrow().clone(),
             ledger: self.to_ledger_snapshot(),
             events: self.to_events_snapshot(),
         }
@@ -1305,7 +1281,7 @@ impl Env {
 
     /// Create a snapshot from the Env's current state.
     pub fn to_ledger_snapshot(&self) -> LedgerSnapshot {
-        let snapshot = self.snapshot.clone().unwrap_or_default();
+        let snapshot = self.internals.snapshot.clone().unwrap_or_default();
         let mut snapshot = (*snapshot).clone();
         snapshot.set_ledger_info(self.ledger().get());
         let budget = soroban_env_host::budget::AsBudget::as_budget(&self.env_impl);


### PR DESCRIPTION
### What
Move the Env testutil internal types into a single type.

### Why
The Env when used with testutils enabled has a few internal fields. Those internal fields are copied around between MaybeEnv and Env, and because they're individual fields there's repetitive calls on each field, and repetitive compiler attributes. It's painful each time we add a new one to remember and find all the places that need adding. Using a single type groups all those repetitive actions so we don't need to keep repeating them for new types to add.

I'm about to add another field.