### PR TITLE
Make fn argument name errors better

### DIFF
--- a/soroban-sdk-macros/src/derive_spec_fn.rs
+++ b/soroban-sdk-macros/src/derive_spec_fn.rs
@@ -66,7 +66,7 @@ pub fn derive_fn_spec(
                         let name = name.try_into().unwrap_or_else(|_| {
                             const MAX: u32 = 30;
                             errors.push(Error::new(
-                                ident.span(),
+                                a.span(),
                                 format!("argument name too long, max length {} characters", MAX),
                             ));
                             StringM::<MAX>::default()


### PR DESCRIPTION
### What
When displaying argument name errors highlight the specific argument name instead of the fn as a whole as the point of the error.

### Why
So that it is easier to see immediately where the error occurs.

There are no test changes. I don't love that there isn't test coverage for compile errors. We used to have them, but removed all compile error testing at some point because in general the impact of breaking compile errors is low, and the tests are very slow because the tests have to run through a full compile and capture compiler output.

### Example

#### Before

```
error: argument name too long, max length 30 characters
 --> tests/empty/src/lib.rs:9:12
  |
9 |     pub fn empty(a234567890123456789001234567890: u64) {}
  |            ^^^^^
```

### After

```
error: argument name too long, max length 30 characters
 --> tests/empty/src/lib.rs:9:18
  |
9 |     pub fn empty(a234567890123456789001234567890: u64) {}
  |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```