### PR TITLE
Fix warnings on contract and contractimpl macros

### DIFF
--- a/soroban-sdk-macros/src/derive_fn.rs
+++ b/soroban-sdk-macros/src/derive_fn.rs
@@ -194,6 +194,7 @@ pub fn derive_contract_function_registration_ctor<'a>(
     quote! {
         #[doc(hidden)]
         #[#crate_path::reexports_for_macros::ctor::ctor]
+        #[allow(non_snake_case)]
         fn #ctor_ident() {
             #(
                 <#ty as #crate_path::testutils::ContractFunctionRegister>::register(

--- a/soroban-sdk-macros/src/derive_fn.rs
+++ b/soroban-sdk-macros/src/derive_fn.rs
@@ -193,6 +193,7 @@ pub fn derive_contract_function_registration_ctor<'a>(
 
     quote! {
         #[doc(hidden)]
+        #[cfg(any(test, feature = "testutils"))]
         #[#crate_path::reexports_for_macros::ctor::ctor]
         #[allow(non_snake_case)]
         fn #ctor_ident() {

--- a/soroban-sdk-macros/src/derive_spec_fn.rs
+++ b/soroban-sdk-macros/src/derive_spec_fn.rs
@@ -166,11 +166,13 @@ pub fn derive_fn_spec(
     Ok(quote! {
         #[doc(hidden)]
         #[allow(non_snake_case)]
+        #[allow(non_upper_case_globals)]
         #(#attrs)*
         #export_attr
         pub static #spec_ident: [u8; #spec_xdr_len] = #ty::#spec_fn_ident();
 
         impl #ty {
+            #[allow(non_snake_case)]
             #(#attrs)*
             pub const fn #spec_fn_ident() -> [u8; #spec_xdr_len] {
                 *#spec_xdr_lit

--- a/soroban-sdk-macros/src/lib.rs
+++ b/soroban-sdk-macros/src/lib.rs
@@ -244,15 +244,13 @@ pub fn contractimpl(metadata: TokenStream, input: TokenStream) -> TokenStream {
                 #imp
                 #derived_ok
             };
-            if cfg!(feature = "testutils") {
-                let cfs = derive_contract_function_registration_ctor(
-                    crate_path,
-                    ty,
-                    trait_ident,
-                    pub_methods.into_iter(),
-                );
-                output.extend(quote! { #cfs });
-            }
+            let cfs = derive_contract_function_registration_ctor(
+                crate_path,
+                ty,
+                trait_ident,
+                pub_methods.into_iter(),
+            );
+            output.extend(quote! { #cfs });
             output.into()
         }
         Err(derived_err) => quote! {

--- a/soroban-sdk-macros/src/lib.rs
+++ b/soroban-sdk-macros/src/lib.rs
@@ -133,7 +133,7 @@ pub fn contract(metadata: TokenStream, input: TokenStream) -> TokenStream {
     let ty_str = quote!(#ty).to_string();
 
     let client_ident = format!("{ty_str}Client");
-    let fn_set_registry_ident = format_ident!("__{ty_str}_fn_set_registry");
+    let fn_set_registry_ident = format_ident!("__{}_fn_set_registry", ty_str.to_lowercase());
     let crate_path = &args.crate_path;
     let client = derive_client_type(&args.crate_path, &ty_str, &client_ident);
     let mut output = quote! {


### PR DESCRIPTION
### What
Fix and disable warnings on contract and contractimpl macros for misformatted item names, and missing fns.

### Why
Starting with the last release warnings started to display on the contract and contractimpl macros because of generated code not following the naming conventions for some items.

In one case it is easier to fix the naming convention, and so that is what was done.

In the other case it is easier to silence the warning, and so that is what was done.

One of the warnings was about a missing function. In this case I think there's an issue with rust-analyzer and how we were generating two dependent parts of code different ways. In one are we were always generating the code feature gated, in the other we were generating it only based on the feature. Rust-analyzer doesn't rebuild proc-macros frequently, and so I think caching of generated code that then had the feature off was to blame.

### Backporting

This change should be backported to the 21 versions as a patch on 21.7 after merging to main.