### PR TITLE
Allow unnecessary unit expression in ContractArgs functions

### DIFF
--- a/soroban-sdk-macros/src/derive_args.rs
+++ b/soroban-sdk-macros/src/derive_args.rs
@@ -79,6 +79,7 @@ pub fn derive_args_impl(name: &str, fns: &[syn_ext::Fn]) -> TokenStream {
 
             quote! {
                 #[inline(always)]
+                #[allow(clippy::unused_unit)]
                 pub fn #fn_ident<#fn_input_lifetime>(#(#fn_input_fn_args),*)
                     -> (#(#fn_input_types,)*)
                 {


### PR DESCRIPTION
### What

Allow the use of an unnecessary unit expression in ContractArgs functions.

### Why

Contract args functions are generated for each function in a contract. They accept a tuple or a unit, and return a tuple or a unit. They provide typing so that developers can build tuples for the args of a contract function with some type safety. They're intended for use in situations where a tuple of args need to be created and passed as a Vec<Val>, which happens on occassion.

For functions that accept no args, a unit expression is the value returned. The existence of the function and the unit expression disappear during build and are a zero cost construct in this case.

For the code generation it is much easier to construct a function that returns either a tuple or a unit, rather than a tuple or nothing.

It is also much easier to understand the intent of the functions if they show their return value than omit it in this specific case.

The warning has no negative impact in this case, especially because it occurs in generated code.

Close #1394

### Known limitations

[TODO or N/A]
