### PR TITLE
Remove must_use attribute from ed25519 error source

### DIFF
--- a/soroban-sdk/src/testutils/sign.rs
+++ b/soroban-sdk/src/testutils/sign.rs
@@ -24,7 +24,6 @@ pub mod ed25519 {
     }
 
     impl<E: std::error::Error> std::error::Error for Error<E> {
-        #[must_use]
         fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
             match self {
                 Self::XdrError(e) => e.source(),


### PR DESCRIPTION
### What
Remove must_use attribute from ed25519 error source implementation.

### Why
The must_use attribute has no effect when applied to a trait method. Clippy started failing on the use here yesterday with the latest nightly:
- https://github.com/stellar/rs-soroban-sdk/actions/runs/13515162660/job/37762422196?pr=1442