### PR TITLE
Check UDT enum integer must derive from `Copy`

### DIFF
--- a/soroban-sdk-macros/src/derive_enum_int.rs
+++ b/soroban-sdk-macros/src/derive_enum_int.rs
@@ -3,13 +3,35 @@ use proc_macro2::TokenStream as TokenStream2;
 use quote::{format_ident, quote};
 use stellar_xdr::curr as stellar_xdr;
 use stellar_xdr::{ScSpecUdtEnumV0, StringM};
-use syn::{spanned::Spanned, Attribute, DataEnum, Error, ExprLit, Ident, Lit, Path, Visibility};
+use syn::{
+    spanned::Spanned, Attribute, DataEnum, Error, ExprLit, Ident, Lit, Meta, Path, Visibility,
+};
 
 use stellar_xdr::{ScSpecEntry, ScSpecUdtEnumCaseV0, WriteXdr};
 
 use crate::{doc::docs_from_attrs, DEFAULT_XDR_RW_LIMITS};
 
 // TODO: Add conversions to/from ScVal types.
+
+fn derives_copy(attrs: &[Attribute]) -> bool {
+    for attr in attrs {
+        if let Meta::List(ml) = &attr.meta {
+            if let Some(_ps) = ml.path.segments.iter().find(|ps| ps.ident == "derive") {
+                if let Some(_tt) = ml.tokens.clone().into_iter().find(|tt| {
+                    // match this token with what we want
+                    if let proc_macro2::TokenTree::Ident(id) = tt {
+                        id.to_string() == "Copy"
+                    } else {
+                        false
+                    }
+                }) {
+                    return true;
+                }
+            }
+        }
+    }
+    false
+}
 
 pub fn derive_type_enum_int(
     path: &Path,
@@ -22,6 +44,16 @@ pub fn derive_type_enum_int(
 ) -> TokenStream2 {
     // Collect errors as they are encountered and emit them at the end.
     let mut errors = Vec::<Error>::new();
+
+    if !derives_copy(attrs) {
+        errors.push(Error::new(
+            enum_ident.span(),
+            format!(
+                "enum integer {} must have `derive(Copy)`",
+                enum_ident.to_string()
+            ),
+        ));
+    }
 
     let variants = &data.variants;
     let (spec_cases, try_froms, try_intos): (Vec<_>, Vec<_>, Vec<_>) = variants


### PR DESCRIPTION
### What

Resolves https://github.com/stellar/rs-soroban-sdk/issues/630

### Why

Previously missing `derive(Copy)` on an UDT enum integer shows up as a cryptic error way down the stack (the contract itself will compile just fine, you get the following error when trying to compile code (e.g. a native unit test) using the generated contract client):

```
error[E0507]: cannot move out of `*self` which is behind a shared reference
 --> tests/udt_enum/src/lib.rs:4:1
  |
4 | #[contracttype]
  | ^^^^^^^^^^^^^^^ move occurs because `*self` has type `UdtEnum`, which does not implement the `Copy` trait
  |
  = note: this error originates in the attribute macro `contracttype` (in Nightly builds, run with -Z macro-backtrace for more info)
```

This change gives a clear error message during contract macro expansion (before compile time):
```
error: enum integer UdtEnum must have `derive(Copy)`
 --> tests/udt_enum/src/lib.rs:6:10
  |
6 | pub enum UdtEnum {
  |          ^^^^^^^
```

### Known limitations

[TODO or N/A]
