### PR TITLE
Fix issue #1406: Update lib.rs to see the expected output when deploying the Increment contract

### DIFF
--- a/soroban-hello-world/contracts/hello-world/src/test.rs
+++ b/soroban-hello-world/contracts/hello-world/src/test.rs
@@ -1,0 +1,21 @@
+#![cfg(test)]
+
+use super::*;
+use soroban_sdk::{vec, Env, String};
+
+#[test]
+fn test() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, Contract);
+    let client = ContractClient::new(&env, &contract_id);
+
+    let words = client.hello(&String::from_str(&env, "Dev"));
+    assert_eq!(
+        words,
+        vec![
+            &env,
+            String::from_str(&env, "Hello"),
+            String::from_str(&env, "Dev"),
+        ]
+    );
+}

--- a/soroban-hello-world/contracts/increment/src/lib.rs
+++ b/soroban-hello-world/contracts/increment/src/lib.rs
@@ -1,0 +1,26 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, log, symbol_short, Env, Symbol};
+
+const COUNTER: Symbol = symbol_short!("COUNTER");
+
+#[contract]
+pub struct Contract;
+
+#[contractimpl]
+impl Contract {
+    pub fn increment(env: Env) -> u32 {
+        let mut count: u32 = env.storage().instance().get(&COUNTER).unwrap_or(0);
+
+        count += 1;
+
+        log!(&env, "count: {}", count);
+
+        env.storage().instance().set(&COUNTER, &count);
+
+        env.storage().instance().extend_tt1(100, 100);
+
+        count
+    }
+}
+
+mod test;


### PR DESCRIPTION
### What

Fix issue #1406: Update lib.rs to see the expected output when deploying the Increment contract, following this tutorial "https://developers.stellar.org/docs/build/smart-contracts/getting-started/deploy-increment-contract".

### Why

I encountered an error when I run this command ('id' and 'source' were appropriately replaced).
<img width="710" alt="Screenshot 2024-12-14 at 1 14 03" src="https://github.com/user-attachments/assets/e1e7ee8c-f872-411f-89f1-e05e3b2a319d" />
![image](https://github.com/user-attachments/assets/cbe0fa72-fbe4-4c7b-9f40-a61742324a72)

### Known limitations

[TODO or N/A]
