### PR TITLE
feat: Allow references in contract methods

### DIFF
--- a/soroban-sdk-macros/src/derive_fn.rs
+++ b/soroban-sdk-macros/src/derive_fn.rs
@@ -64,6 +64,7 @@ pub fn derive_pub_fn(
                 if let Err(e) = map_type(&pat_ty.ty, false, allow_hash) {
                     errors.push(e);
                 }
+                let arg_ref =  matches!(*pat_ty.ty, Type::Reference(_)).then(|| quote!(&));
 
                 let ident = format_ident!("arg_{}", i);
                 let arg = FnArg::Typed(PatType {
@@ -80,7 +81,7 @@ pub fn derive_pub_fn(
                 });
                 let passthrough_call = quote! { #ident };
                 let call = quote! {
-                    <_ as #crate_path::unwrap::UnwrapOptimized>::unwrap_optimized(
+                    #arg_ref<_ as #crate_path::unwrap::UnwrapOptimized>::unwrap_optimized(
                         <_ as #crate_path::TryFromValForContractFn<#crate_path::Env, #crate_path::Val>>::try_from_val_for_contract_fn(
                             &env,
                             &#ident
@@ -103,22 +104,16 @@ pub fn derive_pub_fn(
         "use `{}::new(&env, &contract_id).{}` instead",
         client_ident, &ident
     );
-    let env_call = if let Some(is_ref) = env_input {
+    let env_call = env_input.map(|is_ref| {
         if is_ref {
             quote! { &env, }
         } else {
             quote! { env.clone(), }
         }
-    } else {
-        quote! {}
-    };
+    });
     let slice_args: Vec<TokenStream2> = (0..wrap_args.len()).map(|n| quote! { args[#n] }).collect();
     let arg_count = slice_args.len();
-    let use_trait = if let Some(t) = trait_ident {
-        quote! { use super::#t }
-    } else {
-        quote! {}
-    };
+    let use_trait = trait_ident.map(|t| quote! { use super::#t });
 
     // If errors have occurred, render them instead.
     if !errors.is_empty() {

--- a/soroban-sdk-macros/src/syn_ext.rs
+++ b/soroban-sdk-macros/src/syn_ext.rs
@@ -51,16 +51,19 @@ pub fn fn_arg_ident(arg: &FnArg) -> Result<Ident, Error> {
 /// Returns a clone of the type from the FnArg.
 pub fn fn_arg_ref_type(arg: &FnArg, lifetime: Option<&Lifetime>) -> Result<Type, Error> {
     if let FnArg::Typed(pat_type) = arg {
-        if !matches!(*pat_type.ty, Type::Reference(_)) {
-            Ok(Type::Reference(TypeReference {
+        let type_ref = if let Type::Reference(ref ty) = *pat_type.ty {
+            let mut ty = ty.clone();
+            ty.lifetime = lifetime.cloned();
+            ty
+        } else {
+            TypeReference {
                 and_token: And::default(),
                 lifetime: lifetime.cloned(),
                 mutability: None,
                 elem: pat_type.ty.clone(),
-            }))
-        } else {
-            Ok((*pat_type.ty).clone())
-        }
+            }
+        };
+        Ok(Type::Reference(type_ref))
     } else {
         Err(Error::new(
             arg.span(),
@@ -73,19 +76,24 @@ pub fn fn_arg_ref_type(arg: &FnArg, lifetime: Option<&Lifetime>) -> Result<Type,
 /// arg and its type is not already a reference.
 pub fn fn_arg_make_ref(arg: &FnArg, lifetime: Option<&Lifetime>) -> FnArg {
     if let FnArg::Typed(pat_type) = arg {
-        if !matches!(*pat_type.ty, Type::Reference(_)) {
-            return FnArg::Typed(PatType {
-                attrs: pat_type.attrs.clone(),
-                pat: pat_type.pat.clone(),
-                colon_token: pat_type.colon_token,
-                ty: Box::new(Type::Reference(TypeReference {
-                    and_token: And::default(),
-                    lifetime: lifetime.cloned(),
-                    mutability: None,
-                    elem: pat_type.ty.clone(),
-                })),
-            });
-        }
+        let type_ref = if let Type::Reference(ref ty) = *pat_type.ty {
+            let mut ty = ty.clone();
+            ty.lifetime = lifetime.cloned();
+            ty
+        } else {
+            TypeReference {
+                and_token: And::default(),
+                lifetime: lifetime.cloned(),
+                mutability: None,
+                elem: pat_type.ty.clone(),
+            }
+        };
+        return FnArg::Typed(PatType {
+            attrs: pat_type.attrs.clone(),
+            pat: pat_type.pat.clone(),
+            colon_token: pat_type.colon_token,
+            ty: Box::new(Type::Reference(type_ref)),
+        });
     }
     arg.clone()
 }

--- a/tests/contract_data/src/lib.rs
+++ b/tests/contract_data/src/lib.rs
@@ -6,15 +6,15 @@ pub struct Contract;
 
 #[contractimpl]
 impl Contract {
-    pub fn put(e: Env, key: Symbol, val: Symbol) {
-        e.storage().persistent().set(&key, &val)
+    pub fn put(e: Env, key: &Symbol, val: &Symbol) {
+        e.storage().persistent().set(key, val)
     }
 
-    pub fn get(e: Env, key: Symbol) -> Option<Symbol> {
-        e.storage().persistent().get(&key)
+    pub fn get(e: Env, key: &Symbol) -> Option<Symbol> {
+        e.storage().persistent().get(key)
     }
 
-    pub fn del(e: Env, key: Symbol) {
-        e.storage().persistent().remove(&key)
+    pub fn del(e: Env, key: &Symbol) {
+        e.storage().persistent().remove(key)
     }
 }

--- a/tests/udt/src/lib.rs
+++ b/tests/udt/src/lib.rs
@@ -34,7 +34,7 @@ pub struct Contract;
 
 #[contractimpl]
 impl Contract {
-    pub fn add(a: UdtEnum, b: UdtEnum) -> i64 {
+    pub fn add(a: UdtEnum, b: &UdtEnum) -> i64 {
         let a = match a {
             UdtEnum::UdtA => 0,
             UdtEnum::UdtB(udt) => udt.a + udt.b,
@@ -44,7 +44,7 @@ impl Contract {
         let b = match b {
             UdtEnum::UdtA => 0,
             UdtEnum::UdtB(udt) => udt.a + udt.b,
-            UdtEnum::UdtC(val) => val as i64,
+            UdtEnum::UdtC(val) => *val as i64,
             UdtEnum::UdtD(tup) => tup.0 + tup.1.try_iter().fold(0i64, |sum, i| sum + i.unwrap()),
         };
         a + b


### PR DESCRIPTION
### What

Support references in contract methods:

```rust

#[contractimpl]
impl Contract {
    pub fn foo(e: &Env, a: &Symbol, b: &SomeUDT){
...
```

### Why

Often when testing contracts with unit testing or calling an external interface from within a contract in can be useful to have the argument to the method be a reference.

### Known limitations

Need to test more thoroughly.
