### PR TITLE
Generate a seamless conversion from Address to MuxedAddress arguments in clients

### DIFF
--- a/soroban-sdk-macros/src/derive_client.rs
+++ b/soroban-sdk-macros/src/derive_client.rs
@@ -1,7 +1,7 @@
 use itertools::Itertools;
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
-use syn::{Error, FnArg, LitStr, PatType, Path, Type, TypePath, TypeReference};
+use syn::{Error, FnArg, LitStr, Path, Type, TypePath, TypeReference};
 
 use crate::{
     attribute::pass_through_attr_to_gen_code, map_type::map_type, stellar_xdr::ScSpecTypeDef,
@@ -15,18 +15,6 @@ fn is_muxed_address_type(arg: &FnArg) -> bool {
         }
     }
     false
-}
-
-fn convert_to_into_muxed_address(arg: &FnArg) -> FnArg {
-    if let FnArg::Typed(pat_type) = arg {
-        return FnArg::Typed(PatType {
-            attrs: pat_type.attrs.clone(),
-            pat: pat_type.pat.clone(),
-            colon_token: pat_type.colon_token,
-            ty: Box::new(syn::parse_quote! { impl Into<MuxedAddress> }),
-        });
-    }
-    arg.clone()
 }
 
 pub fn derive_client_type(crate_path: &Path, ty: &str, name: &str) -> TokenStream {
@@ -220,7 +208,7 @@ pub fn derive_client_impl(crate_path: &Path, name: &str, fns: &[syn_ext::Fn]) ->
 
                     let is_muxed_address = is_muxed_address_type(t);
                     let converted_type = if is_muxed_address {
-                        convert_to_into_muxed_address(t)
+                        syn_ext::fn_arg_make_into(t)
                     } else {
                         syn_ext::fn_arg_make_ref(t, None)
                     };

--- a/soroban-sdk-macros/src/syn_ext.rs
+++ b/soroban-sdk-macros/src/syn_ext.rs
@@ -90,6 +90,19 @@ pub fn fn_arg_make_ref(arg: &FnArg, lifetime: Option<&Lifetime>) -> FnArg {
     arg.clone()
 }
 
+pub fn fn_arg_make_into(arg: &FnArg) -> FnArg {
+    if let FnArg::Typed(pat_type) = arg {
+        let ty = &pat_type.ty;
+        return FnArg::Typed(PatType {
+            attrs: pat_type.attrs.clone(),
+            pat: pat_type.pat.clone(),
+            colon_token: pat_type.colon_token,
+            ty: Box::new(syn::parse_quote! { impl Into<#ty> }),
+        });
+    }
+    arg.clone()
+}
+
 pub enum HasFnsItem {
     Trait(ItemTrait),
     Impl(ItemImpl),

--- a/soroban-sdk/src/muxed_address.rs
+++ b/soroban-sdk/src/muxed_address.rs
@@ -159,6 +159,12 @@ impl TryFromVal<Env, &MuxedAddress> for Val {
     }
 }
 
+impl From<&MuxedAddress> for MuxedAddress {
+    fn from(address: &MuxedAddress) -> Self {
+        address.clone()
+    }
+}
+
 impl From<Address> for MuxedAddress {
     fn from(address: Address) -> Self {
         (&address).into()

--- a/soroban-sdk/src/tests/token_spec.rs
+++ b/soroban-sdk/src/tests/token_spec.rs
@@ -61,7 +61,6 @@ fn test_stellar_asset_spec_includes_token_spec() -> Result<(), Error> {
     let stellar_asset_entries: HashSet<ScSpecEntry> =
         ScSpecEntry::read_xdr_iter(&mut Limited::new(stellar_asset_cursor, Limits::none()))
             .collect::<Result<HashSet<_>, _>>()?;
-
     // Check that the token entries are a subset of stellar entries
     assert!(
         token_entries.is_subset(&stellar_asset_entries),

--- a/soroban-sdk/src/token.rs
+++ b/soroban-sdk/src/token.rs
@@ -142,12 +142,12 @@ pub trait TokenInterface {
     /// Emits an event with topics
     /// `["transfer", from: Address, to: Address]
     /// If `to` is not a muxed address (i.e. has no muxed_id set), then data
-    /// will  have the following format (the `Transfer` event defined below):
+    /// will  have the following format (the `Transfer` event):
     /// `data = amount: i128`
     ///
     /// If `to` is a muxed address (i.e. has a muxed_id set), then data will
     /// have be emitted as map with Symbol keys in the following format (the
-    /// `TransferMuxed` event defined below):
+    /// `TransferMuxed` event):
     /// `data = { "amount": i128, "to_muxed_id": u64 }`
     fn transfer(env: Env, from: Address, to: MuxedAddress, amount: i128);
 
@@ -311,7 +311,7 @@ pub(crate) const TOKEN_SPEC_XDR_INPUT: &[&[u8]] = &[
     &Clawback::spec_xdr(),
 ];
 
-pub(crate) const TOKEN_SPEC_XDR_LEN: usize = 5388;
+pub(crate) const TOKEN_SPEC_XDR_LEN: usize = 5724;
 
 impl TokenSpec {
     /// Returns the XDR spec for the Token contract.
@@ -403,9 +403,17 @@ pub trait StellarAssetInterface {
     ///
     /// # Events
     ///
-    /// Emits an event with topics `["transfer", from: Address, to: Address],
-    /// data = amount: i128`
-    fn transfer(env: Env, from: Address, to: Address, amount: i128);
+    /// Emits an event with topics
+    /// `["transfer", from: Address, to: Address]
+    /// If `to` is not a muxed address (i.e. has no muxed_id set), then data
+    /// will  have the following format (the `Transfer` event):
+    /// `data = amount: i128`
+    ///
+    /// If `to` is a muxed address (i.e. has a muxed_id set), then data will
+    /// have be emitted as map with Symbol keys in the following format (the
+    /// `TransferMuxed` event):
+    /// `data = { "amount": i128, "to_muxed_id": u64 }`
+    fn transfer(env: Env, from: Address, to: MuxedAddress, amount: i128);
 
     /// Transfer `amount` from `from` to `to`, consuming the allowance that
     /// `spender` has on `from`'s balance. Authorized by spender
@@ -608,7 +616,7 @@ pub(crate) const STELLAR_ASSET_SPEC_XDR_INPUT: &[&[u8]] = &[
     &SetAuthorized::spec_xdr(),
 ];
 
-pub(crate) const STELLAR_ASSET_SPEC_XDR_LEN: usize = 7320;
+pub(crate) const STELLAR_ASSET_SPEC_XDR_LEN: usize = 7656;
 
 impl StellarAssetSpec {
     /// Returns the XDR spec for the Token contract.

--- a/soroban-sdk/src/token.rs
+++ b/soroban-sdk/src/token.rs
@@ -7,7 +7,7 @@
 //! Use [`TokenClient`] for calling token contracts such as the Stellar Asset
 //! Contract.
 
-use crate::{contractclient, contractevent, contractspecfn, Address, Env, String};
+use crate::{contractclient, contractevent, contractspecfn, Address, Env, MuxedAddress, String};
 
 // The interface below was copied from
 // https://github.com/stellar/rs-soroban-env/blob/main/soroban-env-host/src/native_contract/token/contract.rs
@@ -139,9 +139,17 @@ pub trait TokenInterface {
     ///
     /// # Events
     ///
-    /// Emits an event with topics `["transfer", from: Address, to: Address],
-    /// data = amount: i128`
-    fn transfer(env: Env, from: Address, to: Address, amount: i128);
+    /// Emits an event with topics
+    /// `["transfer", from: Address, to: Address]
+    /// If `to` is not a muxed address (i.e. has no muxed_id set), then data
+    /// will  have the following format (the `Transfer` event defined below):
+    /// `data = amount: i128`
+    ///
+    /// If `to` is a muxed address (i.e. has a muxed_id set), then data will
+    /// have be emitted as map with Symbol keys in the following format (the
+    /// `TransferMuxed` event defined below):
+    /// `data = { "amount": i128, "to_muxed_id": u64 }`
+    fn transfer(env: Env, from: Address, to: MuxedAddress, amount: i128);
 
     /// Transfer `amount` from `from` to `to`, consuming the allowance that
     /// `spender` has on `from`'s balance. Authorized by spender

--- a/soroban-sdk/test_snapshots/tests/muxed_address/test_accept_muxed_address_argument_in_contract.1.json
+++ b/soroban-sdk/test_snapshots/tests/muxed_address/test_accept_muxed_address_argument_in_contract.1.json
@@ -1,0 +1,82 @@
+{
+  "generators": {
+    "address": 5,
+    "nonce": 0,
+    "mux_id": 2
+  },
+  "auth": [
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 23,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/tests/events/src/lib.rs
+++ b/tests/events/src/lib.rs
@@ -86,7 +86,7 @@ mod test {
         let to = Address::generate(&env);
         let amount = 1i128;
 
-        client.transfer(&from, &(&to).into(), &amount);
+        client.transfer(&from, &to, &amount);
 
         assert_eq!(
             env.events().all(),


### PR DESCRIPTION
### What

Generate a seamless conversion from Address to MuxedAddress arguments in clients.

Also switch the token interface to use MuxedAddress, as this shouldn't be a breaking change anymore.

### Why

Besides removing the friction from the token interface users, this change corresponds to the protocol semantics of MuxedAddress - any contract that accepts MuxedAddress is going to be interoperable with the contracts that expect that it accepts just Address.

### Known limitations

N/A
