### PR TITLE
Add Address::from_str

### DIFF
--- a/soroban-sdk/src/address.rs
+++ b/soroban-sdk/src/address.rs
@@ -231,6 +231,18 @@ impl Address {
     /// Prefer using the `Address` directly as input or output argument. Only
     /// use this in special cases when addresses need to be shared between
     /// different environments (e.g. different chains).
+    pub fn from_str(env: &Env, strkey: &str) -> Address {
+        Address::from_string(&String::from_str(env, strkey))
+    }
+
+    /// Creates an `Address` corresponding to the provided Stellar strkey.
+    ///
+    /// The only supported strkey types are account keys (`G...`) and contract keys (`C...`). Any
+    /// other valid or invalid strkey will cause this to panic.
+    ///
+    /// Prefer using the `Address` directly as input or output argument. Only
+    /// use this in special cases when addresses need to be shared between
+    /// different environments (e.g. different chains).
     pub fn from_string(strkey: &String) -> Self {
         let env = strkey.env();
         unsafe {

--- a/soroban-sdk/src/tests/address.rs
+++ b/soroban-sdk/src/tests/address.rs
@@ -1,6 +1,19 @@
 use crate::{Address, Bytes, Env, String, TryIntoVal};
 
 #[test]
+fn test_account_address_str_conversions() {
+    let env = Env::default();
+
+    let strkey = "GA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVSGZ";
+
+    let address = Address::from_str(&env, &strkey);
+    assert_eq!(
+        address.to_string().to_string(),
+        "GA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVSGZ"
+    );
+}
+
+#[test]
 fn test_account_address_conversions() {
     let env = Env::default();
 


### PR DESCRIPTION
### What
Add `Address::from_str`.

### Why
For convenient conversions directly from a &str to an Address in tests:
```rust
Address::from_str(&env, "C...")
```

It is possible to do the same with:
```rust
Address::from_string(String::from_str(&env, "C..."))
```

But that is so verbose, the nested fn calls often get rustfmted to span multiple lines.