### PR TITLE
Update cargo-deny CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -38,7 +38,7 @@ jobs:
     continue-on-error: ${{ matrix.checks == 'advisories' }}
     steps:
     - uses: actions/checkout@v3
-    - uses: EmbarkStudios/cargo-deny-action@e0a440755b184aa50374330fa75cca0f84fcb59a
+    - uses: EmbarkStudios/cargo-deny-action@b01e7a8cfb1f496c52d77361e84c1840d8246393
       with:
         command: check ${{ matrix.checks }}
 


### PR DESCRIPTION
### What
Update cargo-deny CI

### Why
It started panicking when running and fix we used for this on the rs-soroban-env repo was an updated cargo-deny action.