### PR TITLE
Update SDK to use env 21.0.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1111,8 +1111,9 @@ checksum = "4dccd0940a2dcdf68d092b8cbab7dc0ad8fa938bf95787e1b916b0e3d0e8e970"
 
 [[package]]
 name = "soroban-builtin-sdk-macros"
-version = "21.0.1"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=ad83e6cef73ca04f75d03ad1b0f43434886ce93b#ad83e6cef73ca04f75d03ad1b0f43434886ce93b"
+version = "21.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c97a421cb20a81d14b0be51a20029fdf41ebbeaf46de57b77ee08c3d6bcdd344"
 dependencies = [
  "itertools",
  "proc-macro2",
@@ -1122,8 +1123,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-common"
-version = "21.0.1"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=ad83e6cef73ca04f75d03ad1b0f43434886ce93b#ad83e6cef73ca04f75d03ad1b0f43434886ce93b"
+version = "21.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab3a317a07564da61640643ea4081027f41108fbac2f92eab4b4ea14f9131431"
 dependencies = [
  "arbitrary",
  "crate-git-revision",
@@ -1140,8 +1142,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-guest"
-version = "21.0.1"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=ad83e6cef73ca04f75d03ad1b0f43434886ce93b#ad83e6cef73ca04f75d03ad1b0f43434886ce93b"
+version = "21.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6177a425602416528b8acfea2b8192fc5f3a8724fdba2171a1f3d2de9a5aaf9"
 dependencies = [
  "soroban-env-common",
  "static_assertions",
@@ -1149,8 +1152,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-host"
-version = "21.0.1"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=ad83e6cef73ca04f75d03ad1b0f43434886ce93b#ad83e6cef73ca04f75d03ad1b0f43434886ce93b"
+version = "21.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67a8c79ea38779bc4d9338df4487b2c20c38e27d6970defca6258891a6b0d992"
 dependencies = [
  "backtrace",
  "curve25519-dalek",
@@ -1181,8 +1185,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-macros"
-version = "21.0.1"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=ad83e6cef73ca04f75d03ad1b0f43434886ce93b#ad83e6cef73ca04f75d03ad1b0f43434886ce93b"
+version = "21.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "380279c38cb56d9204f6bf43168b07acebc9690ddf0676412f3b574b9ef37495"
 dependencies = [
  "itertools",
  "proc-macro2",
@@ -1283,7 +1288,8 @@ dependencies = [
 [[package]]
 name = "soroban-wasmi"
 version = "0.31.1-soroban.20.0.1"
-source = "git+https://github.com/stellar/wasmi?rev=0ed3f3dee30dc41ebe21972399e0a73a41944aa0#0ed3f3dee30dc41ebe21972399e0a73a41944aa0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "710403de32d0e0c35375518cb995d4fc056d0d48966f2e56ea471b8cb8fc9719"
 dependencies = [
  "smallvec",
  "spin",
@@ -1655,13 +1661,15 @@ checksum = "7ab9b36309365056cd639da3134bf87fa8f3d86008abf99e612384a6eecd459f"
 
 [[package]]
 name = "wasmi_arena"
-version = "0.4.0"
-source = "git+https://github.com/stellar/wasmi?rev=0ed3f3dee30dc41ebe21972399e0a73a41944aa0#0ed3f3dee30dc41ebe21972399e0a73a41944aa0"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "104a7f73be44570cac297b3035d76b169d6599637631cf37a1703326a0727073"
 
 [[package]]
 name = "wasmi_core"
 version = "0.13.0"
-source = "git+https://github.com/stellar/wasmi?rev=0ed3f3dee30dc41ebe21972399e0a73a41944aa0#0ed3f3dee30dc41ebe21972399e0a73a41944aa0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcf1a7db34bff95b85c261002720c00c3a6168256dcb93041d3fa2054d19856a"
 dependencies = [
  "downcast-rs",
  "libm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,19 +24,19 @@ soroban-ledger-snapshot = { version = "21.0.1-preview.1", path = "soroban-ledger
 soroban-token-sdk = { version = "21.0.1-preview.1", path = "soroban-token-sdk" }
 
 [workspace.dependencies.soroban-env-common]
-version = "=21.0.1"
-git = "https://github.com/stellar/rs-soroban-env"
-rev = "ad83e6cef73ca04f75d03ad1b0f43434886ce93b"
+version = "=21.0.2"
+#git = "https://github.com/stellar/rs-soroban-env"
+#rev = "ad83e6cef73ca04f75d03ad1b0f43434886ce93b"
 
 [workspace.dependencies.soroban-env-guest]
-version = "=21.0.1"
-git = "https://github.com/stellar/rs-soroban-env"
-rev = "ad83e6cef73ca04f75d03ad1b0f43434886ce93b"
+version = "=21.0.2"
+#git = "https://github.com/stellar/rs-soroban-env"
+#rev = "ad83e6cef73ca04f75d03ad1b0f43434886ce93b"
 
 [workspace.dependencies.soroban-env-host]
-version = "=21.0.1"
-git = "https://github.com/stellar/rs-soroban-env"
-rev = "ad83e6cef73ca04f75d03ad1b0f43434886ce93b"
+version = "=21.0.2"
+#git = "https://github.com/stellar/rs-soroban-env"
+#rev = "ad83e6cef73ca04f75d03ad1b0f43434886ce93b"
 
 [workspace.dependencies.stellar-strkey]
 version = "=0.0.8"


### PR DESCRIPTION
### What

Update SDK to use env 21.0.2

### Why

Preparing for the release

### Known limitations

N/A
