### PR TITLE
Add module doc for auth module

### DIFF
--- a/soroban-sdk/src/auth.rs
+++ b/soroban-sdk/src/auth.rs
@@ -1,3 +1,5 @@
+//! Auth contains types for building custom account contracts.
+
 use crate::{contracttype, Address, BytesN, Env, Error, Symbol, Val, Vec};
 
 /// Context of a single authorized call performed by an address.


### PR DESCRIPTION
### What
Add module doc for auth module

### Why
The module doesn't have a doc, and it stands out in the docs as the only module without one when viewing all the modules together.