### PR TITLE
Fix importing contract crates into other crates for testing

### DIFF
--- a/soroban-sdk-macros/src/derive_fn.rs
+++ b/soroban-sdk-macros/src/derive_fn.rs
@@ -126,7 +126,7 @@ pub fn derive_pub_fn(
         return Err(quote! { #(#compile_errors)* });
     }
 
-    let testutils_only_code = if cfg!(not(feature = "testutils")) {
+    let testutils_only_code = if cfg!(feature = "testutils") {
         Some(quote! {
             #[deprecated(note = #deprecated_note)]
             pub fn invoke_raw_slice(


### PR DESCRIPTION
### What

Change two locations of the soroban-sdk-macros which were gated on the contract crates `testutils` feature, to be gated on the SDK's `testutils` feature.

### Why

Recently I introduced a bug into the sdk across two changes:
- https://github.com/stellar/rs-soroban-sdk/pull/1344
- https://github.com/stellar/rs-soroban-sdk/pull/1336

The bug was that I changed how some code was gated to be gated on whether the contract's `testutils` feature was enabled, rather than on the SDKs.

Sometime ago in the following issue I changed how all of a contract's testutils are enabled/disabled, by being enabled/disabled by the SDK's testutils feature:
- https://github.com/stellar/rs-soroban-sdk/pull/1301

That change was good, it fixed a horrid issue with testing contracts where you could have some contracts in testutils mode, and others not, leading to strange errors when importing native contracts for testing.

However, when I worked on the two issues above, I inadvertently forgot that we had changed the structure of how testutils code got enabled, and I introduced across those two PRs two new locations where we followed the old pattern and gated on the contract feature set, not the SDKs.

For most users this will have presented no issues because there all of these testutilities are always enabled in a contract's own tests. This masked the issue in all of our own tests, but broke setups like fuzzing where the contract gets imported. All of our fuzz projects unfortunately don't currently build the fuzz components, and so this got missed until someone (me) tried to use them.

### Known limitations

This change doesn't introduce a test to detect this type of breakage. I think the way we can detect this in the future is have our pre-existing test vector build as part of CI. This issue is tracking that follow up work:
- https://github.com/stellar/rs-soroban-sdk/issues/1363

### Merging

This fix is targeting main, but we need a similar fix to target v21, because part of this bug was introduced into v21.7.2. Once this change merges to main, I will partially cherry-pick it into a backport patch release.