### PR TITLE
Remove pin of nightly version for nightly builds

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -137,8 +137,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: stellar/actions/rust-cache@main
-    # TODO: Unpin nightly version after https://github.com/rust-lang/rust/issues/131643 is fixed.
-    - run: rustup install nightly-2024-10-10
+    - run: rustup install nightly
     - uses: stellar/binaries@v15
       with:
         name: cargo-fuzz
@@ -152,8 +151,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: stellar/actions/rust-cache@main
-    # TODO: Unpin nightly version after https://github.com/rust-lang/rust/issues/131643 is fixed.
-    - run: rustup install nightly-2024-10-10
+    - run: rustup install nightly
     - run: make doc
     - name: Check no diffs exist
       run: git add -N . && git diff HEAD --exit-code
@@ -163,8 +161,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: stellar/actions/rust-cache@main
-    # TODO: Unpin nightly version after https://github.com/rust-lang/rust/issues/131643 is fixed.
-    - run: rustup install nightly-2024-10-10
+    - run: rustup install nightly
     - run: make readme
     - run: git add -N . && git diff HEAD --exit-code
 

--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,7 @@ CARGO_DOC_ARGS?=--open
 
 doc: fmt
 	cargo test --doc -p soroban-sdk -p soroban-sdk-macros --features testutils,hazmat
-	# TODO: Unpin nightly version after https://github.com/rust-lang/rust/issues/131643 is fixed.
-	cargo +nightly-2024-10-10 doc -p soroban-sdk --no-deps --all-features $(CARGO_DOC_ARGS)
+	cargo +nightly doc -p soroban-sdk --no-deps --all-features $(CARGO_DOC_ARGS)
 
 test: fmt build
 	cargo hack --feature-powerset --ignore-unknown-features --features testutils --exclude-features docs test
@@ -24,13 +23,11 @@ check: build fmt
 	cargo hack check --release --target wasm32-unknown-unknown
 
 build-fuzz:
-	# TODO: Unpin nightly version after https://github.com/rust-lang/rust/issues/131643 is fixed.
-	cd tests/fuzz/fuzz && cargo +nightly-2024-10-10 fuzz check
+	cd tests/fuzz/fuzz && cargo +nightly fuzz check
 
 readme:
-	# TODO: Unpin nightly version after https://github.com/rust-lang/rust/issues/131643 is fixed.
 	cd soroban-sdk \
-		&& cargo +nightly-2024-10-10 rustdoc -- -Zunstable-options -wjson \
+		&& cargo +nightly rustdoc -- -Zunstable-options -wjson \
 		&& cat ../target/doc/soroban_sdk.json \
 		| jq -r '.index[.root|tostring].docs' \
 		> README.md
@@ -39,7 +36,7 @@ watch:
 	cargo watch --clear --watch-when-idle --shell '$(MAKE)'
 
 watch-doc:
-	cargo +nightly-2024-10-10 watch --clear --watch-when-idle --shell '$(MAKE) doc CARGO_DOC_ARGS='
+	cargo +nightly watch --clear --watch-when-idle --shell '$(MAKE) doc CARGO_DOC_ARGS='
 
 fmt:
 	cargo fmt --all


### PR DESCRIPTION
### What
Remove pin of nightly version for nightly builds.

### Why
The underlying issue for why the version pinning was required has been fixed:
- https://github.com/rust-lang/rust/issues/132427