### PR TITLE
Fix BytesN to ScVal conversion in testutils

### DIFF
--- a/soroban-sdk/src/bytes.rs
+++ b/soroban-sdk/src/bytes.rs
@@ -1076,18 +1076,21 @@ impl<const N: usize> From<&BytesN<N>> for Bytes {
 }
 
 #[cfg(not(target_family = "wasm"))]
-impl<const N: usize> TryFrom<&BytesN<N>> for ScVal {
-    type Error = ConversionError;
-    fn try_from(v: &BytesN<N>) -> Result<Self, ConversionError> {
-        Ok(ScVal::try_from_val(&v.0.env, &v.0.obj.to_val())?)
+impl<const N: usize> From<&BytesN<N>> for ScVal {
+    fn from(v: &BytesN<N>) -> Self {
+        // This conversion occurs only in test utilities, and theoretically all
+        // values should convert to an ScVal because the Env won't let the host
+        // type to exist otherwise, unwrapping. Even if there are edge cases
+        // that don't, this is a trade off for a better test developer
+        // experience.
+        ScVal::try_from_val(&v.0.env, &v.0.obj.to_val()).unwrap()
     }
 }
 
 #[cfg(not(target_family = "wasm"))]
-impl<const N: usize> TryFrom<BytesN<N>> for ScVal {
-    type Error = ConversionError;
-    fn try_from(v: BytesN<N>) -> Result<Self, ConversionError> {
-        (&v).try_into()
+impl<const N: usize> From<BytesN<N>> for ScVal {
+    fn from(v: BytesN<N>) -> Self {
+        (&v).into()
     }
 }
 


### PR DESCRIPTION
### What
Change BytesN to ScVal conversion from TryFrom to From in test utilities.

### Why
Unwrapping is safe because values in test environment must be valid ScVal. Even if this was wrong, it's a good tradeoff that improves the developer experience. The Bytes->ScVal and String->ScVal conversions already use this pattern and it seems BytesN wasn't updated at the same time to use that pattern.