### PR TITLE
Add util to update issuer flags for SAC testing

### DIFF
--- a/soroban-sdk/src/env.rs
+++ b/soroban-sdk/src/env.rs
@@ -762,15 +762,9 @@ impl Env {
         );
         self.env_impl.set_auth_manager(prev_auth_manager).unwrap();
 
-        let issuer = StellarAssetIssuer {
-            env: self.clone(),
-            account_id: issuer_id,
-        };
+        let issuer = StellarAssetIssuer::new(self.clone(), issuer_id);
 
-        StellarAssetContract {
-            address: token_id,
-            issuer: issuer,
-        }
+        StellarAssetContract::new(token_id, issuer)
     }
 
     /// Register the built-in Stellar Asset Contract with provided admin address.
@@ -782,7 +776,7 @@ impl Env {
     /// instance is needed.
     #[deprecated(note = "use [Env::register_stellar_asset_contract_v2]")]
     pub fn register_stellar_asset_contract(&self, admin: Address) -> Address {
-        self.register_stellar_asset_contract_v2(admin).address
+        self.register_stellar_asset_contract_v2(admin).address()
     }
 
     fn register_contract_with_optional_contract_id_and_executable<'a>(

--- a/soroban-sdk/src/tests/token_client.rs
+++ b/soroban-sdk/src/tests/token_client.rs
@@ -50,17 +50,20 @@ fn test_issuer_flags() {
     let admin = Address::generate(&env);
     let sac = env.register_stellar_asset_contract_v2(admin);
 
-    assert_eq!(sac.issuer.flags(), 0);
+    assert_eq!(sac.issuer().flags(), 0);
 
     let required_and_revocable =
         (IssuerAccountFlags::RequiredFlag as u32) | (IssuerAccountFlags::RevocableFlag as u32);
-    sac.issuer.set_flag(IssuerAccountFlags::RequiredFlag);
-    sac.issuer.set_flag(IssuerAccountFlags::RevocableFlag);
+    sac.issuer().set_flag(IssuerAccountFlags::RequiredFlag);
+    sac.issuer().set_flag(IssuerAccountFlags::RevocableFlag);
 
-    assert_eq!(sac.issuer.flags(), required_and_revocable);
+    assert_eq!(sac.issuer().flags(), required_and_revocable);
 
-    sac.issuer.clear_flag(IssuerAccountFlags::RequiredFlag);
-    assert_eq!(sac.issuer.flags(), IssuerAccountFlags::RevocableFlag as u32);
+    sac.issuer().clear_flag(IssuerAccountFlags::RequiredFlag);
+    assert_eq!(
+        sac.issuer().flags(),
+        IssuerAccountFlags::RevocableFlag as u32
+    );
 }
 
 #[test]
@@ -71,7 +74,7 @@ fn test_mock_all_auth() {
 
     let admin = Address::generate(&env);
     let sac = env.register_stellar_asset_contract_v2(admin);
-    let token_contract_id = sac.address.clone();
+    let token_contract_id = sac.address();
 
     let contract_id = env.register_contract(None, TestContract);
     let client = TestContractClient::new(&env, &contract_id);
@@ -119,7 +122,7 @@ fn test_mock_auth() {
     let env = Env::default();
 
     let admin = Address::generate(&env);
-    let token_contract_id = env.register_stellar_asset_contract_v2(admin).address;
+    let token_contract_id = env.register_stellar_asset_contract_v2(admin).address();
 
     let contract_id = env.register_contract(None, TestContract);
     let client = TestContractClient::new(&env, &contract_id);

--- a/soroban-sdk/src/tests/token_client.rs
+++ b/soroban-sdk/src/tests/token_client.rs
@@ -53,14 +53,14 @@ fn test_issuer_flags() {
     assert_eq!(sac.issuer.flags(), 0);
 
     let required_and_revocable =
-        (IssuerAccountFlags::RequiredFlag as i32) | (IssuerAccountFlags::RevocableFlag as i32);
+        (IssuerAccountFlags::RequiredFlag as u32) | (IssuerAccountFlags::RevocableFlag as u32);
     sac.issuer.set_flag(IssuerAccountFlags::RequiredFlag);
     sac.issuer.set_flag(IssuerAccountFlags::RevocableFlag);
 
     assert_eq!(sac.issuer.flags(), required_and_revocable);
 
     sac.issuer.clear_flag(IssuerAccountFlags::RequiredFlag);
-    assert_eq!(sac.issuer.flags(), IssuerAccountFlags::RevocableFlag as i32);
+    assert_eq!(sac.issuer.flags(), IssuerAccountFlags::RevocableFlag as u32);
 }
 
 #[test]

--- a/soroban-sdk/src/tests/token_client.rs
+++ b/soroban-sdk/src/tests/token_client.rs
@@ -5,7 +5,7 @@ use crate::{
 
 use soroban_sdk::{
     contract, contractimpl, contracttype,
-    testutils::{Address as _, IssuerAccountFlags, MockAuth, MockAuthInvoke},
+    testutils::{Address as _, IssuerFlags, MockAuth, MockAuthInvoke},
     token::Client as TokenClient,
     Address, Env, IntoVal, Symbol,
 };
@@ -53,17 +53,14 @@ fn test_issuer_flags() {
     assert_eq!(sac.issuer().flags(), 0);
 
     let required_and_revocable =
-        (IssuerAccountFlags::RequiredFlag as u32) | (IssuerAccountFlags::RevocableFlag as u32);
-    sac.issuer().set_flag(IssuerAccountFlags::RequiredFlag);
-    sac.issuer().set_flag(IssuerAccountFlags::RevocableFlag);
+        (IssuerFlags::RequiredFlag as u32) | (IssuerFlags::RevocableFlag as u32);
+    sac.issuer().set_flag(IssuerFlags::RequiredFlag);
+    sac.issuer().set_flag(IssuerFlags::RevocableFlag);
 
     assert_eq!(sac.issuer().flags(), required_and_revocable);
 
-    sac.issuer().clear_flag(IssuerAccountFlags::RequiredFlag);
-    assert_eq!(
-        sac.issuer().flags(),
-        IssuerAccountFlags::RevocableFlag as u32
-    );
+    sac.issuer().clear_flag(IssuerFlags::RequiredFlag);
+    assert_eq!(sac.issuer().flags(), IssuerFlags::RevocableFlag as u32);
 }
 
 #[test]

--- a/soroban-sdk/src/tests/token_client.rs
+++ b/soroban-sdk/src/tests/token_client.rs
@@ -48,7 +48,12 @@ fn test_mock_all_auth() {
     let env = Env::default();
 
     let admin = Address::generate(&env);
-    let token_contract_id = env.register_stellar_asset_contract(admin);
+    let sac = env.register_stellar_asset_contract_v2(admin);
+    let token_contract_id = sac.address.clone();
+
+    assert_eq!(sac.get_issuer_flags(), 0);
+    sac.overwrite_issuer_flags(1);
+    assert_eq!(sac.get_issuer_flags(), 1);
 
     let contract_id = env.register_contract(None, TestContract);
     let client = TestContractClient::new(&env, &contract_id);
@@ -96,7 +101,7 @@ fn test_mock_auth() {
     let env = Env::default();
 
     let admin = Address::generate(&env);
-    let token_contract_id = env.register_stellar_asset_contract(admin);
+    let token_contract_id = env.register_stellar_asset_contract_v2(admin).address;
 
     let contract_id = env.register_contract(None, TestContract);
     let client = TestContractClient::new(&env, &contract_id);

--- a/soroban-sdk/src/tests/token_client.rs
+++ b/soroban-sdk/src/tests/token_client.rs
@@ -53,14 +53,14 @@ fn test_issuer_flags() {
     assert_eq!(sac.issuer.flags(), 0);
 
     let required_and_revocable =
-        (IssuerAccountFlags::RequiredFlag as u32) | (IssuerAccountFlags::RevocableFlag as u32);
+        (IssuerAccountFlags::RequiredFlag as i32) | (IssuerAccountFlags::RevocableFlag as i32);
     sac.issuer.set_flag(IssuerAccountFlags::RequiredFlag);
     sac.issuer.set_flag(IssuerAccountFlags::RevocableFlag);
 
     assert_eq!(sac.issuer.flags(), required_and_revocable);
 
     sac.issuer.clear_flag(IssuerAccountFlags::RequiredFlag);
-    assert_eq!(sac.issuer.flags(), IssuerAccountFlags::RevocableFlag as u32);
+    assert_eq!(sac.issuer.flags(), IssuerAccountFlags::RevocableFlag as i32);
 }
 
 #[test]

--- a/soroban-sdk/src/testutils.rs
+++ b/soroban-sdk/src/testutils.rs
@@ -433,7 +433,7 @@ impl StellarAssetIssuer {
         Self { env, account_id }
     }
 
-    /// Returns the flags for account_id.
+    /// Returns the flags for the issuer.
     pub fn flags(&self) -> u32 {
         self.env
             .host()

--- a/soroban-sdk/src/testutils.rs
+++ b/soroban-sdk/src/testutils.rs
@@ -420,7 +420,7 @@ pub trait Deployer {
     fn get_contract_code_ttl(&self, contract: &crate::Address) -> u32;
 }
 
-pub use xdr::AccountFlags as IssuerAccountFlags;
+pub use xdr::AccountFlags as IssuerFlags;
 
 #[derive(Clone)]
 pub struct StellarAssetIssuer {

--- a/soroban-sdk/src/testutils.rs
+++ b/soroban-sdk/src/testutils.rs
@@ -427,6 +427,7 @@ pub struct StellarAssetIssuer {
 }
 
 impl StellarAssetIssuer {
+    /// Returns the flags for account_id.
     pub fn flags(&self) -> u32 {
         self.env
             .host()
@@ -448,10 +449,12 @@ impl StellarAssetIssuer {
             .unwrap()
     }
 
+    /// Adds the flag specified to the existing issuer flags
     pub fn set_flag(&self, flag: IssuerAccountFlags) {
         self.overwrite_issuer_flags(self.flags() | (flag as u32))
     }
 
+    /// Clears the flag specified from the existing issuer flags
     pub fn clear_flag(&self, flag: IssuerAccountFlags) {
         self.overwrite_issuer_flags(self.flags() & (!(flag as u32)))
     }

--- a/soroban-sdk/src/testutils.rs
+++ b/soroban-sdk/src/testutils.rs
@@ -422,12 +422,17 @@ pub trait Deployer {
 
 pub use xdr::AccountFlags as IssuerAccountFlags;
 
+#[derive(Clone)]
 pub struct StellarAssetIssuer {
-    pub env: Env,
-    pub account_id: xdr::AccountId,
+    env: Env,
+    account_id: xdr::AccountId,
 }
 
 impl StellarAssetIssuer {
+    pub(crate) fn new(env: Env, account_id: xdr::AccountId) -> Self {
+        Self { env, account_id }
+    }
+
     /// Returns the flags for account_id.
     pub fn flags(&self) -> u32 {
         self.env
@@ -511,6 +516,20 @@ impl StellarAssetIssuer {
 }
 
 pub struct StellarAssetContract {
-    pub address: crate::Address,
-    pub issuer: StellarAssetIssuer,
+    address: crate::Address,
+    issuer: StellarAssetIssuer,
+}
+
+impl StellarAssetContract {
+    pub(crate) fn new(address: crate::Address, issuer: StellarAssetIssuer) -> Self {
+        Self { address, issuer }
+    }
+
+    pub fn address(&self) -> crate::Address {
+        self.address.clone()
+    }
+
+    pub fn issuer(&self) -> StellarAssetIssuer {
+        self.issuer.clone()
+    }
 }

--- a/soroban-sdk/src/testutils.rs
+++ b/soroban-sdk/src/testutils.rs
@@ -6,6 +6,8 @@
 pub mod arbitrary;
 
 mod sign;
+use std::rc::Rc;
+
 pub use sign::ed25519;
 
 mod mock_auth;
@@ -415,4 +417,90 @@ pub trait Deployer {
     /// Panics if there is no contract instance/code corresponding to
     /// the provided address, or if the instance/code has expired.
     fn get_contract_code_ttl(&self, contract: &crate::Address) -> u32;
+}
+
+pub use xdr::AccountFlags as IssuerAccountFlags;
+
+pub struct StellarAssetIssuer {
+    pub env: Env,
+    pub account_id: xdr::AccountId,
+}
+
+impl StellarAssetIssuer {
+    pub fn flags(&self) -> u32 {
+        self.env
+            .host()
+            .with_mut_storage(|storage| {
+                let k = Rc::new(xdr::LedgerKey::Account(xdr::LedgerKeyAccount {
+                    account_id: self.account_id.clone(),
+                }));
+
+                let entry = storage.get(
+                    &k,
+                    soroban_env_host::budget::AsBudget::as_budget(self.env.host()),
+                )?;
+
+                match entry.data {
+                    xdr::LedgerEntryData::Account(ref e) => Ok(e.flags.clone()),
+                    _ => panic!("expected account entry but got {:?}", entry.data),
+                }
+            })
+            .unwrap()
+    }
+
+    pub fn set_flag(&self, flag: IssuerAccountFlags) {
+        self.overwrite_issuer_flags(self.flags() | (flag as u32))
+    }
+
+    pub fn clear_flag(&self, flag: IssuerAccountFlags) {
+        self.overwrite_issuer_flags(self.flags() & (!(flag as u32)))
+    }
+
+    /// Sets the issuer flags field.
+    /// Each flag is a bit with values corresponding to [xdr::AccountFlags]
+    ///
+    /// Use this to test interactions between trustlines/balances and the issuer flags.
+    fn overwrite_issuer_flags(&self, flags: u32) {
+        if u64::from(flags) > xdr::MASK_ACCOUNT_FLAGS_V17 {
+            panic!(
+                "issuer flags value must be at most {}",
+                xdr::MASK_ACCOUNT_FLAGS_V17
+            );
+        }
+
+        self.env
+            .host()
+            .with_mut_storage(|storage| {
+                let k = Rc::new(xdr::LedgerKey::Account(xdr::LedgerKeyAccount {
+                    account_id: self.account_id.clone(),
+                }));
+
+                let mut entry = storage
+                    .get(
+                        &k,
+                        soroban_env_host::budget::AsBudget::as_budget(self.env.host()),
+                    )?
+                    .as_ref()
+                    .clone();
+
+                match entry.data {
+                    xdr::LedgerEntryData::Account(ref mut e) => e.flags = flags,
+                    _ => panic!("expected account entry but got {:?}", entry.data),
+                }
+
+                storage.put(
+                    &k,
+                    &Rc::new(entry),
+                    None,
+                    soroban_env_host::budget::AsBudget::as_budget(self.env.host()),
+                )?;
+                Ok(())
+            })
+            .unwrap();
+    }
+}
+
+pub struct StellarAssetContract {
+    pub address: crate::Address,
+    pub issuer: StellarAssetIssuer,
 }

--- a/soroban-sdk/src/testutils.rs
+++ b/soroban-sdk/src/testutils.rs
@@ -456,12 +456,12 @@ impl StellarAssetIssuer {
     }
 
     /// Adds the flag specified to the existing issuer flags
-    pub fn set_flag(&self, flag: IssuerAccountFlags) {
+    pub fn set_flag(&self, flag: IssuerFlags) {
         self.overwrite_issuer_flags(self.flags() | (flag as u32))
     }
 
     /// Clears the flag specified from the existing issuer flags
-    pub fn clear_flag(&self, flag: IssuerAccountFlags) {
+    pub fn clear_flag(&self, flag: IssuerFlags) {
         self.overwrite_issuer_flags(self.flags() & (!(flag as u32)))
     }
 

--- a/soroban-sdk/src/testutils.rs
+++ b/soroban-sdk/src/testutils.rs
@@ -429,7 +429,7 @@ pub struct StellarAssetIssuer {
 
 impl StellarAssetIssuer {
     /// Returns the flags for account_id.
-    pub fn flags(&self) -> i32 {
+    pub fn flags(&self) -> u32 {
         self.env
             .host()
             .with_mut_storage(|storage| {
@@ -448,19 +448,16 @@ impl StellarAssetIssuer {
                 }
             })
             .unwrap()
-            .try_into()
-            .ok()
-            .unwrap()
     }
 
     /// Adds the flag specified to the existing issuer flags
     pub fn set_flag(&self, flag: IssuerAccountFlags) {
-        self.overwrite_issuer_flags(self.flags() | (flag as i32))
+        self.overwrite_issuer_flags(self.flags() | (flag as u32))
     }
 
     /// Clears the flag specified from the existing issuer flags
     pub fn clear_flag(&self, flag: IssuerAccountFlags) {
-        self.overwrite_issuer_flags(self.flags() & (!(flag as i32)))
+        self.overwrite_issuer_flags(self.flags() & (!(flag as u32)))
     }
 
     pub fn address(&self) -> crate::Address {
@@ -473,8 +470,8 @@ impl StellarAssetIssuer {
     /// Each flag is a bit with values corresponding to [xdr::AccountFlags]
     ///
     /// Use this to test interactions between trustlines/balances and the issuer flags.
-    fn overwrite_issuer_flags(&self, flags: i32) {
-        if u64::try_from(flags).ok().unwrap() > xdr::MASK_ACCOUNT_FLAGS_V17 || flags < 0 {
+    fn overwrite_issuer_flags(&self, flags: u32) {
+        if u64::from(flags) > xdr::MASK_ACCOUNT_FLAGS_V17 {
             panic!(
                 "issuer flags value must be at most {}",
                 xdr::MASK_ACCOUNT_FLAGS_V17
@@ -497,9 +494,7 @@ impl StellarAssetIssuer {
                     .clone();
 
                 match entry.data {
-                    xdr::LedgerEntryData::Account(ref mut e) => {
-                        e.flags = u32::try_from(flags).ok().unwrap()
-                    }
+                    xdr::LedgerEntryData::Account(ref mut e) => e.flags = flags,
                     _ => panic!("expected account entry but got {:?}", entry.data),
                 }
 

--- a/soroban-sdk/test_snapshots/tests/token_client/test_issuer_flags.1.json
+++ b/soroban-sdk/test_snapshots/tests/token_client/test_issuer_flags.1.json
@@ -1,0 +1,334 @@
+{
+  "generators": {
+    "address": 2,
+    "nonce": 0
+  },
+  "auth": [
+    [
+      [
+        "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEGWF",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CBEPDNVYXQGWB5YUBXKJWYJA7OXTZW5LFLNO5JRRGE6Z6C5OSUZPCCEL",
+              "function_name": "set_admin",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ]
+  ],
+  "ledger": {
+    "protocol_version": 21,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "account": {
+            "account_id": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEGWF"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "account": {
+                "account_id": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEGWF",
+                "balance": 0,
+                "seq_num": 0,
+                "num_sub_entries": 0,
+                "inflation_dest": null,
+                "flags": 2,
+                "home_domain": "",
+                "thresholds": "01010101",
+                "signers": [],
+                "ext": "v0"
+              }
+            },
+            "ext": "v0"
+          },
+          null
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEGWF",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 801925984706572462
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEGWF",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 801925984706572462
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CBEPDNVYXQGWB5YUBXKJWYJA7OXTZW5LFLNO5JRRGE6Z6C5OSUZPCCEL",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CBEPDNVYXQGWB5YUBXKJWYJA7OXTZW5LFLNO5JRRGE6Z6C5OSUZPCCEL",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": "stellar_asset",
+                    "storage": [
+                      {
+                        "key": {
+                          "symbol": "METADATA"
+                        },
+                        "val": {
+                          "map": [
+                            {
+                              "key": {
+                                "symbol": "decimal"
+                              },
+                              "val": {
+                                "u32": 7
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "name"
+                              },
+                              "val": {
+                                "string": "aaa:GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEGWF"
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "symbol"
+                              },
+                              "val": {
+                                "string": "aaa"
+                              }
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Admin"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "AssetInfo"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "vec": [
+                            {
+                              "symbol": "AlphaNum4"
+                            },
+                            {
+                              "map": [
+                                {
+                                  "key": {
+                                    "symbol": "asset_code"
+                                  },
+                                  "val": {
+                                    "string": "aaa\\0"
+                                  }
+                                },
+                                {
+                                  "key": {
+                                    "symbol": "issuer"
+                                  },
+                                  "val": {
+                                    "bytes": "0000000000000000000000000000000000000000000000000000000000000002"
+                                  }
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          120960
+        ]
+      ]
+    ]
+  },
+  "events": [
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": null,
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_call"
+              },
+              {
+                "bytes": "48f1b6b8bc0d60f7140dd49b6120fbaf3cdbab2adaeea631313d9f0bae9532f1"
+              },
+              {
+                "symbol": "init_asset"
+              }
+            ],
+            "data": {
+              "bytes": "0000000161616100000000000000000000000000000000000000000000000000000000000000000000000002"
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "48f1b6b8bc0d60f7140dd49b6120fbaf3cdbab2adaeea631313d9f0bae9532f1",
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_return"
+              },
+              {
+                "symbol": "init_asset"
+              }
+            ],
+            "data": "void"
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": null,
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_call"
+              },
+              {
+                "bytes": "48f1b6b8bc0d60f7140dd49b6120fbaf3cdbab2adaeea631313d9f0bae9532f1"
+              },
+              {
+                "symbol": "set_admin"
+              }
+            ],
+            "data": {
+              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "48f1b6b8bc0d60f7140dd49b6120fbaf3cdbab2adaeea631313d9f0bae9532f1",
+        "type_": "contract",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "set_admin"
+              },
+              {
+                "address": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEGWF"
+              },
+              {
+                "string": "aaa:GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEGWF"
+              }
+            ],
+            "data": {
+              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "48f1b6b8bc0d60f7140dd49b6120fbaf3cdbab2adaeea631313d9f0bae9532f1",
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_return"
+              },
+              {
+                "symbol": "set_admin"
+              }
+            ],
+            "data": "void"
+          }
+        }
+      },
+      "failed_call": false
+    }
+  ]
+}

--- a/soroban-sdk/test_snapshots/tests/token_client/test_mock_all_auth.1.json
+++ b/soroban-sdk/test_snapshots/tests/token_client/test_mock_all_auth.1.json
@@ -86,7 +86,7 @@
                 "seq_num": 0,
                 "num_sub_entries": 0,
                 "inflation_dest": null,
-                "flags": 1,
+                "flags": 0,
                 "home_domain": "",
                 "thresholds": "01010101",
                 "signers": [],

--- a/soroban-sdk/test_snapshots/tests/token_client/test_mock_all_auth.1.json
+++ b/soroban-sdk/test_snapshots/tests/token_client/test_mock_all_auth.1.json
@@ -86,7 +86,7 @@
                 "seq_num": 0,
                 "num_sub_entries": 0,
                 "inflation_dest": null,
-                "flags": 0,
+                "flags": 1,
                 "home_domain": "",
                 "thresholds": "01010101",
                 "signers": [],


### PR DESCRIPTION
### What

Resolves #1117 

Instead of making a general `storage` utility to modify the account, I added a specific method to update the issuer flag. because there isn't any reason to mess with the other fields directly. 

I didn't want to expose the xdr in the interface, but doing that would've made the interface more clear.