### PR TITLE
Fix contract-meta warning

### DIFF
--- a/soroban-sdk-macros/src/lib.rs
+++ b/soroban-sdk-macros/src/lib.rs
@@ -349,7 +349,7 @@ pub fn contractmeta(metadata: TokenStream) -> TokenStream {
             args.key
                 .as_bytes()
                 .iter()
-                .map(|b| format!("{b:02x}"))
+                .map(|b| format!("{b:02X}"))
                 .collect::<String>()
         );
         quote! {


### PR DESCRIPTION
### What
Change the format of the variable that contractmeta is written into so that the name is all uppercase.

### Why
Each contract meta is written into a static variable that the compiler picks up and appends to a custom section. The names of the variables need to be unique so they're given a name with a common prefix and a suffix that is the hex encoded version of the key. The hex encoding used lower case alpha characters, which results in a warning because static variables are customarily all upper case.

This change should have no material impact as the variables are not intended for any programmatic use and exist only to inject the data into the custom section.

Related conversation:
- https://discord.com/channels/897514728459468821/971932562765250701/1249733280832557233