### PR TITLE
Revert version bump from #1327

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1216,7 +1216,7 @@ dependencies = [
 
 [[package]]
 name = "soroban-ledger-snapshot"
-version = "22.0.0-rc.1"
+version = "21.7.1"
 dependencies = [
  "pretty_assertions",
  "serde",
@@ -1229,7 +1229,7 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk"
-version = "22.0.0-rc.1"
+version = "21.7.1"
 dependencies = [
  "arbitrary",
  "bytes-lit",
@@ -1253,7 +1253,7 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk-macros"
-version = "22.0.0-rc.1"
+version = "21.7.1"
 dependencies = [
  "crate-git-revision",
  "darling",
@@ -1271,7 +1271,7 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec"
-version = "22.0.0-rc.1"
+version = "21.7.1"
 dependencies = [
  "base64 0.13.1",
  "pretty_assertions",
@@ -1282,7 +1282,7 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec-rust"
-version = "22.0.0-rc.1"
+version = "21.7.1"
 dependencies = [
  "pretty_assertions",
  "prettyplease",
@@ -1297,7 +1297,7 @@ dependencies = [
 
 [[package]]
 name = "soroban-token-sdk"
-version = "22.0.0-rc.1"
+version = "21.7.1"
 dependencies = [
  "soroban-sdk",
 ]
@@ -1415,140 +1415,140 @@ dependencies = [
 
 [[package]]
 name = "test_account"
-version = "22.0.0-rc.1"
+version = "21.7.1"
 dependencies = [
  "soroban-sdk",
 ]
 
 [[package]]
 name = "test_add_i128"
-version = "22.0.0-rc.1"
+version = "21.7.1"
 dependencies = [
  "soroban-sdk",
 ]
 
 [[package]]
 name = "test_add_u128"
-version = "22.0.0-rc.1"
+version = "21.7.1"
 dependencies = [
  "soroban-sdk",
 ]
 
 [[package]]
 name = "test_add_u64"
-version = "22.0.0-rc.1"
+version = "21.7.1"
 dependencies = [
  "soroban-sdk",
 ]
 
 [[package]]
 name = "test_alloc"
-version = "22.0.0-rc.1"
+version = "21.7.1"
 dependencies = [
  "soroban-sdk",
 ]
 
 [[package]]
 name = "test_auth"
-version = "22.0.0-rc.1"
+version = "21.7.1"
 dependencies = [
  "soroban-sdk",
 ]
 
 [[package]]
 name = "test_constructor"
-version = "22.0.0-rc.1"
+version = "21.7.1"
 dependencies = [
  "soroban-sdk",
 ]
 
 [[package]]
 name = "test_contract_data"
-version = "22.0.0-rc.1"
+version = "21.7.1"
 dependencies = [
  "soroban-sdk",
 ]
 
 [[package]]
 name = "test_empty"
-version = "22.0.0-rc.1"
+version = "21.7.1"
 dependencies = [
  "soroban-sdk",
 ]
 
 [[package]]
 name = "test_empty2"
-version = "22.0.0-rc.1"
+version = "21.7.1"
 dependencies = [
  "soroban-sdk",
 ]
 
 [[package]]
 name = "test_errors"
-version = "22.0.0-rc.1"
+version = "21.7.1"
 dependencies = [
  "soroban-sdk",
 ]
 
 [[package]]
 name = "test_events"
-version = "22.0.0-rc.1"
+version = "21.7.1"
 dependencies = [
  "soroban-sdk",
 ]
 
 [[package]]
 name = "test_fuzz"
-version = "22.0.0-rc.1"
+version = "21.7.1"
 dependencies = [
  "soroban-sdk",
 ]
 
 [[package]]
 name = "test_import_contract"
-version = "22.0.0-rc.1"
+version = "21.7.1"
 dependencies = [
  "soroban-sdk",
 ]
 
 [[package]]
 name = "test_invoke_contract"
-version = "22.0.0-rc.1"
+version = "21.7.1"
 dependencies = [
  "soroban-sdk",
 ]
 
 [[package]]
 name = "test_logging"
-version = "22.0.0-rc.1"
+version = "21.7.1"
 dependencies = [
  "soroban-sdk",
 ]
 
 [[package]]
 name = "test_modular"
-version = "22.0.0-rc.1"
+version = "21.7.1"
 dependencies = [
  "soroban-sdk",
 ]
 
 [[package]]
 name = "test_multiimpl"
-version = "22.0.0-rc.1"
+version = "21.7.1"
 dependencies = [
  "soroban-sdk",
 ]
 
 [[package]]
 name = "test_udt"
-version = "22.0.0-rc.1"
+version = "21.7.1"
 dependencies = [
  "soroban-sdk",
 ]
 
 [[package]]
 name = "test_workspace_contract"
-version = "22.0.0-rc.1"
+version = "21.7.1"
 dependencies = [
  "soroban-sdk",
  "test_workspace_lib",
@@ -1556,7 +1556,7 @@ dependencies = [
 
 [[package]]
 name = "test_workspace_lib"
-version = "22.0.0-rc.1"
+version = "21.7.1"
 dependencies = [
  "soroban-sdk",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,16 +12,16 @@ members = [
 ]
 
 [workspace.package]
-version = "22.0.0-rc.1"
+version = "21.7.1"
 rust-version = "1.79.0"
 
 [workspace.dependencies]
-soroban-sdk = { version = "22.0.0-rc.1", path = "soroban-sdk" }
-soroban-sdk-macros = { version = "22.0.0-rc.1", path = "soroban-sdk-macros" }
-soroban-spec = { version = "22.0.0-rc.1", path = "soroban-spec" }
-soroban-spec-rust = { version = "22.0.0-rc.1", path = "soroban-spec-rust" }
-soroban-ledger-snapshot = { version = "22.0.0-rc.1", path = "soroban-ledger-snapshot" }
-soroban-token-sdk = { version = "22.0.0-rc.1", path = "soroban-token-sdk" }
+soroban-sdk = { version = "21.7.1", path = "soroban-sdk" }
+soroban-sdk-macros = { version = "21.7.1", path = "soroban-sdk-macros" }
+soroban-spec = { version = "21.7.1", path = "soroban-spec" }
+soroban-spec-rust = { version = "21.7.1", path = "soroban-spec-rust" }
+soroban-ledger-snapshot = { version = "21.7.1", path = "soroban-ledger-snapshot" }
+soroban-token-sdk = { version = "21.7.1", path = "soroban-token-sdk" }
 
 [workspace.dependencies.soroban-env-common]
 version = "=22.0.0"


### PR DESCRIPTION
### What
Revert version bump from #1327.

### Why
The release process is that we bump just before release.

When we bump before release, it makes it harder to use unreleased changes as a patch against existing contracts dependent on the current version.