### PR TITLE
Allow string macros (env, concat, etc) in contract meta values

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -231,7 +231,7 @@ dependencies = [
  "num-bigint",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -259,7 +259,7 @@ checksum = "45565fc9416b9896014f5732ac776f810ee53a66730c17e4020c3ec064a8f88f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -336,7 +336,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a2785755761f3ddc1492979ce1e48d2c00d09311c39e4466429188f3dd6501"
 dependencies = [
  "quote",
- "syn 2.0.77",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -363,7 +363,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -387,7 +387,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.77",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -398,7 +398,7 @@ checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -446,7 +446,7 @@ checksum = "67e77553c4162a157adbf834ebae5b415acbecbeafc7a74b0e886657506a7611"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -846,6 +846,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
+name = "macro-string"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b27834086c65ec3f9387b096d66e99f221cf081c2b738042aa252bcd41204e3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.103",
+]
+
+[[package]]
 name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -875,7 +886,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -963,7 +974,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479cf940fbbb3426c32c5d5176f62ad57549a0bb84773423ba8be9d089f5faba"
 dependencies = [
  "proc-macro2",
- "syn 2.0.77",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -977,9 +988,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.86"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
+checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
 dependencies = [
  "unicode-ident",
 ]
@@ -1171,7 +1182,7 @@ checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -1214,7 +1225,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -1269,7 +1280,7 @@ dependencies = [
  "itertools",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -1349,7 +1360,7 @@ dependencies = [
  "serde",
  "serde_json",
  "stellar-xdr",
- "syn 2.0.77",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -1371,6 +1382,7 @@ version = "23.0.0-rc.1.1"
 dependencies = [
  "arbitrary",
  "bytes-lit",
+ "crate-git-revision",
  "ctor",
  "curve25519-dalek",
  "derive_arbitrary",
@@ -1397,18 +1409,17 @@ dependencies = [
 name = "soroban-sdk-macros"
 version = "23.0.0-rc.1.1"
 dependencies = [
- "crate-git-revision",
  "darling",
  "itertools",
+ "macro-string",
  "proc-macro2",
  "quote",
- "rustc_version",
  "sha2",
  "soroban-env-common",
  "soroban-spec",
  "soroban-spec-rust",
  "stellar-xdr",
- "syn 2.0.77",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -1433,7 +1444,7 @@ dependencies = [
  "sha2",
  "soroban-spec",
  "stellar-xdr",
- "syn 2.0.77",
+ "syn 2.0.103",
  "thiserror",
 ]
 
@@ -1532,9 +1543,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.77"
+version = "2.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f35bcdf61fd8e7be6caf75f429fdca8beb3ed76584befb503b1569faee373ed"
+checksum = "e4307e30089d6fd6aff212f2da3a1f9e32f3223b1f010fb09b7c95f90f3ca1e8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1726,7 +1737,7 @@ checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -1821,7 +1832,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.103",
  "wasm-bindgen-shared",
 ]
 
@@ -1843,7 +1854,7 @@ checksum = "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.103",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -2006,7 +2017,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -2026,5 +2037,5 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.103",
 ]

--- a/soroban-sdk-macros/Cargo.toml
+++ b/soroban-sdk-macros/Cargo.toml
@@ -14,10 +14,6 @@ rust-version.workspace = true
 proc-macro = true
 doctest = false
 
-[build-dependencies]
-rustc_version = "0.4.0"
-crate-git-revision = "0.0.6"
-
 [dependencies]
 soroban-spec = { workspace = true }
 soroban-spec-rust = { workspace = true }
@@ -28,6 +24,7 @@ quote = "1.0"
 proc-macro2 = "1.0"
 itertools = "0.10.5"
 darling = "0.20.0"
+macro-string = "0.1.4"
 sha2 = "0.10.7"
 
 [features]

--- a/soroban-sdk-macros/build.rs
+++ b/soroban-sdk-macros/build.rs
@@ -1,7 +1,0 @@
-pub fn main() {
-    if let Ok(rustc_version) = rustc_version::version() {
-        println!("cargo:rustc-env=RUSTC_VERSION={rustc_version}");
-    }
-
-    crate_git_revision::init();
-}

--- a/soroban-sdk-macros/src/lib.rs
+++ b/soroban-sdk-macros/src/lib.rs
@@ -28,14 +28,15 @@ use derive_struct::derive_type_struct;
 use derive_struct_tuple::derive_type_struct_tuple;
 
 use darling::{ast::NestedMeta, FromMeta};
+use macro_string::MacroString;
 use proc_macro::TokenStream;
 use proc_macro2::{Literal, Span, TokenStream as TokenStream2};
-use quote::{format_ident, quote};
+use quote::{format_ident, quote, ToTokens};
 use sha2::{Digest, Sha256};
 use std::{fmt::Write, fs};
 use syn::{
-    parse_macro_input, parse_str, spanned::Spanned, Data, DeriveInput, Error, Fields, ItemImpl,
-    ItemStruct, LitStr, Path, Type, Visibility,
+    parse_macro_input, parse_str, spanned::Spanned, Data, DeriveInput, Error, Expr, Fields,
+    ItemImpl, ItemStruct, LitStr, Path, Type, Visibility,
 };
 use syn_ext::HasFnsItem;
 
@@ -280,34 +281,11 @@ pub fn contractimpl(metadata: TokenStream, input: TokenStream) -> TokenStream {
     }
 }
 
-#[proc_macro]
-pub fn contractmetabuiltin(_metadata: TokenStream) -> TokenStream {
-    // The following two lines assume that the soroban-sdk-macros crate always
-    // has the same version as the soroban-sdk, and lives in the same
-    // repository.
-    let rustc_version = env!("RUSTC_VERSION");
-    let sdk_pkg_version = env!("CARGO_PKG_VERSION");
-    let sdk_git_revision = env!("GIT_REVISION");
-    let sdk_version = format!("{sdk_pkg_version}#{sdk_git_revision}");
-    quote! {
-        contractmeta!(
-            // Rustc version.
-            key = "rsver",
-            val = #rustc_version,
-        );
-        contractmeta!(
-            // Rust Soroban SDK version.
-            key = "rssdkver",
-            val = #sdk_version,
-        );
-    }
-    .into()
-}
-
 #[derive(Debug, FromMeta)]
 struct MetadataArgs {
     key: String,
-    val: String,
+    #[darling(with = darling::util::parse_expr::preserve_str_literal)]
+    val: Expr,
 }
 
 #[proc_macro]
@@ -333,7 +311,9 @@ pub fn contractmeta(metadata: TokenStream) -> TokenStream {
             }
         };
 
-        let val: StringM = match args.val.try_into() {
+        let val = args.val.to_token_stream().into();
+        let MacroString(val) = parse_macro_input!(val);
+        let val: StringM = match val.try_into() {
             Ok(k) => k,
             Err(e) => {
                 return Error::new(Span::call_site(), e.to_string())

--- a/soroban-sdk/Cargo.toml
+++ b/soroban-sdk/Cargo.toml
@@ -17,6 +17,7 @@ doctest = false
 
 [build-dependencies]
 rustc_version = "0.4.1"
+crate-git-revision = "0.0.6"
 
 [dependencies]
 soroban-sdk-macros = { workspace = true }

--- a/soroban-sdk/build.rs
+++ b/soroban-sdk/build.rs
@@ -5,4 +5,10 @@ pub fn main() {
             panic!("Rust compiler 1.82+ with target 'wasm32-unknown-unknown' is unsupported by the Soroban Environment, because the 'wasm32-unknown-unknown' target in Rust 1.82+ has features enabled that are not yet supported and not easily disabled: reference-types, multi-value. Use Rust 1.81 to build for the 'wasm32-unknown-unknown' target.");
         }
     }
+
+    if let Ok(rustc_version) = rustc_version::version() {
+        println!("cargo:rustc-env=RUSTC_VERSION={rustc_version}");
+    }
+
+    crate_git_revision::init();
 }

--- a/soroban-sdk/src/lib.rs
+++ b/soroban-sdk/src/lib.rs
@@ -95,7 +95,14 @@ fn __link_sections() {
     #[link_section = "contractenvmetav0"]
     static __ENV_META_XDR: [u8; env::internal::meta::XDR.len()] = env::internal::meta::XDR;
 
-    soroban_sdk_macros::contractmetabuiltin!();
+    // Rustc version.
+    contractmeta!(key = "rsver", val = env!("RUSTC_VERSION"),);
+
+    // Rust Soroban SDK version.
+    contractmeta!(
+        key = "rssdkver",
+        val = concat!(env!("CARGO_PKG_VERSION"), "#", env!("GIT_REVISION")),
+    );
 }
 
 // Re-exports of dependencies used by macros.

--- a/soroban-sdk/src/tests.rs
+++ b/soroban-sdk/src/tests.rs
@@ -13,6 +13,7 @@ mod contract_duration;
 mod contract_fn;
 mod contract_invoke;
 mod contract_invoke_arg_count;
+mod contract_meta;
 mod contract_overlapping_type_fn_names;
 mod contract_snapshot;
 mod contract_store;

--- a/soroban-sdk/src/tests/contract_meta.rs
+++ b/soroban-sdk/src/tests/contract_meta.rs
@@ -1,0 +1,30 @@
+use crate as soroban_sdk;
+use soroban_sdk::contractmeta;
+use stellar_xdr::curr as stellar_xdr;
+use stellar_xdr::{Limits, ReadXdr, ScMetaEntry, ScMetaV0};
+
+#[test]
+fn test_meta_key_val() {
+    contractmeta!(key = "mykey", val = "myval");
+
+    let entry = ScMetaEntry::from_xdr(__CONTRACT_KEY_6d796b6579, Limits::none()).unwrap();
+    let expect = ScMetaEntry::ScMetaV0(ScMetaV0 {
+        key: "mykey".try_into().unwrap(),
+        val: "myval".try_into().unwrap(),
+    });
+
+    assert_eq!(entry, expect);
+}
+
+#[test]
+fn test_meta_env_macro_support() {
+    contractmeta!(key = "binver", val = env!("CARGO_PKG_VERSION"));
+
+    let entry = ScMetaEntry::from_xdr(__CONTRACT_KEY_62696e766572, Limits::none()).unwrap();
+    let expect = ScMetaEntry::ScMetaV0(ScMetaV0 {
+        key: "binver".try_into().unwrap(),
+        val: env!("CARGO_PKG_VERSION").try_into().unwrap(),
+    });
+
+    assert_eq!(entry, expect);
+}


### PR DESCRIPTION
### What
  Enable use of string macros like env! and concat! inside contract meta values.

  ### Why
  Allows for the use of things like environment variables, and concatenating data from multiple places inside contract meta values. Within the SDK this makes it simpler to inject the version of the SDK into the meta. Within contracts this will allow folks to inject things like the version of the crate into meta by using a value like `env!("CARGO_PKG_VERSION")`.