### PR TITLE
Add doc qualifying where contractimport is relative to

### DIFF
--- a/soroban-sdk/src/lib.rs
+++ b/soroban-sdk/src/lib.rs
@@ -242,6 +242,9 @@ pub use soroban_sdk_macros::contracterror;
 /// Import a contract from its WASM file, generating a client, types, and
 /// constant holding the contract file.
 ///
+/// The path given is relative to the workspace root, and not the current
+/// file.
+///
 /// Generates in the current module:
 /// - A `Contract` trait that matches the contracts interface.
 /// - A `ContractClient` struct that has functions for each function in the


### PR DESCRIPTION
### What
Add doc qualifying where the path passed to contractimport is relative to.

### Why
The docs don't say, and you could easily assume it is relative to the current file which is what some built-in Rust macros do. The reason it isn't relative to the current file is because Rust macros don't provide anyway for a non-built-in macro to do that.