### PR TITLE
Fix bug in contractimpl code generation for impl traits using associated types

### DIFF
--- a/soroban-sdk-macros/Cargo.toml
+++ b/soroban-sdk-macros/Cargo.toml
@@ -23,7 +23,7 @@ soroban-spec = { workspace = true }
 soroban-spec-rust = { workspace = true }
 soroban-env-common = { workspace = true }
 stellar-xdr = { workspace = true, features = ["curr", "std"] }
-syn = {version="2.0",features=["full"]}
+syn = {version="2.0.77",features=["full"]}
 quote = "1.0"
 proc-macro2 = "1.0"
 itertools = "0.10.5"

--- a/soroban-sdk-macros/src/syn_ext.rs
+++ b/soroban-sdk-macros/src/syn_ext.rs
@@ -1,12 +1,11 @@
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote, ToTokens};
-use std::collections::HashMap;
 use syn::{
     parse::{Parse, ParseStream},
     punctuated::Punctuated,
     token::Comma,
     AngleBracketedGenericArguments, Attribute, GenericArgument, Path, PathArguments, PathSegment,
-    ReturnType, Token, TypePath,
+    QSelf, ReturnType, Token, TypePath,
 };
 use syn::{
     spanned::Spanned, token::And, Error, FnArg, Ident, ImplItem, ImplItemFn, ItemImpl, ItemTrait,
@@ -217,14 +216,10 @@ fn unpack_result(typ: &Type) -> Option<(Type, Type)> {
 fn flatten_associated_items_in_impl_fns(imp: &mut ItemImpl) {
     // TODO: Flatten associated consts used in functions.
     // Flatten associated types used in functions.
-    let associated_types = imp
-        .items
-        .iter()
-        .filter_map(|item| match item {
-            ImplItem::Type(i) => Some((i.ident.clone(), i.ty.clone())),
-            _ => None,
-        })
-        .collect::<HashMap<_, _>>();
+    let Some((_, trait_, _)) = &imp.trait_ else {
+        return;
+    };
+    let self_ty = &*imp.self_ty;
     let fn_input_types = imp
         .items
         .iter_mut()
@@ -237,19 +232,29 @@ fn flatten_associated_items_in_impl_fns(imp: &mut ItemImpl) {
         })
         .flatten();
     for t in fn_input_types {
-        if let Type::Path(TypePath { qself: None, path }) = t.as_mut() {
-            let segments = &path.segments;
-            if segments.len() == 2
-                && segments.first() == Some(&PathSegment::from(format_ident!("Self")))
-            {
-                if let Some(PathSegment {
-                    arguments: PathArguments::None,
-                    ident,
-                }) = segments.get(1)
-                {
-                    if let Some(resolved_ty) = associated_types.get(ident) {
-                        *t.as_mut() = resolved_ty.clone();
-                    }
+        let span = t.span();
+        if let Type::Path(TypePath {
+            qself: qself @ None,
+            path,
+        }) = t.as_mut()
+        {
+            let segments = path.segments.clone();
+            if segments.first() == Some(&PathSegment::from(format_ident!("Self"))) {
+                *qself = Some(QSelf {
+                    lt_token: Token![<](span),
+                    ty: Box::new(self_ty.clone()),
+                    // The index of the first path segment outside the <>.
+                    // For example, would be 2 for <Type as path::Trait>::AssociatedItem.
+                    position: trait_.segments.len(),
+                    as_token: Some(Token![as](span)),
+                    gt_token: Token![>](span),
+                });
+                *path = trait_.clone();
+                // Add the original path segments after the trait, skipping
+                // the first one which is the Self.
+                for segment in segments.into_iter().skip(1) {
+                    path.segments.push_punct(Token![::](span));
+                    path.segments.push_value(segment);
                 }
             }
         }

--- a/soroban-sdk-macros/src/syn_ext.rs
+++ b/soroban-sdk-macros/src/syn_ext.rs
@@ -1,6 +1,6 @@
-use std::collections::HashMap;
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote, ToTokens};
+use std::collections::HashMap;
 use syn::{
     parse::{Parse, ParseStream},
     punctuated::Punctuated,
@@ -134,44 +134,11 @@ impl Parse for HasFnsItem {
         _ = input.parse::<Token![pub]>();
         let lookahead = input.lookahead1();
         if lookahead.peek(Token![trait]) {
-            input.parse().map(HasFnsItem::Trait)
+            let t = input.parse()?;
+            Ok(HasFnsItem::Trait(t))
         } else if lookahead.peek(Token![impl]) {
-            let mut imp = input.parse::<ItemImpl>()?;
-            // Flatten associated types in functions.
-            let associated = imp
-                .items
-                .iter()
-                .filter_map(|item| match item {
-                    // TODO: Flatten consts to values as well.
-                    ImplItem::Type(i) => Some((i.ident.clone(), i.ty.clone())),
-                    _ => None,
-                })
-                .collect::<HashMap<_, _>>();
-            for item in &mut imp.items {
-                if let ImplItem::Fn(f) = item {
-                    for input in &mut f.sig.inputs {
-                        if let FnArg::Typed(t) = input {
-                            if let Type::Path(TypePath { qself: None, path }) = &mut *t.ty {
-                                let segments = &path.segments;
-                                if segments.len() == 2
-                                    && segments.first()
-                                        == Some(&PathSegment::from(format_ident!("Self")))
-                                {
-                                    if let Some(PathSegment {
-                                        arguments: PathArguments::None,
-                                        ident,
-                                    }) = segments.get(1)
-                                    {
-                                        if let Some(resolved_ty) = associated.get(ident) {
-                                            *t.ty = resolved_ty.clone();
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
+            let mut imp = input.parse()?;
+            flatten_associated_items_in_impl_fns(&mut imp);
             Ok(HasFnsItem::Impl(imp))
         } else {
             Err(lookahead.error())
@@ -244,5 +211,42 @@ fn unpack_result(typ: &Type) -> Option<(Type, Type)> {
             }
         }
         _ => None,
+    }
+}
+
+fn flatten_associated_items_in_impl_fns(imp: &mut ItemImpl) {
+    // TODO: Flatten associated consts used in functions.
+    // Flatten associated types used in functions.
+    let associated_types = imp
+        .items
+        .iter()
+        .filter_map(|item| match item {
+            ImplItem::Type(i) => Some((i.ident.clone(), i.ty.clone())),
+            _ => None,
+        })
+        .collect::<HashMap<_, _>>();
+    for item in &mut imp.items {
+        if let ImplItem::Fn(f) = item {
+            for input in &mut f.sig.inputs {
+                if let FnArg::Typed(t) = input {
+                    if let Type::Path(TypePath { qself: None, path }) = &mut *t.ty {
+                        let segments = &path.segments;
+                        if segments.len() == 2
+                            && segments.first() == Some(&PathSegment::from(format_ident!("Self")))
+                        {
+                            if let Some(PathSegment {
+                                arguments: PathArguments::None,
+                                ident,
+                            }) = segments.get(1)
+                            {
+                                if let Some(resolved_ty) = associated_types.get(ident) {
+                                    *t.ty = resolved_ty.clone();
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
     }
 }

--- a/soroban-sdk/src/tests.rs
+++ b/soroban-sdk/src/tests.rs
@@ -7,6 +7,7 @@ mod bytes_alloc_vec;
 mod bytes_buffer;
 mod contract_add_i32;
 mod contract_assert;
+mod contract_custom_account_impl;
 mod contract_docs;
 mod contract_duration;
 mod contract_fn;

--- a/soroban-sdk/src/tests/contract_custom_account_impl.rs
+++ b/soroban-sdk/src/tests/contract_custom_account_impl.rs
@@ -1,0 +1,48 @@
+use crate::{self as soroban_sdk, BytesN, IntoVal};
+use soroban_sdk::{
+    auth::{Context, CustomAccountInterface},
+    contract, contracterror, contractimpl,
+    crypto::Hash,
+    Env, Vec,
+};
+
+#[contract]
+pub struct Contract;
+
+#[contracterror]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub enum Error {
+    Fail = 1,
+}
+
+#[contractimpl]
+impl CustomAccountInterface for Contract {
+    type Signature = ();
+    type Error = Error;
+
+    /// Check that the signatures and auth contexts are valid.
+    fn __check_auth(
+        _env: Env,
+        _signature_payload: Hash<32>,
+        _signatures: Self::Signature,
+        _auth_contexts: Vec<Context>,
+    ) -> Result<(), Self::Error> {
+        Ok(())
+    }
+}
+
+#[test]
+fn test_functional() {
+    let e = Env::default();
+    let contract_id = e.register(Contract, ());
+    let payload = BytesN::from_array(&e, &[0; 32]);
+    let signature = ();
+    let auth_context = Vec::new(&e);
+    let result = e.try_invoke_contract_check_auth::<Error>(
+        &contract_id,
+        &payload,
+        signature.into_val(&e),
+        &auth_context,
+    );
+    assert_eq!(result, Ok(()));
+}

--- a/soroban-sdk/test_snapshots/tests/contract_custom_account_impl/test_functional.1.json
+++ b/soroban-sdk/test_snapshots/tests/contract_custom_account_impl/test_functional.1.json
@@ -1,0 +1,76 @@
+{
+  "generators": {
+    "address": 1,
+    "nonce": 0
+  },
+  "auth": [
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 22,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/tests/account/src/lib.rs
+++ b/tests/account/src/lib.rs
@@ -21,7 +21,7 @@ impl CustomAccountInterface for Contract {
     fn __check_auth(
         _env: Env,
         _signature_payload: Hash<32>,
-        _signatures: (),
+        _signatures: Self::Signature,
         _auth_contexts: Vec<Context>,
     ) -> Result<(), Error> {
         Ok(())

--- a/tests/fuzz/fuzz/Cargo.lock
+++ b/tests/fuzz/fuzz/Cargo.lock
@@ -210,7 +210,7 @@ dependencies = [
  "num-bigint",
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -302,7 +302,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a2785755761f3ddc1492979ce1e48d2c00d09311c39e4466429188f3dd6501"
 dependencies = [
  "quote",
- "syn 2.0.39",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -329,7 +329,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -353,7 +353,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.39",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -364,7 +364,7 @@ checksum = "29a358ff9f12ec09c3e61fef9b5a9902623a695a46a917b07f269bff1445611a"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -402,7 +402,7 @@ checksum = "67e77553c4162a157adbf834ebae5b415acbecbeafc7a74b0e886657506a7611"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -764,7 +764,7 @@ checksum = "cfb77679af88f8b125209d354a202862602672222e7f2313fdd6dc349bad4712"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -833,7 +833,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2b0377b720bde721213a46cda1289b2f34abf0a436907cad91578c20de0454d"
 dependencies = [
  "proc-macro2",
- "syn 2.0.39",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -847,18 +847,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.69"
+version = "1.0.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "134c189feb4956b20f6f547d2cf727d4c0fe06722b20a0eec87ed445a97f92da"
+checksum = "37d3544b3f2748c54e147655edb5025752e2303145b5aefb3c3ea2c78b973bb0"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.33"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
+checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
 dependencies = [
  "proc-macro2",
 ]
@@ -954,7 +954,7 @@ checksum = "d6c7207fbec9faa48073f3e3074cbe553af6ea512d7c21ba46e434e70ea9fbc1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -995,7 +995,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -1044,7 +1044,7 @@ dependencies = [
  "itertools",
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -1124,7 +1124,7 @@ dependencies = [
  "serde",
  "serde_json",
  "stellar-xdr",
- "syn 2.0.39",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -1174,7 +1174,7 @@ dependencies = [
  "soroban-spec",
  "soroban-spec-rust",
  "stellar-xdr",
- "syn 2.0.39",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -1197,7 +1197,7 @@ dependencies = [
  "sha2",
  "soroban-spec",
  "stellar-xdr",
- "syn 2.0.39",
+ "syn 2.0.90",
  "thiserror",
 ]
 
@@ -1288,9 +1288,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.39"
+version = "2.0.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23e78b90f2fcf45d3e842032ce32e3f2d1545ba6636271dcbf24fa306d87be7a"
+checksum = "919d3b74a5dd0ccd15aeb8f93e7006bd9e14c295087c9896a110f490752bcf31"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1330,7 +1330,7 @@ checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -1405,7 +1405,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.90",
  "wasm-bindgen-shared",
 ]
 
@@ -1427,7 +1427,7 @@ checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.90",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -1580,7 +1580,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -1600,5 +1600,5 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.90",
 ]


### PR DESCRIPTION
### What

Allow associated types in impl of traits, specifically the CustomAccountInterface.

### Why

The use of associated types was allowed until v22 of the SDK, where an assumption in the code generation `contractimpl` macro is causing ambiguous code to be generated when associated types are in use.

Close #1400