### PR TITLE
fix: Cannot use an `Option` with a UDT as `T`

### DIFF
--- a/soroban-sdk/src/tests/contract_udt_option.rs
+++ b/soroban-sdk/src/tests/contract_udt_option.rs
@@ -3,9 +3,16 @@ use soroban_sdk::{contract, contractimpl, contracttype, Env};
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 #[contracttype]
+pub struct InnerUdt {
+    pub c: i32,
+}
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[contracttype]
 pub struct Udt {
     pub a: i32,
     pub b: Option<i32>,
+    pub c: Option<InnerUdt>,
 }
 
 #[contract]
@@ -23,8 +30,16 @@ fn test_functional() {
     let env = Env::default();
     let contract_id = env.register(Contract, ());
 
-    let a = Udt { a: 5, b: None };
-    let b = Udt { a: 10, b: Some(1) };
+    let a = Udt {
+        a: 5,
+        b: None,
+        c: None,
+    };
+    let b = Udt {
+        a: 10,
+        b: Some(1),
+        c: Some(InnerUdt { c: 2 }),
+    };
     let c = ContractClient::new(&env, &contract_id).add(&a, &b);
     assert_eq!(c, (a, b));
 }


### PR DESCRIPTION
With this change  you get the following compiler error:
```rust
error[E0277]: the trait bound `soroban_env_host::xdr::ScVal: TryFrom<&std::option::Option<InnerUdt>>` is not satisfied
  --> soroban-sdk/src/tests/contract_udt_option.rs:11:1
   |
11 | #[contracttype]
   | ^^^^^^^^^^^^^^^ the trait `From<InnerUdt>` is not implemented for `soroban_env_host::xdr::ScVal`, which is required by `&std::option::Option<InnerUdt>: TryInto<_>`
   |
   = help: the following other types implement trait `From<T>`:
             `&'a soroban_env_host::xdr::ScVal` implements `From<ScValObjRef<'a>>`
             `soroban_env_host::xdr::ScVal` implements `From<&()>`
             `soroban_env_host::xdr::ScVal` implements `From<&address::Address>`
             `soroban_env_host::xdr::ScVal` implements `From<&bool>`
             `soroban_env_host::xdr::ScVal` implements `From<&bytes::Bytes>`
             `soroban_env_host::xdr::ScVal` implements `From<&i128>`
             `soroban_env_host::xdr::ScVal` implements `From<&i32>`
             `soroban_env_host::xdr::ScVal` implements `From<&i64>`
           and 36 others
   = note: required for `InnerUdt` to implement `Into<soroban_env_host::xdr::ScVal>`
   = note: required for `soroban_env_host::xdr::ScVal` to implement `From<&std::option::Option<InnerUdt>>`
   = note: 1 redundant requirement hidden
   = note: required for `&std::option::Option<InnerUdt>` to implement `Into<soroban_env_host::xdr::ScVal>`
   = note: required for `soroban_env_host::xdr::ScVal` to implement `TryFrom<&std::option::Option<InnerUdt>>`
   = note: required for `&std::option::Option<InnerUdt>` to implement `TryInto<soroban_env_host::xdr::ScVal>`
   = note: this error originates in the attribute macro `contracttype` (in Nightly builds, run with -Z macro-backtrace for more info)

For more information about this error, try `rustc --explain E0277`.
```