### PR TITLE
Remove Env from extern functions

### DIFF
--- a/soroban-sdk-macros/src/derive_fn.rs
+++ b/soroban-sdk-macros/src/derive_fn.rs
@@ -174,9 +174,12 @@ pub fn derive_pub_fn(
 
             #[deprecated(note = #deprecated_note)]
             #[cfg_attr(target_family = "wasm", export_name = #wrap_export_name)]
-            pub extern "C" fn invoke_raw_extern(env: #crate_path::Env, #(#wrap_args),*) -> #crate_path::Val {
+            pub extern "C" fn invoke_raw_extern(#(#wrap_args),*) -> #crate_path::Val {
                 #[allow(deprecated)]
-                invoke_raw(env, #(#passthrough_calls),*)
+                invoke_raw(
+                    #crate_path::Env::default(),
+                    #(#passthrough_calls),*
+                )
             }
 
             use super::*;


### PR DESCRIPTION
### What
Remove Env parameter from invoke_raw_extern function, that is externed for each callable wasm function.

### Why
The extern functions should need to be C-ABI compatibile for a near future version of Rust which is standardizing the wasm32-unknown-unknown build on C-ABI that up until then wasn't actually C-ABI. On nightly-2025-03-27 we can see a warning already appearing, like that documented at #1458. This impact if not changed is likely that on some future version the build will hard error rather than just warn. The SDK is about to switch to being recommended building for wasm32v1-none anyway, and the warning isn't appearing on it. Presumedly a change like this will or at least may occur to wasm32v1-none too in the future. The change is beneficial in any case as it makes it much clearer as to what is happening contract side during construction. Anyone could not be faulted for wondering what the Env was given the value was not actually a parameter being passed from the host even though it looked like it was.

For anyone wondering why the Env was even included as a parameter, it's a hold over from early contract implementations where we were trying to make the extern functions the actual functions that developers were writing by hand. Those early functions included the Env that in tests would be passed in and be a non-zero sized struct, but then in wasm builds would become a zero sized type which the compiler would omit as a parameter. The SDK no longer needs that hack because the extern functions are code generated via macros and are not the same functions that developers code by hand.

For testing this, other than running all existing tests, I diffed a wasm binary built before and after this change. The only observable difference to the wasm was the embedded sdk version.

Close #1402
Close #1458 