### PR TITLE
Limit the versions of arbitrary/derive_arbitrary to 1.3.x

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1329,6 +1329,7 @@ dependencies = [
  "bytes-lit",
  "ctor",
  "curve25519-dalek",
+ "derive_arbitrary",
  "ed25519-dalek",
  "hex",
  "libfuzzer-sys",

--- a/soroban-sdk/Cargo.toml
+++ b/soroban-sdk/Cargo.toml
@@ -29,7 +29,8 @@ soroban-env-guest = { workspace = true }
 soroban-env-host = { workspace = true, features = [] }
 soroban-ledger-snapshot = { workspace = true }
 stellar-strkey = { workspace = true }
-arbitrary = { version = "1.3.0", features = ["derive"], optional = true }
+arbitrary = { version = "~1.3.0", features = ["derive"], optional = true }
+derive_arbitrary = { version = "~1.3.0", optional = true }
 serde = { version = "1.0.0", features = ["derive"] }
 serde_json = "1.0.0"
 ed25519-dalek = { version = "2.1.1", features = ["rand_core"], optional = true }
@@ -47,14 +48,15 @@ ed25519-dalek = "2.0.0"
 rand = "0.8.5"
 ctor = "0.2.1"
 hex = "0.4.3"
-arbitrary = { version = "1.3.0", features = ["derive"] }
+arbitrary = { version = "~1.3.0", features = ["derive"] }
+derive_arbitrary = { version = "~1.3.0" }
 proptest = "1.2.0"
 proptest-arbitrary-interop = "0.1.0"
 libfuzzer-sys = "0.4.7"
 
 [features]
 alloc = []
-testutils = ["soroban-sdk-macros/testutils", "soroban-env-host/testutils", "dep:ed25519-dalek", "dep:arbitrary", "dep:ctor"]
+testutils = ["soroban-sdk-macros/testutils", "soroban-env-host/testutils", "dep:ed25519-dalek", "dep:arbitrary", "dep:derive_arbitrary", "dep:ctor"]
 hazmat = []
 docs = []
 

--- a/tests/fuzz/fuzz/Cargo.lock
+++ b/tests/fuzz/fuzz/Cargo.lock
@@ -1141,6 +1141,7 @@ dependencies = [
  "arbitrary",
  "bytes-lit",
  "ctor",
+ "derive_arbitrary",
  "ed25519-dalek",
  "rand",
  "rustc_version",


### PR DESCRIPTION
### What
Limit the versions of arbitrary/derive_arbitrary to 1.3.x.

### Why
Arbitrary introduced changes into the 1.4.x releases that no longer compiles with the use of arbitrary in the soroban-sdk:
- https://github.com/rust-fuzz/arbitrary/issues/203
- https://github.com/rust-fuzz/arbitrary/issues/208