### PR TITLE
Change visibility levels of generated soroban-sdk testutils code in acordance with clippy

### DIFF
--- a/soroban-sdk-macros/src/lib.rs
+++ b/soroban-sdk-macros/src/lib.rs
@@ -154,15 +154,15 @@ pub fn contract(metadata: TokenStream, input: TokenStream) -> TokenStream {
                 use std::sync::Mutex;
                 use std::collections::BTreeMap;
 
-                pub(crate) type F = #crate_path::testutils::ContractFunctionF;
+                pub type F = #crate_path::testutils::ContractFunctionF;
 
                 static FUNCS: Mutex<BTreeMap<&'static str, &'static F>> = Mutex::new(BTreeMap::new());
 
-                pub(crate) fn register(name: &'static str, func: &'static F) {
+                pub fn register(name: &'static str, func: &'static F) {
                     FUNCS.lock().unwrap().insert(name, func);
                 }
 
-                pub(crate) fn call(name: &str, env: #crate_path::Env, args: &[#crate_path::Val]) -> Option<#crate_path::Val> {
+                pub fn call(name: &str, env: #crate_path::Env, args: &[#crate_path::Val]) -> Option<#crate_path::Val> {
                     let fopt: Option<&'static F> = FUNCS.lock().unwrap().get(name).map(|f| f.clone());
                     fopt.map(|f| f(env, args))
                 }


### PR DESCRIPTION
### What
With the feature `testutils` enabled in the soroban-sdk, the procedural macro `contract` generates a private module named `__{contract_name}_fn_set_registry` for each contract. Some members used to have the visibility level `pub(crate)` and are now changed to visibility level `pub`.

### Why
This previously triggered the clippy rule [redundant_pub_crate](https://rust-lang.github.io/rust-clippy/master/index.html#redundant_pub_crate). As the rule explains, defining `pub(crate)` inside a private module is unnecessary due to the module's visibility level, and can be potentially misleading.

### Known limitations
This change does not impact functionality in any way and removes the clippy warning for teams that have it enabled, so there are no known limitations.