### PR TITLE
Fix build-fuzz and require it to pass on builds

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,7 +18,7 @@ jobs:
 
   complete:
     if: always()
-    needs: [fmt, check-git-rev-deps, semver-checks, build-and-test, docs, readme, migration-docs]
+    needs: [fmt, check-git-rev-deps, semver-checks, build-and-test, build-fuzz, docs, readme, migration-docs]
     runs-on: ubuntu-latest
     steps:
     - if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')

--- a/tests/fuzz/fuzz/Cargo.lock
+++ b/tests/fuzz/fuzz/Cargo.lock
@@ -1124,7 +1124,7 @@ dependencies = [
 
 [[package]]
 name = "soroban-ledger-snapshot"
-version = "22.0.0-rc.3.1"
+version = "22.0.0-rc.3.2"
 dependencies = [
  "serde",
  "serde_json",
@@ -1136,7 +1136,7 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk"
-version = "22.0.0-rc.3.1"
+version = "22.0.0-rc.3.2"
 dependencies = [
  "arbitrary",
  "bytes-lit",
@@ -1156,7 +1156,7 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk-macros"
-version = "22.0.0-rc.3.1"
+version = "22.0.0-rc.3.2"
 dependencies = [
  "crate-git-revision",
  "darling",
@@ -1174,7 +1174,7 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec"
-version = "22.0.0-rc.3.1"
+version = "22.0.0-rc.3.2"
 dependencies = [
  "base64 0.13.1",
  "stellar-xdr",
@@ -1184,7 +1184,7 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec-rust"
-version = "22.0.0-rc.3.1"
+version = "22.0.0-rc.3.2"
 dependencies = [
  "prettyplease",
  "proc-macro2",
@@ -1293,7 +1293,7 @@ dependencies = [
 
 [[package]]
 name = "test_fuzz"
-version = "22.0.0-rc.3.1"
+version = "22.0.0-rc.3.2"
 dependencies = [
  "soroban-sdk",
 ]


### PR DESCRIPTION
### What
Fix build-fuzz and require it to pass on builds.

### Why
It's easy to break, and when it breaks it doesn't block merges.