### PR TITLE
Generate clear error when a nameless contract argument is used 

### DIFF
--- a/soroban-sdk-macros/src/derive_client.rs
+++ b/soroban-sdk-macros/src/derive_client.rs
@@ -1,6 +1,6 @@
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
-use syn::{Error, FnArg, Pat, Path, Type, TypePath, TypeReference};
+use syn::{Error, FnArg, Path, Type, TypePath, TypeReference};
 
 use crate::syn_ext;
 

--- a/soroban-sdk-macros/src/derive_client.rs
+++ b/soroban-sdk-macros/src/derive_client.rs
@@ -172,16 +172,7 @@ pub fn derive_client_impl(crate_path: &Path, name: &str, fns: &[syn_ext::Fn]) ->
                         Ok(ident) => ident,
                         Err(e) => {
                             errors.push(e);
-                            if let FnArg::Typed(pat_type) = t {
-                                if let Pat::Wild(_) = *pat_type.pat.clone() {
-                                    // This will result in a clear compiler error if an underscore is used as an argument.
-                                    format_ident!("_")
-                                } else {
-                                    format_ident!("")
-                                }
-                            } else {
-                                format_ident!("")
-                            }
+                            format_ident!("_")
                         }
                     };
                     (ident, syn_ext::fn_arg_make_ref(t))

--- a/soroban-sdk-macros/src/derive_client.rs
+++ b/soroban-sdk-macros/src/derive_client.rs
@@ -1,6 +1,6 @@
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
-use syn::{spanned::Spanned, Error, FnArg, Pat, Path, Type, TypePath, TypeReference};
+use syn::{Error, FnArg, Pat, Path, Type, TypePath, TypeReference};
 
 use crate::syn_ext;
 
@@ -170,8 +170,8 @@ pub fn derive_client_impl(crate_path: &Path, name: &str, fns: &[syn_ext::Fn]) ->
                 .map(|t| {
                     let ident = match syn_ext::fn_arg_ident(t) {
                         Ok(ident) => ident,
-                        Err(_) => {
-                            errors.push(Error::new(t.span(), "argument not supported"));
+                        Err(e) => {
+                            errors.push(e);
                             if let FnArg::Typed(pat_type) = t {
                                 if let Pat::Wild(_) = *pat_type.pat.clone() {
                                     // This will result in a clear compiler error if an underscore is used as an argument.

--- a/soroban-sdk-macros/src/syn_ext.rs
+++ b/soroban-sdk-macros/src/syn_ext.rs
@@ -41,7 +41,10 @@ pub fn fn_arg_ident(arg: &FnArg) -> Result<Ident, Error> {
             return Ok(pat_ident.ident);
         }
     }
-    Err(Error::new(arg.span(), "argument not supported"))
+    Err(Error::new(
+        arg.span(),
+        "argument in this form is not supported, use simple named arguments only",
+    ))
 }
 
 /// Returns a clone of FnArg with the type as a reference if the arg is a typed


### PR DESCRIPTION
### What

Resolve #1198

What the error looks like now - 

```

error: argument not supported
 --> src/lib.rs:9:18
  |
9 |     pub fn empty(_: u64) {}
  |                  ^

error: argument not supported
 --> src/lib.rs:9:28
  |
9 |     pub fn empty(dog: u64, _: u64) {}
  |                            ^
```