### PR TITLE
Add docs to the token interface

### DIFF
--- a/soroban-sdk/src/token.rs
+++ b/soroban-sdk/src/token.rs
@@ -330,7 +330,7 @@ pub(crate) const SPEC_XDR_INPUT: &[&[u8]] = &[
     &StellarAssetSpec::spec_xdr_transfer_from(),
 ];
 
-pub(crate) const SPEC_XDR_LEN: usize = 5336;
+pub(crate) const SPEC_XDR_LEN: usize = 6460;
 
 impl StellarAssetSpec {
     /// Returns the XDR spec for the Token contract.

--- a/soroban-sdk/src/token.rs
+++ b/soroban-sdk/src/token.rs
@@ -61,8 +61,9 @@ pub use TokenClient as Client;
 ///
 /// ## Burning
 ///
-/// Tokens allow holders of the token to transfer tokens to other addresses.
-/// Tokens implementing the interface expose a single function for doing so:
+/// Tokens allow holders of the token to burn, i.e. dispose of, tokens without
+/// transferring them to another holder. Tokens implementing the interface
+/// expose a single function for doing so:
 /// - [`burn`][Self::burn]
 ///
 /// ## Allowances


### PR DESCRIPTION
### What
Add docs to the token interface, and a summary that outlines how the different functions are grouped into areas of functionality.

### Why
To help a newcomer engaging with the interface to see which functions are related to each other, and then when digging into the allowance functions specifically, give more understanding and depth in how the functions are intended to work.

Close #966