### PR TITLE
Update soroban-env-* to 21.2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1105,9 +1105,9 @@ checksum = "4dccd0940a2dcdf68d092b8cbab7dc0ad8fa938bf95787e1b916b0e3d0e8e970"
 
 [[package]]
 name = "soroban-builtin-sdk-macros"
-version = "21.2.0"
+version = "21.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44877373b3dc6c662377cb1600e3a62706d75e484b6064f9cd22e467c676b159"
+checksum = "2f57a68ef8777e28e274de0f3a88ad9a5a41d9a2eb461b4dd800b086f0e83b80"
 dependencies = [
  "itertools",
  "proc-macro2",
@@ -1117,9 +1117,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-common"
-version = "21.2.0"
+version = "21.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "590add16843a61b01844e19e89bccaaee6aa21dc76809017b0662c17dc139ee9"
+checksum = "2fd1c89463835fe6da996318156d39f424b4f167c725ec692e5a7a2d4e694b3d"
 dependencies = [
  "arbitrary",
  "crate-git-revision",
@@ -1136,9 +1136,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-guest"
-version = "21.2.0"
+version = "21.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05ec8dc43acdd6c7e7b371acf44fc1a7dac24934ae3b2f05fafd618818548176"
+checksum = "6bfb2536811045d5cd0c656a324cbe9ce4467eb734c7946b74410d90dea5d0ce"
 dependencies = [
  "soroban-env-common",
  "static_assertions",
@@ -1146,9 +1146,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-host"
-version = "21.2.0"
+version = "21.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e25aaffe0c62eb65e0e349f725b4b8b13ad0764d78a15aab5bbccb5c4797726"
+checksum = "2b7a32c28f281c423189f1298960194f0e0fc4eeb72378028171e556d8cd6160"
 dependencies = [
  "backtrace",
  "curve25519-dalek",
@@ -1179,9 +1179,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-macros"
-version = "21.2.0"
+version = "21.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e16b761459fdf3c4b62b24df3941498d14e5246e6fadfb4774ed8114d243aa4"
+checksum = "242926fe5e0d922f12d3796cd7cd02dd824e5ef1caa088f45fce20b618309f64"
 dependencies = [
  "itertools",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,17 +24,17 @@ soroban-ledger-snapshot = { version = "21.5.1", path = "soroban-ledger-snapshot"
 soroban-token-sdk = { version = "21.5.1", path = "soroban-token-sdk" }
 
 [workspace.dependencies.soroban-env-common]
-version = "=21.2.0"
+version = "=21.2.1"
 # git = "https://github.com/stellar/rs-soroban-env"
 # rev = "0c918ac2bd808ba1a850281c6b1c731e7fe50c53"
 
 [workspace.dependencies.soroban-env-guest]
-version = "=21.2.0"
+version = "=21.2.1"
 # git = "https://github.com/stellar/rs-soroban-env"
 # rev = "0c918ac2bd808ba1a850281c6b1c731e7fe50c53"
 
 [workspace.dependencies.soroban-env-host]
-version = "=21.2.0"
+version = "=21.2.1"
 # git = "https://github.com/stellar/rs-soroban-env"
 # rev = "0c918ac2bd808ba1a850281c6b1c731e7fe50c53"
 


### PR DESCRIPTION
### What
Update soroban-env-* to 21.2.1

### Why
To get a release of soroban-sdk with the unpinning of deps in env:
- https://github.com/stellar/rs-soroban-env/pull/1441