### PR TITLE
Remove dead code

### DIFF
--- a/soroban-sdk/src/bytes.rs
+++ b/soroban-sdk/src/bytes.rs
@@ -791,8 +791,12 @@ impl IntoIterator for Bytes {
 pub struct BytesIter(Bytes);
 
 impl BytesIter {
-    fn into_bin(self) -> Bytes {
+    pub fn into_bytes(self) -> Bytes {
         self.0
+    }
+
+    pub fn to_bytes(&self) -> Bytes {
+        self.0.clone()
     }
 }
 

--- a/soroban-sdk/src/events.rs
+++ b/soroban-sdk/src/events.rs
@@ -5,9 +5,6 @@ use core::fmt::Debug;
 use crate::{contracttype, Bytes, Map};
 use crate::{env::internal, unwrap::UnwrapInfallible, Env, IntoVal, Val, Vec};
 
-// TODO: consolidate with host::events::TOPIC_BYTES_LENGTH_LIMIT
-const TOPIC_BYTES_LENGTH_LIMIT: u32 = 32;
-
 /// Events publishes events for the currently executing contract.
 ///
 /// ```

--- a/soroban-sdk/src/lib.rs
+++ b/soroban-sdk/src/lib.rs
@@ -51,7 +51,6 @@
 
 #![cfg_attr(target_family = "wasm", no_std)]
 #![cfg_attr(feature = "docs", feature(doc_cfg))]
-#![allow(dead_code)]
 // The SDK uses #[test] in doctests, and does some sneaky line hiding to have
 // the doctest execute the test inside a main function instead.
 #![allow(clippy::test_attr_in_doctest)]

--- a/soroban-sdk/src/map.rs
+++ b/soroban-sdk/src/map.rs
@@ -292,11 +292,6 @@ impl<K, V> Map<K, V> {
     }
 
     #[inline(always)]
-    pub(crate) fn as_object(&self) -> &MapObject {
-        &self.obj
-    }
-
-    #[inline(always)]
     pub(crate) fn to_object(&self) -> MapObject {
         self.obj
     }

--- a/soroban-sdk/src/vec.rs
+++ b/soroban-sdk/src/vec.rs
@@ -953,7 +953,11 @@ impl<T> VecTryIter<T> {
         }
     }
 
-    fn into_vec(self) -> Vec<T> {
+    pub fn into_vec(self) -> Vec<T> {
+        self.to_vec()
+    }
+
+    pub fn to_vec(&self) -> Vec<T> {
         self.vec.slice(self.start..self.end)
     }
 }


### PR DESCRIPTION
### What

Remove dead code by deleting code, and in some small instances making the code pub visible so that it is no longer flagged as dead.

### Why

Dead code had been allowed in the SDK since the early days, and we don't really need it to be. By allowing it a small amount of dead code has accumulated.

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #1410 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #1409 
<!-- GitButler Footer Boundary Bottom -->

