### PR TITLE
Update semver-checks

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -57,10 +57,10 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - run: rustup update
-    - uses: stellar/binaries@v24
+    - uses: stellar/binaries@v30
       with:
         name: cargo-semver-checks
-        version: 0.32.0
+        version: 0.35.0
     - run: cargo semver-checks
 
   build-and-test:


### PR DESCRIPTION
### What

Update semver-checks to 0.35.0.

### Why

Failing on new Rust.
