### PR TITLE
Allow comparison of SDK types across Envs

### DIFF
--- a/soroban-sdk/src/address.rs
+++ b/soroban-sdk/src/address.rs
@@ -1,7 +1,7 @@
 use core::{cmp::Ordering, convert::Infallible, fmt::Debug};
 
 use super::{
-    env::internal::{AddressObject, Env as _, EnvBase as _},
+    env::internal::{AddressObject, Env as _},
     ConversionError, Env, String, TryFromVal, TryIntoVal, Val,
 };
 
@@ -80,7 +80,10 @@ impl PartialOrd for Address {
 
 impl Ord for Address {
     fn cmp(&self, other: &Self) -> Ordering {
-        self.env.check_same_env(&other.env).unwrap_infallible();
+        #[cfg(not(target_family = "wasm"))]
+        if !self.env.is_same_env(&other.env) {
+            return ScVal::from(self).cmp(&ScVal::from(other));
+        }
         let v = self
             .env
             .obj_cmp(self.obj.to_val(), other.obj.to_val())

--- a/soroban-sdk/src/bytes.rs
+++ b/soroban-sdk/src/bytes.rs
@@ -256,7 +256,10 @@ impl PartialOrd for Bytes {
 
 impl Ord for Bytes {
     fn cmp(&self, other: &Self) -> core::cmp::Ordering {
-        self.env.check_same_env(&other.env).unwrap_infallible();
+        #[cfg(not(target_family = "wasm"))]
+        if !self.env.is_same_env(&other.env) {
+            return ScVal::from(self).cmp(&ScVal::from(other));
+        }
         let v = self
             .env
             .obj_cmp(self.obj.to_val(), other.obj.to_val())

--- a/soroban-sdk/src/env.rs
+++ b/soroban-sdk/src/env.rs
@@ -449,6 +449,14 @@ impl Env {
     }
 }
 
+#[doc(hidden)]
+#[cfg(not(target_family = "wasm"))]
+impl Env {
+    pub(crate) fn is_same_env(&self, other: &Self) -> bool {
+        self.env_impl.check_same_env(&other.env_impl).is_ok()
+    }
+}
+
 #[cfg(any(test, feature = "testutils"))]
 use crate::testutils::cost_estimate::CostEstimate;
 #[cfg(any(test, feature = "testutils"))]

--- a/soroban-sdk/src/map.rs
+++ b/soroban-sdk/src/map.rs
@@ -8,7 +8,7 @@ use crate::{
 };
 
 use super::{
-    env::internal::{Env as _, EnvBase as _, MapObject, U32Val},
+    env::internal::{Env as _, MapObject, U32Val},
     ConversionError, Env, IntoVal, TryFromVal, TryIntoVal, Val, Vec,
 };
 
@@ -139,7 +139,10 @@ where
     V: IntoVal<Env, Val> + TryFromVal<Env, Val>,
 {
     fn cmp(&self, other: &Self) -> core::cmp::Ordering {
-        self.env.check_same_env(&other.env).unwrap_infallible();
+        #[cfg(not(target_family = "wasm"))]
+        if !self.env.is_same_env(&other.env) {
+            return ScVal::from(self).cmp(&ScVal::from(other));
+        }
         let v = self
             .env
             .obj_cmp(self.obj.to_val(), other.obj.to_val())

--- a/soroban-sdk/src/num.rs
+++ b/soroban-sdk/src/num.rs
@@ -46,7 +46,10 @@ macro_rules! impl_num_wrapping_val_type {
                     // The object-to-small number comparisons are handled by `obj_cmp`,
                     // so it's safe to handle all the other cases using it.
                     _ => {
-                        self.env.check_same_env(&other.env).unwrap_infallible();
+                        #[cfg(not(target_family = "wasm"))]
+                        if !self.env.is_same_env(&other.env) {
+                            return ScVal::from(self).cmp(&ScVal::from(other));
+                        }
                         let v = self.env.obj_cmp(self_raw, other_raw).unwrap_infallible();
                         v.cmp(&0)
                     }

--- a/soroban-sdk/src/string.rs
+++ b/soroban-sdk/src/string.rs
@@ -65,7 +65,10 @@ impl PartialOrd for String {
 
 impl Ord for String {
     fn cmp(&self, other: &Self) -> core::cmp::Ordering {
-        self.env.check_same_env(&other.env).unwrap_infallible();
+        #[cfg(not(target_family = "wasm"))]
+        if !self.env.is_same_env(&other.env) {
+            return ScVal::from(self).cmp(&ScVal::from(other));
+        }
         let v = self
             .env
             .obj_cmp(self.obj.to_val(), other.obj.to_val())

--- a/soroban-sdk/src/tests.rs
+++ b/soroban-sdk/src/tests.rs
@@ -4,6 +4,7 @@ mod address;
 mod auth;
 mod bytes_alloc_vec;
 mod bytes_buffer;
+mod cmp_across_env_in_tests;
 mod contract_add_i32;
 mod contract_assert;
 mod contract_custom_account_impl;

--- a/soroban-sdk/src/tests/cmp_across_env_in_tests.rs
+++ b/soroban-sdk/src/tests/cmp_across_env_in_tests.rs
@@ -1,0 +1,135 @@
+use crate::{self as soroban_sdk};
+use soroban_sdk::{vec, Address, Bytes, BytesN, Env, Map, String, Vec};
+
+#[test]
+fn test_address() {
+    let e1 = Env::default();
+    let e2 = Env::default();
+
+    // Two addresses with the same value should be comparable and equal even though they
+    // belong to different environments.
+    let a1 = Address::from_str(
+        &e1,
+        "CA3D5KRYM6CB7OWQ6TWYRR3Z4T7GNZLKERYNZGGA5SOAOPIFY6YQGAXE",
+    );
+    let a2 = Address::from_str(
+        &e2,
+        "CA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUWDA",
+    );
+    assert_ne!(a1, a2);
+
+    // Two addresses with different values should be comparable and not equal even though they
+    // belong to different environments.
+    let a1 = Address::from_str(
+        &e1,
+        "CA3D5KRYM6CB7OWQ6TWYRR3Z4T7GNZLKERYNZGGA5SOAOPIFY6YQGAXE",
+    );
+    let a2 = Address::from_str(
+        &e2,
+        "CA3D5KRYM6CB7OWQ6TWYRR3Z4T7GNZLKERYNZGGA5SOAOPIFY6YQGAXE",
+    );
+    assert_eq!(a1, a2);
+}
+
+#[test]
+fn test_string() {
+    let e1 = Env::default();
+    let e2 = Env::default();
+
+    // Two strings with different values should be comparable and not equal even though they
+    // belong to different environments.
+    let s1 = String::from_str(&e1, "hello");
+    let s2 = String::from_str(&e2, "world");
+    assert_ne!(s1, s2);
+
+    // Two strings with the same value should be comparable and equal even though they
+    // belong to different environments.
+    let s1 = String::from_str(&e1, "hello");
+    let s2 = String::from_str(&e2, "hello");
+    assert_eq!(s1, s2);
+}
+
+#[test]
+fn test_bytes() {
+    let e1 = Env::default();
+    let e2 = Env::default();
+
+    // Two bytes with different values should be comparable and not equal even though they
+    // belong to different environments.
+    let b1 = Bytes::from_slice(&e1, &[1, 2, 3]);
+    let b2 = Bytes::from_slice(&e2, &[4, 5, 6]);
+    assert_ne!(b1, b2);
+
+    // Two bytes with the same value should be comparable and equal even though they
+    // belong to different environments.
+    let b1 = Bytes::from_slice(&e1, &[1, 2, 3]);
+    let b2 = Bytes::from_slice(&e2, &[1, 2, 3]);
+    assert_eq!(b1, b2);
+}
+
+#[test]
+fn test_bytesn() {
+    let e1 = Env::default();
+    let e2 = Env::default();
+
+    // Two bytesn with different values should be comparable and not equal even though they
+    // belong to different environments.
+    let b1 = BytesN::from_array(&e1, &[1, 2, 3]);
+    let b2 = BytesN::from_array(&e2, &[4, 5, 6]);
+    assert_ne!(b1, b2);
+
+    // Two bytesn with the same value should be comparable and equal even though they
+    // belong to different environments.
+    let b1 = BytesN::from_array(&e1, &[1, 2, 3]);
+    let b2 = BytesN::from_array(&e2, &[1, 2, 3]);
+    assert_eq!(b1, b2);
+}
+
+#[test]
+fn test_vec() {
+    let e1 = Env::default();
+    let e2 = Env::default();
+
+    // Two vecs with different values should be comparable and not equal even though they
+    // belong to different environments.
+    let v1: Vec<i32> = vec![&e1, 1, 2, 3];
+    let v2: Vec<i32> = vec![&e2, 4, 5, 6];
+    assert_ne!(v1, v2);
+
+    // Two vecs with the same value should be comparable and equal even though they
+    // belong to different environments.
+    let v1: Vec<i32> = vec![&e1, 1, 2, 3];
+    let v2: Vec<i32> = vec![&e2, 1, 2, 3];
+    assert_eq!(v1, v2);
+}
+
+#[test]
+fn test_map() {
+    let e1 = Env::default();
+    let e2 = Env::default();
+
+    // Two maps with different values should be comparable and not equal even though they
+    // belong to different environments.
+    let mut m1: Map<String, i32> = Map::new(&e1);
+    m1.set(String::from_str(&e1, "a"), 1);
+    m1.set(String::from_str(&e1, "b"), 2);
+
+    let mut m2: Map<String, i32> = Map::new(&e2);
+    m2.set(String::from_str(&e2, "c"), 3);
+    m2.set(String::from_str(&e2, "d"), 4);
+
+    assert_ne!(m1, m2);
+
+    // Two maps with the same value should be comparable and equal even though they
+    // belong to different environments.
+    let mut m1: Map<String, i32> = Map::new(&e1);
+    m1.set(String::from_str(&e1, "a"), 1);
+    m1.set(String::from_str(&e1, "b"), 2);
+
+    let mut m2: Map<String, i32> = Map::new(&e2);
+    m2.set(String::from_str(&e2, "a"), 1);
+    m2.set(String::from_str(&e2, "b"), 2);
+
+    assert_eq!(m1, m2);
+}
+

--- a/soroban-sdk/src/tests/cmp_across_env_in_tests.rs
+++ b/soroban-sdk/src/tests/cmp_across_env_in_tests.rs
@@ -132,4 +132,3 @@ fn test_map() {
 
     assert_eq!(m1, m2);
 }
-

--- a/soroban-sdk/src/vec.rs
+++ b/soroban-sdk/src/vec.rs
@@ -126,7 +126,10 @@ where
     T: IntoVal<Env, Val> + TryFromVal<Env, Val>,
 {
     fn cmp(&self, other: &Self) -> core::cmp::Ordering {
-        self.env.check_same_env(&other.env).unwrap_infallible();
+        #[cfg(not(target_family = "wasm"))]
+        if !self.env.is_same_env(&other.env) {
+            return ScVal::from(self).cmp(&ScVal::from(other));
+        }
         let v = self
             .env
             .obj_cmp(self.obj.to_val(), other.obj.to_val())


### PR DESCRIPTION
### What
Updates every type that is a handle to a type stored in the host so that it is comparable with itself via a conversion to an `ScVal` even when the values are across different `Env`s.

### Why
To make it much easier to perform differential testing.

Today it is not possible to compare values of an SDK type, when the values are a handles to values stored on different hosts. This is because the comparison of SDK types is supported by calling through to the host. It makes sense for comparison to work this way because the value is on the host side.

However when writing tests it is helpful to be able to compare SDK types even if they belong to different Envs. The main use case is differential tests, where two sequences of invokes should be comparable.

In tests the efficiency of the comparison is not important, so converting to ScVal is an okay way to fall back to do the comparison. In some ways this is a bit of a hack, but it's the least disruptive way of supporting the comparison, and avoids introducing a ton of code to the Env that would otherwise be out of place.

Talking to @graydon we have quite solid testing around the consistency of ScVal and Val values, so converting the Vals to ScVal to do the comparison is safe.

Close #1360 