### PR TITLE
Fix Hash<> not cloneable

### DIFF
--- a/soroban-sdk/src/crypto.rs
+++ b/soroban-sdk/src/crypto.rs
@@ -18,6 +18,8 @@ use crate::{
 /// **__Note:_** A Hash should not be used with storage, since no guarantee can
 /// be made about the Bytes stored as to whether they were infact from a secure
 /// cryptographic hash function.
+#[derive(Clone)]
+#[repr(transparent)]
 pub struct Hash<const N: usize>(BytesN<N>);
 
 impl<const N: usize> Hash<N> {


### PR DESCRIPTION
### What
Implement Clone for the Hash<> type introduced in v21.

### Why
The BytesN<> type implements Clone, and the Hash<> type was added to replace BytesN<> in certain situations. It is harder to upgrade code in the wild that was written using BytesN<> because Hash<> isn't cloneable.

Hash<> can be cloned, there's no reason to keep it.

The type is also marked as transparent same as BytesN<> in this change.
