### PR TITLE
Preserve the recording auth settings when temporarily switching to recording auth.

### DIFF
--- a/soroban-sdk/src/env.rs
+++ b/soroban-sdk/src/env.rs
@@ -965,7 +965,9 @@ impl Env {
             .unwrap();
 
         let prev_auth_manager = self.env_impl.snapshot_auth_manager().unwrap();
-        self.env_impl.switch_to_recording_auth(true).unwrap();
+        self.env_impl
+            .switch_to_recording_auth_inherited_from_snapshot(&prev_auth_manager)
+            .unwrap();
         self.invoke_contract::<()>(
             &token_id,
             &soroban_sdk_macros::internal_symbol_short!("set_admin"),
@@ -1014,7 +1016,9 @@ impl Env {
         constructor_args: Vec<Val>,
     ) -> Address {
         let prev_auth_manager = self.env_impl.snapshot_auth_manager().unwrap();
-        self.env_impl.switch_to_recording_auth(true).unwrap();
+        self.env_impl
+            .switch_to_recording_auth_inherited_from_snapshot(&prev_auth_manager)
+            .unwrap();
         let args_vec: std::vec::Vec<xdr::ScVal> =
             constructor_args.iter().map(|v| v.into_val(self)).collect();
         let contract_id: Address = self


### PR DESCRIPTION
### What

Preserve the recording auth settings when temporarily switching to recording auth.

### Why

Previously this didn't matter as we've only switched for the contract instantiation, but now the contract instantiation may run custom logic due to constructors, so we need to preserve the settings (currently only disallowing non-root auth).


### Known limitations

N/A