### PR TITLE
Deprecate fuzz_catch_panic

### DIFF
--- a/soroban-sdk/src/testutils/arbitrary.rs
+++ b/soroban-sdk/src/testutils/arbitrary.rs
@@ -11,7 +11,6 @@
 //! This module
 //!
 //! - defines the [`SorobanArbitrary`] trait,
-//! - defines the [`fuzz_catch_panic`] helper,
 //! - reexports the [`arbitrary`] crate and the [`Arbitrary`] type.
 //!
 //! This module is only available when the "testutils" Cargo feature is defined.
@@ -1249,11 +1248,10 @@ mod fuzz_test_helpers {
     ///     let contract = ExampleContract::new(env, &env.register_contract(None, ExampleContract {}));
     ///
     ///     let addresses: Address = input.deposit_address.into_val(&env);
-    ///     let r = fuzz_catch_panic(|| {
-    ///         contract.deposit(deposit_address, input.deposit_amount);
-    ///     });
+    ///     let r = contract.try_deposit(deposit_address, input.deposit_amount);
     /// });
     /// ```
+    #[deprecated(note = "use [Env::try_invoke] or the try_ functions on a contract client")]
     pub fn fuzz_catch_panic<F, R>(f: F) -> std::thread::Result<R>
     where
         F: FnOnce() -> R,


### PR DESCRIPTION
### What

Deprecate `fuzz_catch_panic`, encouraging developers to use the `try_` invoke functions instead.

### Why

The fuzz_catch_panic function catches panics that occur when the contract fails and generates a panic. It is necessary to often catch panics when testing contracts because contract errors are populated up to the test as a panic when called from their regular client invoking function.

However, contract clients, and the env, also have `try_` variants of each function for calling a contract. When the try variant is used, panics and contract errors are caught and molded into a `Result<Result<_,_>, Result<_,_>>` developers can assert on. Developers in tests can then assert did the contract:
1. Succeed and return the expected type, `Ok(Ok(_))`
2. Error and return an expected contract error type as defined by a `contracterror` enum, `Err(Ok(_))`
3. Succeed and return an unexpected type, `Ok(Err(_))`
4. Error and return an abort (panic), or system / host error, or a contract error not included in the `contracterror` enum, `Err(Err(_))`

### Known limitations

As far as I can tell the purposes of `fuzz_catch_panic` can be served by the `Env` `try_invoke` and the generated contract client `try_` functions, but I'd be interested to hear from @brson to confirm if I'm missing any case where we'd want to keep `fuzz_catch_panic`.

### Docs

The stellar-docs need updating as well.