### PR TITLE
Do not generate client fns for reserved hook functions

### DIFF
--- a/soroban-sdk-macros/src/derive_client.rs
+++ b/soroban-sdk-macros/src/derive_client.rs
@@ -133,6 +133,13 @@ pub fn derive_client_impl(crate_path: &Path, name: &str, fns: &[syn_ext::Fn]) ->
     let mut errors = Vec::<Error>::new();
     let fns: Vec<_> = fns
         .iter()
+        .filter(|f| {
+            // Skip generating client functions for calling contract functions
+            // that start with '__', because the Soroban Env won't let those
+            // functions be invoked directly as they're reserved for callbacks
+            // and hooks.
+            f.ident.to_string().starts_with("__")
+        })
         .map(|f| {
             let fn_ident = &f.ident;
             let fn_try_ident = format_ident!("try_{}", &f.ident);

--- a/soroban-sdk-macros/src/derive_client.rs
+++ b/soroban-sdk-macros/src/derive_client.rs
@@ -138,7 +138,7 @@ pub fn derive_client_impl(crate_path: &Path, name: &str, fns: &[syn_ext::Fn]) ->
             // that start with '__', because the Soroban Env won't let those
             // functions be invoked directly as they're reserved for callbacks
             // and hooks.
-            f.ident.to_string().starts_with("__")
+            !f.ident.to_string().starts_with("__")
         })
         .map(|f| {
             let fn_ident = &f.ident;


### PR DESCRIPTION
### What
Do not generate client fns for reserved hook functions.

### Why
There's no value in generating client functions for reserved hook functions (that begin with '__') because the Soroban Env won't let them be invoked directly anyway. So by generating the functions we're creating code that can never successfully be called.

Note that the function should still be generated into the interface/trait so that someone implementing the contracts trait implements the entire contract and not a subset.

Related to https://github.com/stellar/stellar-cli/issues/1344