### PR TITLE
Add conversion from Address ref to MuxedAddress

### DIFF
--- a/soroban-sdk/src/muxed_address.rs
+++ b/soroban-sdk/src/muxed_address.rs
@@ -161,6 +161,12 @@ impl TryFromVal<Env, &MuxedAddress> for Val {
 
 impl From<Address> for MuxedAddress {
     fn from(address: Address) -> Self {
+        (&address).into()
+    }
+}
+
+impl From<&Address> for MuxedAddress {
+    fn from(address: &Address) -> Self {
         address
             .as_object()
             .try_into_val(address.env())


### PR DESCRIPTION
### What
  Add implementation of From<&Address> trait for MuxedAddress to allow converting from Address references.

  ### Why
Avoid unnecessary cloning when converting from Address references to MuxedAddress. When creating a MuxedAddress from an Address an &Address is only needed anyway.