### PR TITLE
Add warning icon to struct CryptoHazmat

### DIFF
--- a/soroban-sdk/src/crypto.rs
+++ b/soroban-sdk/src/crypto.rs
@@ -168,7 +168,7 @@ impl Crypto {
     }
 }
 
-/// Hazardous Materials
+/// # ⚠️ Hazardous Materials
 ///
 /// Cryptographic functions under [CryptoHazmat] are low-leveled which can be
 /// insecure if misused. They are not generally recommended. Using them

--- a/soroban-sdk/src/env.rs
+++ b/soroban-sdk/src/env.rs
@@ -319,7 +319,7 @@ impl Env {
         Crypto::new(self)
     }
 
-    /// Hazardous Materials
+    /// # ⚠️ Hazardous Materials
     ///
     /// Get a [CryptoHazmat] for accessing the cryptographic functions that are
     /// not generally recommended. Using them incorrectly can introduce security


### PR DESCRIPTION
### What

Add warning icon to struct CryptoHazmat. 

### Why

To highlight the Hazardous Materials warning in doc.rs similar to [this trait](https://docs.rs/signature/2.1.0/signature/hazmat/trait.PrehashVerifier.html#-security-warning).
Current [docs here](https://docs.rs/soroban-sdk/21.0.1-preview.2/soroban_sdk/crypto/struct.CryptoHazmat.html).