### PR TITLE
fix deprecation message

### DIFF
--- a/soroban-sdk/src/env.rs
+++ b/soroban-sdk/src/env.rs
@@ -1639,7 +1639,7 @@ impl Env {
     }
 
     /// Get the budget that tracks the resources consumed for the environment.
-    #[deprecated(note = "use cost_estimate().detailed_metering()")]
+    #[deprecated(note = "use cost_estimate().budget()")]
     pub fn budget(&self) -> Budget {
         Budget::new(self.env_impl.budget_cloned())
     }


### PR DESCRIPTION
### What

Update the deprecation message on the Env::budget function to direct the user to the correct new function to use.

### Why

It pointed to a non-existent function.
