### PR TITLE
Muxed address support sketch for Soroban SDK, `transfer_muxed` edition

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -158,9 +158,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
+checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "base16ct"
@@ -188,24 +188,24 @@ checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
 name = "bit-set"
-version = "0.5.3"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
 dependencies = [
  "bit-vec",
 ]
 
 [[package]]
 name = "bit-vec"
-version = "0.6.3"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
-version = "2.6.0"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
+checksum = "8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36"
 
 [[package]]
 name = "block-buffer"
@@ -218,9 +218,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.16.0"
+version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
+checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
 
 [[package]]
 name = "byteorder"
@@ -237,14 +237,14 @@ dependencies = [
  "num-bigint",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.98",
 ]
 
 [[package]]
 name = "cc"
-version = "1.1.21"
+version = "1.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07b1695e2c7e8fc85310cde85aeaab7e3097f593c91d209d3f9df76c928100f0"
+checksum = "c736e259eea577f443d5c86c304f9f4ae0295c43f3ba05c21f1d66b5f06001af"
 dependencies = [
  "jobserver",
  "libc",
@@ -259,9 +259,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.38"
+version = "0.4.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
+checksum = "7e36cc9d416881d2e24f9a963be5fb1cd90966419ac844274161d10488b3e825"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
@@ -284,9 +284,9 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.14"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "608697df725056feaccfa42cffdaeeec3fccc4ffc38358ecd19b243e716a78e0"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
 ]
@@ -331,7 +331,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a2785755761f3ddc1492979ce1e48d2c00d09311c39e4466429188f3dd6501"
 dependencies = [
  "quote",
- "syn 2.0.77",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -358,7 +358,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -382,7 +382,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.77",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -393,14 +393,14 @@ checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.98",
 ]
 
 [[package]]
 name = "data-encoding"
-version = "2.6.0"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8566979429cf69b49a5c740c60791108e86440e8be149bbea4fe54d2c32d6e2"
+checksum = "575f75dfd25738df5b91b8e43e14d44bda14637a58fae779fd2b064f8bf3e010"
 
 [[package]]
 name = "der"
@@ -441,7 +441,7 @@ checksum = "67e77553c4162a157adbf834ebae5b415acbecbeafc7a74b0e886657506a7611"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -514,9 +514,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.13.0"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
+checksum = "b7914353092ddf589ad78f25c5c1c21b7f80b0ff8621e7c814c3485b5306da9d"
 
 [[package]]
 name = "elliptic-curve"
@@ -538,18 +538,18 @@ dependencies = [
 
 [[package]]
 name = "equivalent"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
+checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -566,9 +566,9 @@ checksum = "b90ca2580b73ab6a1f724b76ca11ab632df820fd6040c336200d2c1df7b3c82c"
 
 [[package]]
 name = "expect-test"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e0be0a561335815e06dab7c62e50353134c796e7a6155402a64bcff66b6a5e0"
+checksum = "63af43ff4431e848fb47472a920f14fa71c24de13255a5692e93d4e90302acb0"
 dependencies = [
  "dissimilar",
  "once_cell",
@@ -576,9 +576,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.1.1"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "ff"
@@ -622,8 +622,20 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a49c392881ce6d5c3b8cb70f98717b7c07aabbdff06687b9030dbfbe2725f8"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.13.3+wasi-0.2.2",
+ "windows-targets",
 ]
 
 [[package]]
@@ -654,9 +666,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.14.5"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
 
 [[package]]
 name = "hex"
@@ -724,12 +736,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.5.0"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68b900aa2f7301e21c36462b170ee99994de34dff39a4a6a528e80e7376d07e5"
+checksum = "8c9c992b02b5b4c94ea26e32fe5bccb7aa7d9f390ab5c1221ff895bc7ea8b652"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.5",
+ "hashbrown 0.15.2",
  "serde",
 ]
 
@@ -750,9 +762,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.11"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
+checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
 
 [[package]]
 name = "jobserver"
@@ -765,18 +777,19 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.70"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1868808506b929d7b0cfa8f75951347aa71bb21144b7791bae35d9bccfcfe37a"
+checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
 dependencies = [
+ "once_cell",
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "k256"
-version = "0.13.3"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "956ff9b67e26e1a6a866cb758f12c6f8746208489e3e4a4b5580802f2f0a587b"
+checksum = "f6e3919bbaa2945715f0bb6d3934a173d1e9a59ac23767fbaaef277265a7411b"
 dependencies = [
  "cfg-if",
  "ecdsa",
@@ -801,38 +814,37 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.158"
+version = "0.2.170"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439"
+checksum = "875b3680cb2f8f71bdcf9a30f38d48282f5d3c95cbf9b3fa57269bb5d5c06828"
 
 [[package]]
 name = "libfuzzer-sys"
-version = "0.4.7"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a96cfd5557eb82f2b83fed4955246c988d331975a002961b07c81584d107e7f7"
+checksum = "cf78f52d400cf2d84a3a973a78a592b4adc535739e0a5597a0da6f0c357adc75"
 dependencies = [
  "arbitrary",
  "cc",
- "once_cell",
 ]
 
 [[package]]
 name = "libm"
-version = "0.2.8"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
+checksum = "8355be11b20d696c8f18f6cc018c4e372165b1fa8126cef092399c9951984ffa"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.14"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "log"
-version = "0.4.22"
+version = "0.4.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
+checksum = "30bde2b3dc3671ae49d8e2e9f044c7c005836e7a023ee57cffa25ab82764bb9e"
 
 [[package]]
 name = "memchr"
@@ -864,7 +876,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -883,14 +895,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
- "libm",
 ]
 
 [[package]]
 name = "once_cell"
-version = "1.19.0"
+version = "1.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+checksum = "945462a4b81e43c4e3ba96bd7b49d834c6f61198356aa858733bc4acf3cbe62e"
 
 [[package]]
 name = "p256"
@@ -947,12 +958,12 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.2.22"
+version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479cf940fbbb3426c32c5d5176f62ad57549a0bb84773423ba8be9d089f5faba"
+checksum = "6924ced06e1f7dfe3fa48d57b9f74f55d8915f5036121bef647ef4b204895fac"
 dependencies = [
  "proc-macro2",
- "syn 2.0.77",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -966,18 +977,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.86"
+version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
+checksum = "60946a68e5f9d28b0dc1c21bb8a97ee7d018a8b322fa57838ba31cc878e22d99"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "proptest"
-version = "1.5.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4c2511913b88df1637da85cc8d96ec8e43a3f8bb8ccb71ee1ac240d6f3df58d"
+checksum = "14cae93065090804185d3b75f0bf93b8eeda30c7a9b4a33d3bdb3988d6229e50"
 dependencies = [
  "bit-set",
  "bit-vec",
@@ -1011,9 +1022,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
-version = "1.0.37"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
+checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
 dependencies = [
  "proc-macro2",
 ]
@@ -1045,7 +1056,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
 ]
 
 [[package]]
@@ -1059,9 +1070,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "rfc6979"
@@ -1084,16 +1095,22 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.37"
+version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8acb788b847c24f28525660c4d7758620a7210875711f79e7f663cc152726811"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
  "bitflags",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c45b9784283f1b2e7fb61b42047c2fd678ef0960d4f6f1eba131594cc369d4"
 
 [[package]]
 name = "rusty-fork"
@@ -1109,9 +1126,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.18"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
+checksum = "6ea1a2d0a644769cc99faa24c3ad26b379b786fe7c36fd3c546254801650e6dd"
 
 [[package]]
 name = "sec1"
@@ -1128,35 +1145,35 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.23"
+version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
+checksum = "f79dfe2d285b0488816f30e700a7438c5a73d816b5b7d3ac72fbc48b0d185e03"
 
 [[package]]
 name = "serde"
-version = "1.0.210"
+version = "1.0.218"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8e3592472072e6e22e0a54d5904d9febf8508f65fb8552499a1abc7d1078c3a"
+checksum = "e8dfc9d19bdbf6d17e22319da49161d5d0108e4188e8b680aef6299eed22df60"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.210"
+version = "1.0.218"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
+checksum = "f09503e191f4e797cb8aac08e9a4a4695c5edf6a2e70e376d961ddd5c969f82b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.98",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.128"
+version = "1.0.139"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ff5456707a1de34e7e37f2a6fd3d3f808c318259cbd01ab6377795054b483d8"
+checksum = "44f86c3acccc9c65b153fe1b85a3be07fe5515274ec9f0653b4a0875731c72a6"
 dependencies = [
  "itoa",
  "memchr",
@@ -1166,15 +1183,15 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.9.0"
+version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cecfa94848272156ea67b2b1a53f20fc7bc638c4a46d2f8abde08f05f4b857"
+checksum = "d6b6f7f2fcb69f747921f79f3926bd1e203fce4fef62c268dd3abfb6d86029aa"
 dependencies = [
  "base64 0.22.1",
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.5.0",
+ "indexmap 2.7.1",
  "serde",
  "serde_derive",
  "serde_json",
@@ -1184,14 +1201,14 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.9.0"
+version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8fee4991ef4f274617a51ad4af30519438dacb2f56ac773b08a1922ff743350"
+checksum = "8d00caa5193a3c8362ac2b73be6b9e768aa5a4b2f721d8f4b339600c3cb51f8e"
 dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -1233,27 +1250,23 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.13.2"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+checksum = "7fcf8323ef1faaee30a44a340193b1ac6814fd9b7b4e88e9d4519a3e4abe1cfd"
 
 [[package]]
 name = "soroban-builtin-sdk-macros"
-version = "22.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf2e42bf80fcdefb3aae6ff3c7101a62cf942e95320ed5b518a1705bc11c6b2f"
+version = "23.0.0"
 dependencies = [
  "itertools",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.98",
 ]
 
 [[package]]
 name = "soroban-env-common"
-version = "22.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "027cd856171bfd6ad2c0ffb3b7dfe55ad7080fb3050c36ad20970f80da634472"
+version = "23.0.0"
 dependencies = [
  "arbitrary",
  "crate-git-revision",
@@ -1270,9 +1283,7 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-guest"
-version = "22.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a07dda1ae5220d975979b19ad4fd56bc86ec7ec1b4b25bc1c5d403f934e592e"
+version = "23.0.0"
 dependencies = [
  "soroban-env-common",
  "static_assertions",
@@ -1280,9 +1291,7 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-host"
-version = "22.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66e8b03a4191d485eab03f066336112b2a50541a7553179553dc838b986b94dd"
+version = "23.0.0"
 dependencies = [
  "ark-bls12-381",
  "ark-ec",
@@ -1293,7 +1302,7 @@ dependencies = [
  "ed25519-dalek",
  "elliptic-curve",
  "generic-array",
- "getrandom",
+ "getrandom 0.2.15",
  "hex-literal",
  "hmac",
  "k256",
@@ -1316,9 +1325,7 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-macros"
-version = "22.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00eff744764ade3bc480e4909e3a581a240091f3d262acdce80b41f7069b2bd9"
+version = "23.0.0"
 dependencies = [
  "itertools",
  "proc-macro2",
@@ -1326,7 +1333,7 @@ dependencies = [
  "serde",
  "serde_json",
  "stellar-xdr",
- "syn 2.0.77",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -1385,7 +1392,7 @@ dependencies = [
  "soroban-spec",
  "soroban-spec-rust",
  "stellar-xdr",
- "syn 2.0.77",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -1410,7 +1417,7 @@ dependencies = [
  "sha2",
  "soroban-spec",
  "stellar-xdr",
- "syn 2.0.77",
+ "syn 2.0.98",
  "thiserror",
 ]
 
@@ -1424,8 +1431,7 @@ dependencies = [
 [[package]]
 name = "soroban-wasmi"
 version = "0.31.1-soroban.20.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "710403de32d0e0c35375518cb995d4fc056d0d48966f2e56ea471b8cb8fc9719"
+source = "git+https://github.com/stellar/wasmi?rev=0ed3f3dee30dc41ebe21972399e0a73a41944aa0#0ed3f3dee30dc41ebe21972399e0a73a41944aa0"
 dependencies = [
  "smallvec",
  "spin",
@@ -1470,8 +1476,6 @@ dependencies = [
 [[package]]
 name = "stellar-xdr"
 version = "22.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ce69db907e64d1e70a3dce8d4824655d154749426a6132b25395c49136013e4"
 dependencies = [
  "arbitrary",
  "base64 0.13.1",
@@ -1508,9 +1512,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.77"
+version = "2.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f35bcdf61fd8e7be6caf75f429fdca8beb3ed76584befb503b1569faee373ed"
+checksum = "36147f1a48ae0ec2b5b3bc5b537d267457555a10dc06f3dbc8cb11ba3006d3b1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1519,15 +1523,16 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.12.0"
+version = "3.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04cbcdd0c794ebb0d4cf35e88edd2f7d2c4c3e9a5a6dab322839b321c6a87a64"
+checksum = "22e5a0acb1f3f55f65cc4a866c361b2fb2a0ff6366785ae6fbb5f85df07ba230"
 dependencies = [
  "cfg-if",
  "fastrand",
+ "getrandom 0.3.1",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1680,29 +1685,29 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.63"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0342370b38b6a11b6cc11d6a805569958d54cfa061a29969c3b5ce2ea405724"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.63"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.98",
 ]
 
 [[package]]
 name = "time"
-version = "0.3.36"
+version = "0.3.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
+checksum = "35e7868883861bd0e56d9ac6efcaaca0d6d5d82a2a7ec8209ff492c07cf37b21"
 dependencies = [
  "deranged",
  "itoa",
@@ -1721,9 +1726,9 @@ checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "time-macros"
-version = "0.2.18"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
+checksum = "2834e6017e3e5e4b9834939793b282bc03b37a3336245fa820e35e233e2a85de"
 dependencies = [
  "num-conv",
  "time-core",
@@ -1731,9 +1736,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.17.0"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
 
 [[package]]
 name = "unarray"
@@ -1743,9 +1748,9 @@ checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.13"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
+checksum = "00e2473a93778eb0bad35909dff6a10d28e63f792f16ed15e404fca9d5eeedbe"
 
 [[package]]
 name = "version_check"
@@ -1755,9 +1760,9 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wait-timeout"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
 dependencies = [
  "libc",
 ]
@@ -1769,36 +1774,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
-name = "wasm-bindgen"
-version = "0.2.93"
+name = "wasi"
+version = "0.13.3+wasi-0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a82edfc16a6c469f5f44dc7b571814045d60404b55a0ee849f9bcfa2e63dd9b5"
+checksum = "26816d2e1a4a36a2940b96c5296ce403917633dff8f3440e9b236ed6f6bacad2"
+dependencies = [
+ "wit-bindgen-rt",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
 dependencies = [
  "cfg-if",
  "once_cell",
+ "rustversion",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.93"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9de396da306523044d3302746f1208fa71d7532227f15e347e2d93e4145dd77b"
+checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
 dependencies = [
  "bumpalo",
  "log",
- "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.98",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.93"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "585c4c91a46b072c92e908d99cb1dcdf95c5218eeb6f3bf1efa991ee7a68cccf"
+checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1806,34 +1820,35 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.93"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836"
+checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.98",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.93"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c62a0a307cb4a311d3a07867860911ca130c3494e8c2719593806c08bc5d0484"
+checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+dependencies = [
+ "unicode-ident",
+]
 
 [[package]]
 name = "wasmi_arena"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "104a7f73be44570cac297b3035d76b169d6599637631cf37a1703326a0727073"
+version = "0.4.0"
+source = "git+https://github.com/stellar/wasmi?rev=0ed3f3dee30dc41ebe21972399e0a73a41944aa0#0ed3f3dee30dc41ebe21972399e0a73a41944aa0"
 
 [[package]]
 name = "wasmi_core"
 version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcf1a7db34bff95b85c261002720c00c3a6168256dcb93041d3fa2054d19856a"
+source = "git+https://github.com/stellar/wasmi?rev=0ed3f3dee30dc41ebe21972399e0a73a41944aa0#0ed3f3dee30dc41ebe21972399e0a73a41944aa0"
 dependencies = [
  "downcast-rs",
  "libm",
@@ -1847,7 +1862,7 @@ version = "0.116.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a58e28b80dd8340cb07b8242ae654756161f6fc8d0038123d679b7b99964fa50"
 dependencies = [
- "indexmap 2.5.0",
+ "indexmap 2.7.1",
  "semver",
 ]
 
@@ -1865,15 +1880,6 @@ name = "windows-core"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
-dependencies = [
- "windows-targets",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
  "windows-targets",
 ]
@@ -1952,6 +1958,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
+name = "wit-bindgen-rt"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3268f3d866458b787f390cf61f4bbb563b922d091359f9608842999eaee3943c"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "yansi"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1975,7 +1990,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -1995,5 +2010,5 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.98",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,17 +24,17 @@ soroban-ledger-snapshot = { version = "22.0.7", path = "soroban-ledger-snapshot"
 soroban-token-sdk = { version = "22.0.7", path = "soroban-token-sdk" }
 
 [workspace.dependencies.soroban-env-common]
-version = "=22.1.3"
+version = "=23.0.0"
 #git = "https://github.com/stellar/rs-soroban-env"
 #rev = "bd0c80a1fe171e75f8d745f17975a73927d44ecd"
 
 [workspace.dependencies.soroban-env-guest]
-version = "=22.1.3"
+version = "=23.0.0"
 #git = "https://github.com/stellar/rs-soroban-env"
 #rev = "bd0c80a1fe171e75f8d745f17975a73927d44ecd"
 
 [workspace.dependencies.soroban-env-host]
-version = "=22.1.3"
+version = "=23.0.0"
 #git = "https://github.com/stellar/rs-soroban-env"
 #rev = "bd0c80a1fe171e75f8d745f17975a73927d44ecd"
 
@@ -44,16 +44,19 @@ version = "=0.0.9"
 [workspace.dependencies.stellar-xdr]
 version = "=22.1.0"
 default-features = false
-features = ["curr"]
+features = ["next"]
 #git = "https://github.com/stellar/rs-stellar-xdr"
 #rev = "67be5955a15f1d3a4df83fe86e6ae107f687141b"
 
-#[patch.crates-io]
-#soroban-env-common = { path = "../rs-soroban-env/soroban-env-common" }
-#soroban-env-guest = { path = "../rs-soroban-env/soroban-env-guest" }
-#soroban-env-host = { path = "../rs-soroban-env/soroban-env-host" }
-#[patch."https://github.com/stellar/rs-stellar-xdr"]
-#stellar-xdr = { path = "../rs-stellar-xdr/" }
+[patch.crates-io]
+#[patch."https://github.com/stellar/rs-soroban-env"]
+soroban-env-common = { path = "../rs-soroban-env2/soroban-env-common" }
+soroban-env-guest = { path = "../rs-soroban-env2/soroban-env-guest" }
+soroban-env-host = { path = "../rs-soroban-env2/soroban-env-host" }
+stellar-xdr = { path = "../rs-stellar-xdr/" }
+
+[patch."https://github.com/stellar/rs-stellar-xdr"]
+stellar-xdr = { path = "../rs-stellar-xdr/" }
 
 [profile.dev]
 overflow-checks = true

--- a/soroban-sdk-macros/Cargo.toml
+++ b/soroban-sdk-macros/Cargo.toml
@@ -22,7 +22,7 @@ crate-git-revision = "0.0.6"
 soroban-spec = { workspace = true }
 soroban-spec-rust = { workspace = true }
 soroban-env-common = { workspace = true }
-stellar-xdr = { workspace = true, features = ["curr", "std"] }
+stellar-xdr = { workspace = true, features = ["next", "std"] }
 syn = {version="2.0.77",features=["full"]}
 quote = "1.0"
 proc-macro2 = "1.0"

--- a/soroban-sdk-macros/src/derive_enum.rs
+++ b/soroban-sdk-macros/src/derive_enum.rs
@@ -3,7 +3,7 @@ use proc_macro2::{Literal, TokenStream as TokenStream2};
 use quote::{format_ident, quote};
 use syn::{spanned::Spanned, Attribute, DataEnum, Error, Fields, Ident, Path, Visibility};
 
-use stellar_xdr::curr as stellar_xdr;
+use stellar_xdr::next as stellar_xdr;
 use stellar_xdr::{
     Error as XdrError, ScSpecEntry, ScSpecTypeDef, ScSpecUdtUnionCaseTupleV0, ScSpecUdtUnionCaseV0,
     ScSpecUdtUnionCaseVoidV0, ScSpecUdtUnionV0, StringM, VecM, WriteXdr, SCSYMBOL_LIMIT,

--- a/soroban-sdk-macros/src/derive_enum_int.rs
+++ b/soroban-sdk-macros/src/derive_enum_int.rs
@@ -1,7 +1,7 @@
 use itertools::MultiUnzip;
 use proc_macro2::TokenStream as TokenStream2;
 use quote::{format_ident, quote};
-use stellar_xdr::curr as stellar_xdr;
+use stellar_xdr::next as stellar_xdr;
 use stellar_xdr::{ScSpecUdtEnumV0, StringM};
 use syn::{spanned::Spanned, Attribute, DataEnum, Error, ExprLit, Ident, Lit, Path, Visibility};
 

--- a/soroban-sdk-macros/src/derive_error_enum_int.rs
+++ b/soroban-sdk-macros/src/derive_error_enum_int.rs
@@ -1,7 +1,7 @@
 use itertools::MultiUnzip;
 use proc_macro2::TokenStream as TokenStream2;
 use quote::{format_ident, quote};
-use stellar_xdr::curr as stellar_xdr;
+use stellar_xdr::next as stellar_xdr;
 use stellar_xdr::{ScSpecEntry, ScSpecUdtErrorEnumCaseV0, ScSpecUdtErrorEnumV0, StringM, WriteXdr};
 use syn::{spanned::Spanned, Attribute, DataEnum, Error, ExprLit, Ident, Lit, Path};
 

--- a/soroban-sdk-macros/src/derive_spec_fn.rs
+++ b/soroban-sdk-macros/src/derive_spec_fn.rs
@@ -1,6 +1,6 @@
 use proc_macro2::TokenStream as TokenStream2;
 use quote::{format_ident, quote};
-use stellar_xdr::curr as stellar_xdr;
+use stellar_xdr::next as stellar_xdr;
 use stellar_xdr::{
     ScSpecEntry, ScSpecFunctionInputV0, ScSpecFunctionV0, ScSpecTypeDef, ScSymbol, StringM, VecM,
     WriteXdr, SCSYMBOL_LIMIT,

--- a/soroban-sdk-macros/src/derive_struct.rs
+++ b/soroban-sdk-macros/src/derive_struct.rs
@@ -3,7 +3,7 @@ use proc_macro2::{Literal, TokenStream as TokenStream2};
 use quote::{format_ident, quote};
 use syn::{Attribute, DataStruct, Error, Ident, Path, Visibility};
 
-use stellar_xdr::curr as stellar_xdr;
+use stellar_xdr::next as stellar_xdr;
 use stellar_xdr::{
     ScSpecEntry, ScSpecTypeDef, ScSpecUdtStructFieldV0, ScSpecUdtStructV0, StringM, WriteXdr,
 };

--- a/soroban-sdk-macros/src/derive_struct_tuple.rs
+++ b/soroban-sdk-macros/src/derive_struct_tuple.rs
@@ -3,7 +3,7 @@ use proc_macro2::{Literal, TokenStream as TokenStream2};
 use quote::{format_ident, quote};
 use syn::{Attribute, DataStruct, Error, Ident, Path, Visibility};
 
-use stellar_xdr::curr as stellar_xdr;
+use stellar_xdr::next as stellar_xdr;
 use stellar_xdr::{
     ScSpecEntry, ScSpecTypeDef, ScSpecUdtStructFieldV0, ScSpecUdtStructV0, StringM, WriteXdr,
 };

--- a/soroban-sdk-macros/src/doc.rs
+++ b/soroban-sdk-macros/src/doc.rs
@@ -1,5 +1,5 @@
 use itertools::Itertools;
-use stellar_xdr::curr as stellar_xdr;
+use stellar_xdr::next as stellar_xdr;
 use stellar_xdr::StringM;
 use syn::{Attribute, Expr, ExprLit, Lit, Meta, MetaNameValue};
 

--- a/soroban-sdk-macros/src/lib.rs
+++ b/soroban-sdk-macros/src/lib.rs
@@ -41,7 +41,7 @@ use syn_ext::HasFnsItem;
 
 use soroban_spec_rust::{generate_from_wasm, GenerateFromFileError};
 
-use stellar_xdr::curr as stellar_xdr;
+use stellar_xdr::next as stellar_xdr;
 use stellar_xdr::{Limits, ScMetaEntry, ScMetaV0, StringM, WriteXdr};
 
 pub(crate) const DEFAULT_XDR_RW_LIMITS: Limits = Limits {

--- a/soroban-sdk-macros/src/map_type.rs
+++ b/soroban-sdk-macros/src/map_type.rs
@@ -1,4 +1,4 @@
-use stellar_xdr::curr as stellar_xdr;
+use stellar_xdr::next as stellar_xdr;
 use stellar_xdr::{
     ScSpecTypeBytesN, ScSpecTypeDef, ScSpecTypeMap, ScSpecTypeOption, ScSpecTypeResult,
     ScSpecTypeTuple, ScSpecTypeUdt, ScSpecTypeVec,
@@ -34,7 +34,8 @@ pub fn map_type(t: &Type, allow_hash: bool) -> Result<ScSpecTypeDef, Error> {
                     "String" => Ok(ScSpecTypeDef::String),
                     "Error" => Ok(ScSpecTypeDef::Error),
                     "Bytes" => Ok(ScSpecTypeDef::Bytes),
-                    "Address" => Ok(ScSpecTypeDef::Address),
+                    "Address" => Ok(ScSpecTypeDef::AddressV2(false)),
+                    "MuxedAddress" => Ok(ScSpecTypeDef::AddressV2(true)),
                     "Timepoint" => Ok(ScSpecTypeDef::Timepoint),
                     "Duration" => Ok(ScSpecTypeDef::Duration),
                     s => Ok(ScSpecTypeDef::Udt(ScSpecTypeUdt {

--- a/soroban-sdk/Cargo.toml
+++ b/soroban-sdk/Cargo.toml
@@ -42,7 +42,7 @@ ctor = { version = "0.2.9", optional = true }
 [dev-dependencies]
 soroban-sdk-macros = { workspace = true, features = ["testutils"] }
 soroban-env-host = { workspace = true, features = ["testutils"] }
-stellar-xdr = { workspace = true, features = ["curr", "std"] }
+stellar-xdr = { workspace = true, features = ["next", "std"] }
 soroban-spec = { workspace = true }
 ed25519-dalek = "2.0.0"
 rand = "0.8.5"

--- a/soroban-sdk/src/address.rs
+++ b/soroban-sdk/src/address.rs
@@ -55,6 +55,9 @@ impl Debug for Address {
                         let strkey = Strkey::Contract(Contract(contract_id.0));
                         write!(f, "Contract({})", strkey.to_string())?;
                     }
+                    xdr::ScAddress::MuxedAccount(_) => {
+                        write!(f, "MuxedAccount()")?;
+                    }
                 }
             } else {
                 return Err(core::fmt::Error);
@@ -80,10 +83,6 @@ impl PartialOrd for Address {
 
 impl Ord for Address {
     fn cmp(&self, other: &Self) -> Ordering {
-        #[cfg(not(target_family = "wasm"))]
-        if !self.env.is_same_env(&other.env) {
-            return ScVal::from(self).cmp(&ScVal::from(other));
-        }
         let v = self
             .env
             .obj_cmp(self.obj.to_val(), other.obj.to_val())

--- a/soroban-sdk/src/bytes.rs
+++ b/soroban-sdk/src/bytes.rs
@@ -256,10 +256,6 @@ impl PartialOrd for Bytes {
 
 impl Ord for Bytes {
     fn cmp(&self, other: &Self) -> core::cmp::Ordering {
-        #[cfg(not(target_family = "wasm"))]
-        if !self.env.is_same_env(&other.env) {
-            return ScVal::from(self).cmp(&ScVal::from(other));
-        }
         let v = self
             .env
             .obj_cmp(self.obj.to_val(), other.obj.to_val())

--- a/soroban-sdk/src/lib.rs
+++ b/soroban-sdk/src/lib.rs
@@ -758,6 +758,7 @@ pub mod unwrap;
 mod env;
 
 mod address;
+mod muxed_address;
 mod symbol;
 
 pub use env::{ConversionError, Env};
@@ -819,6 +820,7 @@ mod vec;
 pub use address::Address;
 pub use bytes::{Bytes, BytesN};
 pub use map::Map;
+pub use muxed_address::MuxedAddress;
 pub use symbol::Symbol;
 pub use vec::Vec;
 mod num;

--- a/soroban-sdk/src/map.rs
+++ b/soroban-sdk/src/map.rs
@@ -139,10 +139,6 @@ where
     V: IntoVal<Env, Val> + TryFromVal<Env, Val>,
 {
     fn cmp(&self, other: &Self) -> core::cmp::Ordering {
-        #[cfg(not(target_family = "wasm"))]
-        if !self.env.is_same_env(&other.env) {
-            return ScVal::from(self).cmp(&ScVal::from(other));
-        }
         let v = self
             .env
             .obj_cmp(self.obj.to_val(), other.obj.to_val())

--- a/soroban-sdk/src/muxed_address.rs
+++ b/soroban-sdk/src/muxed_address.rs
@@ -1,0 +1,203 @@
+use core::{cmp::Ordering, convert::Infallible, fmt::Debug};
+
+use super::{
+    env::internal::{AddressObject, Env as _, MuxedAddressObject, Tag},
+    ConversionError, Env, TryFromVal, TryIntoVal, Val,
+};
+use crate::{unwrap::UnwrapInfallible, Address};
+
+#[cfg(not(target_family = "wasm"))]
+use crate::env::internal::xdr::{ScAddress, ScVal};
+
+#[derive(Clone)]
+enum AddressObjectWrapper {
+    Address(AddressObject),
+    MuxedAddress(MuxedAddressObject),
+}
+
+#[derive(Clone)]
+pub struct MuxedAddress {
+    env: Env,
+    obj: AddressObjectWrapper,
+}
+
+impl Debug for MuxedAddress {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "MuxedAddress(..)")?;
+        Ok(())
+    }
+}
+
+impl Eq for MuxedAddress {}
+
+impl PartialEq for MuxedAddress {
+    fn eq(&self, other: &Self) -> bool {
+        self.partial_cmp(other) == Some(Ordering::Equal)
+    }
+}
+
+impl PartialOrd for MuxedAddress {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(Ord::cmp(self, other))
+    }
+}
+
+impl Ord for MuxedAddress {
+    fn cmp(&self, other: &Self) -> Ordering {
+        let v = self
+            .env
+            .obj_cmp(self.to_val(), other.to_val())
+            .unwrap_infallible();
+        v.cmp(&0)
+    }
+}
+
+impl TryFromVal<Env, MuxedAddressObject> for MuxedAddress {
+    type Error = Infallible;
+
+    fn try_from_val(env: &Env, val: &MuxedAddressObject) -> Result<Self, Self::Error> {
+        Ok(unsafe { MuxedAddress::unchecked_new(env.clone(), *val) })
+    }
+}
+
+impl TryFromVal<Env, AddressObject> for MuxedAddress {
+    type Error = Infallible;
+
+    fn try_from_val(env: &Env, val: &AddressObject) -> Result<Self, Self::Error> {
+        Ok(unsafe { MuxedAddress::unchecked_new_from_address(env.clone(), *val) })
+    }
+}
+
+impl TryFromVal<Env, Val> for MuxedAddress {
+    type Error = ConversionError;
+
+    fn try_from_val(env: &Env, val: &Val) -> Result<Self, Self::Error> {
+        if val.get_tag() == Tag::AddressObject {
+            Ok(AddressObject::try_from_val(env, val)?
+                .try_into_val(env)
+                .unwrap_infallible())
+        } else {
+            Ok(MuxedAddressObject::try_from_val(env, val)?
+                .try_into_val(env)
+                .unwrap_infallible())
+        }
+    }
+}
+
+impl TryFromVal<Env, MuxedAddress> for Val {
+    type Error = ConversionError;
+
+    fn try_from_val(_env: &Env, v: &MuxedAddress) -> Result<Self, Self::Error> {
+        Ok(v.to_val())
+    }
+}
+
+impl TryFromVal<Env, &MuxedAddress> for Val {
+    type Error = ConversionError;
+
+    fn try_from_val(_env: &Env, v: &&MuxedAddress) -> Result<Self, Self::Error> {
+        Ok(v.to_val())
+    }
+}
+
+impl From<Address> for MuxedAddress {
+    fn from(address: Address) -> Self {
+        address
+            .as_object()
+            .try_into_val(address.env())
+            .unwrap_infallible()
+    }
+}
+
+impl MuxedAddress {
+    pub fn to_address(&self) -> Address {
+        match &self.obj {
+            AddressObjectWrapper::Address(address_object) => {
+                Address::try_from_val(&self.env, address_object).unwrap_infallible()
+            }
+            AddressObjectWrapper::MuxedAddress(muxed_address_object) => {
+                self.env.muxed_address_to_address(*muxed_address_object)
+            }
+        }
+    }
+
+    #[inline(always)]
+    pub(crate) unsafe fn unchecked_new_from_address(env: Env, obj: AddressObject) -> Self {
+        Self {
+            env,
+            obj: AddressObjectWrapper::Address(obj),
+        }
+    }
+
+    #[inline(always)]
+    pub(crate) unsafe fn unchecked_new(env: Env, obj: MuxedAddressObject) -> Self {
+        Self {
+            env,
+            obj: AddressObjectWrapper::MuxedAddress(obj),
+        }
+    }
+
+    #[inline(always)]
+    pub fn env(&self) -> &Env {
+        &self.env
+    }
+
+    pub fn as_val(&self) -> &Val {
+        match &self.obj {
+            AddressObjectWrapper::Address(o) => o.as_val(),
+            AddressObjectWrapper::MuxedAddress(o) => o.as_val(),
+        }
+    }
+
+    pub fn to_val(&self) -> Val {
+        match self.obj {
+            AddressObjectWrapper::Address(o) => o.to_val(),
+            AddressObjectWrapper::MuxedAddress(o) => o.to_val(),
+        }
+    }
+}
+
+#[cfg(not(target_family = "wasm"))]
+impl TryFromVal<Env, ScVal> for MuxedAddress {
+    type Error = ConversionError;
+    fn try_from_val(env: &Env, val: &ScVal) -> Result<Self, Self::Error> {
+        let v = Val::try_from_val(env, val)?;
+        match val {
+            ScVal::Address(sc_address) => match sc_address {
+                ScAddress::Account(_) | ScAddress::Contract(_) => {
+                    Ok(AddressObject::try_from_val(env, &v)?
+                        .try_into_val(env)
+                        .unwrap_infallible())
+                }
+                ScAddress::MuxedAccount(_) => Ok(MuxedAddressObject::try_from_val(env, &v)?
+                    .try_into_val(env)
+                    .unwrap_infallible()),
+            },
+            _ => panic!("incorrect scval type"),
+        }
+    }
+}
+
+#[cfg(not(target_family = "wasm"))]
+impl TryFromVal<Env, ScAddress> for MuxedAddress {
+    type Error = ConversionError;
+    fn try_from_val(env: &Env, val: &ScAddress) -> Result<Self, Self::Error> {
+        ScVal::Address(val.clone()).try_into_val(env)
+    }
+}
+
+#[cfg(any(test, feature = "testutils"))]
+#[cfg_attr(feature = "docs", doc(cfg(feature = "testutils")))]
+impl crate::testutils::MuxedAddress for MuxedAddress {
+    fn from_account_id(env: &Env, account_key: &[u8; 32], id: u64) -> crate::MuxedAddress {
+        let sc_val = ScVal::Address(crate::env::internal::xdr::ScAddress::MuxedAccount(
+            crate::env::internal::xdr::MuxedAccount::MuxedEd25519(
+                crate::env::internal::xdr::MuxedAccountMed25519 {
+                    id,
+                    ed25519: crate::env::internal::xdr::Uint256(account_key.clone()),
+                },
+            ),
+        ));
+        sc_val.try_into_val(env).unwrap()
+    }
+}

--- a/soroban-sdk/src/num.rs
+++ b/soroban-sdk/src/num.rs
@@ -2,8 +2,8 @@ use core::{cmp::Ordering, convert::Infallible, fmt::Debug};
 
 use super::{
     env::internal::{
-        DurationSmall, DurationVal, Env as _, EnvBase as _, I256Small, I256Val, TimepointSmall,
-        TimepointVal, U256Small, U256Val,
+        DurationSmall, DurationVal, Env as _, I256Small, I256Val, TimepointSmall, TimepointVal,
+        U256Small, U256Val,
     },
     Bytes, ConversionError, Env, TryFromVal, TryIntoVal, Val,
 };
@@ -46,10 +46,6 @@ macro_rules! impl_num_wrapping_val_type {
                     // The object-to-small number comparisons are handled by `obj_cmp`,
                     // so it's safe to handle all the other cases using it.
                     _ => {
-                        #[cfg(not(target_family = "wasm"))]
-                        if !self.env.is_same_env(&other.env) {
-                            return ScVal::from(self).cmp(&ScVal::from(other));
-                        }
                         let v = self.env.obj_cmp(self_raw, other_raw).unwrap_infallible();
                         v.cmp(&0)
                     }
@@ -217,7 +213,6 @@ impl U256 {
     }
 
     pub fn from_be_bytes(env: &Env, bytes: &Bytes) -> Self {
-        env.check_same_env(bytes.env()).unwrap_infallible();
         let val = env
             .u256_val_from_be_bytes(bytes.to_object())
             .unwrap_infallible();
@@ -247,7 +242,6 @@ impl U256 {
     }
 
     pub fn add(&self, other: &U256) -> U256 {
-        self.env.check_same_env(&other.env).unwrap_infallible();
         let val = self.env.u256_add(self.val, other.val).unwrap_infallible();
         U256 {
             env: self.env.clone(),
@@ -256,7 +250,6 @@ impl U256 {
     }
 
     pub fn sub(&self, other: &U256) -> U256 {
-        self.env.check_same_env(&other.env).unwrap_infallible();
         let val = self.env.u256_sub(self.val, other.val).unwrap_infallible();
         U256 {
             env: self.env.clone(),
@@ -265,7 +258,6 @@ impl U256 {
     }
 
     pub fn mul(&self, other: &U256) -> U256 {
-        self.env.check_same_env(&other.env).unwrap_infallible();
         let val = self.env.u256_mul(self.val, other.val).unwrap_infallible();
         U256 {
             env: self.env.clone(),
@@ -274,7 +266,6 @@ impl U256 {
     }
 
     pub fn div(&self, other: &U256) -> U256 {
-        self.env.check_same_env(&other.env).unwrap_infallible();
         let val = self.env.u256_div(self.val, other.val).unwrap_infallible();
         U256 {
             env: self.env.clone(),
@@ -283,7 +274,6 @@ impl U256 {
     }
 
     pub fn rem_euclid(&self, other: &U256) -> U256 {
-        self.env.check_same_env(&other.env).unwrap_infallible();
         let val = self
             .env
             .u256_rem_euclid(self.val, other.val)
@@ -372,7 +362,6 @@ impl I256 {
     }
 
     pub fn from_be_bytes(env: &Env, bytes: &Bytes) -> Self {
-        env.check_same_env(bytes.env()).unwrap_infallible();
         let val = env
             .i256_val_from_be_bytes(bytes.to_object())
             .unwrap_infallible();
@@ -404,7 +393,6 @@ impl I256 {
     }
 
     pub fn add(&self, other: &I256) -> I256 {
-        self.env.check_same_env(&other.env).unwrap_infallible();
         let val = self.env.i256_add(self.val, other.val).unwrap_infallible();
         I256 {
             env: self.env.clone(),
@@ -413,7 +401,6 @@ impl I256 {
     }
 
     pub fn sub(&self, other: &I256) -> I256 {
-        self.env.check_same_env(&other.env).unwrap_infallible();
         let val = self.env.i256_sub(self.val, other.val).unwrap_infallible();
         I256 {
             env: self.env.clone(),
@@ -422,7 +409,6 @@ impl I256 {
     }
 
     pub fn mul(&self, other: &I256) -> I256 {
-        self.env.check_same_env(&other.env).unwrap_infallible();
         let val = self.env.i256_mul(self.val, other.val).unwrap_infallible();
         I256 {
             env: self.env.clone(),
@@ -431,7 +417,6 @@ impl I256 {
     }
 
     pub fn div(&self, other: &I256) -> I256 {
-        self.env.check_same_env(&other.env).unwrap_infallible();
         let val = self.env.i256_div(self.val, other.val).unwrap_infallible();
         I256 {
             env: self.env.clone(),
@@ -440,7 +425,6 @@ impl I256 {
     }
 
     pub fn rem_euclid(&self, other: &I256) -> I256 {
-        self.env.check_same_env(&other.env).unwrap_infallible();
         let val = self
             .env
             .i256_rem_euclid(self.val, other.val)

--- a/soroban-sdk/src/string.rs
+++ b/soroban-sdk/src/string.rs
@@ -65,10 +65,6 @@ impl PartialOrd for String {
 
 impl Ord for String {
     fn cmp(&self, other: &Self) -> core::cmp::Ordering {
-        #[cfg(not(target_family = "wasm"))]
-        if !self.env.is_same_env(&other.env) {
-            return ScVal::from(self).cmp(&ScVal::from(other));
-        }
         let v = self
             .env
             .obj_cmp(self.obj.to_val(), other.obj.to_val())

--- a/soroban-sdk/src/symbol.rs
+++ b/soroban-sdk/src/symbol.rs
@@ -82,9 +82,6 @@ impl Ord for Symbol {
                     }
                     #[cfg(not(target_family = "wasm"))]
                     (Ok(e1), Ok(e2)) => {
-                        if !e1.is_same_env(&e2) {
-                            return ScVal::from(self).cmp(&ScVal::from(other));
-                        }
                         let v = e1.obj_cmp(self_raw, other_raw).unwrap_infallible();
                         v.cmp(&0)
                     }

--- a/soroban-sdk/src/tests/contract_add_i32.rs
+++ b/soroban-sdk/src/tests/contract_add_i32.rs
@@ -1,6 +1,6 @@
 use crate as soroban_sdk;
 use soroban_sdk::{contract, contractimpl, Env};
-use stellar_xdr::curr as stellar_xdr;
+use stellar_xdr::next as stellar_xdr;
 use stellar_xdr::{
     Limits, ReadXdr, ScSpecEntry, ScSpecFunctionInputV0, ScSpecFunctionV0, ScSpecTypeDef,
 };

--- a/soroban-sdk/src/tests/contract_docs.rs
+++ b/soroban-sdk/src/tests/contract_docs.rs
@@ -1,7 +1,7 @@
 mod fn_ {
     use crate as soroban_sdk;
     use soroban_sdk::{contract, contractimpl, Env};
-    use stellar_xdr::curr as stellar_xdr;
+    use stellar_xdr::next as stellar_xdr;
     use stellar_xdr::{Limits, ReadXdr, ScSpecEntry, ScSpecFunctionV0};
 
     #[contract]
@@ -39,7 +39,7 @@ mod fn_ {
 mod struct_ {
     use crate as soroban_sdk;
     use soroban_sdk::contracttype;
-    use stellar_xdr::curr as stellar_xdr;
+    use stellar_xdr::next as stellar_xdr;
     use stellar_xdr::{Limits, ReadXdr, ScSpecEntry, ScSpecUdtStructFieldV0, ScSpecUdtStructV0};
 
     /// S holds a and
@@ -83,7 +83,7 @@ mod struct_ {
 mod struct_tuple {
     use crate as soroban_sdk;
     use soroban_sdk::contracttype;
-    use stellar_xdr::curr as stellar_xdr;
+    use stellar_xdr::next as stellar_xdr;
     use stellar_xdr::{Limits, ReadXdr, ScSpecEntry, ScSpecUdtStructFieldV0, ScSpecUdtStructV0};
 
     /// S holds two u64s.
@@ -125,7 +125,7 @@ mod struct_tuple {
 mod enum_ {
     use crate as soroban_sdk;
     use soroban_sdk::contracttype;
-    use stellar_xdr::curr as stellar_xdr;
+    use stellar_xdr::next as stellar_xdr;
     use stellar_xdr::{
         Limits, ReadXdr, ScSpecEntry, ScSpecUdtUnionCaseTupleV0, ScSpecUdtUnionCaseV0,
         ScSpecUdtUnionCaseVoidV0, ScSpecUdtUnionV0,
@@ -177,7 +177,7 @@ mod enum_ {
 mod enum_int {
     use crate as soroban_sdk;
     use soroban_sdk::contracttype;
-    use stellar_xdr::curr as stellar_xdr;
+    use stellar_xdr::next as stellar_xdr;
     use stellar_xdr::{Limits, ReadXdr, ScSpecEntry, ScSpecUdtEnumCaseV0, ScSpecUdtEnumV0};
 
     /// E has variants A and B.
@@ -220,7 +220,7 @@ mod enum_int {
 mod enum_error_int {
     use crate as soroban_sdk;
     use soroban_sdk::contracterror;
-    use stellar_xdr::curr as stellar_xdr;
+    use stellar_xdr::next as stellar_xdr;
     use stellar_xdr::{
         Limits, ReadXdr, ScSpecEntry, ScSpecUdtErrorEnumCaseV0, ScSpecUdtErrorEnumV0,
     };

--- a/soroban-sdk/src/tests/contract_fn.rs
+++ b/soroban-sdk/src/tests/contract_fn.rs
@@ -1,6 +1,6 @@
 use crate as soroban_sdk;
 use soroban_sdk::{contract, contractimpl, Env};
-use stellar_xdr::curr as stellar_xdr;
+use stellar_xdr::next as stellar_xdr;
 use stellar_xdr::{
     Limits, ReadXdr, ScSpecEntry, ScSpecFunctionInputV0, ScSpecFunctionV0, ScSpecTypeDef,
 };

--- a/soroban-sdk/src/tests/contract_udt_struct.rs
+++ b/soroban-sdk/src/tests/contract_udt_struct.rs
@@ -2,7 +2,7 @@ use crate as soroban_sdk;
 use soroban_sdk::{
     contract, contractimpl, contracttype, map, symbol_short, ConversionError, Env, TryFromVal,
 };
-use stellar_xdr::curr as stellar_xdr;
+use stellar_xdr::next as stellar_xdr;
 use stellar_xdr::{
     Limits, ReadXdr, ScSpecEntry, ScSpecFunctionInputV0, ScSpecFunctionV0, ScSpecTypeDef,
     ScSpecTypeTuple, ScSpecTypeUdt,

--- a/soroban-sdk/src/tests/contract_udt_struct_tuple.rs
+++ b/soroban-sdk/src/tests/contract_udt_struct_tuple.rs
@@ -3,7 +3,7 @@ use soroban_sdk::{
     contract, contractimpl, contracttype, vec, ConversionError, Env, IntoVal, TryFromVal,
     TryIntoVal, Val, Vec,
 };
-use stellar_xdr::curr as stellar_xdr;
+use stellar_xdr::next as stellar_xdr;
 use stellar_xdr::{
     Limits, ReadXdr, ScSpecEntry, ScSpecFunctionInputV0, ScSpecFunctionV0, ScSpecTypeDef,
     ScSpecTypeTuple, ScSpecTypeUdt,

--- a/soroban-sdk/src/tests/contractimport.rs
+++ b/soroban-sdk/src/tests/contractimport.rs
@@ -1,6 +1,6 @@
 use crate as soroban_sdk;
 use soroban_sdk::{contract, contractimpl, Address, Env};
-use stellar_xdr::curr as stellar_xdr;
+use stellar_xdr::next as stellar_xdr;
 use stellar_xdr::{ScSpecEntry, ScSpecFunctionInputV0, ScSpecFunctionV0, ScSpecTypeDef};
 
 mod addcontract {

--- a/soroban-sdk/src/tests/cost_estimate.rs
+++ b/soroban-sdk/src/tests/cost_estimate.rs
@@ -1,8 +1,8 @@
 use crate as soroban_sdk;
+use crate::env::xdr::ContractCostType;
 use expect_test::expect;
 use soroban_sdk::Env;
 use soroban_sdk_macros::symbol_short;
-use stellar_xdr::curr::ContractCostType;
 
 mod contract_data {
     use crate as soroban_sdk;

--- a/soroban-sdk/src/tests/token_spec.rs
+++ b/soroban-sdk/src/tests/token_spec.rs
@@ -1,4 +1,4 @@
-use crate as soroban_sdk;
+use crate::{self as soroban_sdk, mux_token::StellarAssetMuxSpec};
 
 use soroban_sdk::{
     token::{StellarAssetSpec, SPEC_XDR_INPUT, SPEC_XDR_LEN},
@@ -16,6 +16,16 @@ fn test_spec_xdr_len() {
 #[test]
 fn test_spec_xdr() -> Result<(), Error> {
     let xdr = StellarAssetSpec::spec_xdr();
+    let cursor = std::io::Cursor::new(xdr);
+    for spec_entry in ScSpecEntry::read_xdr_iter(&mut Limited::new(cursor, Limits::none())) {
+        spec_entry?;
+    }
+    Ok(())
+}
+
+#[test]
+fn test_mux_spec_xdr() -> Result<(), Error> {
+    let xdr = StellarAssetMuxSpec::spec_xdr();
     let cursor = std::io::Cursor::new(xdr);
     for spec_entry in ScSpecEntry::read_xdr_iter(&mut Limited::new(cursor, Limits::none())) {
         spec_entry?;

--- a/soroban-sdk/src/testutils.rs
+++ b/soroban-sdk/src/testutils.rs
@@ -438,6 +438,10 @@ pub trait Address {
     fn generate(env: &Env) -> crate::Address;
 }
 
+pub trait MuxedAddress {
+    fn from_account_id(env: &Env, account_key: &[u8; 32], id: u64) -> crate::MuxedAddress;
+}
+
 pub trait Deployer {
     /// Gets the TTL of the given contract's instance.
     ///

--- a/soroban-sdk/src/token.rs
+++ b/soroban-sdk/src/token.rs
@@ -7,7 +7,7 @@
 //! Use [`TokenClient`] for calling token contracts such as the Stellar Asset
 //! Contract.
 
-use crate::{contractclient, contractspecfn, Address, Env, String};
+use crate::{contractclient, contractspecfn, Address, Env, MuxedAddress, String};
 
 // The interface below was copied from
 // https://github.com/stellar/rs-soroban-env/blob/main/soroban-env-host/src/native_contract/token/contract.rs
@@ -228,6 +228,11 @@ pub trait TokenInterface {
     ///
     /// If the contract has not yet been initialized.
     fn symbol(env: Env) -> String;
+}
+
+#[contractclient(crate_path = "crate", name = "MuxTokenClient")]
+pub trait MuxTokenInterface {
+    fn transfer_muxed(env: Env, from: MuxedAddress, to: MuxedAddress, amount: i128);
 }
 
 /// Interface for admin capabilities for Token contracts, such as the Stellar

--- a/soroban-sdk/src/vec.rs
+++ b/soroban-sdk/src/vec.rs
@@ -126,10 +126,6 @@ where
     T: IntoVal<Env, Val> + TryFromVal<Env, Val>,
 {
     fn cmp(&self, other: &Self) -> core::cmp::Ordering {
-        #[cfg(not(target_family = "wasm"))]
-        if !self.env.is_same_env(&other.env) {
-            return ScVal::from(self).cmp(&ScVal::from(other));
-        }
         let v = self
             .env
             .obj_cmp(self.obj.to_val(), other.obj.to_val())

--- a/soroban-sdk/test_snapshots/tests/auth/auth_10_one/test.1.json
+++ b/soroban-sdk/test_snapshots/tests/auth/auth_10_one/test.1.json
@@ -59,7 +59,7 @@
     ]
   ],
   "ledger": {
-    "protocol_version": 22,
+    "protocol_version": 23,
     "sequence_number": 0,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",

--- a/soroban-sdk/test_snapshots/tests/auth/auth_15_one_repeat/test.1.json
+++ b/soroban-sdk/test_snapshots/tests/auth/auth_15_one_repeat/test.1.json
@@ -57,7 +57,7 @@
     ]
   ],
   "ledger": {
-    "protocol_version": 22,
+    "protocol_version": 23,
     "sequence_number": 0,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",

--- a/soroban-sdk/test_snapshots/tests/auth/auth_17_no_consume_requirement/test.1.json
+++ b/soroban-sdk/test_snapshots/tests/auth/auth_17_no_consume_requirement/test.1.json
@@ -34,7 +34,7 @@
     ]
   ],
   "ledger": {
-    "protocol_version": 22,
+    "protocol_version": 23,
     "sequence_number": 0,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",

--- a/soroban-sdk/test_snapshots/tests/auth/auth_20_deep_one_address/test.1.json
+++ b/soroban-sdk/test_snapshots/tests/auth/auth_20_deep_one_address/test.1.json
@@ -28,7 +28,7 @@
     ]
   ],
   "ledger": {
-    "protocol_version": 22,
+    "protocol_version": 23,
     "sequence_number": 0,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",

--- a/soroban-sdk/test_snapshots/tests/auth/auth_20_deep_one_address/test_auth_tree.1.json
+++ b/soroban-sdk/test_snapshots/tests/auth/auth_20_deep_one_address/test_auth_tree.1.json
@@ -10,7 +10,7 @@
     []
   ],
   "ledger": {
-    "protocol_version": 22,
+    "protocol_version": 23,
     "sequence_number": 0,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",

--- a/soroban-sdk/test_snapshots/tests/auth/auth_30_deep_one_address_repeat/test.1.json
+++ b/soroban-sdk/test_snapshots/tests/auth/auth_30_deep_one_address_repeat/test.1.json
@@ -46,7 +46,7 @@
     ]
   ],
   "ledger": {
-    "protocol_version": 22,
+    "protocol_version": 23,
     "sequence_number": 0,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",

--- a/soroban-sdk/test_snapshots/tests/auth/auth_30_deep_one_address_repeat/test_auth_tree.1.json
+++ b/soroban-sdk/test_snapshots/tests/auth/auth_30_deep_one_address_repeat/test_auth_tree.1.json
@@ -10,7 +10,7 @@
     []
   ],
   "ledger": {
-    "protocol_version": 22,
+    "protocol_version": 23,
     "sequence_number": 0,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",

--- a/soroban-sdk/test_snapshots/tests/auth/auth_35_deep_one_address_repeat_grouped/test.1.json
+++ b/soroban-sdk/test_snapshots/tests/auth/auth_35_deep_one_address_repeat_grouped/test.1.json
@@ -46,7 +46,7 @@
     ]
   ],
   "ledger": {
-    "protocol_version": 22,
+    "protocol_version": 23,
     "sequence_number": 0,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",

--- a/soroban-sdk/test_snapshots/tests/auth/auth_35_deep_one_address_repeat_grouped/test_auth_tree.1.json
+++ b/soroban-sdk/test_snapshots/tests/auth/auth_35_deep_one_address_repeat_grouped/test_auth_tree.1.json
@@ -10,7 +10,7 @@
     []
   ],
   "ledger": {
-    "protocol_version": 22,
+    "protocol_version": 23,
     "sequence_number": 0,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",

--- a/soroban-sdk/test_snapshots/tests/auth/auth_40_multi_one_address/test_auth_as_tree.1.json
+++ b/soroban-sdk/test_snapshots/tests/auth/auth_40_multi_one_address/test_auth_as_tree.1.json
@@ -43,7 +43,7 @@
     ]
   ],
   "ledger": {
-    "protocol_version": 22,
+    "protocol_version": 23,
     "sequence_number": 0,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",

--- a/soroban-sdk/test_snapshots/tests/auth/auth_40_multi_one_address/test_auth_not_allowed_with_separated_tree.1.json
+++ b/soroban-sdk/test_snapshots/tests/auth/auth_40_multi_one_address/test_auth_not_allowed_with_separated_tree.1.json
@@ -11,7 +11,7 @@
     []
   ],
   "ledger": {
-    "protocol_version": 22,
+    "protocol_version": 23,
     "sequence_number": 0,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",

--- a/soroban-sdk/test_snapshots/tests/contract_add_i32/test_functional.1.json
+++ b/soroban-sdk/test_snapshots/tests/contract_add_i32/test_functional.1.json
@@ -8,7 +8,7 @@
     []
   ],
   "ledger": {
-    "protocol_version": 22,
+    "protocol_version": 23,
     "sequence_number": 0,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",

--- a/soroban-sdk/test_snapshots/tests/contract_assert/test_invoke_expect_error.1.json
+++ b/soroban-sdk/test_snapshots/tests/contract_assert/test_invoke_expect_error.1.json
@@ -8,7 +8,7 @@
     []
   ],
   "ledger": {
-    "protocol_version": 22,
+    "protocol_version": 23,
     "sequence_number": 0,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",

--- a/soroban-sdk/test_snapshots/tests/contract_assert/test_try_invoke.1.json
+++ b/soroban-sdk/test_snapshots/tests/contract_assert/test_try_invoke.1.json
@@ -8,7 +8,7 @@
     []
   ],
   "ledger": {
-    "protocol_version": 22,
+    "protocol_version": 23,
     "sequence_number": 0,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",

--- a/soroban-sdk/test_snapshots/tests/contract_custom_account_impl/test_functional.1.json
+++ b/soroban-sdk/test_snapshots/tests/contract_custom_account_impl/test_functional.1.json
@@ -8,7 +8,7 @@
     []
   ],
   "ledger": {
-    "protocol_version": 22,
+    "protocol_version": 23,
     "sequence_number": 0,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",

--- a/soroban-sdk/test_snapshots/tests/contract_docs/fn_/test_functional.1.json
+++ b/soroban-sdk/test_snapshots/tests/contract_docs/fn_/test_functional.1.json
@@ -8,7 +8,7 @@
     []
   ],
   "ledger": {
-    "protocol_version": 22,
+    "protocol_version": 23,
     "sequence_number": 0,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",

--- a/soroban-sdk/test_snapshots/tests/contract_duration/test_functional.1.json
+++ b/soroban-sdk/test_snapshots/tests/contract_duration/test_functional.1.json
@@ -8,7 +8,7 @@
     []
   ],
   "ledger": {
-    "protocol_version": 22,
+    "protocol_version": 23,
     "sequence_number": 0,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",

--- a/soroban-sdk/test_snapshots/tests/contract_fn/test_functional.1.json
+++ b/soroban-sdk/test_snapshots/tests/contract_fn/test_functional.1.json
@@ -8,7 +8,7 @@
     []
   ],
   "ledger": {
-    "protocol_version": 22,
+    "protocol_version": 23,
     "sequence_number": 0,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",

--- a/soroban-sdk/test_snapshots/tests/contract_invoke/test_invoke_expect_error.1.json
+++ b/soroban-sdk/test_snapshots/tests/contract_invoke/test_invoke_expect_error.1.json
@@ -8,7 +8,7 @@
     []
   ],
   "ledger": {
-    "protocol_version": 22,
+    "protocol_version": 23,
     "sequence_number": 0,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",

--- a/soroban-sdk/test_snapshots/tests/contract_invoke/test_invoke_expect_string.1.json
+++ b/soroban-sdk/test_snapshots/tests/contract_invoke/test_invoke_expect_string.1.json
@@ -8,7 +8,7 @@
     []
   ],
   "ledger": {
-    "protocol_version": 22,
+    "protocol_version": 23,
     "sequence_number": 0,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",

--- a/soroban-sdk/test_snapshots/tests/contract_invoke/test_try_invoke.1.json
+++ b/soroban-sdk/test_snapshots/tests/contract_invoke/test_try_invoke.1.json
@@ -8,7 +8,7 @@
     []
   ],
   "ledger": {
-    "protocol_version": 22,
+    "protocol_version": 23,
     "sequence_number": 0,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",

--- a/soroban-sdk/test_snapshots/tests/contract_invoke_arg_count/test_correct_arg_count.1.json
+++ b/soroban-sdk/test_snapshots/tests/contract_invoke_arg_count/test_correct_arg_count.1.json
@@ -9,7 +9,7 @@
     []
   ],
   "ledger": {
-    "protocol_version": 22,
+    "protocol_version": 23,
     "sequence_number": 0,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",

--- a/soroban-sdk/test_snapshots/tests/contract_invoke_arg_count/test_too_few_args.1.json
+++ b/soroban-sdk/test_snapshots/tests/contract_invoke_arg_count/test_too_few_args.1.json
@@ -9,7 +9,7 @@
     []
   ],
   "ledger": {
-    "protocol_version": 22,
+    "protocol_version": 23,
     "sequence_number": 0,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",

--- a/soroban-sdk/test_snapshots/tests/contract_invoke_arg_count/test_too_many_args.1.json
+++ b/soroban-sdk/test_snapshots/tests/contract_invoke_arg_count/test_too_many_args.1.json
@@ -9,7 +9,7 @@
     []
   ],
   "ledger": {
-    "protocol_version": 22,
+    "protocol_version": 23,
     "sequence_number": 0,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",

--- a/soroban-sdk/test_snapshots/tests/contract_overlapping_type_fn_names/test_functional.1.json
+++ b/soroban-sdk/test_snapshots/tests/contract_overlapping_type_fn_names/test_functional.1.json
@@ -8,7 +8,7 @@
     []
   ],
   "ledger": {
-    "protocol_version": 22,
+    "protocol_version": 23,
     "sequence_number": 0,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",

--- a/soroban-sdk/test_snapshots/tests/contract_snapshot/test.1.json
+++ b/soroban-sdk/test_snapshots/tests/contract_snapshot/test.1.json
@@ -8,7 +8,7 @@
     []
   ],
   "ledger": {
-    "protocol_version": 22,
+    "protocol_version": 23,
     "sequence_number": 0,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",

--- a/soroban-sdk/test_snapshots/tests/contract_snapshot/test.2.json
+++ b/soroban-sdk/test_snapshots/tests/contract_snapshot/test.2.json
@@ -9,7 +9,7 @@
     []
   ],
   "ledger": {
-    "protocol_version": 22,
+    "protocol_version": 23,
     "sequence_number": 0,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",

--- a/soroban-sdk/test_snapshots/tests/contract_store/test_storage.1.json
+++ b/soroban-sdk/test_snapshots/tests/contract_store/test_storage.1.json
@@ -41,7 +41,7 @@
     []
   ],
   "ledger": {
-    "protocol_version": 22,
+    "protocol_version": 23,
     "sequence_number": 0,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",

--- a/soroban-sdk/test_snapshots/tests/contract_store/test_temp_storage_extension_past_max_ttl_panics.1.json
+++ b/soroban-sdk/test_snapshots/tests/contract_store/test_temp_storage_extension_past_max_ttl_panics.1.json
@@ -9,7 +9,7 @@
     []
   ],
   "ledger": {
-    "protocol_version": 22,
+    "protocol_version": 23,
     "sequence_number": 0,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",

--- a/soroban-sdk/test_snapshots/tests/contract_timepoint/test_functional.1.json
+++ b/soroban-sdk/test_snapshots/tests/contract_timepoint/test_functional.1.json
@@ -8,7 +8,7 @@
     []
   ],
   "ledger": {
-    "protocol_version": 22,
+    "protocol_version": 23,
     "sequence_number": 0,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",

--- a/soroban-sdk/test_snapshots/tests/contract_udt_enum/test_functional.1.json
+++ b/soroban-sdk/test_snapshots/tests/contract_udt_enum/test_functional.1.json
@@ -8,7 +8,7 @@
     []
   ],
   "ledger": {
-    "protocol_version": 22,
+    "protocol_version": 23,
     "sequence_number": 0,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",

--- a/soroban-sdk/test_snapshots/tests/contract_udt_enum_error/test_error.1.json
+++ b/soroban-sdk/test_snapshots/tests/contract_udt_enum_error/test_error.1.json
@@ -8,7 +8,7 @@
     []
   ],
   "ledger": {
-    "protocol_version": 22,
+    "protocol_version": 23,
     "sequence_number": 0,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",

--- a/soroban-sdk/test_snapshots/tests/contract_udt_enum_error/test_success.1.json
+++ b/soroban-sdk/test_snapshots/tests/contract_udt_enum_error/test_success.1.json
@@ -8,7 +8,7 @@
     []
   ],
   "ledger": {
-    "protocol_version": 22,
+    "protocol_version": 23,
     "sequence_number": 0,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",

--- a/soroban-sdk/test_snapshots/tests/contract_udt_option/test_functional.1.json
+++ b/soroban-sdk/test_snapshots/tests/contract_udt_option/test_functional.1.json
@@ -8,7 +8,7 @@
     []
   ],
   "ledger": {
-    "protocol_version": 22,
+    "protocol_version": 23,
     "sequence_number": 0,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",

--- a/soroban-sdk/test_snapshots/tests/contract_udt_struct/test_functional.1.json
+++ b/soroban-sdk/test_snapshots/tests/contract_udt_struct/test_functional.1.json
@@ -8,7 +8,7 @@
     []
   ],
   "ledger": {
-    "protocol_version": 22,
+    "protocol_version": 23,
     "sequence_number": 0,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",

--- a/soroban-sdk/test_snapshots/tests/contract_udt_struct/test_long_names_functional.1.json
+++ b/soroban-sdk/test_snapshots/tests/contract_udt_struct/test_long_names_functional.1.json
@@ -8,7 +8,7 @@
     []
   ],
   "ledger": {
-    "protocol_version": 22,
+    "protocol_version": 23,
     "sequence_number": 0,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",

--- a/soroban-sdk/test_snapshots/tests/contract_udt_struct_tuple/test_functional.1.json
+++ b/soroban-sdk/test_snapshots/tests/contract_udt_struct_tuple/test_functional.1.json
@@ -8,7 +8,7 @@
     []
   ],
   "ledger": {
-    "protocol_version": 22,
+    "protocol_version": 23,
     "sequence_number": 0,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",

--- a/soroban-sdk/test_snapshots/tests/cost_estimate/test_cost_estimate_budget.1.json
+++ b/soroban-sdk/test_snapshots/tests/cost_estimate/test_cost_estimate_budget.1.json
@@ -7,7 +7,7 @@
     []
   ],
   "ledger": {
-    "protocol_version": 22,
+    "protocol_version": 23,
     "sequence_number": 0,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",

--- a/soroban-sdk/test_snapshots/tests/cost_estimate/test_cost_estimate_with_storage.1.json
+++ b/soroban-sdk/test_snapshots/tests/cost_estimate/test_cost_estimate_with_storage.1.json
@@ -4,13 +4,10 @@
     "nonce": 0
   },
   "auth": [
-    [],
-    [],
-    [],
     []
   ],
   "ledger": {
-    "protocol_version": 22,
+    "protocol_version": 23,
     "sequence_number": 0,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
@@ -50,6 +47,37 @@
             "ext": "v0"
           },
           6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CBKMUZNFQIAL775XBB2W2GP5CNHBM5YGH6C3XB7AY6SUVO2IBU3VYK2V",
+            "key": {
+              "symbol": "k1"
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CBKMUZNFQIAL775XBB2W2GP5CNHBM5YGH6C3XB7AY6SUVO2IBU3VYK2V",
+                "key": {
+                  "symbol": "k1"
+                },
+                "durability": "persistent",
+                "val": {
+                  "symbol": "v1"
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
         ]
       ],
       [

--- a/soroban-sdk/test_snapshots/tests/env/default_and_from_snapshot_same_settings.1.json
+++ b/soroban-sdk/test_snapshots/tests/env/default_and_from_snapshot_same_settings.1.json
@@ -9,7 +9,7 @@
     []
   ],
   "ledger": {
-    "protocol_version": 22,
+    "protocol_version": 23,
     "sequence_number": 0,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",

--- a/soroban-sdk/test_snapshots/tests/env/default_and_from_snapshot_same_settings.2.json
+++ b/soroban-sdk/test_snapshots/tests/env/default_and_from_snapshot_same_settings.2.json
@@ -9,7 +9,7 @@
     []
   ],
   "ledger": {
-    "protocol_version": 22,
+    "protocol_version": 23,
     "sequence_number": 0,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",

--- a/soroban-sdk/test_snapshots/tests/env/register_contract_deploys_predictable_contract_ids.1.json
+++ b/soroban-sdk/test_snapshots/tests/env/register_contract_deploys_predictable_contract_ids.1.json
@@ -7,7 +7,7 @@
     []
   ],
   "ledger": {
-    "protocol_version": 22,
+    "protocol_version": 23,
     "sequence_number": 0,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",

--- a/soroban-sdk/test_snapshots/tests/env/register_contract_deploys_predictable_contract_ids.2.json
+++ b/soroban-sdk/test_snapshots/tests/env/register_contract_deploys_predictable_contract_ids.2.json
@@ -9,7 +9,7 @@
     []
   ],
   "ledger": {
-    "protocol_version": 22,
+    "protocol_version": 23,
     "sequence_number": 0,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",

--- a/soroban-sdk/test_snapshots/tests/env/register_contract_deploys_predictable_contract_ids.3.json
+++ b/soroban-sdk/test_snapshots/tests/env/register_contract_deploys_predictable_contract_ids.3.json
@@ -9,7 +9,7 @@
     []
   ],
   "ledger": {
-    "protocol_version": 22,
+    "protocol_version": 23,
     "sequence_number": 0,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",

--- a/soroban-sdk/test_snapshots/tests/max_ttl/max.1.json
+++ b/soroban-sdk/test_snapshots/tests/max_ttl/max.1.json
@@ -8,7 +8,7 @@
     []
   ],
   "ledger": {
-    "protocol_version": 22,
+    "protocol_version": 23,
     "sequence_number": 1,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",

--- a/soroban-sdk/test_snapshots/tests/prng/test_prng_fill_array.1.json
+++ b/soroban-sdk/test_snapshots/tests/prng/test_prng_fill_array.1.json
@@ -8,7 +8,7 @@
     []
   ],
   "ledger": {
-    "protocol_version": 22,
+    "protocol_version": 23,
     "sequence_number": 0,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",

--- a/soroban-sdk/test_snapshots/tests/prng/test_prng_fill_bytes.1.json
+++ b/soroban-sdk/test_snapshots/tests/prng/test_prng_fill_bytes.1.json
@@ -8,7 +8,7 @@
     []
   ],
   "ledger": {
-    "protocol_version": 22,
+    "protocol_version": 23,
     "sequence_number": 0,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",

--- a/soroban-sdk/test_snapshots/tests/prng/test_prng_fill_bytesn.1.json
+++ b/soroban-sdk/test_snapshots/tests/prng/test_prng_fill_bytesn.1.json
@@ -8,7 +8,7 @@
     []
   ],
   "ledger": {
-    "protocol_version": 22,
+    "protocol_version": 23,
     "sequence_number": 0,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",

--- a/soroban-sdk/test_snapshots/tests/prng/test_prng_fill_slice.1.json
+++ b/soroban-sdk/test_snapshots/tests/prng/test_prng_fill_slice.1.json
@@ -8,7 +8,7 @@
     []
   ],
   "ledger": {
-    "protocol_version": 22,
+    "protocol_version": 23,
     "sequence_number": 0,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",

--- a/soroban-sdk/test_snapshots/tests/prng/test_prng_fill_u64.1.json
+++ b/soroban-sdk/test_snapshots/tests/prng/test_prng_fill_u64.1.json
@@ -8,7 +8,7 @@
     []
   ],
   "ledger": {
-    "protocol_version": 22,
+    "protocol_version": 23,
     "sequence_number": 0,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",

--- a/soroban-sdk/test_snapshots/tests/prng/test_prng_gen_array.1.json
+++ b/soroban-sdk/test_snapshots/tests/prng/test_prng_gen_array.1.json
@@ -8,7 +8,7 @@
     []
   ],
   "ledger": {
-    "protocol_version": 22,
+    "protocol_version": 23,
     "sequence_number": 0,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",

--- a/soroban-sdk/test_snapshots/tests/prng/test_prng_gen_bytesn.1.json
+++ b/soroban-sdk/test_snapshots/tests/prng/test_prng_gen_bytesn.1.json
@@ -8,7 +8,7 @@
     []
   ],
   "ledger": {
-    "protocol_version": 22,
+    "protocol_version": 23,
     "sequence_number": 0,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",

--- a/soroban-sdk/test_snapshots/tests/prng/test_prng_gen_len_bytes.1.json
+++ b/soroban-sdk/test_snapshots/tests/prng/test_prng_gen_len_bytes.1.json
@@ -8,7 +8,7 @@
     []
   ],
   "ledger": {
-    "protocol_version": 22,
+    "protocol_version": 23,
     "sequence_number": 0,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",

--- a/soroban-sdk/test_snapshots/tests/prng/test_prng_gen_range_u64.1.json
+++ b/soroban-sdk/test_snapshots/tests/prng/test_prng_gen_range_u64.1.json
@@ -8,7 +8,7 @@
     []
   ],
   "ledger": {
-    "protocol_version": 22,
+    "protocol_version": 23,
     "sequence_number": 0,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",

--- a/soroban-sdk/test_snapshots/tests/prng/test_prng_gen_range_u64_panic_on_invalid_range.1.json
+++ b/soroban-sdk/test_snapshots/tests/prng/test_prng_gen_range_u64_panic_on_invalid_range.1.json
@@ -7,7 +7,7 @@
     []
   ],
   "ledger": {
-    "protocol_version": 22,
+    "protocol_version": 23,
     "sequence_number": 0,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",

--- a/soroban-sdk/test_snapshots/tests/prng/test_prng_gen_u64.1.json
+++ b/soroban-sdk/test_snapshots/tests/prng/test_prng_gen_u64.1.json
@@ -8,7 +8,7 @@
     []
   ],
   "ledger": {
-    "protocol_version": 22,
+    "protocol_version": 23,
     "sequence_number": 0,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",

--- a/soroban-sdk/test_snapshots/tests/prng/test_prng_seed.1.json
+++ b/soroban-sdk/test_snapshots/tests/prng/test_prng_seed.1.json
@@ -8,7 +8,7 @@
     []
   ],
   "ledger": {
-    "protocol_version": 22,
+    "protocol_version": 23,
     "sequence_number": 0,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",

--- a/soroban-sdk/test_snapshots/tests/prng/test_prng_seed.2.json
+++ b/soroban-sdk/test_snapshots/tests/prng/test_prng_seed.2.json
@@ -8,7 +8,7 @@
     []
   ],
   "ledger": {
-    "protocol_version": 22,
+    "protocol_version": 23,
     "sequence_number": 0,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",

--- a/soroban-sdk/test_snapshots/tests/prng/test_prng_shuffle.1.json
+++ b/soroban-sdk/test_snapshots/tests/prng/test_prng_shuffle.1.json
@@ -9,7 +9,7 @@
     []
   ],
   "ledger": {
-    "protocol_version": 22,
+    "protocol_version": 23,
     "sequence_number": 0,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",

--- a/soroban-sdk/test_snapshots/tests/prng/test_vec_shuffle.1.json
+++ b/soroban-sdk/test_snapshots/tests/prng/test_vec_shuffle.1.json
@@ -9,7 +9,7 @@
     []
   ],
   "ledger": {
-    "protocol_version": 22,
+    "protocol_version": 23,
     "sequence_number": 0,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",

--- a/soroban-sdk/test_snapshots/tests/storage_testutils/all.1.json
+++ b/soroban-sdk/test_snapshots/tests/storage_testutils/all.1.json
@@ -9,7 +9,7 @@
     []
   ],
   "ledger": {
-    "protocol_version": 22,
+    "protocol_version": 23,
     "sequence_number": 0,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",

--- a/soroban-sdk/test_snapshots/tests/storage_testutils/temp_entry_expiration.1.json
+++ b/soroban-sdk/test_snapshots/tests/storage_testutils/temp_entry_expiration.1.json
@@ -8,7 +8,7 @@
     []
   ],
   "ledger": {
-    "protocol_version": 22,
+    "protocol_version": 23,
     "sequence_number": 2000,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",

--- a/soroban-sdk/test_snapshots/tests/storage_testutils/test_persistent_entry_expiration.1.json
+++ b/soroban-sdk/test_snapshots/tests/storage_testutils/test_persistent_entry_expiration.1.json
@@ -7,7 +7,7 @@
     []
   ],
   "ledger": {
-    "protocol_version": 22,
+    "protocol_version": 23,
     "sequence_number": 1100,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",

--- a/soroban-sdk/test_snapshots/tests/storage_testutils/ttl_getters.1.json
+++ b/soroban-sdk/test_snapshots/tests/storage_testutils/ttl_getters.1.json
@@ -17,7 +17,7 @@
     []
   ],
   "ledger": {
-    "protocol_version": 22,
+    "protocol_version": 23,
     "sequence_number": 1000,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",

--- a/soroban-sdk/test_snapshots/tests/token_client/test_issuer_flags.1.json
+++ b/soroban-sdk/test_snapshots/tests/token_client/test_issuer_flags.1.json
@@ -25,7 +25,7 @@
     ]
   ],
   "ledger": {
-    "protocol_version": 22,
+    "protocol_version": 23,
     "sequence_number": 0,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",

--- a/soroban-sdk/test_snapshots/tests/token_client/test_mock_all_auth.1.json
+++ b/soroban-sdk/test_snapshots/tests/token_client/test_mock_all_auth.1.json
@@ -62,7 +62,7 @@
     []
   ],
   "ledger": {
-    "protocol_version": 22,
+    "protocol_version": 23,
     "sequence_number": 0,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",

--- a/soroban-sdk/test_snapshots/tests/token_client/test_mock_auth.1.json
+++ b/soroban-sdk/test_snapshots/tests/token_client/test_mock_auth.1.json
@@ -62,7 +62,7 @@
     []
   ],
   "ledger": {
-    "protocol_version": 22,
+    "protocol_version": 23,
     "sequence_number": 0,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",

--- a/soroban-spec-rust/Cargo.toml
+++ b/soroban-spec-rust/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2021"
 rust-version.workspace = true
 
 [dependencies]
-stellar-xdr = { workspace = true, features = ["curr", "std", "serde"] }
+stellar-xdr = { workspace = true, features = ["next", "std", "serde"] }
 soroban-spec = { workspace = true }
 thiserror = "1.0.32"
 syn = {version="2.0",features=["full"]}
@@ -22,3 +22,4 @@ prettyplease = "0.2.4"
 
 [dev-dependencies]
 pretty_assertions = "1.2.1"
+

--- a/soroban-spec-rust/src/lib.rs
+++ b/soroban-spec-rust/src/lib.rs
@@ -6,7 +6,7 @@ use std::{fs, io};
 use proc_macro2::TokenStream;
 use quote::quote;
 use sha2::{Digest, Sha256};
-use stellar_xdr::curr as stellar_xdr;
+use stellar_xdr::next as stellar_xdr;
 use stellar_xdr::ScSpecEntry;
 use syn::Error;
 

--- a/soroban-spec-rust/src/trait.rs
+++ b/soroban-spec-rust/src/trait.rs
@@ -1,6 +1,6 @@
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
-use stellar_xdr::curr as stellar_xdr;
+use stellar_xdr::next as stellar_xdr;
 use stellar_xdr::ScSpecFunctionV0;
 
 use super::types::generate_type_ident;

--- a/soroban-spec-rust/src/types.rs
+++ b/soroban-spec-rust/src/types.rs
@@ -1,6 +1,6 @@
 use proc_macro2::{Literal, TokenStream};
 use quote::{format_ident, quote};
-use stellar_xdr::curr as stellar_xdr;
+use stellar_xdr::next as stellar_xdr;
 use stellar_xdr::{
     ScSpecTypeDef, ScSpecUdtEnumV0, ScSpecUdtErrorEnumV0, ScSpecUdtStructV0, ScSpecUdtUnionV0,
 };
@@ -148,6 +148,13 @@ pub fn generate_type_ident(spec: &ScSpecTypeDef) -> TokenStream {
         ScSpecTypeDef::Error => quote! { soroban_sdk::Error },
         ScSpecTypeDef::Bytes => quote! { soroban_sdk::Bytes },
         ScSpecTypeDef::Address => quote! { soroban_sdk::Address },
+        ScSpecTypeDef::AddressV2(supports_muxing) => {
+            if *supports_muxing {
+                quote! { soroban_sdk::MuxedAddress }
+            } else {
+                quote! { soroban_sdk::Address }
+            }
+        }
         ScSpecTypeDef::String => quote! { soroban_sdk::String },
         ScSpecTypeDef::Option(o) => {
             let value_ident = generate_type_ident(&o.value_type);

--- a/soroban-spec/Cargo.toml
+++ b/soroban-spec/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2021"
 rust-version.workspace = true
 
 [dependencies]
-stellar-xdr = { workspace = true, features = ["curr", "std", "serde"] }
+stellar-xdr = { workspace = true, features = ["next", "std", "serde"] }
 base64 = "0.13.0"
 thiserror = "1.0.32"
 wasmparser = "0.116.1"

--- a/soroban-spec/src/read.rs
+++ b/soroban-spec/src/read.rs
@@ -1,6 +1,6 @@
 use std::io::Cursor;
 
-use stellar_xdr::curr as stellar_xdr;
+use stellar_xdr::next as stellar_xdr;
 use stellar_xdr::{Limited, Limits, ReadXdr, ScSpecEntry};
 use wasmparser::{BinaryReaderError, Parser, Payload};
 

--- a/soroban-token-sdk/src/event.rs
+++ b/soroban-token-sdk/src/event.rs
@@ -1,8 +1,14 @@
-use soroban_sdk::{symbol_short, Address, Env, Symbol};
+use soroban_sdk::{symbol_short, Address, Env, IntoVal, MuxedAddress, Symbol, Val};
 
 pub struct Events {
     env: Env,
 }
+
+mod sealed {
+    pub trait IsAddressType {}
+}
+impl sealed::IsAddressType for Address {}
+impl sealed::IsAddressType for MuxedAddress {}
 
 impl Events {
     #[inline(always)]
@@ -17,7 +23,12 @@ impl Events {
             .publish(topics, (amount, expiration_ledger));
     }
 
-    pub fn transfer(&self, from: Address, to: Address, amount: i128) {
+    pub fn transfer<AddressType: sealed::IsAddressType + IntoVal<Env, Val>>(
+        &self,
+        from: AddressType,
+        to: AddressType,
+        amount: i128,
+    ) {
         let topics = (symbol_short!("transfer"), from, to);
         self.env.events().publish(topics, amount);
     }


### PR DESCRIPTION
This just uses a separate interface/contract function that accepts `MuxedAddress` and doesn't introduce any opt-ins/outs of exposing the muxed address type.
