### PR TITLE
Fix reference type restrictions in map_type

### DIFF
--- a/soroban-sdk-macros/src/map_type.rs
+++ b/soroban-sdk-macros/src/map_type.rs
@@ -199,3 +199,30 @@ pub fn map_type(t: &Type, allow_ref: bool, allow_hash: bool) -> Result<ScSpecTyp
         _ => Err(Error::new(t.span(), "unsupported type"))?,
     }
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use syn::parse_quote;
+
+    #[test]
+    fn test_path() {
+        let ty = syn::Type::Path(parse_quote!(u32));
+        let res = map_type(&ty, false, false);
+        assert_eq!(res.unwrap(), ScSpecTypeDef::U32);
+    }
+
+    #[test]
+    fn test_ref() {
+        let ty = Type::Reference(parse_quote!(&u32));
+        let res = map_type(&ty, true, false);
+        assert_eq!(res.unwrap(), ScSpecTypeDef::U32);
+    }
+
+    #[test]
+    fn test_ref_error_when_ref_not_allowed() {
+        let ty = Type::Reference(parse_quote!(&u32));
+        let res = map_type(&ty, false, false);
+        assert!(res.is_err());
+    }
+}

--- a/soroban-sdk-macros/src/map_type.rs
+++ b/soroban-sdk-macros/src/map_type.rs
@@ -19,7 +19,13 @@ pub const G2_SERIALIZED_SIZE: u32 = FP2_SERIALIZED_SIZE * 2;
 #[allow(clippy::too_many_lines)]
 pub fn map_type(t: &Type, allow_ref: bool, allow_hash: bool) -> Result<ScSpecTypeDef, Error> {
     match t {
-        Type::Reference(TypeReference { elem, .. }) => map_type(elem, allow_ref, allow_hash),
+        Type::Reference(TypeReference { elem, .. }) => {
+            if allow_ref {
+                map_type(elem, allow_ref, allow_hash)
+            } else {
+                Err(Error::new(t.span(), "reference types unsupported"))
+            }
+        }
         Type::Path(TypePath {
             qself: None,
             path: Path { segments, .. },

--- a/soroban-sdk-macros/src/map_type.rs
+++ b/soroban-sdk-macros/src/map_type.rs
@@ -23,7 +23,7 @@ pub fn map_type(t: &Type, allow_ref: bool, allow_hash: bool) -> Result<ScSpecTyp
             if allow_ref {
                 map_type(elem, allow_ref, allow_hash)
             } else {
-                Err(Error::new(t.span(), "reference types unsupported"))
+                Err(Error::new(t.span(), "references unsupported"))
             }
         }
         Type::Path(TypePath {


### PR DESCRIPTION
### What
  Disallow reference types in map_type, offering up an error message indicating that they are not supported, when map_type is instructed that it is being used in a situation where reference types are not supported.

  ### Why
  In #1499 I added support for ref types to map_type, to support ref types on types that use the `contractevent` macro. When implementing I added an `allow_ref` parameter that call sites used to indicate to the map_type function if refs are supported. This is because while contractevent types were getting ref support, all other use cases like function args and contracttype types would not be. The reason that the map_type function cares if they are supported or not is because it is the central location where meaningful error messages about the type in use are generated. If map_type doesn't error and provide a meaningful error message, there will be other side-effect failures during compilation that are just harder for the developer to reason about and understand why they are occurring. Unfortunately when implementing ref types into map_type I failed to actually add a guard to the function to error if a ref type is detected in a situation that was not allowed.

This really begs the question why didn't tests catch this. The answer being that unfortunately we don't have tests for compile failures anymore. In the early days we did have a small suite of compile failure tests that were effective at catching bugs like this, but because each test triggered its own compiler it was extremely slow. I removed the test suite in those early days because even with a small test suite the cost to run it seemed out sized with the impact of bugs in this specific area. We might want to consider bringing them back and running them on a schedule or non-pr-blocking case. Separate to that this function should have had some unit tests, it's perfectly suited for that, so I've included a couple to start with and to cover the case being fixed.