### PR TITLE
Fix bls documentation - G1/G2 compression flag must be *unset*

### DIFF
--- a/soroban-sdk/src/crypto/bls12_381.rs
+++ b/soroban-sdk/src/crypto/bls12_381.rs
@@ -26,7 +26,7 @@ pub struct Bls12_381 {
 ///   `Fp`
 /// - The most significant three bits (bits 0-3) of the first byte are reserved
 ///   for encoding flags:
-///   - compression_flag (bit 0): Must always be set (1), as only uncompressed
+///   - compression_flag (bit 0): Must always be unset (0), as only uncompressed
 ///     points are supported.
 ///   - infinity_flag (bit 1): Set if the point is the point at infinity (zero
 ///     point), in which case all other bits must be zero.
@@ -57,7 +57,7 @@ pub struct G1Affine(BytesN<96>);
 ///   are components of `Fp2` (each being `Fp`).
 /// - The most significant three bits (bits 0-3) of the first byte are reserved
 ///   for encoding flags:
-///   - compression_flag (bit 0): Must always be set (1), as only uncompressed
+///   - compression_flag (bit 0): Must always be unset (0), as only uncompressed
 ///     points are supported.
 ///   - infinity_flag (bit 1): Set if the point is the point at infinity (zero
 ///     point), in which case all other bits must be zero.


### PR DESCRIPTION
### What

Fix a bug in the documentation. The G1/G2 compression flag must be **unset (0)**.
Splits out from https://github.com/stellar/rs-soroban-sdk/pull/1449 and addresses https://github.com/stellar/rs-soroban-sdk/pull/1449#discussion_r1987312581

### Why

In our BLS12-381 implementation all input points are expected in an uncompressed format.
Here is the [validation logic](https://github.com/stellar/rs-soroban-env/blob/02d4b525f9231d8b82dadde9d06224099405be1d/soroban-env-host/src/crypto/bls12_381.rs#L146-L158) on the host side, which is consistent with uncompressed point checking (the only allowed set flag is the infinity flag). 

### Known limitations

[TODO or N/A]
