### PR TITLE
Fix function lifetime annotation in syn_ext.rs for rust nightly

### DIFF
--- a/soroban-sdk-macros/src/syn_ext.rs
+++ b/soroban-sdk-macros/src/syn_ext.rs
@@ -106,7 +106,7 @@ impl HasFnsItem {
         }
     }
 
-    pub fn fns(&'_ self) -> Vec<Fn> {
+    pub fn fns(&self) -> Vec<Fn<'_>> {
         match self {
             HasFnsItem::Trait(t) => trait_methods(t)
                 .map(|m| Fn {


### PR DESCRIPTION
### What
  Correct the lifetime annotation in the fns() method of HasFnsItem.

  ### Why
  Rust nightly has started erroring on this lifetime annotation that was confusing.