### PR TITLE
Revert "Generate all types of addresses when fuzzing. (#1122)"

### DIFF
--- a/soroban-sdk/src/testutils/arbitrary.rs
+++ b/soroban-sdk/src/testutils/arbitrary.rs
@@ -627,7 +627,7 @@ mod objects {
 
     #[derive(Arbitrary, Debug, Clone, Eq, PartialEq, Ord, PartialOrd)]
     pub struct ArbitraryAddress {
-        inner: crate::env::xdr::ScAddress,
+        inner: [u8; 32],
     }
 
     impl SorobanArbitrary for Address {
@@ -637,7 +637,10 @@ mod objects {
     impl TryFromVal<Env, ArbitraryAddress> for Address {
         type Error = ConversionError;
         fn try_from_val(env: &Env, v: &ArbitraryAddress) -> Result<Self, Self::Error> {
-            Ok(v.inner.into_val(env))
+            use crate::env::xdr::{Hash, ScAddress};
+
+            let sc_addr = ScVal::Address(ScAddress::Contract(Hash(v.inner)));
+            Ok(sc_addr.into_val(env))
         }
     }
 


### PR DESCRIPTION
This reverts commit 6b04bfc0509519f846379928f0143c5079b1f936.

Closes https://github.com/stellar/rs-soroban-sdk/issues/1221

### What

In https://github.com/stellar/rs-soroban-sdk/pull/1122, I changed the impl of `Arbitrary` for `Address` to generate all types of addresses instead of only contract addresses. I no longer think that was the correct thing to do, so this changes the impl back to only generate contract addresses.

### Why

Described in the issue https://github.com/stellar/rs-soroban-sdk/issues/1221

In short, native addresses are difficult to test with, particularly in conjunction with the native token contract, because they require set up of storage and trustlines. Doing this setup is possible, but is not obvious, and users running into such errors during testing are likely to get stuck.

### Known limitations

This is arguably a breaking change, though only to the testing environment, and only to fuzzers. I think it is likely there are so few fuzzing users that nobody will notice; better to do it sooner than later.
