### PR TITLE
Remove unused makefile targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,20 +35,8 @@ readme:
 		| jq -r '.index[.root|tostring].docs' \
 		> README.md
 
-watch:
-	cargo watch --clear --watch-when-idle --shell '$(MAKE)'
-
-watch-doc:
-	cargo +nightly-2024-10-10 watch --clear --watch-when-idle --shell '$(MAKE) doc CARGO_DOC_ARGS='
-
 fmt:
 	cargo fmt --all
 
 clean:
 	cargo clean
-
-bump-version:
-	cargo workspaces version --all --force '*' --no-git-commit --yes custom $(VERSION)
-
-publish:
-	cargo workspaces publish --all --force '*' --from-git --yes


### PR DESCRIPTION
### What
Remove the watch and watch-doc makefile targets.

### Why
They're not used. Cargo watch is also deprecated and the author recommends using other tools.