### PR TITLE
Add a conversion from Hash->Bytes

### DIFF
--- a/soroban-sdk/src/crypto.rs
+++ b/soroban-sdk/src/crypto.rs
@@ -71,6 +71,12 @@ impl<const N: usize> IntoVal<Env, BytesN<N>> for Hash<N> {
     }
 }
 
+impl<const N: usize> Into<Bytes> for Hash<N> {
+    fn into(self) -> Bytes {
+        self.0.into()
+    }
+}
+
 impl<const N: usize> Into<BytesN<N>> for Hash<N> {
     fn into(self) -> BytesN<N> {
         self.0


### PR DESCRIPTION
### What
Add a conversion from `Hash`->`Bytes`.

### Why
In a prototype I'm working on I take a `Hash` value and append it to an existing `Bytes`, and noticed that prior to this release of the SDK I could call `.into()` on the value because it was prior a `BytesN<32>`. Now that it is a `Hash` I don't seem to be able to call `.into()` on it in the same context.

Since the type is trivially convertible to a `BytesN<32>` it seems reasonable to keep the trivial convertibility into a `Bytes`.