### PR TITLE
Add wasm size to output

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -113,6 +113,12 @@ jobs:
       run: rm -fr **/test_snapshots
     - name: Build for wasm
       run: cargo-hack hack build --target wasm32-unknown-unknown --profile release
+    - name: Wasm Size
+      run: |
+        cd target/wasm32-unknown-unknown/release/ && \
+          for i in *.wasm ; do \
+            ls -l "$$i"; \
+          done
     - if: "!matrix.sys.cdylib-cross-compile-workaround"
       name: Build for native
       run: cargo-hack hack --feature-powerset --exclude-features docs build --target ${{ matrix.sys.target }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -117,7 +117,7 @@ jobs:
       run: |
         cd target/wasm32-unknown-unknown/release/ && \
           for i in *.wasm ; do \
-            ls -l "$$i"; \
+            ls -l "$i"; \
           done
     - if: "!matrix.sys.cdylib-cross-compile-workaround"
       name: Build for native


### PR DESCRIPTION
### What
Add wasm size to output

### Why
So that it's easy to look at PRs to see how they change the size of the test vectors when built.