### PR TITLE
Add nice compiler error when Copy is missing on error enums and enum ints

### DIFF
--- a/soroban-sdk-macros/src/derive_enum_int.rs
+++ b/soroban-sdk-macros/src/derive_enum_int.rs
@@ -96,6 +96,7 @@ pub fn derive_type_enum_int(
     // Output.
     quote! {
         #spec_gen
+        const _: () = { fn assert_copy(v: #enum_ident) -> impl Copy { v } };
 
         impl #path::TryFromVal<#path::Env, #path::Val> for #enum_ident {
             type Error = #path::ConversionError;

--- a/soroban-sdk-macros/src/derive_error_enum_int.rs
+++ b/soroban-sdk-macros/src/derive_error_enum_int.rs
@@ -92,6 +92,7 @@ pub fn derive_type_error_enum_int(
     // Output.
     quote! {
         #spec_gen
+        const _: () = { fn assert_copy(v: #enum_ident) -> impl Copy { v } };
 
         impl TryFrom<#path::Error> for #enum_ident {
             type Error = #path::Error;


### PR DESCRIPTION
### What
Add nice compiler error when Copy is missing on error enums and enum ints.

### Why
The existing compiler error is not very intuitive. The existing error will still be outputted but a more direct error describing the problem and the fix will be output first.

#### Before

```
error[E0507]: cannot move out of `*val` which is behind a shared reference
  --> tests/errors/src/lib.rs:15:1
   |
15 | #[contracterror]
   | ^^^^^^^^^^^^^^^^ move occurs because `*val` has type `Error`, which does not implement the `Copy` trait
   |
   = note: this error originates in the attribute macro `contracterror` (in Nightly builds, run with -Z macro-backtrace for more info)
help: consider cloning the value if the performance cost is acceptable
   |
15 | #[contracterror].clone()
   |                 ++++++++
```

#### After

```
error[E0277]: the trait bound `Error: core::marker::Copy` is not satisfied
  --> tests/errors/src/lib.rs:15:1
   |
15 | #[contracterror]
   | ^^^^^^^^^^^^^^^^ the trait `core::marker::Copy` is not implemented for `Error`
   |
help: consider annotating `Error` with `#[derive(Copy)]`
   |
17 + #[derive(Copy)]
18 | pub enum Error {
   |

error[E0507]: cannot move out of `*val` which is behind a shared reference
  --> tests/errors/src/lib.rs:15:1
   |
15 | #[contracterror]
   | ^^^^^^^^^^^^^^^^ move occurs because `*val` has type `Error`, which does not implement the `Copy` trait
   |
   = note: this error originates in the attribute macro `contracterror` (in Nightly builds, run with -Z macro-backtrace for more info)
help: consider cloning the value if the performance cost is acceptable
   |
15 | #[contracterror].clone()
   |                 ++++++++
```

Close #630