### PR TITLE
Remove leading underscores from fn args in specs

### DIFF
--- a/soroban-sdk-macros/src/derive_spec_fn.rs
+++ b/soroban-sdk-macros/src/derive_spec_fn.rs
@@ -64,6 +64,16 @@ pub fn derive_fn_spec(
                     "".to_string()
                 };
 
+                // Strip any underscore prefix characters. Implementation's that do not use an
+                // argument will prefix an underscore to the variable name to signal to the
+                // compiler that the developer acknowledges they will not be using the parameter.
+                // Keeping the underscore out of the spec ensures that the spec doesn't communicate
+                // implementation details and doesn't change when implementations start or stop
+                // using a variable in the implementation. It also ensures spec consistency between
+                // implementations of the same trait even if some of those implementations do not
+                // use all the inputs.
+                let name = name.trim_start_matches("_");
+
                 // If fn is a __check_auth implementation, allow the first argument,
                 // signature_payload of type Bytes (32 size), to be a Hash.
                 let allow_hash = ident == "__check_auth" && i == 0;

--- a/soroban-sdk/src/tests/contract_duration.rs
+++ b/soroban-sdk/src/tests/contract_duration.rs
@@ -27,7 +27,7 @@ fn test_spec() {
         name: "exec".try_into().unwrap(),
         inputs: [xdr::ScSpecFunctionInputV0 {
             doc: "".try_into().unwrap(),
-            name: "_d".try_into().unwrap(),
+            name: "d".try_into().unwrap(),
             type_: xdr::ScSpecTypeDef::Duration,
         }]
         .try_into()

--- a/soroban-sdk/src/tests/contract_fn.rs
+++ b/soroban-sdk/src/tests/contract_fn.rs
@@ -13,6 +13,10 @@ impl Contract {
     pub fn add(_e: &Env, a: i32, b: i32) -> i32 {
         a + b
     }
+
+    pub fn add_with_unused_arg(_e: &Env, a: i32, _b: i32) -> i32 {
+        a + 2
+    }
 }
 
 #[test]
@@ -32,6 +36,31 @@ fn test_spec() {
     let expect = ScSpecEntry::FunctionV0(ScSpecFunctionV0 {
         doc: "".try_into().unwrap(),
         name: "add".try_into().unwrap(),
+        inputs: vec![
+            ScSpecFunctionInputV0 {
+                doc: "".try_into().unwrap(),
+                name: "a".try_into().unwrap(),
+                type_: ScSpecTypeDef::I32,
+            },
+            ScSpecFunctionInputV0 {
+                doc: "".try_into().unwrap(),
+                name: "b".try_into().unwrap(),
+                type_: ScSpecTypeDef::I32,
+            },
+        ]
+        .try_into()
+        .unwrap(),
+        outputs: vec![ScSpecTypeDef::I32].try_into().unwrap(),
+    });
+    assert_eq!(entries, expect);
+}
+
+#[test]
+fn test_spec_with_unused_arg() {
+    let entries = ScSpecEntry::from_xdr(__SPEC_XDR_FN_ADD_WITH_UNUSED_ARG, Limits::none()).unwrap();
+    let expect = ScSpecEntry::FunctionV0(ScSpecFunctionV0 {
+        doc: "".try_into().unwrap(),
+        name: "add_with_unused_arg".try_into().unwrap(),
         inputs: vec![
             ScSpecFunctionInputV0 {
                 doc: "".try_into().unwrap(),

--- a/soroban-sdk/src/tests/contract_timepoint.rs
+++ b/soroban-sdk/src/tests/contract_timepoint.rs
@@ -27,7 +27,7 @@ fn test_spec() {
         name: "exec".try_into().unwrap(),
         inputs: [xdr::ScSpecFunctionInputV0 {
             doc: "".try_into().unwrap(),
-            name: "_t".try_into().unwrap(),
+            name: "t".try_into().unwrap(),
             type_: xdr::ScSpecTypeDef::Timepoint,
         }]
         .try_into()


### PR DESCRIPTION
### What
  Strip leading underscores from function argument names in the generated contract spec.

  ### Why
  Prevents implementation details from leaking into the spec and ensures consistency across different implementations of the same trait. Underscores are used as prefixes to argument names when a function implementation doesn't make use of the argument. That's an implementation detail, and surfacing that implementation detail into specs causes different implementations of the same trait to be different even though the interface is the same.

I debated about whether it should only strip a single underscore, or any number of underscores. I went with it stripping all underscores because I think it would be more surprising if `__arg` became `_arg` or stayed as `__arg` when `_arg` becomes `arg`.