### PR TITLE
Put crypto hazmat behind a feature

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,9 +5,9 @@ export RUSTFLAGS=-Dwarnings
 CARGO_DOC_ARGS?=--open
 
 doc: fmt
-	cargo test --doc -p soroban-sdk -p soroban-sdk-macros --features testutils
+	cargo test --doc -p soroban-sdk -p soroban-sdk-macros --features testutils,hazmat
     # TODO: Upgrade to latest nightly after problem that was introduced in nightly-2024-02-05 (https://github.com/dalek-cryptography/curve25519-dalek/issues/618) is resolved.
-	cargo +nightly doc -p soroban-sdk --no-deps --features docs,testutils $(CARGO_DOC_ARGS)
+	cargo +nightly doc -p soroban-sdk --no-deps --all-features $(CARGO_DOC_ARGS)
 
 test: fmt build
 	cargo hack --feature-powerset --ignore-unknown-features --features testutils --exclude-features docs test

--- a/soroban-sdk/Cargo.toml
+++ b/soroban-sdk/Cargo.toml
@@ -50,6 +50,7 @@ proptest-arbitrary-interop = "0.1.0"
 [features]
 alloc = []
 testutils = ["soroban-sdk-macros/testutils", "soroban-env-host/testutils", "dep:ed25519-dalek", "dep:arbitrary", "dep:ctor"]
+hazmat = []
 docs = []
 
 [package.metadata.docs.rs]

--- a/soroban-sdk/src/crypto.rs
+++ b/soroban-sdk/src/crypto.rs
@@ -174,7 +174,13 @@ impl Crypto {
 /// insecure if misused. They are not generally recommended. Using them
 /// incorrectly can introduce security vulnerabilities. Please use [Crypto] if
 /// possible.
+#[cfg(any(test, feature = "hazmat"))]
+#[cfg_attr(feature = "docs", doc(cfg(feature = "hazmat")))]
 pub struct CryptoHazmat {
+    env: Env,
+}
+#[cfg(not(any(test, feature = "hazmat")))]
+pub(crate) struct CryptoHazmat {
     env: Env,
 }
 

--- a/soroban-sdk/src/env.rs
+++ b/soroban-sdk/src/env.rs
@@ -117,14 +117,8 @@ use crate::unwrap::UnwrapInfallible;
 use crate::unwrap::UnwrapOptimized;
 use crate::InvokeError;
 use crate::{
-    crypto::{Crypto, CryptoHazmat},
-    deploy::Deployer,
-    events::Events,
-    ledger::Ledger,
-    logs::Logs,
-    prng::Prng,
-    storage::Storage,
-    Address, Vec,
+    crypto::Crypto, deploy::Deployer, events::Events, ledger::Ledger, logs::Logs, prng::Prng,
+    storage::Storage, Address, Vec,
 };
 use internal::{
     AddressObject, Bool, BytesObject, DurationObject, I128Object, I256Object, I256Val, I64Object,
@@ -321,12 +315,15 @@ impl Env {
 
     /// # ⚠️ Hazardous Materials
     ///
-    /// Get a [CryptoHazmat] for accessing the cryptographic functions that are
-    /// not generally recommended. Using them incorrectly can introduce security
-    /// vulnerabilities. Please use [Crypto] if possible.
+    /// Get a [CryptoHazmat][crate::crypto::CryptoHazmat] for accessing the
+    /// cryptographic functions that are not generally recommended. Using them
+    /// incorrectly can introduce security vulnerabilities. Use [Crypto] if
+    /// possible.
+    #[cfg(any(test, feature = "hazmat"))]
+    #[cfg_attr(feature = "docs", doc(cfg(feature = "hazmat")))]
     #[inline(always)]
-    pub fn crypto_hazmat(&self) -> CryptoHazmat {
-        CryptoHazmat::new(self)
+    pub fn crypto_hazmat(&self) -> crate::crypto::CryptoHazmat {
+        crate::crypto::CryptoHazmat::new(self)
     }
 
     /// Get a [Prng] for accessing the current functions which provide pseudo-randomness.


### PR DESCRIPTION
### What
Add a new feature, `hazmat`, that is required to use the crypto hazmat capabilities.

### Why
The crypto hazmat capabilities are intended for use by folks who really need it and know what they're doing with lower level crypto primitives. There's not much in there right now but it'll likely expand over time. Most devs won't need it. There are warnings in the docs, but one additional layer or barrier so that someone can't accidentally include a call to hazmat without something else being done that's very visible, like enabling a feature, might as @graydon put it, prevent something sad happening.