### PR TITLE
Add derive traits for TokenMetadata struct

### DIFF
--- a/soroban-token-sdk/src/metadata.rs
+++ b/soroban-token-sdk/src/metadata.rs
@@ -2,7 +2,7 @@ use soroban_sdk::{contracttype, symbol_short, unwrap::UnwrapOptimized, Env, Stri
 
 const METADATA_KEY: Symbol = symbol_short!("METADATA");
 
-#[derive(Clone)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
 #[contracttype]
 pub struct TokenMetadata {
     pub decimal: u32,


### PR DESCRIPTION
### What
Add Debug, PartialEq, Eq, PartialOrd, and Ord trait implementations to TokenMetadata struct.

### Why
Support comparison operations and debug formatting for token metadata. The type is simple, and it's reasonable to include these impls.

Close #1444