### PR TITLE
Add test demonstrating issue with using Option inside an enum

### DIFF
--- a/soroban-sdk/src/tests.rs
+++ b/soroban-sdk/src/tests.rs
@@ -18,6 +18,7 @@ mod contract_store;
 mod contract_timepoint;
 mod contract_udt_enum;
 mod contract_udt_enum_error;
+mod contract_udt_enum_option;
 mod contract_udt_option;
 mod contract_udt_struct;
 mod contract_udt_struct_tuple;

--- a/soroban-sdk/src/tests/contract_udt_enum_option.rs
+++ b/soroban-sdk/src/tests/contract_udt_enum_option.rs
@@ -1,0 +1,8 @@
+use crate::{self as soroban_sdk};
+use soroban_sdk::{contracttype, Address};
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum Test {
+    Variant(Option<Address>, Address, i128),
+}


### PR DESCRIPTION
### What
Add test demonstrating issue with using Option inside an enum.

(cherry picked from commit 68411e7e92b11e6316c269d4f7ccae86cd37cfaf)

### Why
This was added to a patch release recently and we should retain the test in main.