### PR TITLE
Add fn for changing an Env's test config

### DIFF
--- a/soroban-sdk/src/env.rs
+++ b/soroban-sdk/src/env.rs
@@ -487,6 +487,7 @@ impl Env {
         f((*self.test_state.generators).borrow_mut())
     }
 
+    /// Create an Env with the test config.
     pub fn new_with_config(config: EnvTestConfig) -> Env {
         struct EmptySnapshotSource();
 
@@ -513,6 +514,11 @@ impl Env {
         };
 
         Env::new_for_testutils(config, rf, None, info, None)
+    }
+
+    /// Change the test config of an Env.
+    pub fn set_config(&mut self, config: EnvTestConfig) {
+        self.test_state.config = config;
     }
 
     /// Used by multiple constructors to configure test environments consistently.
@@ -1246,7 +1252,7 @@ impl Env {
     /// Events, as an output source only, are not loaded into the Env.
     pub fn from_snapshot(s: Snapshot) -> Env {
         Env::new_for_testutils(
-            EnvTestConfig::default(), // TODO: Allow setting the config.
+            EnvTestConfig::default(),
             Rc::new(s.ledger.clone()),
             Some(Rc::new(RefCell::new(s.generators))),
             s.ledger.ledger_info(),

--- a/soroban-sdk/src/tests/env.rs
+++ b/soroban-sdk/src/tests/env.rs
@@ -175,3 +175,32 @@ fn test_snapshot_file_disabled() {
     let _ = std::fs::remove_file(&p1);
     let _ = std::fs::remove_file(&p2);
 }
+
+/// Test that the test snapshot file is not written when disabled after
+/// creation.
+#[test]
+fn test_snapshot_file_disabled_after_creation() {
+    let p = std::path::Path::new("test_snapshots")
+        .join("tests")
+        .join("env")
+        .join("test_snapshot_file_disabled_after_creation");
+    let p1 = p.with_extension("1.json");
+    assert!(!p1.exists());
+    let p2 = p.with_extension("2.json");
+    assert!(!p2.exists());
+    {
+        let e1 = Env::default();
+        let _ = e1.register_contract(None, Contract);
+        let mut e2 = Env::default();
+        e2.set_config(EnvTestConfig {
+            capture_snapshot_at_drop: false,
+        });
+        let _ = e2.register_contract(None, Contract);
+        assert!(!p1.exists());
+        assert!(!p2.exists());
+    }
+    assert!(p1.exists());
+    assert!(!p2.exists());
+    let _ = std::fs::remove_file(&p1);
+    let _ = std::fs::remove_file(&p2);
+}


### PR DESCRIPTION
### What
Add fn for changing an Envs config after creation.

### Why
There are ways to create Envs without an opportunity to set a config.

It's cumbersome to offer a way to set the config with all of the different ways, and adding a function for changing it after creation is the simplest way today to achieve this.

This could create problems if in the future the config contains items that aren't easily changeable after instatiation of the Env. That problem doesn't exist today at least. In the future if we introduce items like that we'd probably need to resort to checking if the value is changing, and if so, panicing with a meaningful error message. That's not great, but still better for the overall API I think, especially given this is in tests.

Close #1306