### PR TITLE
Fix contractimpl macro composability with third party macros

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -852,6 +852,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
+name = "must_be_empty"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70a261672ce542b9c17753db9b6d9d921cf8b48ef1dd9952726db5ad9a5f9312"
+dependencies = [
+ "proc-macro-error",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -973,6 +984,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
 dependencies = [
  "elliptic-curve",
+]
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
 ]
 
 [[package]]
@@ -1670,6 +1705,14 @@ dependencies = [
 name = "test_logging"
 version = "23.0.0-rc.1.1"
 dependencies = [
+ "soroban-sdk",
+]
+
+[[package]]
+name = "test_macros"
+version = "23.0.0-rc.1.1"
+dependencies = [
+ "must_be_empty",
  "soroban-sdk",
 ]
 

--- a/tests/macros/Cargo.toml
+++ b/tests/macros/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "test_macros"
+version.workspace = true
+authors = ["Stellar Development Foundation <info@stellar.org>"]
+license = "Apache-2.0"
+edition = "2021"
+publish = false
+rust-version.workspace = true
+
+[lib]
+crate-type = ["cdylib"]
+doctest = false
+
+[dependencies]
+soroban-sdk = {path = "../../soroban-sdk"}
+
+# The must_be_empty crate is used to test functions that have third party
+# attributes in use on functions inside contractimpl blocks. It's selected
+# because it is a small simple function attribute macro, and not for any
+# functionality it actually provides.
+must_be_empty = "0.1.0"
+
+[dev-dependencies]
+soroban-sdk = {path = "../../soroban-sdk", features = ["testutils"]}

--- a/tests/macros/src/lib.rs
+++ b/tests/macros/src/lib.rs
@@ -1,0 +1,31 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl};
+use must_be_empty::must_be_empty;
+
+#[contract]
+pub struct Contract;
+
+#[contractimpl]
+impl Contract {
+    // The must_be_empty attribute macro is used to test functions that have third party attributes
+    // in use on functions inside contractimpl blocks, to ensure the contractimpl macro and other
+    // SDKs macros interact well with third party macros.
+    #[must_be_empty]
+    pub fn empty() {}
+}
+
+#[cfg(test)]
+mod test {
+    use soroban_sdk::Env;
+
+    use crate::{Contract, ContractClient};
+
+    #[test]
+    fn test_hello() {
+        let e = Env::default();
+        let contract_id = e.register(Contract, ());
+        let client = ContractClient::new(&e, &contract_id);
+
+        client.empty();
+    }
+}


### PR DESCRIPTION
### What
  Add a test vector that demonstrates a composability issue with third party function macros. Apple the existing filtering of which attributes get applied to the generated exported functions also to the generated spec constant.

  ### Why
  In #1427 I moved where the attributes were used as part of fixing another bug, and inadvertently moved the expansion of the attributes to the line before where the attributes are filtered. The filter ensures that only a specific set of attributes get applied to the generated code. The attributes still need to go through the filter for their use on the spec constant and it was an error on my part not to also move the filter.

Close #1509