### PR TITLE
Add CI concurrency group

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
   merge_group:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_protected == 'true' && github.sha || github.ref }}-{{ github.event_name }}
+  cancel-in-progress: true
+
 defaults:
   run:
     shell: bash


### PR DESCRIPTION
### What

Add CI concurrency group limiting to one build per branch, including main, canceling any older runs.


### Why

Limit CI resource usage, especially of mac and windows instances. We never need out-of-date commit CI runs to complete on PRs.

