### PR TITLE
Truncate docs stored in wasm rather than panic when length exceeded

### DIFF
--- a/soroban-sdk-macros/src/derive_enum.rs
+++ b/soroban-sdk-macros/src/derive_enum.rs
@@ -139,7 +139,7 @@ pub fn derive_type_enum(
     // Generated code spec.
     let spec_gen = if spec {
         let spec_entry = ScSpecEntry::UdtUnionV0(ScSpecUdtUnionV0 {
-            doc: docs_from_attrs(attrs).try_into().unwrap(), // TODO: Truncate docs, or display friendly compile error.
+            doc: docs_from_attrs(attrs),
             lib: lib.as_deref().unwrap_or_default().try_into().unwrap(),
             name: enum_ident.to_string().try_into().unwrap(),
             cases: spec_cases.try_into().unwrap(),
@@ -289,7 +289,7 @@ fn map_empty_variant(
     attrs: &[Attribute],
 ) -> VariantTokens {
     let spec_case = ScSpecUdtUnionCaseV0::VoidV0(ScSpecUdtUnionCaseVoidV0 {
-        doc: docs_from_attrs(attrs).try_into().unwrap(), // TODO: Truncate docs, or display friendly compile error.
+        doc: docs_from_attrs(attrs),
         name: case_name.try_into().unwrap_or_else(|_| StringM::default()),
     });
     let try_from = quote! {
@@ -376,7 +376,7 @@ fn map_tuple_variant(
             }
         };
         ScSpecUdtUnionCaseV0::TupleV0(ScSpecUdtUnionCaseTupleV0 {
-            doc: docs_from_attrs(attrs).try_into().unwrap(), // TODO: Truncate docs, or display friendly compile error.
+            doc: docs_from_attrs(attrs),
             name: case_name.try_into().unwrap_or_else(|_| StringM::default()),
             type_: field_types.try_into().unwrap(),
         })

--- a/soroban-sdk-macros/src/derive_enum_int.rs
+++ b/soroban-sdk-macros/src/derive_enum_int.rs
@@ -49,7 +49,7 @@ pub fn derive_type_enum_int(
                 0
             };
             let spec_case = ScSpecUdtEnumCaseV0 {
-                doc: docs_from_attrs(&v.attrs).try_into().unwrap(), // TODO: Truncate docs, or display friendly compile error.
+                doc: docs_from_attrs(&v.attrs),
                 name: name.try_into().unwrap_or_else(|_| StringM::default()),
                 value: discriminant,
             };
@@ -68,7 +68,7 @@ pub fn derive_type_enum_int(
     // Generated code spec.
     let spec_gen = if spec {
         let spec_entry = ScSpecEntry::UdtEnumV0(ScSpecUdtEnumV0 {
-            doc: docs_from_attrs(attrs).try_into().unwrap(), // TODO: Truncate docs, or display friendly compile error.
+            doc: docs_from_attrs(attrs),
             lib: lib.as_deref().unwrap_or_default().try_into().unwrap(),
             name: enum_ident.to_string().try_into().unwrap(),
             cases: spec_cases.try_into().unwrap(),

--- a/soroban-sdk-macros/src/derive_error_enum_int.rs
+++ b/soroban-sdk-macros/src/derive_error_enum_int.rs
@@ -44,7 +44,7 @@ pub fn derive_type_error_enum_int(
                 0
             };
             let spec_case = ScSpecUdtErrorEnumCaseV0 {
-                doc: docs_from_attrs(&v.attrs).try_into().unwrap(), // TODO: Truncate docs, or display friendly compile error.
+                doc: docs_from_attrs(&v.attrs),
                 name: name.try_into().unwrap_or_else(|_| StringM::default()),
                 value: discriminant,
             };
@@ -66,7 +66,7 @@ pub fn derive_type_error_enum_int(
     // Generated code spec.
     let spec_gen = if spec {
         let spec_entry = ScSpecEntry::UdtErrorEnumV0(ScSpecUdtErrorEnumV0 {
-            doc: docs_from_attrs(attrs).try_into().unwrap(), // TODO: Truncate docs, or display friendly compile error.
+            doc: docs_from_attrs(attrs),
             lib: lib.as_deref().unwrap_or_default().try_into().unwrap(),
             name: enum_ident.to_string().try_into().unwrap(),
             cases: spec_cases.try_into().unwrap(),

--- a/soroban-sdk-macros/src/derive_spec_fn.rs
+++ b/soroban-sdk-macros/src/derive_spec_fn.rs
@@ -119,7 +119,7 @@ pub fn derive_fn_spec(
     // Generated code spec.
     let name = &format!("{}", ident);
     let spec_entry = ScSpecEntry::FunctionV0(ScSpecFunctionV0 {
-        doc: docs_from_attrs(attrs).try_into().unwrap(), // TODO: Truncate docs, or display friendly compile error.
+        doc: docs_from_attrs(attrs),
         name: name.try_into().unwrap_or_else(|_| {
             errors.push(Error::new(
                 ident.span(),

--- a/soroban-sdk-macros/src/derive_struct.rs
+++ b/soroban-sdk-macros/src/derive_struct.rs
@@ -36,7 +36,7 @@ pub fn derive_type_struct(
             let field_name = field_ident.to_string();
             let field_idx_lit = Literal::usize_unsuffixed(field_num);
             let spec_field = ScSpecUdtStructFieldV0 {
-                doc: docs_from_attrs(&field.attrs).try_into().unwrap(), // TODO: Truncate docs, or display friendly compile error.
+                doc: docs_from_attrs(&field.attrs),
                 name: field_name.clone().try_into().unwrap_or_else(|_| {
                     const MAX: u32 = 30;
                     errors.push(Error::new(field_ident.span(), format!("struct field name is too long: {}, max is {MAX}", field_name.len())));
@@ -77,7 +77,7 @@ pub fn derive_type_struct(
     // Generated code spec.
     let spec_gen = if spec {
         let spec_entry = ScSpecEntry::UdtStructV0(ScSpecUdtStructV0 {
-            doc: docs_from_attrs(attrs).try_into().unwrap(), // TODO: Truncate docs, or display friendly compile error.
+            doc: docs_from_attrs(attrs),
             lib: lib.as_deref().unwrap_or_default().try_into().unwrap(),
             name: ident.to_string().try_into().unwrap(),
             fields: spec_fields.try_into().unwrap(),

--- a/soroban-sdk-macros/src/derive_struct_tuple.rs
+++ b/soroban-sdk-macros/src/derive_struct_tuple.rs
@@ -34,7 +34,7 @@ pub fn derive_type_struct_tuple(
             let field_idx_lit = Literal::usize_unsuffixed(field_idx);
             let field_name = format!("{}", field_idx);
             let field_spec = ScSpecUdtStructFieldV0 {
-                doc: docs_from_attrs(&field.attrs).try_into().unwrap(), // TODO: Truncate docs, or display friendly compile error.
+                doc: docs_from_attrs(&field.attrs),
                 name: field_name.try_into().unwrap_or_else(|_| StringM::default()),
                 type_: match map_type(&field.ty, false) {
                     Ok(t) => t,
@@ -66,7 +66,7 @@ pub fn derive_type_struct_tuple(
     // Generated code spec.
     let spec_gen = if spec {
         let spec_entry = ScSpecEntry::UdtStructV0(ScSpecUdtStructV0 {
-            doc: docs_from_attrs(attrs).try_into().unwrap(), // TODO: Truncate docs, or display friendly compile error.
+            doc: docs_from_attrs(attrs),
             lib: lib.as_deref().unwrap_or_default().try_into().unwrap(),
             name: ident.to_string().try_into().unwrap(),
             fields: field_specs.try_into().unwrap(),

--- a/soroban-sdk-macros/src/doc.rs
+++ b/soroban-sdk-macros/src/doc.rs
@@ -1,8 +1,12 @@
 use itertools::Itertools;
+use stellar_xdr::curr as stellar_xdr;
+use stellar_xdr::StringM;
 use syn::{Attribute, Expr, ExprLit, Lit, Meta, MetaNameValue};
 
-pub fn docs_from_attrs(attrs: &[Attribute]) -> String {
-    attrs
+const DOCS_MAX_LEN: u32 = 1024;
+
+pub fn docs_from_attrs(attrs: &[Attribute]) -> StringM<DOCS_MAX_LEN> {
+    let mut docs = attrs
         .iter()
         .filter(|a| a.path().is_ident("doc"))
         .filter_map(|a| match &a.meta {
@@ -17,4 +21,8 @@ pub fn docs_from_attrs(attrs: &[Attribute]) -> String {
         })
         .map(|s| s.trim().to_string())
         .join("\n")
+        .as_bytes()
+        .to_vec();
+    docs.truncate(DOCS_MAX_LEN as usize);
+    docs.try_into().unwrap()
 }


### PR DESCRIPTION
### What
Truncate docs stored in the wasm spec rather than panic when the length of the docs exceeds the length that can be stored in the wasm.

### Why
Today the SDK panicks if any item such as a contract type, or function, contain rust docs that are more than 1kb in length. Instead of panicking the SDK should truncate since it is not critical information, and helps a developer just keep moving forward rather than having to iterate on the length of their docs.

See the following conversation:
- https://discord.com/channels/897514728459468821/1224968435314724946