### PR TITLE
Fix client code gen to use efficient symbol

### DIFF
--- a/soroban-sdk-macros/src/symbol.rs
+++ b/soroban-sdk-macros/src/symbol.rs
@@ -1,0 +1,40 @@
+use proc_macro2::TokenStream;
+use quote::quote;
+use syn::{Error, LitStr, Path};
+
+use soroban_env_common::{Symbol, SymbolError};
+
+/// Generates code that renders the Symbol as a compile-time const Symbol if
+/// small enough, otherwise generates a compile error.
+///
+/// Also generates a compile error if the string cannot be represented as a
+/// Symbol.
+pub fn short(crate_path: &Path, s: &LitStr) -> TokenStream {
+    match Symbol::try_from_small_str(&s.value()) {
+        Ok(_) => quote! {{
+            #[allow(deprecated)]
+            const SYMBOL: #crate_path::Symbol = #crate_path::Symbol::short(#s);
+            SYMBOL
+        }},
+        Err(e) => Error::new(s.span(), format!("{e}")).to_compile_error(),
+    }
+}
+
+/// Generates code that renders the Symbol as a compile-time const Symbol if
+/// small enough, otherwise as a Symbol::new construction.
+///
+/// Also generates a compile error if the string cannot be represented as a
+/// Symbol.
+pub fn short_or_long(crate_path: &Path, env: TokenStream, s: &LitStr) -> TokenStream {
+    match Symbol::try_from_small_str(&s.value()) {
+        Ok(_) => quote! {{
+            #[allow(deprecated)]
+            const SYMBOL: #crate_path::Symbol = #crate_path::Symbol::short(#s);
+            SYMBOL
+        }},
+        Err(SymbolError::TooLong(_)) => quote! {{
+            #crate_path::Symbol::new(#env, #s)
+        }},
+        Err(e) => Error::new(s.span(), format!("{e}")).to_compile_error(),
+    }
+}


### PR DESCRIPTION
### What
Change the client generated code to use the efficient compile time const Symbol generation for contract invocation function names when the function names are small enough.

### Why
The client is intended to be a zero-cost abstraction when compared with invoking a contract with `env.invoke_contract(cid, fn, args)`, but currently it is ~200 bytes more expensive in WASM size. This is because the generated client code is using runtime conversion from a &str to a Symbol for all symbols, even small ones that can be converted to a Symbol at compile time using const expressions.

This change reduces the size of contracts using a single short symbol by ~200 bytes.

Close #1290 