### PR TITLE
Add option to disable test snapshots on Env

### DIFF
--- a/soroban-sdk/src/env.rs
+++ b/soroban-sdk/src/env.rs
@@ -267,14 +267,6 @@ impl Default for EnvTestConfig {
     }
 }
 
-#[cfg(any(test, feature = "testutils"))]
-#[derive(Clone, Default)]
-struct EnvTestState {
-    generators: Rc<RefCell<Generators>>,
-    auth_snapshot: Rc<RefCell<AuthSnapshot>>,
-    snapshot: Option<Rc<LedgerSnapshot>>,
-}
-
 impl Env {
     /// Panic with the given error.
     ///

--- a/soroban-sdk/src/env.rs
+++ b/soroban-sdk/src/env.rs
@@ -131,11 +131,7 @@ use internal::{
 pub struct MaybeEnv {
     maybe_env_impl: internal::MaybeEnvImpl,
     #[cfg(any(test, feature = "testutils"))]
-    generators: Option<Rc<RefCell<Generators>>>,
-    #[cfg(any(test, feature = "testutils"))]
-    auth_snapshot: Option<Rc<RefCell<AuthSnapshot>>>,
-    #[cfg(any(test, feature = "testutils"))]
-    snapshot: Option<Rc<LedgerSnapshot>>,
+    internals: Option<EnvInternals>,
 }
 
 #[cfg(target_family = "wasm")]
@@ -145,10 +141,6 @@ impl TryFrom<MaybeEnv> for Env {
     fn try_from(_value: MaybeEnv) -> Result<Self, Self::Error> {
         Ok(Env {
             env_impl: internal::EnvImpl {},
-            #[cfg(any(test, feature = "testutils"))]
-            generators: value.generators,
-            #[cfg(any(test, feature = "testutils"))]
-            snapshot: value.snapshot,
         })
     }
 }
@@ -165,10 +157,6 @@ impl MaybeEnv {
     pub const fn none() -> Self {
         Self {
             maybe_env_impl: internal::EnvImpl {},
-            #[cfg(any(test, feature = "testutils"))]
-            generators: None,
-            #[cfg(any(test, feature = "testutils"))]
-            snapshot: None,
         }
     }
 }
@@ -180,11 +168,7 @@ impl MaybeEnv {
         Self {
             maybe_env_impl: None,
             #[cfg(any(test, feature = "testutils"))]
-            generators: None,
-            #[cfg(any(test, feature = "testutils"))]
-            auth_snapshot: None,
-            #[cfg(any(test, feature = "testutils"))]
-            snapshot: None,
+            internals: None,
         }
     }
 }
@@ -194,10 +178,6 @@ impl From<Env> for MaybeEnv {
     fn from(value: Env) -> Self {
         MaybeEnv {
             maybe_env_impl: value.env_impl,
-            #[cfg(any(test, feature = "testutils"))]
-            generators: Some(value.generators),
-            #[cfg(any(test, feature = "testutils"))]
-            snapshot: value.snapshot,
         }
     }
 }
@@ -211,11 +191,7 @@ impl TryFrom<MaybeEnv> for Env {
             Ok(Env {
                 env_impl,
                 #[cfg(any(test, feature = "testutils"))]
-                generators: value.generators.unwrap_or_default(),
-                #[cfg(any(test, feature = "testutils"))]
-                auth_snapshot: value.auth_snapshot.unwrap_or_default(),
-                #[cfg(any(test, feature = "testutils"))]
-                snapshot: value.snapshot,
+                internals: value.internals.unwrap_or_default(),
             })
         } else {
             Err(ConversionError)
@@ -229,11 +205,7 @@ impl From<Env> for MaybeEnv {
         MaybeEnv {
             maybe_env_impl: Some(value.env_impl.clone()),
             #[cfg(any(test, feature = "testutils"))]
-            generators: Some(value.generators.clone()),
-            #[cfg(any(test, feature = "testutils"))]
-            auth_snapshot: Some(value.auth_snapshot.clone()),
-            #[cfg(any(test, feature = "testutils"))]
-            snapshot: value.snapshot.clone(),
+            internals: Some(value.internals.clone()),
         }
     }
 }
@@ -250,11 +222,7 @@ impl From<Env> for MaybeEnv {
 pub struct Env {
     env_impl: internal::EnvImpl,
     #[cfg(any(test, feature = "testutils"))]
-    generators: Rc<RefCell<Generators>>,
-    #[cfg(any(test, feature = "testutils"))]
-    auth_snapshot: Rc<RefCell<AuthSnapshot>>,
-    #[cfg(any(test, feature = "testutils"))]
-    snapshot: Option<Rc<LedgerSnapshot>>,
+    internals: EnvInternals,
 }
 
 impl Default for Env {
@@ -269,6 +237,14 @@ impl Default for Env {
     fn default() -> Self {
         Self::default_with_testutils()
     }
+}
+
+#[cfg(any(test, feature = "testutils"))]
+#[derive(Clone, Default)]
+struct EnvInternals {
+    generators: Rc<RefCell<Generators>>,
+    auth_snapshot: Rc<RefCell<AuthSnapshot>>,
+    snapshot: Option<Rc<LedgerSnapshot>>,
 }
 
 impl Env {
@@ -478,7 +454,7 @@ impl Env {
 
     #[doc(hidden)]
     pub(crate) fn with_generator<T>(&self, f: impl FnOnce(RefMut<'_, Generators>) -> T) -> T {
-        f((*self.generators).borrow_mut())
+        f((*self.internals.generators).borrow_mut())
     }
 
     fn default_with_testutils() -> Env {
@@ -554,9 +530,11 @@ impl Env {
 
         let env = Env {
             env_impl,
-            generators: generators.unwrap_or_default(),
-            snapshot,
-            auth_snapshot,
+            internals: EnvInternals {
+                generators: generators.unwrap_or_default(),
+                snapshot,
+                auth_snapshot,
+            },
         };
 
         env.ledger().set(ledger_info);
@@ -611,9 +589,7 @@ impl Env {
             ) -> Option<Val> {
                 let env = Env {
                     env_impl: env_impl.clone(),
-                    generators: Default::default(),
-                    auth_snapshot: Default::default(),
-                    snapshot: None,
+                    internals: Default::default(),
                 };
                 self.0.call(
                     crate::Symbol::try_from_val(&env, func)
@@ -1064,7 +1040,7 @@ impl Env {
     /// # fn main() { }
     /// ```
     pub fn auths(&self) -> std::vec::Vec<(Address, AuthorizedInvocation)> {
-        (*self.auth_snapshot)
+        (*self.internals.auth_snapshot)
             .borrow()
             .0
             .last()
@@ -1266,8 +1242,8 @@ impl Env {
     /// Create a snapshot from the Env's current state.
     pub fn to_snapshot(&self) -> Snapshot {
         Snapshot {
-            generators: (*self.generators).borrow().clone(),
-            auth: (*self.auth_snapshot).borrow().clone(),
+            generators: (*self.internals.generators).borrow().clone(),
+            auth: (*self.internals.auth_snapshot).borrow().clone(),
             ledger: self.to_ledger_snapshot(),
             events: self.to_events_snapshot(),
         }
@@ -1305,7 +1281,7 @@ impl Env {
 
     /// Create a snapshot from the Env's current state.
     pub fn to_ledger_snapshot(&self) -> LedgerSnapshot {
-        let snapshot = self.snapshot.clone().unwrap_or_default();
+        let snapshot = self.internals.snapshot.clone().unwrap_or_default();
         let mut snapshot = (*snapshot).clone();
         snapshot.set_ledger_info(self.ledger().get());
         let budget = soroban_env_host::budget::AsBudget::as_budget(&self.env_impl);

--- a/soroban-sdk/src/lib.rs
+++ b/soroban-sdk/src/lib.rs
@@ -725,9 +725,8 @@ mod env;
 mod address;
 mod symbol;
 
-pub use env::ConversionError;
+pub use env::{ConversionError, Env, EnvTestConfig};
 
-pub use env::Env;
 /// Raw value of the Soroban smart contract platform that types can be converted
 /// to and from for storing, or passing between contracts.
 ///

--- a/soroban-sdk/src/lib.rs
+++ b/soroban-sdk/src/lib.rs
@@ -725,7 +725,7 @@ mod env;
 mod address;
 mod symbol;
 
-pub use env::{ConversionError, Env, EnvTestConfig};
+pub use env::{ConversionError, Env};
 
 /// Raw value of the Soroban smart contract platform that types can be converted
 /// to and from for storing, or passing between contracts.

--- a/soroban-sdk/src/tests/env.rs
+++ b/soroban-sdk/src/tests/env.rs
@@ -147,3 +147,20 @@ fn test_snapshot_file() {
     let _ = std::fs::remove_file(&p1);
     let _ = std::fs::remove_file(&p2);
 }
+
+/// Test that the test snapshot file is not written when disabled.
+#[test]
+fn test_snapshot_file_disabled() {
+    let p = std::path::Path::new("test_snapshots")
+        .join("tests")
+        .join("env")
+        .join("test_snapshot_file");
+    let p1 = p.with_extension("1.json");
+    assert!(!p1.exists());
+    {
+        let _ = Env::default();
+        assert!(!p1.exists());
+    }
+    assert!(p1.exists());
+    let _ = std::fs::remove_file(&p1);
+}

--- a/soroban-sdk/src/tests/env.rs
+++ b/soroban-sdk/src/tests/env.rs
@@ -1,5 +1,6 @@
 use crate::{
     self as soroban_sdk, contract, contractimpl,
+    env::EnvTestConfig,
     testutils::{Address as _, Logs as _},
     Address, Env, Error,
 };
@@ -157,10 +158,18 @@ fn test_snapshot_file_disabled() {
         .join("test_snapshot_file");
     let p1 = p.with_extension("1.json");
     assert!(!p1.exists());
+    let p2 = p.with_extension("1.json");
+    assert!(!p2.exists());
     {
         let _ = Env::default();
+        let _ = Env::new_with_config(EnvTestConfig {
+            capture_snapshot_at_drop: false,
+        });
         assert!(!p1.exists());
+        assert!(!p2.exists());
     }
     assert!(p1.exists());
+    assert!(!p2.exists());
     let _ = std::fs::remove_file(&p1);
+    let _ = std::fs::remove_file(&p2);
 }

--- a/soroban-sdk/src/tests/env.rs
+++ b/soroban-sdk/src/tests/env.rs
@@ -155,16 +155,18 @@ fn test_snapshot_file_disabled() {
     let p = std::path::Path::new("test_snapshots")
         .join("tests")
         .join("env")
-        .join("test_snapshot_file");
+        .join("test_snapshot_file_disabled");
     let p1 = p.with_extension("1.json");
     assert!(!p1.exists());
-    let p2 = p.with_extension("1.json");
+    let p2 = p.with_extension("2.json");
     assert!(!p2.exists());
     {
-        let _ = Env::default();
-        let _ = Env::new_with_config(EnvTestConfig {
+        let e1 = Env::default();
+        let _ = e1.register_contract(None, Contract);
+        let e2 = Env::new_with_config(EnvTestConfig {
             capture_snapshot_at_drop: false,
         });
+        let _ = e2.register_contract(None, Contract);
         assert!(!p1.exists());
         assert!(!p2.exists());
     }

--- a/soroban-sdk/src/testutils.rs
+++ b/soroban-sdk/src/testutils.rs
@@ -18,6 +18,8 @@ pub mod storage;
 use crate::{xdr, Env, Val, Vec};
 use soroban_ledger_snapshot::LedgerSnapshot;
 
+pub use crate::env::EnvTestConfig;
+
 #[derive(Default, Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub struct Snapshot {


### PR DESCRIPTION
### What
Add option to disable test snapshots on Env

### Why
In some situations a developer needs to disable test snapshots. The default is that they are always on, in the interest of giving all developers a way to identify unexpected and otherwise untested for changed behavior during SDK upgrades, no protocol releases, or their own developer lifecycle.

Close #1225

### Merging
This change is dependent on the following change merging first, and will be kept in draft state until then:
- #1234 