### PR TITLE
Make trait functions that have default implementations callable

### DIFF
--- a/soroban-sdk-macros/src/derive_contractimpl_trait_default_fns_not_overridden.rs
+++ b/soroban-sdk-macros/src/derive_contractimpl_trait_default_fns_not_overridden.rs
@@ -1,0 +1,93 @@
+use crate::{
+    default_crate_path, derive_args::derive_args_impl, derive_client::derive_client_impl,
+    derive_fn::derive_pub_fn, derive_spec_fn::derive_fn_spec, syn_ext,
+};
+use darling::{ast::NestedMeta, Error, FromMeta};
+use proc_macro2::{Ident, TokenStream as TokenStream2};
+use quote::{quote, ToTokens};
+use syn::{LitStr, Path, Type};
+
+#[derive(Debug, FromMeta)]
+struct Args {
+    #[darling(default = "default_crate_path")]
+    crate_path: Path,
+    trait_ident: Ident,
+    trait_default_fns: Vec<LitStr>,
+    impl_ident: Ident,
+    impl_fns: Vec<LitStr>,
+    client_name: String,
+    args_name: String,
+    spec_name: Type,
+}
+
+pub fn derive_contractimpl_trait_default_fns_not_overridden(
+    metadata: TokenStream2,
+) -> TokenStream2 {
+    match derive_or_err(metadata) {
+        Ok(tokens) => tokens,
+        Err(err) => err.write_errors(),
+    }
+}
+
+fn derive_or_err(metadata: TokenStream2) -> Result<TokenStream2, Error> {
+    let args = NestedMeta::parse_meta_list(metadata.into())?;
+    let args = Args::from_list(&args)?;
+    let derived = derive(&args)?;
+    Ok(quote! {
+        #derived
+    }
+    .into())
+}
+
+fn derive(args: &Args) -> Result<TokenStream2, Error> {
+    let ident = &args.impl_ident;
+    let trait_ident = &args.trait_ident;
+
+    let trait_default_fns = syn_ext::strs_to_signatures(&args.trait_default_fns);
+    let impl_fns = syn_ext::strs_to_signatures(&args.impl_fns);
+
+    // Filter the list of default fns down to only default fns that have not been redefined /
+    // overridden in the input fns.
+    let fns = trait_default_fns
+        .into_iter()
+        .filter(|f| !impl_fns.iter().any(|o| f.ident == o.ident))
+        .collect::<Vec<_>>();
+
+    let mut output = quote! {};
+    for f in &fns {
+        output.extend(derive_pub_fn(
+            &args.crate_path,
+            ident.to_token_stream(),
+            &f.ident,
+            &[],
+            &f.inputs,
+            Some(trait_ident),
+            &args.client_name,
+        ));
+        output.extend(derive_fn_spec(
+            &args.spec_name,
+            &f.ident,
+            &[],
+            &f.inputs,
+            &f.output,
+            true, // TODO: pass down the 'export' parameter
+        ));
+    }
+    output.extend(derive_client_impl(
+        &args.crate_path,
+        &args.client_name,
+        fns.iter()
+            .map(Into::into)
+            .collect::<Vec<syn_ext::Fn>>()
+            .as_slice(),
+    ));
+    output.extend(derive_args_impl(
+        &args.args_name,
+        fns.iter()
+            .map(Into::into)
+            .collect::<Vec<syn_ext::Fn>>()
+            .as_slice(),
+    ));
+
+    Ok(output)
+}

--- a/soroban-sdk-macros/src/derive_fn.rs
+++ b/soroban-sdk-macros/src/derive_fn.rs
@@ -13,7 +13,7 @@ use syn::{
 #[allow(clippy::too_many_arguments)]
 pub fn derive_pub_fn(
     crate_path: &Path,
-    call: &TokenStream2,
+    self_ty: TokenStream2,
     ident: &Ident,
     attrs: &[Attribute],
     inputs: &Punctuated<FnArg, Comma>,
@@ -22,6 +22,8 @@ pub fn derive_pub_fn(
 ) -> Result<TokenStream2, TokenStream2> {
     // Collect errors as they are encountered and emit them at the end.
     let mut errors = Vec::<Error>::new();
+
+    let call = quote! { <super::#self_ty>::#ident };
 
     // Prepare the env input.
     let env_input = inputs.first().and_then(|a| match a {

--- a/soroban-sdk-macros/src/derive_trait.rs
+++ b/soroban-sdk-macros/src/derive_trait.rs
@@ -1,0 +1,109 @@
+use crate::default_crate_path;
+use darling::{ast::NestedMeta, Error, FromMeta};
+use heck::ToSnakeCase;
+use proc_macro2::{Ident, TokenStream as TokenStream2};
+use quote::ToTokens;
+use quote::{format_ident, quote};
+use syn::{parse2, ImplItemFn, ItemTrait, Path, TraitItem, TraitItemFn, Type};
+
+#[derive(Debug, FromMeta)]
+struct Args {
+    #[darling(default = "default_crate_path")]
+    crate_path: Path,
+}
+
+pub fn derive_trait(metadata: TokenStream2, input: TokenStream2) -> TokenStream2 {
+    match derive_or_err(metadata, input) {
+        Ok(tokens) => tokens,
+        Err(err) => err.write_errors(),
+    }
+}
+
+fn derive_or_err(metadata: TokenStream2, input: TokenStream2) -> Result<TokenStream2, Error> {
+    let args = NestedMeta::parse_meta_list(metadata.into())?;
+    let args = Args::from_list(&args)?;
+    let input = parse2(input)?;
+    let derived = derive(&args, &input)?;
+    Ok(quote! {
+        #derived
+        #input
+    }
+    .into())
+}
+
+fn derive(args: &Args, input: &ItemTrait) -> Result<TokenStream2, Error> {
+    let path = &args.crate_path;
+
+    let trait_ident = &input.ident;
+
+    let fns = input.items.iter().filter_map(|i| match i {
+        TraitItem::Fn(TraitItemFn {
+            default: Some(_),
+            sig,
+            ..
+        }) => Some(sig.to_token_stream().to_string()),
+        _ => None,
+    });
+
+    let macro_ident = macro_ident(&input.ident);
+    let hidden_macro_ident = format_ident!("__{}", macro_ident);
+
+    let output = quote! {
+        #[doc(hidden)]
+        #[allow(unused_macros)]
+        #[macro_export]
+        macro_rules! #hidden_macro_ident {
+            (
+                $impl_ident:ty,
+                $impl_fns:expr,
+                $client_name:literal,
+                $args_name:literal,
+                $spec_name:literal $(,)?
+            ) => {
+                #path::contractimpl_trait_default_fns_not_overridden!(
+                    trait_ident = #trait_ident,
+                    trait_default_fns = [#(#fns),*],
+                    impl_ident = $impl_ident,
+                    impl_fns = $impl_fns,
+                    client_name = $client_name,
+                    args_name = $args_name,
+                    spec_name = $spec_name,
+                );
+            }
+        }
+
+        /// Macro for `contractimpl`ing the default functions of the trait that are not overriden
+        /// inside the macro block.
+        pub use #hidden_macro_ident as #macro_ident;
+    };
+
+    Ok(output)
+}
+
+pub fn generate_call_to_contractimpl_for_trait(
+    trait_ident: &Ident,
+    impl_ident: &Type,
+    pub_methods: &Vec<&ImplItemFn>,
+    client_ident: &str,
+    args_ident: &str,
+    spec_ident: &str,
+) -> TokenStream2 {
+    let macro_ident = macro_ident(trait_ident);
+    let impl_fns = pub_methods
+        .iter()
+        .map(|f| f.sig.to_token_stream().to_string());
+    quote! {
+        #macro_ident!(
+            #impl_ident,
+            [#(#impl_fns),*],
+            #client_ident,
+            #args_ident,
+            #spec_ident,
+        );
+    }
+}
+
+fn macro_ident(trait_ident: &Ident) -> Ident {
+    let lower = trait_ident.to_string().to_snake_case();
+    format_ident!("contractimpl_for_{lower}")
+}

--- a/soroban-sdk-macros/src/lib.rs
+++ b/soroban-sdk-macros/src/lib.rs
@@ -4,6 +4,7 @@ mod arbitrary;
 mod attribute;
 mod derive_args;
 mod derive_client;
+mod derive_contractimpl_trait_default_fns_not_overridden;
 mod derive_enum;
 mod derive_enum_int;
 mod derive_error_enum_int;
@@ -12,6 +13,7 @@ mod derive_fn;
 mod derive_spec_fn;
 mod derive_struct;
 mod derive_struct_tuple;
+mod derive_trait;
 mod doc;
 mod map_type;
 mod path;
@@ -20,6 +22,7 @@ mod syn_ext;
 
 use derive_args::{derive_args_impl, derive_args_type};
 use derive_client::{derive_client_impl, derive_client_type};
+use derive_contractimpl_trait_default_fns_not_overridden::derive_contractimpl_trait_default_fns_not_overridden;
 use derive_enum::derive_type_enum;
 use derive_enum_int::derive_type_enum_int;
 use derive_error_enum_int::derive_type_error_enum_int;
@@ -28,6 +31,7 @@ use derive_fn::{derive_contract_function_registration_ctor, derive_pub_fn};
 use derive_spec_fn::derive_fn_spec;
 use derive_struct::derive_type_struct;
 use derive_struct_tuple::derive_type_struct_tuple;
+use derive_trait::{derive_trait, generate_call_to_contractimpl_for_trait};
 
 use darling::{ast::NestedMeta, FromMeta};
 use macro_string::MacroString;
@@ -244,10 +248,9 @@ pub fn contractimpl(metadata: TokenStream, input: TokenStream) -> TokenStream {
         .iter()
         .map(|m| {
             let ident = &m.sig.ident;
-            let call = quote! { <super::#ty>::#ident };
             derive_pub_fn(
                 crate_path,
-                &call,
+                ty.to_token_stream(),
                 ident,
                 &m.attrs,
                 &m.sig.inputs,
@@ -257,6 +260,17 @@ pub fn contractimpl(metadata: TokenStream, input: TokenStream) -> TokenStream {
         })
         .collect();
 
+    let contractimpl_for_trait = trait_ident.map(|trait_ident| {
+        generate_call_to_contractimpl_for_trait(
+            trait_ident.into(),
+            ty,
+            &pub_methods,
+            &client_ident,
+            &args_ident,
+            &ty_str,
+        )
+    });
+
     match derived {
         Ok(derived_ok) => {
             let mut output = quote! {
@@ -265,6 +279,7 @@ pub fn contractimpl(metadata: TokenStream, input: TokenStream) -> TokenStream {
                 #[#crate_path::contractspecfn(name = #ty_str)]
                 #imp
                 #derived_ok
+                #contractimpl_for_trait
             };
             let cfs = derive_contract_function_registration_ctor(
                 crate_path,
@@ -281,6 +296,16 @@ pub fn contractimpl(metadata: TokenStream, input: TokenStream) -> TokenStream {
         }
         .into(),
     }
+}
+
+#[proc_macro_attribute]
+pub fn contracttrait(metadata: TokenStream, input: TokenStream) -> TokenStream {
+    derive_trait(metadata.into(), input.into()).into()
+}
+
+#[proc_macro]
+pub fn contractimpl_trait_default_fns_not_overridden(input: TokenStream) -> TokenStream {
+    derive_contractimpl_trait_default_fns_not_overridden(input.into()).into()
 }
 
 #[derive(Debug, FromMeta)]

--- a/soroban-sdk/src/lib.rs
+++ b/soroban-sdk/src/lib.rs
@@ -391,6 +391,18 @@ pub use soroban_sdk_macros::contract;
 /// ```
 pub use soroban_sdk_macros::contractimpl;
 
+/// Generates code the same as contractimpl does, but for the default functions of a trait that are
+/// not overriden.
+///
+/// This macro is used internally and is not intended to be used directly by contracts.
+#[doc(hidden)]
+pub use soroban_sdk_macros::contractimpl_trait_default_fns_not_overridden;
+
+/// Marks the trait as intended to provide contract functions that a `contractimpl` can implement.
+/// Functions with default implementation are callable on the contract.
+/// TODO: Add rust docs.
+pub use soroban_sdk_macros::contracttrait;
+
 /// Adds a serialized SCMetaEntry::SCMetaV0 to the WASM contracts custom section
 /// under the section name 'contractmetav0'. Contract developers can use this to
 /// append metadata to their contract.


### PR DESCRIPTION
_This pull request is an experiment. At the moment it exists to evaluate if a solution like this is ergonomic and meaningful. It might lead to being merged with some further tuning and tidying. It came out of the idea I shared at https://github.com/stellar/rs-soroban-sdk/issues/1451#issuecomment-3068036433, that leverages the idea to use declarative macros (thanks to @willemneal) that can be code generated as a way to generate macro code for traits which can be later called by a contract implementing._

### What

Make trait functions that have default implementations callable on contracts.

### Examples

The following are a couple examples. The second one is also at:
- https://github.com/leighmcculloch/stellar--rs-soroban-sdk--i1451

#### Simple Example

Contract developer implements trait that has some default behaviour:

```rust
#![no_std]
use soroban_sdk::{contract, contractimpl, Env};
use library::{ Pause, contractimpl_for_pause };

#[contract]
pub struct Contract;

#[contractimpl]
impl Pause for Contract {}
```

Library developer defines trait with some default behaviour:

```rust
#![no_std]
use soroban_sdk::{contracttrait, symbol_short, Env};

#[contracttrait]
pub trait Pause {
    fn pause(env: &Env, paused: bool) {
        env.storage().persistent().set(&symbol_short!("paused"), &paused)
    }

    fn paused(env: &Env) -> bool {
        env.storage().persistent().get(&symbol_short!("paused")).unwrap_or(false)
    }
}
```

#### Hooks for Integrating Other Behaviour

Contract developer implements trait that has some default behaviour, along with provide an implementation for the hooks where auth is almost certainly required:

```rust
#![no_std]
use soroban_sdk::{contract, contractimpl, Env};
use library::{Pause, PauseHooks, contractimpl_for_pause };

#[contract]
pub struct Contract;

#[contractimpl]
impl Pause for Contract {}

impl PauseHooks for Contract {
    fn pause_before(_: &Env) {
        // TODO: Auth, etc.
    }
}
```

Library developer defines trait with some default behaviour, along with a second trait that contains non-contract functions that won't be callable, but that the library developer wants the contract developer to implement.

```rust
#![no_std]
use soroban_sdk::{contracttrait, symbol_short, Env};

#[contracttrait]
pub trait Pause : PauseHooks {
    fn pause(env: &Env, paused: bool) {
        Self::pause_before(env);
        env.storage().persistent().set(&symbol_short!("paused"), &paused)
    }

    fn paused(env: &Env) -> bool {
        env.storage().persistent().get(&symbol_short!("paused")).unwrap_or(false)
    }
}

pub trait PauseHooks {
    fn pause_before(env: &Env);
}
```

### Why

When defining traits that have default functions, and implementing them for a contract, the default functions do not get exported. The default functions do get exported when overridden by the contract. That difference in behaviour is surprising, and surprising behaviour can lead to bugs.

Resolve #1451 

### Discussion

The solution is relatively elegant and requires the developer to learn very little. The code looks almost identical to any other Rust application wanting to use a trait with a default implementation. There are a couple oddities though:

1. The code generated declarative macro, named in the examples above as `contractimpl_for_pause`, must be manually imported. As far as I can tell there's no way to avoid this in Rust today. The rust compiler error output will suggest importing it, so conveniently the compiler will point anyone using this feature to the exact solution they need. Open to ideas though if anyone has any thoughts for how to improve it.

2. All functions in a `#[contracttrait]` become callable. That's why in the second example you need a second trait for functions not intended to be callable. This isn't unique to this solution and is an oddity that exists today. 

### Try It Out

Try this pull request out locally:

1. Check out the working example at https://github.com/leighmcculloch/stellar--rs-soroban-sdk--i1451

or

1. Edit your `Cargo.toml` file so that the `soroban-sdk` imports look like this:
    ```toml
    [dependencies]
    soroban-sdk = { git = "https://github.com/stellar/rs-soroban-sdk", branch = "i1451" }

    [dev-dependencies]
    soroban-sdk = { git = "https://github.com/stellar/rs-soroban-sdk", branch = "i1451", features = ["testutils"] }
    ```

2. Add `#[contracttrait]` to the top of any trait your contract is implementing.

3. Add a function to the trait, or modify an existing function, to have a default implementation.