### PR TITLE
Add `register` and `register_at` fns to replace `register_contract`, `register_contract_with_constructor`, `register_contract_wasm`, `register_contract_wasm_with_constructor`

### DIFF
--- a/soroban-sdk/README.md
+++ b/soroban-sdk/README.md
@@ -26,7 +26,7 @@ fn test() {
 # #[cfg(feature = "testutils")]
 # fn main() {
     let env = Env::default();
-    let contract_id = env.register_contract(None, HelloContract);
+    let contract_id = env.register(HelloContract, ());
     let client = HelloContractClient::new(&env, &contract_id);
 
     let words = client.hello(&symbol_short!("Dev"));

--- a/soroban-sdk/src/deploy.rs
+++ b/soroban-sdk/src/deploy.rs
@@ -36,7 +36,7 @@
 //! # #[cfg(feature = "testutils")]
 //! # fn main() {
 //!     let env = Env::default();
-//!     let contract_address = env.register_contract(None, Contract);
+//!     let contract_address = env.register(Contract, ());
 //!     let contract = ContractClient::new(&env, &contract_address);
 //!     // Upload the contract code before deploying its instance.
 //!     let wasm_hash = env.deployer().upload_contract_wasm(DEPLOYED_WASM);
@@ -71,7 +71,7 @@
 //! # #[cfg(feature = "testutils")]
 //! # fn main() {
 //!     let env = Env::default();
-//!     let contract_address = env.register_contract(None, Contract);
+//!     let contract_address = env.register(Contract, ());
 //!     let contract = ContractClient::new(&env, &contract_address);
 //!     // Upload the contract code before deploying its instance.
 //!     let wasm_hash = env.deployer().upload_contract_wasm(DEPLOYED_WASM_WITH_CTOR);

--- a/soroban-sdk/src/env.rs
+++ b/soroban-sdk/src/env.rs
@@ -455,7 +455,7 @@ use crate::{
     testutils::{
         budget::Budget, Address as _, AuthSnapshot, AuthorizedInvocation, ConstructorArgs,
         ContractFunctionSet, EventsSnapshot, Generators, Ledger as _, MockAuth, MockAuthContract,
-        Snapshot, StellarAssetContract, StellarAssetIssuer,
+        Register, Snapshot, StellarAssetContract, StellarAssetIssuer,
     },
     Bytes, BytesN,
 };
@@ -469,39 +469,6 @@ use soroban_ledger_snapshot::LedgerSnapshot;
 use std::{path::Path, rc::Rc};
 #[cfg(any(test, feature = "testutils"))]
 use xdr::{LedgerEntry, LedgerKey, LedgerKeyContractData, SorobanAuthorizationEntry};
-
-#[cfg(any(test, feature = "testutils"))]
-pub trait Register {
-    fn register<'i, I, A>(self, env: &Env, id: I, args: A) -> Address
-    where
-        I: Into<Option<&'i Address>>,
-        A: ConstructorArgs;
-}
-
-#[cfg(any(test, feature = "testutils"))]
-impl<C> Register for C
-where
-    C: ContractFunctionSet + 'static,
-{
-    fn register<'i, I, A>(self, env: &Env, id: I, args: A) -> Address
-    where
-        I: Into<Option<&'i Address>>,
-        A: ConstructorArgs,
-    {
-        env.register_contract_with_constructor(id, self, args)
-    }
-}
-
-#[cfg(any(test, feature = "testutils"))]
-impl<'w> Register for &'w [u8] {
-    fn register<'i, I, A>(self, env: &Env, id: I, args: A) -> Address
-    where
-        I: Into<Option<&'i Address>>,
-        A: ConstructorArgs,
-    {
-        env.register_contract_wasm_with_constructor(id, self, args)
-    }
-}
 
 #[cfg(any(test, feature = "testutils"))]
 #[cfg_attr(feature = "docs", doc(cfg(feature = "testutils")))]

--- a/soroban-sdk/src/events.rs
+++ b/soroban-sdk/src/events.rs
@@ -43,7 +43,7 @@ const TOPIC_BYTES_LENGTH_LIMIT: u32 = 32;
 /// # #[cfg(feature = "testutils")]
 /// # fn main() {
 /// #     let env = Env::default();
-/// #     let contract_id = env.register_contract(None, Contract);
+/// #     let contract_id = env.register(Contract, ());
 /// #     ContractClient::new(&env, &contract_id).f();
 /// # }
 /// # #[cfg(not(feature = "testutils"))]

--- a/soroban-sdk/src/ledger.rs
+++ b/soroban-sdk/src/ledger.rs
@@ -31,7 +31,7 @@ use crate::{env::internal, unwrap::UnwrapInfallible, BytesN, Env, TryIntoVal};
 /// # #[cfg(feature = "testutils")]
 /// # fn main() {
 /// #     let env = Env::default();
-/// #     let contract_id = env.register_contract(None, Contract);
+/// #     let contract_id = env.register(Contract, ());
 /// #     ContractClient::new(&env, &contract_id).f();
 /// # }
 /// # #[cfg(not(feature = "testutils"))]

--- a/soroban-sdk/src/lib.rs
+++ b/soroban-sdk/src/lib.rs
@@ -26,7 +26,7 @@
 //! # #[cfg(feature = "testutils")]
 //! # fn main() {
 //!     let env = Env::default();
-//!     let contract_id = env.register_contract(None, HelloContract);
+//!     let contract_id = env.register(HelloContract, ());
 //!     let client = HelloContractClient::new(&env, &contract_id);
 //!
 //!     let words = client.hello(&symbol_short!("Dev"));
@@ -197,7 +197,7 @@ pub use soroban_sdk_macros::symbol_short;
 ///     let env = Env::default();
 ///
 ///     // Register the contract defined in this crate.
-///     let contract_id = env.register_contract(None, Contract);
+///     let contract_id = env.register(Contract, ());
 ///
 ///     // Create a client for calling the contract.
 ///     let client = ContractClient::new(&env, &contract_id);
@@ -244,7 +244,7 @@ pub use soroban_sdk_macros::symbol_short;
 ///     let env = Env::default();
 ///
 ///     // Register the contract defined in this crate.
-///     let contract_id = env.register_contract(None, Contract);
+///     let contract_id = env.register(Contract, ());
 ///
 ///     // Create a client for calling the contract.
 ///     let client = ContractClient::new(&env, &contract_id);
@@ -296,7 +296,7 @@ pub use soroban_sdk_macros::contracterror;
 ///     let contract_a_id = env.register_contract_wasm(None, contract_a::WASM);
 ///
 ///     // Register contract B defined in this crate.
-///     let contract_b_id = env.register_contract(None, ContractB);
+///     let contract_b_id = env.register(ContractB, ());
 ///
 ///     // Create a client for calling contract B.
 ///     let client = ContractBClient::new(&env, &contract_b_id);
@@ -342,7 +342,7 @@ pub use soroban_sdk_macros::contractimport;
 /// # #[cfg(feature = "testutils")]
 /// # fn main() {
 ///     let env = Env::default();
-///     let contract_id = env.register_contract(None, HelloContract);
+///     let contract_id = env.register(HelloContract, ());
 ///     let client = HelloContractClient::new(&env, &contract_id);
 ///
 ///     let words = client.hello(&symbol_short!("Dev"));
@@ -383,7 +383,7 @@ pub use soroban_sdk_macros::contract;
 /// # #[cfg(feature = "testutils")]
 /// # fn main() {
 ///     let env = Env::default();
-///     let contract_id = env.register_contract(None, HelloContract);
+///     let contract_id = env.register(HelloContract, ());
 ///     let client = HelloContractClient::new(&env, &contract_id);
 ///
 ///     let words = client.hello(&symbol_short!("Dev"));
@@ -423,7 +423,7 @@ pub use soroban_sdk_macros::contractimpl;
 /// # #[cfg(feature = "testutils")]
 /// # fn main() {
 ///     let env = Env::default();
-///     let contract_id = env.register_contract(None, HelloContract);
+///     let contract_id = env.register(HelloContract, ());
 ///     let client = HelloContractClient::new(&env, &contract_id);
 ///
 ///     let words = client.hello(&symbol_short!("Dev"));
@@ -503,7 +503,7 @@ pub use soroban_sdk_macros::contractmeta;
 /// # #[cfg(feature = "testutils")]
 /// # fn main() {
 ///     let env = Env::default();
-///     let contract_id = env.register_contract(None, Contract);
+///     let contract_id = env.register(Contract, ());
 ///     let client = ContractClient::new(&env, &contract_id);
 ///
 ///     assert_eq!(client.increment(&1), 1);
@@ -577,7 +577,7 @@ pub use soroban_sdk_macros::contractmeta;
 /// # #[cfg(feature = "testutils")]
 /// # fn main() {
 ///     let env = Env::default();
-///     let contract_id = env.register_contract(None, Contract);
+///     let contract_id = env.register(Contract, ());
 ///     let client = ContractClient::new(&env, &contract_id);
 ///
 ///     assert_eq!(client.get(), None);
@@ -637,7 +637,7 @@ pub use soroban_sdk_macros::contracttype;
 ///     let env = Env::default();
 ///
 ///     // Register the hello contract.
-///     let contract_id = env.register_contract(None, HelloContract);
+///     let contract_id = env.register(HelloContract, ());
 ///
 ///     // Create a client for the hello contract, that was constructed using
 ///     // the trait.

--- a/soroban-sdk/src/prng.rs
+++ b/soroban-sdk/src/prng.rs
@@ -120,7 +120,7 @@ impl Prng {
     /// # #[cfg(feature = "testutils")]
     /// # fn main() {
     /// #     let env = Env::default();
-    /// #     let contract_id = env.register_contract(None, Contract);
+    /// #     let contract_id = env.register(Contract, ());
     /// #     env.as_contract(&contract_id, || {
     /// #         env.prng().seed(Bytes::from_array(&env, &[1; 32]));
     /// let mut value: u64 = 0;
@@ -143,7 +143,7 @@ impl Prng {
     /// # #[cfg(feature = "testutils")]
     /// # fn main() {
     /// #     let env = Env::default();
-    /// #     let contract_id = env.register_contract(None, Contract);
+    /// #     let contract_id = env.register(Contract, ());
     /// #     env.as_contract(&contract_id, || {
     /// #         env.prng().seed(Bytes::from_array(&env, &[1; 32]));
     /// let mut value = [0u8; 32];
@@ -188,7 +188,7 @@ impl Prng {
     /// # #[cfg(feature = "testutils")]
     /// # fn main() {
     /// #     let env = Env::default();
-    /// #     let contract_id = env.register_contract(None, Contract);
+    /// #     let contract_id = env.register(Contract, ());
     /// #     env.as_contract(&contract_id, || {
     /// #         env.prng().seed(Bytes::from_array(&env, &[1; 32]));
     /// let value: u64 = env.prng().gen();
@@ -210,7 +210,7 @@ impl Prng {
     /// # #[cfg(feature = "testutils")]
     /// # fn main() {
     /// #     let env = Env::default();
-    /// #     let contract_id = env.register_contract(None, Contract);
+    /// #     let contract_id = env.register(Contract, ());
     /// #     env.as_contract(&contract_id, || {
     /// #         env.prng().seed(Bytes::from_array(&env, &[1; 32]));
     /// let value: [u8; 32] = env.prng().gen();
@@ -258,7 +258,7 @@ impl Prng {
     /// # #[cfg(feature = "testutils")]
     /// # fn main() {
     /// #     let env = Env::default();
-    /// #     let contract_id = env.register_contract(None, Contract);
+    /// #     let contract_id = env.register(Contract, ());
     /// #     env.as_contract(&contract_id, || {
     /// #         env.prng().seed(Bytes::from_array(&env, &[1; 32]));
     /// // Get a value of length 32 bytes.
@@ -307,7 +307,7 @@ impl Prng {
     /// # #[cfg(feature = "testutils")]
     /// # fn main() {
     /// #     let env = Env::default();
-    /// #     let contract_id = env.register_contract(None, Contract);
+    /// #     let contract_id = env.register(Contract, ());
     /// #     env.as_contract(&contract_id, || {
     /// #         env.prng().seed(Bytes::from_array(&env, &[1; 32]));
     /// // Get a value in the range of 1 to 100, inclusive.
@@ -347,7 +347,7 @@ impl Prng {
     /// # #[cfg(feature = "testutils")]
     /// # fn main() {
     /// #     let env = Env::default();
-    /// #     let contract_id = env.register_contract(None, Contract);
+    /// #     let contract_id = env.register(Contract, ());
     /// #     env.as_contract(&contract_id, || {
     /// #         env.prng().seed(Bytes::from_array(&env, &[1; 32]));
     /// // Get a value in the range of 1 to 100, inclusive.

--- a/soroban-sdk/src/storage.rs
+++ b/soroban-sdk/src/storage.rs
@@ -53,7 +53,7 @@ use crate::{
 /// # #[cfg(feature = "testutils")]
 /// # fn main() {
 /// #     let env = Env::default();
-/// #     let contract_id = env.register_contract(None, Contract);
+/// #     let contract_id = env.register(Contract, ());
 /// #     ContractClient::new(&env, &contract_id).f();
 /// # }
 /// # #[cfg(not(feature = "testutils"))]

--- a/soroban-sdk/src/tests/auth/auth_10_one.rs
+++ b/soroban-sdk/src/tests/auth/auth_10_one.rs
@@ -22,7 +22,7 @@ impl Contract {
 #[test]
 fn test() {
     let e = Env::default();
-    let contract_id = e.register_contract(None, Contract);
+    let contract_id = e.register(Contract, ());
     let client = ContractClient::new(&e, &contract_id);
 
     let a = Address::generate(&e);

--- a/soroban-sdk/src/tests/auth/auth_15_one_repeat.rs
+++ b/soroban-sdk/src/tests/auth/auth_15_one_repeat.rs
@@ -26,7 +26,7 @@ impl Contract {
 #[test]
 fn test() {
     let e = Env::default();
-    let contract_id = e.register_contract(None, Contract);
+    let contract_id = e.register(Contract, ());
     let client = ContractClient::new(&e, &contract_id);
 
     let a = Address::generate(&e);

--- a/soroban-sdk/src/tests/auth/auth_17_no_consume_requirement.rs
+++ b/soroban-sdk/src/tests/auth/auth_17_no_consume_requirement.rs
@@ -31,7 +31,7 @@ impl Contract {
 #[test]
 fn test() {
     let e = Env::default();
-    let contract_id = e.register_contract(None, Contract);
+    let contract_id = e.register(Contract, ());
     let client = ContractClient::new(&e, &contract_id);
 
     let a = Address::generate(&e);

--- a/soroban-sdk/src/tests/auth/auth_20_deep_one_address.rs
+++ b/soroban-sdk/src/tests/auth/auth_20_deep_one_address.rs
@@ -31,8 +31,8 @@ impl ContractB {
 #[test]
 fn test() {
     let e = Env::default();
-    let contract_a_id = e.register_contract(None, ContractA);
-    let contract_b_id = e.register_contract(None, ContractB);
+    let contract_a_id = e.register(ContractA, ());
+    let contract_b_id = e.register(ContractB, ());
     let client = ContractAClient::new(&e, &contract_a_id);
 
     let a = Address::generate(&e);
@@ -61,8 +61,8 @@ fn test() {
 #[should_panic = "HostError: Error(Auth, InvalidAction)"]
 fn test_auth_tree() {
     let e = Env::default();
-    let contract_a_id = e.register_contract(None, ContractA);
-    let contract_b_id = e.register_contract(None, ContractB);
+    let contract_a_id = e.register(ContractA, ());
+    let contract_b_id = e.register(ContractB, ());
     let client = ContractAClient::new(&e, &contract_a_id);
 
     let a = Address::generate(&e);

--- a/soroban-sdk/src/tests/auth/auth_30_deep_one_address_repeat.rs
+++ b/soroban-sdk/src/tests/auth/auth_30_deep_one_address_repeat.rs
@@ -32,8 +32,8 @@ impl ContractB {
 #[test]
 fn test() {
     let e = Env::default();
-    let contract_a_id = e.register_contract(None, ContractA);
-    let contract_b_id = e.register_contract(None, ContractB);
+    let contract_a_id = e.register(ContractA, ());
+    let contract_b_id = e.register(ContractB, ());
     let client = ContractAClient::new(&e, &contract_a_id);
 
     let a = Address::generate(&e);
@@ -76,8 +76,8 @@ fn test() {
 #[should_panic = "HostError: Error(Auth, InvalidAction)"]
 fn test_auth_tree() {
     let e = Env::default();
-    let contract_a_id = e.register_contract(None, ContractA);
-    let contract_b_id = e.register_contract(None, ContractB);
+    let contract_a_id = e.register(ContractA, ());
+    let contract_b_id = e.register(ContractB, ());
     let client = ContractAClient::new(&e, &contract_a_id);
 
     let a = Address::generate(&e);

--- a/soroban-sdk/src/tests/auth/auth_35_deep_one_address_repeat_grouped.rs
+++ b/soroban-sdk/src/tests/auth/auth_35_deep_one_address_repeat_grouped.rs
@@ -32,8 +32,8 @@ impl ContractB {
 #[test]
 fn test() {
     let e = Env::default();
-    let contract_a_id = e.register_contract(None, ContractA);
-    let contract_b_id = e.register_contract(None, ContractB);
+    let contract_a_id = e.register(ContractA, ());
+    let contract_b_id = e.register(ContractB, ());
     let client = ContractAClient::new(&e, &contract_a_id);
 
     let a = Address::generate(&e);
@@ -76,8 +76,8 @@ fn test() {
 #[should_panic = "HostError: Error(Auth, InvalidAction)"]
 fn test_auth_tree() {
     let e = Env::default();
-    let contract_a_id = e.register_contract(None, ContractA);
-    let contract_b_id = e.register_contract(None, ContractB);
+    let contract_a_id = e.register(ContractA, ());
+    let contract_b_id = e.register(ContractB, ());
     let client = ContractAClient::new(&e, &contract_a_id);
 
     let a = Address::generate(&e);

--- a/soroban-sdk/src/tests/auth/auth_40_multi_one_address.rs
+++ b/soroban-sdk/src/tests/auth/auth_40_multi_one_address.rs
@@ -32,8 +32,8 @@ impl ContractB {
 #[test]
 fn test_auth_not_allowed_with_separated_tree() {
     let e = Env::default();
-    let contract_a_id = e.register_contract(None, ContractA);
-    let contract_b_id = e.register_contract(None, ContractB);
+    let contract_a_id = e.register(ContractA, ());
+    let contract_b_id = e.register(ContractB, ());
     let client = ContractAClient::new(&e, &contract_a_id);
 
     let a = Address::generate(&e);
@@ -66,8 +66,8 @@ fn test_auth_not_allowed_with_separated_tree() {
 #[test]
 fn test_auth_as_tree() {
     let e = Env::default();
-    let contract_a_id = e.register_contract(None, ContractA);
-    let contract_b_id = e.register_contract(None, ContractB);
+    let contract_a_id = e.register(ContractA, ());
+    let contract_b_id = e.register(ContractB, ());
     let client = ContractAClient::new(&e, &contract_a_id);
 
     let a = Address::generate(&e);

--- a/soroban-sdk/src/tests/budget.rs
+++ b/soroban-sdk/src/tests/budget.rs
@@ -18,7 +18,7 @@ impl Contract {
 #[test]
 fn test_budget() {
     let e = Env::default();
-    let contract_id = e.register_contract(None, Contract);
+    let contract_id = e.register(Contract, ());
     let client = ContractClient::new(&e, &contract_id);
 
     e.budget().reset_default();

--- a/soroban-sdk/src/tests/contract_add_i32.rs
+++ b/soroban-sdk/src/tests/contract_add_i32.rs
@@ -18,7 +18,7 @@ impl Contract {
 #[test]
 fn test_functional() {
     let e = Env::default();
-    let contract_id = e.register_contract(None, Contract);
+    let contract_id = e.register(Contract, ());
 
     let a = 10i32;
     let b = 12i32;

--- a/soroban-sdk/src/tests/contract_assert.rs
+++ b/soroban-sdk/src/tests/contract_assert.rs
@@ -22,7 +22,7 @@ impl Contract {
 #[should_panic(expected = "Error(Contract, #1")]
 fn test_invoke_expect_error() {
     let e = Env::default();
-    let contract_id = e.register_contract(None, Contract);
+    let contract_id = e.register(Contract, ());
 
     ContractClient::new(&e, &contract_id).assert(&0);
 }
@@ -30,7 +30,7 @@ fn test_invoke_expect_error() {
 #[test]
 fn test_try_invoke() {
     let e = Env::default();
-    let contract_id = e.register_contract(None, Contract);
+    let contract_id = e.register(Contract, ());
 
     let res = ContractClient::new(&e, &contract_id).try_assert(&0);
     assert_eq!(res, Err(Ok(soroban_sdk::Error::from_contract_error(1))));

--- a/soroban-sdk/src/tests/contract_docs.rs
+++ b/soroban-sdk/src/tests/contract_docs.rs
@@ -18,7 +18,7 @@ mod fn_ {
     #[test]
     fn test_functional() {
         let env = Env::default();
-        let contract_id = env.register_contract(None, Contract);
+        let contract_id = env.register(Contract, ());
         let client = ContractClient::new(&env, &contract_id);
         client.add();
     }

--- a/soroban-sdk/src/tests/contract_duration.rs
+++ b/soroban-sdk/src/tests/contract_duration.rs
@@ -12,7 +12,7 @@ impl Contract {
 #[test]
 fn test_functional() {
     let env = Env::default();
-    let contract_id = env.register_contract(None, Contract);
+    let contract_id = env.register(Contract, ());
     let client = ContractClient::new(&env, &contract_id);
 
     let t: Duration = xdr::ScVal::Duration(xdr::Duration(0)).into_val(&env);

--- a/soroban-sdk/src/tests/contract_fn.rs
+++ b/soroban-sdk/src/tests/contract_fn.rs
@@ -18,7 +18,7 @@ impl Contract {
 #[test]
 fn test_functional() {
     let e = Env::default();
-    let contract_id = e.register_contract(None, Contract);
+    let contract_id = e.register(Contract, ());
 
     let a = 10i32;
     let b = 12i32;

--- a/soroban-sdk/src/tests/contract_invoke.rs
+++ b/soroban-sdk/src/tests/contract_invoke.rs
@@ -15,7 +15,7 @@ impl Contract {
 #[should_panic(expected = "I panicked")]
 fn test_invoke_expect_string() {
     let e = Env::default();
-    let contract_id = e.register_contract(None, Contract);
+    let contract_id = e.register(Contract, ());
 
     ContractClient::new(&e, &contract_id).panic();
 }
@@ -24,7 +24,7 @@ fn test_invoke_expect_string() {
 #[should_panic(expected = "Error(WasmVm, InvalidAction)")]
 fn test_invoke_expect_error() {
     let e = Env::default();
-    let contract_id = e.register_contract(None, Contract);
+    let contract_id = e.register(Contract, ());
 
     ContractClient::new(&e, &contract_id).panic();
 }
@@ -34,7 +34,7 @@ fn test_try_invoke() {
     use soroban_env_host::xdr::{ScErrorCode, ScErrorType};
 
     let e = Env::default();
-    let contract_id = e.register_contract(None, Contract);
+    let contract_id = e.register(Contract, ());
 
     let res = ContractClient::new(&e, &contract_id).try_panic();
     assert_eq!(

--- a/soroban-sdk/src/tests/contract_invoke_arg_count.rs
+++ b/soroban-sdk/src/tests/contract_invoke_arg_count.rs
@@ -32,9 +32,9 @@ impl AddContract {
 fn test_correct_arg_count() {
     let e = Env::default();
 
-    let add_contract_id = e.register_contract(None, AddContract);
+    let add_contract_id = e.register(AddContract, ());
 
-    let contract_id = e.register_contract(None, Contract);
+    let contract_id = e.register(Contract, ());
     let client = ContractClient::new(&e, &contract_id);
 
     let x = 10i32;
@@ -48,9 +48,9 @@ fn test_correct_arg_count() {
 fn test_too_few_args() {
     let e = Env::default();
 
-    let add_contract_id = e.register_contract(None, AddContract);
+    let add_contract_id = e.register(AddContract, ());
 
-    let contract_id = e.register_contract(None, Contract);
+    let contract_id = e.register(Contract, ());
     let client = ContractClient::new(&e, &contract_id);
 
     let x = 10i32;
@@ -62,9 +62,9 @@ fn test_too_few_args() {
 fn test_too_many_args() {
     let e = Env::default();
 
-    let add_contract_id = e.register_contract(None, AddContract);
+    let add_contract_id = e.register(AddContract, ());
 
-    let contract_id = e.register_contract(None, Contract);
+    let contract_id = e.register(Contract, ());
     let client = ContractClient::new(&e, &contract_id);
 
     let x = 10i32;

--- a/soroban-sdk/src/tests/contract_overlapping_type_fn_names.rs
+++ b/soroban-sdk/src/tests/contract_overlapping_type_fn_names.rs
@@ -20,7 +20,7 @@ impl Contract {
 #[test]
 fn test_functional() {
     let env = Env::default();
-    let contract_id = env.register_contract(None, Contract);
+    let contract_id = env.register(Contract, ());
 
     let client = ContractClient::new(&env, &contract_id);
     let s = client.state();

--- a/soroban-sdk/src/tests/contract_snapshot.rs
+++ b/soroban-sdk/src/tests/contract_snapshot.rs
@@ -17,7 +17,7 @@ impl Contract {
 #[test]
 fn test() {
     let e = Env::default();
-    let contract_id = e.register_contract(None, Contract);
+    let contract_id = e.register(Contract, ());
     let contract_id_xdr = xdr::ScAddress::try_from(&contract_id).unwrap();
     let client = ContractClient::new(&e, &contract_id);
 
@@ -28,7 +28,7 @@ fn test() {
 
     let e = Env::from_ledger_snapshot(snapshot);
     let contract_id = Address::try_from_val(&e, &contract_id_xdr).unwrap();
-    e.register_contract(&contract_id, Contract);
+    e.register_at(&contract_id, Contract, ());
     let client = ContractClient::new(&e, &contract_id);
 
     assert_eq!(client.get(&2), 4);

--- a/soroban-sdk/src/tests/contract_store.rs
+++ b/soroban-sdk/src/tests/contract_store.rs
@@ -61,7 +61,7 @@ fn test_storage() {
     e.ledger().set_min_temp_entry_ttl(50);
     e.ledger().set_max_entry_ttl(20_000);
 
-    let contract_id = e.register_contract(None, Contract);
+    let contract_id = e.register(Contract, ());
     let client = ContractClient::new(&e, &contract_id);
 
     // Smoke test instance bump before putting any data into it.
@@ -186,7 +186,7 @@ fn test_temp_storage_extension_past_max_ttl_panics() {
     let e = Env::default();
     e.ledger().set_min_temp_entry_ttl(50);
     e.ledger().set_max_entry_ttl(20_000);
-    let contract_id = e.register_contract(None, Contract);
+    let contract_id = e.register(Contract, ());
     let client = ContractClient::new(&e, &contract_id);
     e.as_contract(&contract_id, || {
         e.storage().temporary().set(&DataKey::Key(11), &2222_i32);

--- a/soroban-sdk/src/tests/contract_timepoint.rs
+++ b/soroban-sdk/src/tests/contract_timepoint.rs
@@ -12,7 +12,7 @@ impl Contract {
 #[test]
 fn test_functional() {
     let env = Env::default();
-    let contract_id = env.register_contract(None, Contract);
+    let contract_id = env.register(Contract, ());
     let client = ContractClient::new(&env, &contract_id);
 
     let t: Timepoint = xdr::ScVal::Timepoint(xdr::TimePoint(0)).into_val(&env);

--- a/soroban-sdk/src/tests/contract_udt_enum.rs
+++ b/soroban-sdk/src/tests/contract_udt_enum.rs
@@ -34,7 +34,7 @@ impl Contract {
 #[test]
 fn test_functional() {
     let env = Env::default();
-    let contract_id = env.register_contract(None, Contract);
+    let contract_id = env.register(Contract, ());
     let client = ContractClient::new(&env, &contract_id);
 
     let a = Udt::Aaa;

--- a/soroban-sdk/src/tests/contract_udt_option.rs
+++ b/soroban-sdk/src/tests/contract_udt_option.rs
@@ -21,7 +21,7 @@ impl Contract {
 #[test]
 fn test_functional() {
     let env = Env::default();
-    let contract_id = env.register_contract(None, Contract);
+    let contract_id = env.register(Contract, ());
 
     let a = Udt { a: 5, b: None };
     let b = Udt { a: 10, b: Some(1) };

--- a/soroban-sdk/src/tests/contract_udt_struct.rs
+++ b/soroban-sdk/src/tests/contract_udt_struct.rs
@@ -47,7 +47,7 @@ impl Contract {
 #[test]
 fn test_functional() {
     let env = Env::default();
-    let contract_id = env.register_contract(None, Contract);
+    let contract_id = env.register(Contract, ());
 
     let a = Udt { a: 5, b: 7 };
     let b = Udt { a: 10, b: 14 };
@@ -58,7 +58,7 @@ fn test_functional() {
 #[test]
 fn test_long_names_functional() {
     let env = Env::default();
-    let contract_id = env.register_contract(None, Contract);
+    let contract_id = env.register(Contract, ());
 
     let a = UdtWithLongName {
         this_is_a_very_long_name_12345: 1_000_000_000_000,

--- a/soroban-sdk/src/tests/contract_udt_struct_tuple.rs
+++ b/soroban-sdk/src/tests/contract_udt_struct_tuple.rs
@@ -35,7 +35,7 @@ fn test_conversion() {
 #[test]
 fn test_functional() {
     let env = Env::default();
-    let contract_id = env.register_contract(None, Contract);
+    let contract_id = env.register(Contract, ());
 
     let a = Udt(5, 7);
     let b = Udt(10, 14);

--- a/soroban-sdk/src/tests/contractimport.rs
+++ b/soroban-sdk/src/tests/contractimport.rs
@@ -46,9 +46,9 @@ impl Contract {
 fn test_functional() {
     let e = Env::default();
 
-    let add_contract_id = e.register_contract_wasm(None, addcontract::WASM);
+    let add_contract_id = e.register(addcontract::WASM, ());
 
-    let contract_id = e.register_contract(None, Contract);
+    let contract_id = e.register(Contract, ());
     let client = ContractClient::new(&e, &contract_id);
 
     let x = 10u64;
@@ -62,9 +62,9 @@ fn test_register_at_id() {
     let e = Env::default();
 
     let add_contract_id = Address::from_contract_id(&e, [1; 32]);
-    e.register_contract_wasm(&add_contract_id, addcontract::WASM);
+    e.register_at(&add_contract_id, addcontract::WASM, ());
 
-    let contract_id = e.register_contract(None, Contract);
+    let contract_id = e.register(Contract, ());
     let client = ContractClient::new(&e, &contract_id);
 
     let x = 10u64;
@@ -76,12 +76,12 @@ fn test_register_at_id() {
 #[test]
 fn test_reregister_wasm() {
     let e = Env::default();
-    let add_contract_id = e.register_contract_wasm(None, addcontract_u128::WASM);
+    let add_contract_id = e.register(addcontract_u128::WASM, ());
     // Reregister the contract with different code replacing the code. This is
     // the contract we expect to be executed.
-    e.register_contract_wasm(&add_contract_id, addcontract::WASM);
+    e.register_at(&add_contract_id, addcontract::WASM, ());
 
-    let contract_id = e.register_contract(None, Contract);
+    let contract_id = e.register(Contract, ());
     let client = ContractClient::new(&e, &contract_id);
 
     let x = 10u64;
@@ -95,12 +95,12 @@ fn test_reregister_over_wasm_with_rust_impl() {
     let e = Env::default();
 
     // Register a contract with wasm.
-    let other_contract_id = e.register_contract_wasm(None, addcontract::WASM);
+    let other_contract_id = e.register(addcontract::WASM, ());
     // Reregister the contract with a rust impl instead that does something
     // different.
-    e.register_contract(&other_contract_id, subcontract::Contract);
+    e.register_at(&other_contract_id, subcontract::Contract, ());
 
-    let contract_id = e.register_contract(None, Contract);
+    let contract_id = e.register(Contract, ());
     let client = ContractClient::new(&e, &contract_id);
 
     let x = 12u64;

--- a/soroban-sdk/src/tests/contractimport_with_error.rs
+++ b/soroban-sdk/src/tests/contractimport_with_error.rs
@@ -22,9 +22,9 @@ impl Contract {
 fn test_functional() {
     let e = Env::default();
 
-    let err_contract_id = e.register_contract_wasm(None, errcontract::WASM);
+    let err_contract_id = e.register(errcontract::WASM, ());
 
-    let contract_id = e.register_contract(None, Contract);
+    let contract_id = e.register(Contract, ());
     let client = ContractClient::new(&e, &contract_id);
 
     let z = client.hello_with(&err_contract_id, &0);

--- a/soroban-sdk/src/tests/env.rs
+++ b/soroban-sdk/src/tests/env.rs
@@ -44,8 +44,8 @@ fn default_and_from_snapshot_same_settings() {
     assert!(env1.host().source_account_address().unwrap().is_some());
     assert!(env2.host().source_account_address().unwrap().is_some());
 
-    let c1addr = env1.register_contract(None, Contract);
-    let c2addr = env2.register_contract(None, Contract);
+    let c1addr = env1.register(Contract, ());
+    let c2addr = env2.register(Contract, ());
 
     let c1client = ContractClient::new(&env1, &c1addr);
     let c2client = ContractClient::new(&env2, &c2addr);
@@ -83,21 +83,21 @@ fn register_contract_deploys_predictable_contract_ids() {
     let env1 = Env::default();
     let env2 = Env::from_snapshot(env1.to_snapshot());
 
-    let env1addr1 = env1.register_contract(None, Contract);
+    let env1addr1 = env1.register(Contract, ());
     println!("env1 addr1 {:?}", env1addr1.contract_id());
-    let env1addr2 = env1.register_contract(None, Contract);
+    let env1addr2 = env1.register(Contract, ());
     println!("env1 addr2 {:?}", env1addr2.contract_id());
-    let env2addr1 = env2.register_contract(None, Contract);
+    let env2addr1 = env2.register(Contract, ());
     println!("env2 addr1 {:?}", env2addr1.contract_id());
-    let env2addr2 = env2.register_contract(None, Contract);
+    let env2addr2 = env2.register(Contract, ());
     println!("env2 addr2 {:?}", env2addr2.contract_id());
 
     let env3 = Env::from_snapshot(env1.to_snapshot());
-    let env1addr3 = env1.register_contract(None, Contract);
+    let env1addr3 = env1.register(Contract, ());
     println!("env1 addr3 {:?}", env1addr3.contract_id());
-    let env2addr3 = env2.register_contract(None, Contract);
+    let env2addr3 = env2.register(Contract, ());
     println!("env2 addr3 {:?}", env2addr3.contract_id());
-    let env3addr3 = env3.register_contract(None, Contract);
+    let env3addr3 = env3.register(Contract, ());
     println!("env3 addr3 {:?}", env3addr3.contract_id());
 
     // Check that contracts deployed in the envs are consistent and predictable.
@@ -132,9 +132,9 @@ fn test_snapshot_file() {
         assert!(!p2.exists());
         {
             let e3 = Env::default(); // When dropped will be written to p1.
-            let _ = e3.register_contract(None, Contract);
+            let _ = e3.register(Contract, ());
         } // Env dropped, written to p1.
-        let c = e1.register_contract(None, Contract);
+        let c = e1.register(Contract, ());
         assert!(p1.exists());
         assert!(!p2.exists());
         e1.as_contract(&c, || {});
@@ -163,11 +163,11 @@ fn test_snapshot_file_disabled() {
     let _ = std::fs::remove_file(&p2);
     {
         let e1 = Env::default();
-        let _ = e1.register_contract(None, Contract);
+        let _ = e1.register(Contract, ());
         let e2 = Env::new_with_config(EnvTestConfig {
             capture_snapshot_at_drop: false,
         });
-        let _ = e2.register_contract(None, Contract);
+        let _ = e2.register(Contract, ());
         assert!(!p1.exists());
         assert!(!p2.exists());
     }
@@ -190,12 +190,12 @@ fn test_snapshot_file_disabled_after_creation() {
     let _ = std::fs::remove_file(&p2);
     {
         let e1 = Env::default();
-        let _ = e1.register_contract(None, Contract);
+        let _ = e1.register(Contract, ());
         let mut e2 = Env::default();
         e2.set_config(EnvTestConfig {
             capture_snapshot_at_drop: false,
         });
-        let _ = e2.register_contract(None, Contract);
+        let _ = e2.register(Contract, ());
         assert!(!p1.exists());
         assert!(!p2.exists());
     }

--- a/soroban-sdk/src/tests/max_ttl.rs
+++ b/soroban-sdk/src/tests/max_ttl.rs
@@ -7,7 +7,7 @@ pub struct Contract;
 #[test]
 fn max() {
     let e = Env::default();
-    let contract_id = e.register_contract(None, Contract);
+    let contract_id = e.register(Contract, ());
 
     e.ledger().set_sequence_number(1);
     e.ledger().set_max_entry_ttl(5);

--- a/soroban-sdk/src/tests/prng.rs
+++ b/soroban-sdk/src/tests/prng.rs
@@ -9,7 +9,7 @@ pub struct TestPrngContract;
 fn test_prng_seed() {
     let e = Env::default();
     e.host().set_base_prng_seed([0; 32]).unwrap();
-    let id = e.register_contract(None, TestPrngContract);
+    let id = e.register(TestPrngContract, ());
     e.as_contract(&id, || {
         e.prng().seed(bytes!(
             &e,
@@ -19,7 +19,7 @@ fn test_prng_seed() {
     });
 
     let e = Env::default();
-    let id = e.register_contract(None, TestPrngContract);
+    let id = e.register(TestPrngContract, ());
     e.host().set_base_prng_seed([2; 32]).unwrap();
     e.as_contract(&id, || {
         e.prng().seed(bytes!(
@@ -33,7 +33,7 @@ fn test_prng_seed() {
 #[test]
 fn test_prng_shuffle() {
     let e = Env::default();
-    let id = e.register_contract(None, TestPrngContract);
+    let id = e.register(TestPrngContract, ());
 
     e.as_contract(&id, || {
         let v = vec![&e, 1, 2, 3];
@@ -49,7 +49,7 @@ fn test_prng_shuffle() {
 #[test]
 fn test_vec_shuffle() {
     let e = Env::default();
-    let id = e.register_contract(None, TestPrngContract);
+    let id = e.register(TestPrngContract, ());
 
     e.as_contract(&id, || {
         let v = vec![&e, 1, 2, 3];
@@ -69,7 +69,7 @@ fn test_vec_shuffle() {
 #[test]
 fn test_prng_fill_u64() {
     let e = Env::default();
-    let id = e.register_contract(None, TestPrngContract);
+    let id = e.register(TestPrngContract, ());
 
     e.as_contract(&id, || {
         let mut v: u64 = 0;
@@ -83,7 +83,7 @@ fn test_prng_fill_u64() {
 #[test]
 fn test_prng_gen_u64() {
     let e = Env::default();
-    let id = e.register_contract(None, TestPrngContract);
+    let id = e.register(TestPrngContract, ());
 
     e.as_contract(&id, || {
         assert_eq!(e.prng().gen::<u64>(), 6775509081846337106);
@@ -94,7 +94,7 @@ fn test_prng_gen_u64() {
 #[test]
 fn test_prng_gen_range_u64() {
     let e = Env::default();
-    let id = e.register_contract(None, TestPrngContract);
+    let id = e.register(TestPrngContract, ());
 
     e.as_contract(&id, || {
         assert_eq!(e.prng().gen_range::<u64>(..), 6775509081846337106);
@@ -114,7 +114,7 @@ fn test_prng_gen_range_u64() {
 #[should_panic(expected = "Error(Value, InvalidInput)")]
 fn test_prng_gen_range_u64_panic_on_invalid_range() {
     let e = Env::default();
-    let id = e.register_contract(None, TestPrngContract);
+    let id = e.register(TestPrngContract, ());
 
     e.as_contract(&id, || {
         e.prng().gen_range::<u64>(u64::MAX..u64::MAX);
@@ -124,7 +124,7 @@ fn test_prng_gen_range_u64_panic_on_invalid_range() {
 #[test]
 fn test_prng_fill_bytes() {
     let e = Env::default();
-    let id = e.register_contract(None, TestPrngContract);
+    let id = e.register(TestPrngContract, ());
 
     e.as_contract(&id, || {
         let mut v = Bytes::from_array(&e, &[0u8; 32]);
@@ -156,7 +156,7 @@ fn test_prng_fill_bytes() {
 #[test]
 fn test_prng_gen_len_bytes() {
     let e = Env::default();
-    let id = e.register_contract(None, TestPrngContract);
+    let id = e.register(TestPrngContract, ());
 
     e.as_contract(&id, || {
         assert_eq!(
@@ -185,7 +185,7 @@ fn test_prng_gen_len_bytes() {
 #[test]
 fn test_prng_fill_bytesn() {
     let e = Env::default();
-    let id = e.register_contract(None, TestPrngContract);
+    let id = e.register(TestPrngContract, ());
 
     e.as_contract(&id, || {
         let mut v = BytesN::from_array(&e, &[0u8; 32]);
@@ -217,7 +217,7 @@ fn test_prng_fill_bytesn() {
 #[test]
 fn test_prng_gen_bytesn() {
     let e = Env::default();
-    let id = e.register_contract(None, TestPrngContract);
+    let id = e.register(TestPrngContract, ());
 
     e.as_contract(&id, || {
         assert_eq!(
@@ -246,7 +246,7 @@ fn test_prng_gen_bytesn() {
 #[test]
 fn test_prng_fill_slice() {
     let e = Env::default();
-    let id = e.register_contract(None, TestPrngContract);
+    let id = e.register(TestPrngContract, ());
 
     e.as_contract(&id, || {
         let mut buf = [0u8; 32];
@@ -273,7 +273,7 @@ fn test_prng_fill_slice() {
 #[test]
 fn test_prng_fill_array() {
     let e = Env::default();
-    let id = e.register_contract(None, TestPrngContract);
+    let id = e.register(TestPrngContract, ());
 
     e.as_contract(&id, || {
         let mut v = [0u8; 32];
@@ -299,7 +299,7 @@ fn test_prng_fill_array() {
 #[test]
 fn test_prng_gen_array() {
     let e = Env::default();
-    let id = e.register_contract(None, TestPrngContract);
+    let id = e.register(TestPrngContract, ());
 
     e.as_contract(&id, || {
         assert_eq!(

--- a/soroban-sdk/src/tests/storage_testutils.rs
+++ b/soroban-sdk/src/tests/storage_testutils.rs
@@ -12,7 +12,7 @@ pub struct Contract;
 #[test]
 fn all() {
     let e = Env::default();
-    let id = e.register_contract(None, Contract);
+    let id = e.register(Contract, ());
 
     e.as_contract(&id, || {
         e.storage().instance().set(&1, &2);
@@ -49,8 +49,8 @@ fn ttl_getters() {
     e.ledger().set_min_persistent_entry_ttl(100);
     e.ledger().set_min_temp_entry_ttl(10);
 
-    let contract_a = e.register_contract(None, Contract);
-    let contract_b = e.register_contract(None, Contract);
+    let contract_a = e.register(Contract, ());
+    let contract_b = e.register(Contract, ());
     let setup = || {
         e.storage().persistent().set(&1, &3);
         e.storage().temporary().set(&2, &4);
@@ -113,7 +113,7 @@ fn temp_entry_expiration() {
     let e = Env::default();
     e.ledger().set_sequence_number(1000);
     e.ledger().set_min_temp_entry_ttl(100);
-    let contract = e.register_contract(None, Contract);
+    let contract = e.register(Contract, ());
     e.as_contract(&contract, || {
         e.storage().temporary().set(&1, &2);
 
@@ -145,7 +145,7 @@ fn test_persistent_entry_expiration() {
     e.ledger().set_sequence_number(1000);
     e.ledger().set_min_persistent_entry_ttl(100);
 
-    let contract = e.register_contract(None, Contract);
+    let contract = e.register(Contract, ());
     e.as_contract(&contract, || {
         e.storage().persistent().set(&1, &2);
 

--- a/soroban-sdk/src/tests/token_client.rs
+++ b/soroban-sdk/src/tests/token_client.rs
@@ -73,7 +73,7 @@ fn test_mock_all_auth() {
     let sac = env.register_stellar_asset_contract_v2(admin);
     let token_contract_id = sac.address();
 
-    let contract_id = env.register_contract(None, TestContract);
+    let contract_id = env.register(TestContract, ());
     let client = TestContractClient::new(&env, &contract_id);
     client.init(&token_contract_id);
 
@@ -121,7 +121,7 @@ fn test_mock_auth() {
     let admin = Address::generate(&env);
     let token_contract_id = env.register_stellar_asset_contract_v2(admin).address();
 
-    let contract_id = env.register_contract(None, TestContract);
+    let contract_id = env.register(TestContract, ());
     let client = TestContractClient::new(&env, &contract_id);
     client.init(&token_contract_id);
 

--- a/soroban-sdk/src/testutils.rs
+++ b/soroban-sdk/src/testutils.rs
@@ -23,6 +23,36 @@ use soroban_ledger_snapshot::LedgerSnapshot;
 
 pub use crate::env::EnvTestConfig;
 
+pub trait Register {
+    fn register<'i, I, A>(self, env: &Env, id: I, args: A) -> crate::Address
+    where
+        I: Into<Option<&'i crate::Address>>,
+        A: ConstructorArgs;
+}
+
+impl<C> Register for C
+where
+    C: ContractFunctionSet + 'static,
+{
+    fn register<'i, I, A>(self, env: &Env, id: I, args: A) -> crate::Address
+    where
+        I: Into<Option<&'i crate::Address>>,
+        A: ConstructorArgs,
+    {
+        env.register_contract_with_constructor(id, self, args)
+    }
+}
+
+impl<'w> Register for &'w [u8] {
+    fn register<'i, I, A>(self, env: &Env, id: I, args: A) -> crate::Address
+    where
+        I: Into<Option<&'i crate::Address>>,
+        A: ConstructorArgs,
+    {
+        env.register_contract_wasm_with_constructor(id, self, args)
+    }
+}
+
 pub trait ConstructorArgs: IntoVal<Env, Vec<Val>> {}
 
 impl<T> ConstructorArgs for Vec<T> {}

--- a/tests/account/src/lib.rs
+++ b/tests/account/src/lib.rs
@@ -44,8 +44,8 @@ mod test {
     #[test]
     fn test() {
         let e = Env::default();
-        let test_contract_id = e.register_contract(None, TestContract);
-        let contract_id = e.register_contract(None, Contract);
+        let test_contract_id = e.register(TestContract, ());
+        let contract_id = e.register(Contract, ());
 
         e.set_auths(&[MockAuth {
             address: &contract_id,

--- a/tests/add_i128/src/lib.rs
+++ b/tests/add_i128/src/lib.rs
@@ -20,7 +20,7 @@ mod test {
     #[test]
     fn test_add() {
         let e = Env::default();
-        let contract_id = e.register_contract(None, Contract);
+        let contract_id = e.register(Contract, ());
         let client = ContractClient::new(&e, &contract_id);
 
         let x = 2i128.pow(70);

--- a/tests/add_u128/src/lib.rs
+++ b/tests/add_u128/src/lib.rs
@@ -20,7 +20,7 @@ mod test {
     #[test]
     fn test_add() {
         let e = Env::default();
-        let contract_id = e.register_contract(None, Contract);
+        let contract_id = e.register(Contract, ());
         let client = ContractClient::new(&e, &contract_id);
 
         let x = 2u128.pow(70);

--- a/tests/add_u64/src/lib.rs
+++ b/tests/add_u64/src/lib.rs
@@ -20,7 +20,7 @@ mod test {
     #[test]
     fn test_add() {
         let e = Env::default();
-        let contract_id = e.register_contract(None, Contract);
+        let contract_id = e.register(Contract, ());
         let client = ContractClient::new(&e, &contract_id);
 
         let x = 10u64;

--- a/tests/alloc/src/lib.rs
+++ b/tests/alloc/src/lib.rs
@@ -30,7 +30,7 @@ mod test {
     #[test]
     fn test_add() {
         let e = Env::default();
-        let contract_id = e.register_contract(None, Contract);
+        let contract_id = e.register(Contract, ());
         let client = ContractClient::new(&e, &contract_id);
 
         let list = client.num_list(&5);

--- a/tests/auth/src/lib.rs
+++ b/tests/auth/src/lib.rs
@@ -33,7 +33,7 @@ mod test_a {
     fn test_with_mock_all_auth() {
         let e = Env::default();
 
-        let contract_id = e.register_contract(None, ContractA);
+        let contract_id = e.register(ContractA, ());
         let client = ContractAClient::new(&e, &contract_id);
 
         let a = Address::generate(&e);
@@ -60,7 +60,7 @@ mod test_a {
     fn test_with_mock_auth() {
         let e = Env::default();
 
-        let contract_id = e.register_contract(None, ContractA);
+        let contract_id = e.register(ContractA, ());
         let client = ContractAClient::new(&e, &contract_id);
 
         let a = Address::generate(&e);
@@ -97,10 +97,10 @@ mod test_a {
     fn test_with_real_contract_auth_approve() {
         let e = Env::default();
 
-        let contract_id = e.register_contract(None, ContractA);
+        let contract_id = e.register(ContractA, ());
         let client = ContractAClient::new(&e, &contract_id);
 
-        let a = e.register_contract(None, auth_approve::Contract);
+        let a = e.register(auth_approve::Contract, ());
         let a_xdr: ScAddress = (&a).try_into().unwrap();
 
         let r = client
@@ -143,10 +143,10 @@ mod test_a {
     fn test_with_real_contract_auth_decline() {
         let e = Env::default();
 
-        let contract_id = e.register_contract(None, ContractA);
+        let contract_id = e.register(ContractA, ());
         let client = ContractAClient::new(&e, &contract_id);
 
-        let a = e.register_contract(None, auth_decline::Contract);
+        let a = e.register(auth_decline::Contract, ());
         let a_xdr: ScAddress = (&a).try_into().unwrap();
 
         let r = client
@@ -251,8 +251,8 @@ mod test_b {
     fn test_with_mock_all_auth() {
         let e = Env::default();
 
-        let contract_a_id = e.register_contract(None, ContractA);
-        let contract_b_id = e.register_contract(None, ContractB);
+        let contract_a_id = e.register(ContractA, ());
+        let contract_b_id = e.register(ContractB, ());
         let client = ContractBClient::new(&e, &contract_b_id);
 
         let a = Address::generate(&e);
@@ -286,8 +286,8 @@ mod test_b {
     fn test_with_mock_auth() {
         let e = Env::default();
 
-        let contract_a_id = e.register_contract(None, ContractA);
-        let contract_b_id = e.register_contract(None, ContractB);
+        let contract_a_id = e.register(ContractA, ());
+        let contract_b_id = e.register(ContractB, ());
         let client = ContractBClient::new(&e, &contract_b_id);
 
         let a = Address::generate(&e);
@@ -336,11 +336,11 @@ mod test_b {
     fn test_with_real_contract_auth_approve() {
         let e = Env::default();
 
-        let contract_a_id = e.register_contract(None, ContractA);
-        let contract_b_id = e.register_contract(None, ContractB);
+        let contract_a_id = e.register(ContractA, ());
+        let contract_b_id = e.register(ContractB, ());
         let client = ContractBClient::new(&e, &contract_b_id);
 
-        let a = e.register_contract(None, auth_approve::Contract);
+        let a = e.register(auth_approve::Contract, ());
         let a_xdr: ScAddress = (&a).try_into().unwrap();
 
         let r = client
@@ -399,11 +399,11 @@ mod test_b {
     fn test_with_real_contract_auth_decline() {
         let e = Env::default();
 
-        let contract_a_id = e.register_contract(None, ContractA);
-        let contract_b_id = e.register_contract(None, ContractB);
+        let contract_a_id = e.register(ContractA, ());
+        let contract_b_id = e.register(ContractB, ());
         let client = ContractBClient::new(&e, &contract_b_id);
 
-        let a = e.register_contract(None, auth_decline::Contract);
+        let a = e.register(auth_decline::Contract, ());
         let a_xdr: ScAddress = (&a).try_into().unwrap();
 
         let r = client

--- a/tests/constructor/src/lib.rs
+++ b/tests/constructor/src/lib.rs
@@ -37,7 +37,7 @@ impl Contract {
 #[test]
 fn test_constructor() {
     let env = Env::default();
-    let contract_id = env.register_contract_with_constructor(None, Contract, (100_u32, 1000_i64));
+    let contract_id = env.register(Contract, (100_u32, 1000_i64));
     let client = ContractClient::new(&env, &contract_id);
     assert_eq!(client.get_data(&DataKey::Persistent(100)), Some(1000));
     assert_eq!(client.get_data(&DataKey::Temp(200)), Some(2000));
@@ -52,26 +52,26 @@ fn test_constructor() {
 #[should_panic(expected = "constructor invocation has failed with error")]
 fn test_passing_no_constructor_arguments_causes_panic() {
     let env = Env::default();
-    let _ = env.register_contract(None, Contract);
+    let _ = env.register(Contract, ());
 }
 
 #[test]
 #[should_panic(expected = "constructor invocation has failed with error")]
 fn test_missing_constructor_arguments_causes_panic() {
     let env = Env::default();
-    let _ = env.register_contract_with_constructor(None, Contract, (100_u32,));
+    let _ = env.register(Contract, (100_u32,));
 }
 
 #[test]
 #[should_panic(expected = "constructor invocation has failed with error")]
 fn test_passing_extra_constructor_arguments_causes_panic() {
     let env = Env::default();
-    let _ = env.register_contract_with_constructor(None, Contract, (100_u32, 1000_i64, 123_u32));
+    let _ = env.register(Contract, (100_u32, 1000_i64, 123_u32));
 }
 
 #[test]
 #[should_panic(expected = "constructor invocation has failed with error")]
 fn test_passing_incorrectly_typed_constructor_arguments_causes_panic() {
     let env = Env::default();
-    let _ = env.register_contract_with_constructor(None, Contract, (100_u32, 1000_u32));
+    let _ = env.register(Contract, (100_u32, 1000_u32));
 }

--- a/tests/empty/src/lib.rs
+++ b/tests/empty/src/lib.rs
@@ -18,7 +18,7 @@ mod test {
     #[test]
     fn test_hello() {
         let e = Env::default();
-        let contract_id = e.register_contract(None, Contract);
+        let contract_id = e.register(Contract, ());
         let client = ContractClient::new(&e, &contract_id);
 
         client.empty();

--- a/tests/empty2/src/lib.rs
+++ b/tests/empty2/src/lib.rs
@@ -16,7 +16,7 @@ mod test {
     #[test]
     fn test_hello() {
         let e = Env::default();
-        let contract_id = e.register_contract(None, Contract);
+        let contract_id = e.register(Contract, ());
         let _client = ContractClient::new(&e, &contract_id);
     }
 }

--- a/tests/errors/src/lib.rs
+++ b/tests/errors/src/lib.rs
@@ -51,7 +51,7 @@ mod test {
     #[test]
     fn hello_ok() {
         let e = Env::default();
-        let contract_id = e.register_contract(None, Contract);
+        let contract_id = e.register(Contract, ());
         let client = ContractClient::new(&e, &contract_id);
 
         let res = client.hello(&0);
@@ -62,7 +62,7 @@ mod test {
     #[test]
     fn try_hello_ok() {
         let e = Env::default();
-        let contract_id = e.register_contract(None, Contract);
+        let contract_id = e.register(Contract, ());
         let client = ContractClient::new(&e, &contract_id);
 
         let res = client.try_hello(&0);
@@ -73,7 +73,7 @@ mod test {
     #[test]
     fn try_hello_error() {
         let e = Env::default();
-        let contract_id = e.register_contract(None, Contract);
+        let contract_id = e.register(Contract, ());
         let client = ContractClient::new(&e, &contract_id);
 
         let res = client.try_hello(&1);
@@ -84,7 +84,7 @@ mod test {
     #[test]
     fn try_hello_error_panic() {
         let e = Env::default();
-        let contract_id = e.register_contract(None, Contract);
+        let contract_id = e.register(Contract, ());
         let client = ContractClient::new(&e, &contract_id);
 
         let res = client.try_hello(&2);
@@ -95,7 +95,7 @@ mod test {
     #[test]
     fn try_hello_error_panic_string() {
         let e = Env::default();
-        let contract_id = e.register_contract(None, Contract);
+        let contract_id = e.register(Contract, ());
         let client = ContractClient::new(&e, &contract_id);
 
         let res = client.try_hello(&3);
@@ -106,7 +106,7 @@ mod test {
     #[test]
     fn try_hello_error_unexpected_contract_error() {
         let e = Env::default();
-        let contract_id = e.register_contract(None, Contract);
+        let contract_id = e.register(Contract, ());
         let client = ContractClient::new(&e, &contract_id);
 
         let res = client.try_hello(&4);

--- a/tests/events/src/lib.rs
+++ b/tests/events/src/lib.rs
@@ -28,7 +28,7 @@ mod test {
     #[test]
     fn test_pub_event() {
         let env = Env::default();
-        let contract_id = env.register_contract(None, Contract);
+        let contract_id = env.register(Contract, ());
         let client = ContractClient::new(&env, &contract_id);
 
         client.hello();

--- a/tests/fuzz/fuzz/fuzz_targets/fuzz_target_1.rs
+++ b/tests/fuzz/fuzz/fuzz_targets/fuzz_target_1.rs
@@ -2,7 +2,10 @@
 
 use libfuzzer_sys::fuzz_target;
 
-use soroban_sdk::{testutils::arbitrary::{arbitrary,Arbitrary,SorobanArbitrary}, Env, IntoVal, U256};
+use soroban_sdk::{
+    testutils::arbitrary::{arbitrary, Arbitrary, SorobanArbitrary},
+    Env, IntoVal, U256,
+};
 
 use test_fuzz::{Contract, ContractClient};
 
@@ -18,7 +21,7 @@ fuzz_target!(|input: Input| {
     let a: U256 = input.a.into_val(&env);
     let b: U256 = input.b.into_val(&env);
 
-    let contract_id = env.register_contract(None, Contract);
+    let contract_id = env.register(Contract, ());
     let client = ContractClient::new(&env, &contract_id);
 
     let _ = client.run(&a, &b);

--- a/tests/import_contract/src/lib.rs
+++ b/tests/import_contract/src/lib.rs
@@ -26,9 +26,9 @@ mod test {
     #[test]
     fn test_add() {
         let e = Env::default();
-        let add_contract_id = e.register_contract_wasm(None, addcontract::WASM);
+        let add_contract_id = e.register(addcontract::WASM, ());
 
-        let contract_id = e.register_contract(None, Contract);
+        let contract_id = e.register(Contract, ());
         let client = ContractClient::new(&e, &contract_id);
 
         let x = 10u64;

--- a/tests/invoke_contract/src/lib.rs
+++ b/tests/invoke_contract/src/lib.rs
@@ -36,9 +36,9 @@ mod test {
     fn test_add() {
         let e = Env::default();
 
-        let add_contract_id = e.register_contract(None, AddContract);
+        let add_contract_id = e.register(AddContract, ());
 
-        let contract_id = e.register_contract(None, Contract);
+        let contract_id = e.register(Contract, ());
         let client = ContractClient::new(&e, &contract_id);
 
         let x = 10i32;

--- a/tests/logging/src/lib.rs
+++ b/tests/logging/src/lib.rs
@@ -37,7 +37,7 @@ mod test {
     #[test]
     fn test_logging() {
         let env = Env::default();
-        let contract_id = env.register_contract(None, Contract);
+        let contract_id = env.register(Contract, ());
         let client = ContractClient::new(&env, &contract_id);
 
         client.hello();

--- a/tests/modular/src/test.rs
+++ b/tests/modular/src/test.rs
@@ -7,7 +7,7 @@ use soroban_sdk::Env;
 fn test() {
     let env = Env::default();
 
-    let id = env.register_contract(None, Contract);
+    let id = env.register(Contract, ());
     let client = ContractClient::new(&env, &id);
 
     assert_eq!(client.zero(), 0);

--- a/tests/multiimpl/src/lib.rs
+++ b/tests/multiimpl/src/lib.rs
@@ -32,7 +32,7 @@ mod test {
     #[test]
     fn test_hello() {
         let e = Env::default();
-        let contract_id = e.register_contract(None, Contract);
+        let contract_id = e.register(Contract, ());
         let client = ContractClient::new(&e, &contract_id);
 
         client.empty();

--- a/tests/udt/src/lib.rs
+++ b/tests/udt/src/lib.rs
@@ -79,7 +79,7 @@ mod test {
     #[test]
     fn test_add() {
         let e = Env::default();
-        let contract_id = e.register_contract(None, Contract);
+        let contract_id = e.register(Contract, ());
         let client = ContractClient::new(&e, &contract_id);
 
         let udt = UdtStruct {

--- a/tests/workspace_contract/src/lib.rs
+++ b/tests/workspace_contract/src/lib.rs
@@ -22,7 +22,7 @@ mod test {
     fn test_add() {
         let e = Env::default();
 
-        let contract_id = e.register_contract(None, Contract);
+        let contract_id = e.register(Contract, ());
         let client = ContractClient::new(&e, &contract_id);
 
         let z = client.value();


### PR DESCRIPTION
### What

Add `register` and `register_at` fns.

Deprecate `register_contract` and `register_contract_wasm`.

Unexport `register_contract_with_constructor` and `register_contract_wasm_with_constructor`.

### Why

To reorient the register functions around what we expect the common cases to be:
 - registering without a contract id specified
 - registering with a constructor specified

It's always been odd that the first parameter to most `register_contract` calls is `None`. It's confusing to look at the first time you see it, and for the most part most developers do not need to set a value for the contract id.

Most contracts need initialization, and therefore I think most contracts over time will gain constructors.

To do so in a way that is backwards compatible with previous releases.

Close https://github.com/stellar/rs-soroban-sdk/issues/1341

### Known limitations

It would be better imo if we could add the constructor arguments to the existing `register_contract` and `register_contract_wasm` fns, but that would be a breaking change.

The `deploy_with_constructor` functions still exist which is inconsistent, but harder to align because to change the `deploy` function to always accept constructor args would be a breaking change.

It's possible to update code that uses the existing register functions using a regex find and replace, but it's not the most trivial regex to work out. If folks wish to resolve the deprecation warning they'll need to update potentially every test they've written. That in itself is not a great developer experience.

The old and new way don't look that different, and so for existing Soroban developers, the change from the old to new way may be confusing at a glance.

This PR doesn't touch the register stellar asset contract functions at all. Ideas?