### PR TITLE
Bump versions; separate extend contract code and TTL for contract code and instance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1136,7 +1136,7 @@ dependencies = [
  "soroban-env-macros",
  "soroban-wasmi",
  "static_assertions",
- "stellar-xdr 21.0.0",
+ "stellar-xdr",
  "wasmparser",
 ]
 
@@ -1194,7 +1194,7 @@ dependencies = [
  "quote",
  "serde",
  "serde_json",
- "stellar-xdr 21.0.0",
+ "stellar-xdr",
  "syn",
 ]
 
@@ -1231,7 +1231,7 @@ dependencies = [
  "soroban-sdk-macros",
  "soroban-spec",
  "stellar-strkey",
- "stellar-xdr 20.1.0",
+ "stellar-xdr",
 ]
 
 [[package]]
@@ -1248,7 +1248,7 @@ dependencies = [
  "soroban-env-common",
  "soroban-spec",
  "soroban-spec-rust",
- "stellar-xdr 20.1.0",
+ "stellar-xdr",
  "syn",
 ]
 
@@ -1258,7 +1258,7 @@ version = "20.5.0"
 dependencies = [
  "base64 0.13.1",
  "pretty_assertions",
- "stellar-xdr 20.1.0",
+ "stellar-xdr",
  "thiserror",
  "wasmparser",
 ]
@@ -1273,7 +1273,7 @@ dependencies = [
  "quote",
  "sha2",
  "soroban-spec",
- "stellar-xdr 20.1.0",
+ "stellar-xdr",
  "syn",
  "thiserror",
 ]
@@ -1329,20 +1329,6 @@ dependencies = [
  "base32",
  "crate-git-revision",
  "thiserror",
-]
-
-[[package]]
-name = "stellar-xdr"
-version = "20.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e59cdf3eb4467fb5a4b00b52e7de6dca72f67fac6f9b700f55c95a5d86f09c9d"
-dependencies = [
- "crate-git-revision",
- "escape-bytes",
- "hex",
- "serde",
- "serde_with",
- "stellar-strkey",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1112,7 +1112,7 @@ checksum = "4dccd0940a2dcdf68d092b8cbab7dc0ad8fa938bf95787e1b916b0e3d0e8e970"
 [[package]]
 name = "soroban-builtin-sdk-macros"
 version = "21.0.0"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=4d9b1020f7b5baa0f972eb08ed8aa2cd3343ad7c#4d9b1020f7b5baa0f972eb08ed8aa2cd3343ad7c"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=8867a5d5b05681bde5eb8cf2031f615b1e8d8889#8867a5d5b05681bde5eb8cf2031f615b1e8d8889"
 dependencies = [
  "itertools",
  "proc-macro2",
@@ -1123,7 +1123,7 @@ dependencies = [
 [[package]]
 name = "soroban-env-common"
 version = "21.0.0"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=4d9b1020f7b5baa0f972eb08ed8aa2cd3343ad7c#4d9b1020f7b5baa0f972eb08ed8aa2cd3343ad7c"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=8867a5d5b05681bde5eb8cf2031f615b1e8d8889#8867a5d5b05681bde5eb8cf2031f615b1e8d8889"
 dependencies = [
  "arbitrary",
  "crate-git-revision",
@@ -1141,7 +1141,7 @@ dependencies = [
 [[package]]
 name = "soroban-env-guest"
 version = "21.0.0"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=4d9b1020f7b5baa0f972eb08ed8aa2cd3343ad7c#4d9b1020f7b5baa0f972eb08ed8aa2cd3343ad7c"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=8867a5d5b05681bde5eb8cf2031f615b1e8d8889#8867a5d5b05681bde5eb8cf2031f615b1e8d8889"
 dependencies = [
  "soroban-env-common",
  "static_assertions",
@@ -1150,7 +1150,7 @@ dependencies = [
 [[package]]
 name = "soroban-env-host"
 version = "21.0.0"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=4d9b1020f7b5baa0f972eb08ed8aa2cd3343ad7c#4d9b1020f7b5baa0f972eb08ed8aa2cd3343ad7c"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=8867a5d5b05681bde5eb8cf2031f615b1e8d8889#8867a5d5b05681bde5eb8cf2031f615b1e8d8889"
 dependencies = [
  "backtrace",
  "curve25519-dalek",
@@ -1182,7 +1182,7 @@ dependencies = [
 [[package]]
 name = "soroban-env-macros"
 version = "21.0.0"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=4d9b1020f7b5baa0f972eb08ed8aa2cd3343ad7c#4d9b1020f7b5baa0f972eb08ed8aa2cd3343ad7c"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=8867a5d5b05681bde5eb8cf2031f615b1e8d8889#8867a5d5b05681bde5eb8cf2031f615b1e8d8889"
 dependencies = [
  "itertools",
  "proc-macro2",
@@ -1328,7 +1328,7 @@ dependencies = [
 [[package]]
 name = "stellar-xdr"
 version = "20.1.0"
-source = "git+https://github.com/stellar/rs-stellar-xdr?rev=a80c899c61e869fd00b7b475a4947ab6aaf9dcac#a80c899c61e869fd00b7b475a4947ab6aaf9dcac"
+source = "git+https://github.com/stellar/rs-stellar-xdr?rev=d0138770652a615e3cd99447f2f2727658c17450#d0138770652a615e3cd99447f2f2727658c17450"
 dependencies = [
  "arbitrary",
  "base64 0.13.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1112,7 +1112,8 @@ checksum = "4dccd0940a2dcdf68d092b8cbab7dc0ad8fa938bf95787e1b916b0e3d0e8e970"
 [[package]]
 name = "soroban-builtin-sdk-macros"
 version = "21.0.0"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=8867a5d5b05681bde5eb8cf2031f615b1e8d8889#8867a5d5b05681bde5eb8cf2031f615b1e8d8889"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8d93e2e24ebe7c0704f8609cad25d1ab75acf4424b9f501e8689362f3885104"
 dependencies = [
  "itertools",
  "proc-macro2",
@@ -1123,7 +1124,8 @@ dependencies = [
 [[package]]
 name = "soroban-env-common"
 version = "21.0.0"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=8867a5d5b05681bde5eb8cf2031f615b1e8d8889#8867a5d5b05681bde5eb8cf2031f615b1e8d8889"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4f82fd953b35e8c81f6c5be30e28ec82ba4122221f721a939e9a3844f23eb4f"
 dependencies = [
  "arbitrary",
  "crate-git-revision",
@@ -1134,14 +1136,15 @@ dependencies = [
  "soroban-env-macros",
  "soroban-wasmi",
  "static_assertions",
- "stellar-xdr",
+ "stellar-xdr 21.0.0",
  "wasmparser",
 ]
 
 [[package]]
 name = "soroban-env-guest"
 version = "21.0.0"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=8867a5d5b05681bde5eb8cf2031f615b1e8d8889#8867a5d5b05681bde5eb8cf2031f615b1e8d8889"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7314ba04a308ffbd7a9a53661a3247eaab7d68254045a4c3757f66ead8506c2"
 dependencies = [
  "soroban-env-common",
  "static_assertions",
@@ -1150,7 +1153,8 @@ dependencies = [
 [[package]]
 name = "soroban-env-host"
 version = "21.0.0"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=8867a5d5b05681bde5eb8cf2031f615b1e8d8889#8867a5d5b05681bde5eb8cf2031f615b1e8d8889"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83c7605e4a2c6057a52b4c4d75f0600249941e4e2fd783bf82ff14ac603b7177"
 dependencies = [
  "backtrace",
  "curve25519-dalek",
@@ -1182,14 +1186,15 @@ dependencies = [
 [[package]]
 name = "soroban-env-macros"
 version = "21.0.0"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=8867a5d5b05681bde5eb8cf2031f615b1e8d8889#8867a5d5b05681bde5eb8cf2031f615b1e8d8889"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b00bceab0c1f00856e362f82fa5b20375923a40ae1920534c406a5772b20b7bd"
 dependencies = [
  "itertools",
  "proc-macro2",
  "quote",
  "serde",
  "serde_json",
- "stellar-xdr",
+ "stellar-xdr 21.0.0",
  "syn",
 ]
 
@@ -1226,7 +1231,7 @@ dependencies = [
  "soroban-sdk-macros",
  "soroban-spec",
  "stellar-strkey",
- "stellar-xdr",
+ "stellar-xdr 20.1.0",
 ]
 
 [[package]]
@@ -1243,7 +1248,7 @@ dependencies = [
  "soroban-env-common",
  "soroban-spec",
  "soroban-spec-rust",
- "stellar-xdr",
+ "stellar-xdr 20.1.0",
  "syn",
 ]
 
@@ -1253,7 +1258,7 @@ version = "20.5.0"
 dependencies = [
  "base64 0.13.1",
  "pretty_assertions",
- "stellar-xdr",
+ "stellar-xdr 20.1.0",
  "thiserror",
  "wasmparser",
 ]
@@ -1268,7 +1273,7 @@ dependencies = [
  "quote",
  "sha2",
  "soroban-spec",
- "stellar-xdr",
+ "stellar-xdr 20.1.0",
  "syn",
  "thiserror",
 ]
@@ -1283,7 +1288,8 @@ dependencies = [
 [[package]]
 name = "soroban-wasmi"
 version = "0.31.1-soroban.20.0.1"
-source = "git+https://github.com/stellar/wasmi?rev=0ed3f3dee30dc41ebe21972399e0a73a41944aa0#0ed3f3dee30dc41ebe21972399e0a73a41944aa0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "710403de32d0e0c35375518cb995d4fc056d0d48966f2e56ea471b8cb8fc9719"
 dependencies = [
  "smallvec",
  "spin",
@@ -1328,7 +1334,22 @@ dependencies = [
 [[package]]
 name = "stellar-xdr"
 version = "20.1.0"
-source = "git+https://github.com/stellar/rs-stellar-xdr?rev=d0138770652a615e3cd99447f2f2727658c17450#d0138770652a615e3cd99447f2f2727658c17450"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e59cdf3eb4467fb5a4b00b52e7de6dca72f67fac6f9b700f55c95a5d86f09c9d"
+dependencies = [
+ "crate-git-revision",
+ "escape-bytes",
+ "hex",
+ "serde",
+ "serde_with",
+ "stellar-strkey",
+]
+
+[[package]]
+name = "stellar-xdr"
+version = "21.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "193cef4375f498306b3b39d2182b8e1192904fc90dd2eec8b3f3007b87c427c7"
 dependencies = [
  "arbitrary",
  "base64 0.13.1",
@@ -1647,13 +1668,15 @@ checksum = "7ab9b36309365056cd639da3134bf87fa8f3d86008abf99e612384a6eecd459f"
 
 [[package]]
 name = "wasmi_arena"
-version = "0.4.0"
-source = "git+https://github.com/stellar/wasmi?rev=0ed3f3dee30dc41ebe21972399e0a73a41944aa0#0ed3f3dee30dc41ebe21972399e0a73a41944aa0"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "104a7f73be44570cac297b3035d76b169d6599637631cf37a1703326a0727073"
 
 [[package]]
 name = "wasmi_core"
 version = "0.13.0"
-source = "git+https://github.com/stellar/wasmi?rev=0ed3f3dee30dc41ebe21972399e0a73a41944aa0#0ed3f3dee30dc41ebe21972399e0a73a41944aa0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcf1a7db34bff95b85c261002720c00c3a6168256dcb93041d3fa2054d19856a"
 dependencies = [
  "downcast-rs",
  "libm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,18 +42,18 @@ soroban-token-sdk = { version = "20.5.0", path = "soroban-token-sdk" }
 
 [workspace.dependencies.soroban-env-common]
 version = "=21.0.0"
-git = "https://github.com/stellar/rs-soroban-env"
-rev = "8867a5d5b05681bde5eb8cf2031f615b1e8d8889"
+# git = "https://github.com/stellar/rs-soroban-env"
+# rev = "8867a5d5b05681bde5eb8cf2031f615b1e8d8889"
 
 [workspace.dependencies.soroban-env-guest]
 version = "=21.0.0"
-git = "https://github.com/stellar/rs-soroban-env"
-rev = "8867a5d5b05681bde5eb8cf2031f615b1e8d8889"
+# git = "https://github.com/stellar/rs-soroban-env"
+# rev = "8867a5d5b05681bde5eb8cf2031f615b1e8d8889"
 
 [workspace.dependencies.soroban-env-host]
 version = "=21.0.0"
-git = "https://github.com/stellar/rs-soroban-env"
-rev = "8867a5d5b05681bde5eb8cf2031f615b1e8d8889"
+# git = "https://github.com/stellar/rs-soroban-env"
+# rev = "8867a5d5b05681bde5eb8cf2031f615b1e8d8889"
 
 [workspace.dependencies.stellar-strkey]
 version = "=0.0.8"
@@ -62,8 +62,8 @@ version = "=0.0.8"
 version = "=20.1.0"
 default-features = false
 features = ["curr"]
-git = "https://github.com/stellar/rs-stellar-xdr"
-rev = "d0138770652a615e3cd99447f2f2727658c17450"
+# git = "https://github.com/stellar/rs-stellar-xdr"
+# rev = "d0138770652a615e3cd99447f2f2727658c17450"
 
 #[patch."https://github.com/stellar/rs-soroban-env"]
 #soroban-env-common = { path = "../rs-soroban-env/soroban-env-common" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ version = "=21.0.0"
 version = "=0.0.8"
 
 [workspace.dependencies.stellar-xdr]
-version = "=20.1.0"
+version = "=21.0.0"
 default-features = false
 features = ["curr"]
 # git = "https://github.com/stellar/rs-stellar-xdr"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,17 +43,17 @@ soroban-token-sdk = { version = "20.5.0", path = "soroban-token-sdk" }
 [workspace.dependencies.soroban-env-common]
 version = "=21.0.0"
 git = "https://github.com/stellar/rs-soroban-env"
-rev = "4d9b1020f7b5baa0f972eb08ed8aa2cd3343ad7c"
+rev = "8867a5d5b05681bde5eb8cf2031f615b1e8d8889"
 
 [workspace.dependencies.soroban-env-guest]
 version = "=21.0.0"
 git = "https://github.com/stellar/rs-soroban-env"
-rev = "4d9b1020f7b5baa0f972eb08ed8aa2cd3343ad7c"
+rev = "8867a5d5b05681bde5eb8cf2031f615b1e8d8889"
 
 [workspace.dependencies.soroban-env-host]
 version = "=21.0.0"
 git = "https://github.com/stellar/rs-soroban-env"
-rev = "4d9b1020f7b5baa0f972eb08ed8aa2cd3343ad7c"
+rev = "8867a5d5b05681bde5eb8cf2031f615b1e8d8889"
 
 [workspace.dependencies.stellar-strkey]
 version = "=0.0.8"
@@ -63,7 +63,7 @@ version = "=20.1.0"
 default-features = false
 features = ["curr"]
 git = "https://github.com/stellar/rs-stellar-xdr"
-rev = "a80c899c61e869fd00b7b475a4947ab6aaf9dcac"
+rev = "d0138770652a615e3cd99447f2f2727658c17450"
 
 #[patch."https://github.com/stellar/rs-soroban-env"]
 #soroban-env-common = { path = "../rs-soroban-env/soroban-env-common" }

--- a/soroban-sdk-macros/src/map_type.rs
+++ b/soroban-sdk-macros/src/map_type.rs
@@ -1,7 +1,7 @@
 use stellar_xdr::curr as stellar_xdr;
 use stellar_xdr::{
     ScSpecTypeBytesN, ScSpecTypeDef, ScSpecTypeMap, ScSpecTypeOption, ScSpecTypeResult,
-    ScSpecTypeTuple, ScSpecTypeUdt, ScSpecTypeVec,
+    ScSpecTypeTuple, ScSpecTypeUdt, ScSpecTypeVec, ScSpectTypeHash,
 };
 use syn::{
     spanned::Spanned, Error, Expr, ExprLit, GenericArgument, Lit, Path, PathArguments, PathSegment,
@@ -104,13 +104,23 @@ pub fn map_type(t: &Type) -> Result<ScSpecTypeDef, Error> {
                         }
                         "BytesN" => {
                             let n = match args.as_slice() {
-                            [GenericArgument::Const(Expr::Lit(ExprLit { lit: Lit::Int(int), .. }))] => int.base10_parse()?,
-                            [..] => Err(Error::new(
-                                t.span(),
-                                "incorrect number of generic arguments, expect one for BytesN<N>",
-                            ))?,
-                        };
+                                [GenericArgument::Const(Expr::Lit(ExprLit { lit: Lit::Int(int), .. }))] => int.base10_parse()?,
+                                [..] => Err(Error::new(
+                                    t.span(),
+                                    "incorrect number of generic arguments, expect one for BytesN<N>",
+                                ))?,
+                            };
                             Ok(ScSpecTypeDef::BytesN(ScSpecTypeBytesN { n }))
+                        }
+                        "Hash" => {
+                            let n = match args.as_slice() {
+                                [GenericArgument::Const(Expr::Lit(ExprLit { lit: Lit::Int(int), .. }))] => int.base10_parse()?,
+                                [..] => Err(Error::new(
+                                    t.span(),
+                                    "incorrect number of generic arguments, expect one for BytesN<N>",
+                                ))?,
+                            };
+                            Ok(ScSpecTypeDef::Hash(ScSpectTypeHash { n }))
                         }
                         _ => Err(Error::new(
                             angle_bracketed.span(),

--- a/soroban-sdk/src/deploy.rs
+++ b/soroban-sdk/src/deploy.rs
@@ -152,14 +152,7 @@ impl Deployer {
     /// The TTL is the number of ledgers between the current ledger and the final ledger the data can still be accessed.
     pub fn extend_ttl(&self, contract_address: Address, threshold: u32, extend_to: u32) {
         self.env
-            .extend_contract_instance_ttl(
-                contract_address.to_object(),
-                threshold.into(),
-                extend_to.into(),
-            )
-            .unwrap_infallible();
-        self.env
-            .extend_contract_code_ttl(
+            .extend_contract_instance_and_code_ttl(
                 contract_address.to_object(),
                 threshold.into(),
                 extend_to.into(),

--- a/soroban-sdk/src/deploy.rs
+++ b/soroban-sdk/src/deploy.rs
@@ -152,7 +152,39 @@ impl Deployer {
     /// The TTL is the number of ledgers between the current ledger and the final ledger the data can still be accessed.
     pub fn extend_ttl(&self, contract_address: Address, threshold: u32, extend_to: u32) {
         self.env
-            .extend_contract_instance_and_code_ttl(
+            .extend_contract_instance_ttl(
+                contract_address.to_object(),
+                threshold.into(),
+                extend_to.into(),
+            )
+            .unwrap_infallible();
+        self.env
+            .extend_contract_code_ttl(
+                contract_address.to_object(),
+                threshold.into(),
+                extend_to.into(),
+            )
+            .unwrap_infallible();
+    }
+
+    pub fn extend_ttl_for_contract_instance(
+        &self,
+        contract_address: Address,
+        threshold: u32,
+        extend_to: u32,
+    ) {
+        self.env
+            .extend_contract_instance_ttl(
+                contract_address.to_object(),
+                threshold.into(),
+                extend_to.into(),
+            )
+            .unwrap_infallible();
+    }
+
+    pub fn extend_ttl_for_code(&self, contract_address: Address, threshold: u32, extend_to: u32) {
+        self.env
+            .extend_contract_code_ttl(
                 contract_address.to_object(),
                 threshold.into(),
                 extend_to.into(),

--- a/soroban-spec-rust/src/types.rs
+++ b/soroban-spec-rust/src/types.rs
@@ -175,6 +175,10 @@ pub fn generate_type_ident(spec: &ScSpecTypeDef) -> TokenStream {
             let n = Literal::u32_unsuffixed(b.n);
             quote! { soroban_sdk::BytesN<#n> }
         }
+        ScSpecTypeDef::Hash(b) => {
+            let n = Literal::u32_unsuffixed(b.n);
+            quote! { soroban_sdk::Hash<#n> }
+        }
         ScSpecTypeDef::Udt(u) => {
             let ident = format_ident!("{}", u.name.to_utf8_string().unwrap());
             quote! { #ident }


### PR DESCRIPTION
### What
- Bump env and xdr, pick up `Hash` type.
- Adapt the deployer to allow bumping TTL for contract code and instance separately.