### PR TITLE
Deprecate old events publish method

### DIFF
--- a/soroban-sdk/src/events.rs
+++ b/soroban-sdk/src/events.rs
@@ -82,9 +82,7 @@ impl Events {
         Events(env.clone())
     }
 
-    /// Publish an event.
-    ///
-    /// The event is defined using the [`contractevent`][crate::contractevent] macro.
+    /// Publish an event defined using the [`contractevent`][crate::contractevent] macro.
     #[inline(always)]
     pub fn publish_event(&self, e: &(impl Event + ?Sized)) {
         let env = self.env();
@@ -105,6 +103,7 @@ impl Events {
     /// - [Map]
     /// - [Bytes]/[BytesN][crate::BytesN] longer than 32 bytes
     /// - [contracttype]
+    #[deprecated(note = "use the #[contractevent] macro on a contract event type")]
     #[inline(always)]
     pub fn publish<T, D>(&self, topics: T, data: D)
     where


### PR DESCRIPTION
### What
  Marked the publish method in the Events class as deprecated with a note to use the #[contractevent] macro instead to define the event and publish that value.

  ### Why
  The #[contractevent] macro is the preferred way to define and publish contract events as it will include the event into the contract spec. Moving forward it is very much preferred way to define the event so that downstream systems can generate bindings for contract events.