### PR TITLE
Add in contract assertions to prng functions

### DIFF
--- a/soroban-sdk/src/lib.rs
+++ b/soroban-sdk/src/lib.rs
@@ -117,6 +117,24 @@ pub mod reexports_for_macros {
     pub use ::ctor;
 }
 
+/// Assert in contract asserts that the contract is currently executing within a
+/// contract. The macro maps to code when testutils are enabled or in tests,
+/// otherwise maps to nothing.
+#[macro_export]
+macro_rules! assert_in_contract {
+    ($env:expr $(,)?) => {{
+        {
+            #[cfg(any(test, feature = "testutils"))]
+            assert!(
+                ($env).in_contract(),
+                "this function is not accessible outside of a contract, wrap \
+                the call with `env.as_contract()` to access it from a \
+                particular contract"
+            );
+        }
+    }};
+}
+
 /// Create a short [Symbol] constant with the given string.
 ///
 /// A short symbol's maximum length is 9 characters. For longer symbols, use

--- a/soroban-sdk/src/prng.rs
+++ b/soroban-sdk/src/prng.rs
@@ -96,6 +96,7 @@ impl Prng {
     /// low risk tolerance, see the module-level comment.**
     pub fn seed(&self, seed: Bytes) {
         let env = self.env();
+        assert_in_contract!(env);
         internal::Env::prng_reseed(env, seed.into()).unwrap_infallible();
     }
 
@@ -379,6 +380,7 @@ impl Prng {
 impl<T> Shuffle for Vec<T> {
     fn shuffle(&mut self, prng: &Prng) {
         let env = prng.env();
+        assert_in_contract!(env);
         let obj = internal::Env::prng_vec_shuffle(env, self.to_object()).unwrap_infallible();
         *self = unsafe { Self::unchecked_new(env.clone(), obj) };
     }
@@ -454,6 +456,7 @@ impl Fill for u64 {
 impl Gen for u64 {
     fn gen(prng: &Prng) -> Self {
         let env = prng.env();
+        assert_in_contract!(env);
         internal::Env::prng_u64_in_inclusive_range(env, u64::MIN, u64::MAX).unwrap_infallible()
     }
 }
@@ -463,6 +466,7 @@ impl GenRange for u64 {
 
     fn gen_range(prng: &Prng, r: impl RangeBounds<Self::RangeBound>) -> Self {
         let env = prng.env();
+        assert_in_contract!(env);
         let start_bound = match r.start_bound() {
             Bound::Included(b) => *b,
             Bound::Excluded(b) => *b + 1,
@@ -485,6 +489,7 @@ impl Fill for Bytes {
     /// If the length of Bytes is greater than u32::MAX in length.
     fn fill(&mut self, prng: &Prng) {
         let env = prng.env();
+        assert_in_contract!(env);
         let len: u32 = self.len();
         let obj = internal::Env::prng_bytes_new(env, len.into()).unwrap_infallible();
         *self = unsafe { Bytes::unchecked_new(env.clone(), obj) };
@@ -496,6 +501,7 @@ impl GenLen for Bytes {
     /// Generates the Bytes with the Prng of the given length.
     fn gen_len(prng: &Prng, len: u32) -> Self {
         let env = prng.env();
+        assert_in_contract!(env);
         let obj = internal::Env::prng_bytes_new(env, len.into()).unwrap_infallible();
         unsafe { Bytes::unchecked_new(env.clone(), obj) }
     }
@@ -521,6 +527,7 @@ impl<const N: usize> Gen for BytesN<N> {
     /// If the length of BytesN is greater than u32::MAX in length.
     fn gen(prng: &Prng) -> Self {
         let env = prng.env();
+        assert_in_contract!(env);
         let len: u32 = N.try_into().unwrap_optimized();
         let obj = internal::Env::prng_bytes_new(env, len.into()).unwrap_infallible();
         unsafe { BytesN::unchecked_new(env.clone(), obj) }
@@ -535,6 +542,7 @@ impl Fill for [u8] {
     /// If the slice is greater than u32::MAX in length.
     fn fill(&mut self, prng: &Prng) {
         let env = prng.env();
+        assert_in_contract!(env);
         let len: u32 = self.len().try_into().unwrap_optimized();
         let bytes: Bytes = internal::Env::prng_bytes_new(env, len.into())
             .unwrap_infallible()
@@ -551,6 +559,7 @@ impl<const N: usize> Fill for [u8; N] {
     /// If the array is greater than u32::MAX in length.
     fn fill(&mut self, prng: &Prng) {
         let env = prng.env();
+        assert_in_contract!(env);
         let len: u32 = N.try_into().unwrap_optimized();
         let bytes: Bytes = internal::Env::prng_bytes_new(env, len.into())
             .unwrap_infallible()

--- a/soroban-sdk/src/storage.rs
+++ b/soroban-sdk/src/storage.rs
@@ -86,8 +86,7 @@ impl Storage {
     /// This should be used for data that requires persistency, such as token
     /// balances, user properties etc.
     pub fn persistent(&self) -> Persistent {
-        #[cfg(any(test, feature = "testutils"))]
-        self.verify_in_contract("persistent");
+        assert_in_contract!(self.env);
 
         Persistent {
             storage: self.clone(),
@@ -106,8 +105,7 @@ impl Storage {
     /// This should be used for data that needs to only exist for a limited
     /// period of time, such as oracle data, claimable balances, offer, etc.
     pub fn temporary(&self) -> Temporary {
-        #[cfg(any(test, feature = "testutils"))]
-        self.verify_in_contract("persistent");
+        assert_in_contract!(self.env);
 
         Temporary {
             storage: self.clone(),
@@ -140,8 +138,7 @@ impl Storage {
     /// operates on etc. Do not use this with any data that can scale in
     /// unbounded fashion (such as user balances).
     pub fn instance(&self) -> Instance {
-        #[cfg(any(test, feature = "testutils"))]
-        self.verify_in_contract("persistent");
+        assert_in_contract!(self.env);
 
         Instance {
             storage: self.clone(),
@@ -298,17 +295,6 @@ impl Storage {
 
     fn get_internal(&self, key: Val, storage_type: StorageType) -> Val {
         internal::Env::get_contract_data(&self.env, key, storage_type).unwrap_infallible()
-    }
-
-    #[cfg(any(test, feature = "testutils"))]
-    fn verify_in_contract(&self, storage_kind: &str) {
-        if !self.env.in_contract() {
-            panic!(
-                "'{storage_kind}' storage is not accessible outside of the \
-                    contract, wrap the call with `env.as_contract()` to \
-                    access it from a particular contract"
-            );
-        }
     }
 }
 

--- a/soroban-sdk/src/tests/prng.rs
+++ b/soroban-sdk/src/tests/prng.rs
@@ -318,3 +318,76 @@ fn test_prng_gen_array() {
         );
     });
 }
+
+#[test]
+#[should_panic(expected = "`env.as_contract()`")]
+fn useful_error_message_for_access_outside_contract_seed() {
+    let e = Env::default();
+    e.prng().seed(crate::Bytes::from_array(&e, &[0u8; 32]));
+}
+
+#[test]
+#[should_panic(expected = "`env.as_contract()`")]
+fn useful_error_message_for_access_outside_contract_shuffle() {
+    let e = Env::default();
+    e.prng().shuffle(&mut Vec::<u64>::new(&e));
+}
+
+#[test]
+#[should_panic(expected = "`env.as_contract()`")]
+fn useful_error_message_for_access_outside_contract_gen_u64() {
+    let e = Env::default();
+    let _: u64 = e.prng().gen();
+}
+
+#[test]
+#[should_panic(expected = "`env.as_contract()`")]
+fn useful_error_message_for_access_outside_contract_gen_bytesn() {
+    let e = Env::default();
+    let _: BytesN<32> = e.prng().gen();
+}
+
+#[test]
+#[should_panic(expected = "`env.as_contract()`")]
+fn useful_error_message_for_access_outside_contract_gen_range() {
+    let e = Env::default();
+    let _: u64 = e.prng().gen_range(1..20);
+}
+
+#[test]
+#[should_panic(expected = "`env.as_contract()`")]
+fn useful_error_message_for_access_outside_contract_fill_bytes() {
+    let e = Env::default();
+    e.prng().fill(&mut Bytes::new(&e));
+}
+
+#[test]
+#[should_panic(expected = "`env.as_contract()`")]
+fn useful_error_message_for_access_outside_contract_fill_bytesn() {
+    let e = Env::default();
+    e.prng().fill(&mut BytesN::from_array(&e, &[0u8; 32]));
+}
+
+#[test]
+#[should_panic(expected = "`env.as_contract()`")]
+fn useful_error_message_for_access_outside_contract_fill_slice() {
+    let e = Env::default();
+    let mut arr = [0u8; 32];
+    let slice = arr.as_mut();
+    e.prng().fill(slice);
+}
+
+#[test]
+#[should_panic(expected = "`env.as_contract()`")]
+fn useful_error_message_for_access_outside_contract_fill_array() {
+    let e = Env::default();
+    let mut arr = [0u8; 32];
+    e.prng().fill(&mut arr);
+}
+
+#[test]
+#[should_panic(expected = "`env.as_contract()`")]
+fn useful_error_message_for_access_outside_contract_gen_len() {
+    let e = Env::default();
+    let _: Bytes = e.prng().gen_len(32);
+}


### PR DESCRIPTION
### What
Add in contract assertions to prng functions.

### Why
It's really easy to think you can use the prng functions inside your tests to help setup random test data, without reaslising that these functions are restricted to use within a contract.

Close #1165