### PR TITLE
Document the accuracy of the ledger timestamp

### DIFF
--- a/soroban-sdk/src/ledger.rs
+++ b/soroban-sdk/src/ledger.rs
@@ -75,14 +75,18 @@ impl Ledger {
 
     /// Returns a unix timestamp for when the ledger was closed.
     ///
-    /// The close time is a UNIX timestamp indicating when the ledger closes.
-    /// Its accuracy depends on the system clock of the validator proposing the
-    /// block. Consequently, consensus may confirm a close time that lags a few
-    /// seconds behind or up to 60 seconds ahead.
+    /// The timestamp is a UNIX timestamp indicating when the ledger closes.
     ///
-    /// The timestamp is the number of seconds, excluding leap seconds,
-    /// that have elapsed since unix epoch. Unix epoch is January 1st, 1970,
-    /// at 00:00:00 UTC.
+    /// Its accuracy depends on the system clock of the validator proposing the
+    /// block. Consequently, the close time proposed by a validator may be
+    /// earlier or later than the actual time, by a few seconds past and up to
+    /// 60 seconds ahead of other validators.
+    ///
+    /// It is guaranteed to always be greater than a timestamp for an earlier
+    /// ledger.
+    ///
+    /// It is the number of seconds, excluding leap seconds, that have elapsed
+    /// since unix epoch. Unix epoch is January 1st, 1970, at 00:00:00 UTC.
     pub fn timestamp(&self) -> u64 {
         internal::Env::get_ledger_timestamp(self.env())
             .unwrap_infallible()

--- a/soroban-sdk/src/ledger.rs
+++ b/soroban-sdk/src/ledger.rs
@@ -3,6 +3,9 @@ use crate::{env::internal, unwrap::UnwrapInfallible, BytesN, Env, TryIntoVal};
 
 /// Ledger retrieves information about the current ledger.
 ///
+/// For more details about the ledger and the ledger header that the values in the Ledger are derived from, see:
+///  - https://developers.stellar.org/docs/learn/encyclopedia/network-configuration/ledger-headers
+///
 /// ### Examples
 ///
 /// ```
@@ -75,19 +78,12 @@ impl Ledger {
 
     /// Returns a unix timestamp for when the ledger was closed.
     ///
-    /// The timestamp is a UNIX timestamp indicating when the ledger closes.
-    ///
-    /// Its accuracy depends on the system clock of the validator proposing the
-    /// ledger. Consequently, the value may be earlier or later than the current
-    /// time of other validators, by a few seconds past and up to 60 seconds
-    /// ahead.
-    ///
-    /// The timestamp is guaranteed to always be greater than a timestamp for an
-    /// earlier ledger.
-    ///
     /// The timestamp is the number of seconds, excluding leap seconds, that
     /// have elapsed since unix epoch. Unix epoch is January 1st, 1970, at
     /// 00:00:00 UTC.
+    ///
+    /// For more details see:
+    ///  - https://developers.stellar.org/docs/learn/encyclopedia/network-configuration/ledger-headers#close-time
     pub fn timestamp(&self) -> u64 {
         internal::Env::get_ledger_timestamp(self.env())
             .unwrap_infallible()

--- a/soroban-sdk/src/ledger.rs
+++ b/soroban-sdk/src/ledger.rs
@@ -75,6 +75,11 @@ impl Ledger {
 
     /// Returns a unix timestamp for when the ledger was closed.
     ///
+    /// The close time is a UNIX timestamp indicating when the ledger closes.
+    /// Its accuracy depends on the system clock of the validator proposing the
+    /// block. Consequently, consensus may confirm a close time that lags a few
+    /// seconds behind or up to 60 seconds ahead.
+    ///
     /// The timestamp is the number of seconds, excluding leap seconds,
     /// that have elapsed since unix epoch. Unix epoch is January 1st, 1970,
     /// at 00:00:00 UTC.

--- a/soroban-sdk/src/ledger.rs
+++ b/soroban-sdk/src/ledger.rs
@@ -78,15 +78,16 @@ impl Ledger {
     /// The timestamp is a UNIX timestamp indicating when the ledger closes.
     ///
     /// Its accuracy depends on the system clock of the validator proposing the
-    /// block. Consequently, the close time proposed by a validator may be
-    /// earlier or later than the actual time, by a few seconds past and up to
-    /// 60 seconds ahead of other validators.
+    /// ledger. Consequently, the value may be earlier or later than the current
+    /// time of other validators, by a few seconds past and up to 60 seconds
+    /// ahead.
     ///
-    /// It is guaranteed to always be greater than a timestamp for an earlier
-    /// ledger.
+    /// The timestamp is guaranteed to always be greater than a timestamp for an
+    /// earlier ledger.
     ///
-    /// It is the number of seconds, excluding leap seconds, that have elapsed
-    /// since unix epoch. Unix epoch is January 1st, 1970, at 00:00:00 UTC.
+    /// The timestamp is the number of seconds, excluding leap seconds, that
+    /// have elapsed since unix epoch. Unix epoch is January 1st, 1970, at
+    /// 00:00:00 UTC.
     pub fn timestamp(&self) -> u64 {
         internal::Env::get_ledger_timestamp(self.env())
             .unwrap_infallible()


### PR DESCRIPTION
### What
Document the accuracy of the ledger timestamp.

### Why
It's important that the accuracy is known by developers relying on the timestamp for certain use cases. The update here is taken from a recent update in the Stellar docs and communicates the same.

Related stellar/stellar-docs#509
Related stellar/stellar-docs#572

Close #1258