### PR TITLE
Fix rust 2024 incompatibilities

### DIFF
--- a/soroban-ledger-snapshot/Cargo.toml
+++ b/soroban-ledger-snapshot/Cargo.toml
@@ -18,5 +18,5 @@ serde_with = { version = "3.4.0", features = ["hex"] }
 serde_json = "1.0.0"
 thiserror = "1.0"
 
-[dev_dependencies]
+[dev-dependencies]
 pretty_assertions = "1.2.1"

--- a/soroban-sdk-macros/Cargo.toml
+++ b/soroban-sdk-macros/Cargo.toml
@@ -14,7 +14,7 @@ rust-version.workspace = true
 proc-macro = true
 doctest = false
 
-[build_dependencies]
+[build-dependencies]
 rustc_version = "0.4.0"
 crate-git-revision = "0.0.6"
 

--- a/soroban-spec-rust/Cargo.toml
+++ b/soroban-spec-rust/Cargo.toml
@@ -20,5 +20,5 @@ proc-macro2 = "1.0"
 sha2 = "0.10.7"
 prettyplease = "0.2.4"
 
-[dev_dependencies]
+[dev-dependencies]
 pretty_assertions = "1.2.1"

--- a/soroban-spec/Cargo.toml
+++ b/soroban-spec/Cargo.toml
@@ -16,5 +16,5 @@ base64 = "0.13.0"
 thiserror = "1.0.32"
 wasmparser = "0.116.1"
 
-[dev_dependencies]
+[dev-dependencies]
 pretty_assertions = "1.2.1"


### PR DESCRIPTION
### What
Change dev_dependencies and build_dependencies into their hyphen separated versions.

### Why
Rust edition 2024 that'll be released in October 2024 won't support the underscore variant any longer.