### PR TITLE
fix: ensure that the trait derive macro generate ctors

### DIFF
--- a/soroban-sdk-macros/src/derive_contractimpl_trait_default_fns_not_overridden.rs
+++ b/soroban-sdk-macros/src/derive_contractimpl_trait_default_fns_not_overridden.rs
@@ -78,35 +78,18 @@ fn derive(args: &Args) -> Result<TokenStream2, Error> {
     output.extend(derive_client_impl(
         &args.crate_path,
         &args.client_name,
-        fns.iter()
-            .map(Into::into)
-            .collect::<Vec<syn_ext::Fn>>()
-            .as_slice(),
+        fns.iter().map(Into::into).collect::<Vec<_>>().as_slice(),
     ));
     output.extend(derive_args_impl(
         &args.args_name,
-        fns.iter()
-            .map(Into::into)
-            .collect::<Vec<syn_ext::Fn>>()
-            .as_slice(),
+        fns.iter().map(Into::into).collect::<Vec<_>>().as_slice(),
     ));
     // Setup ctor for all methods.
-    let methods: Vec<_> = fns
-        .into_iter()
-        .chain(impl_fns.into_iter())
-        .map(|sig| syn::ImplItemFn {
-            attrs: vec![],
-            vis: syn::Visibility::Inherited,
-            defaultness: None,
-            sig: sig.clone(),
-            block: syn::parse_quote! {{}},
-        })
-        .collect();
     output.extend(derive_contract_function_registration_ctor(
         &args.crate_path,
         &impl_ty,
         Some(trait_ident),
-        methods.iter(),
+        fns.iter().chain(impl_fns.iter()),
     ));
     Ok(output)
 }

--- a/soroban-sdk-macros/src/derive_fn.rs
+++ b/soroban-sdk-macros/src/derive_fn.rs
@@ -7,7 +7,8 @@ use syn::{
     punctuated::Punctuated,
     spanned::Spanned,
     token::{Colon, Comma},
-    Attribute, Error, FnArg, Ident, Pat, PatIdent, PatType, Path, Type, TypePath, TypeReference,
+    Attribute, Error, FnArg, Ident, Pat, PatIdent, PatType, Path, Signature, Type, TypePath,
+    TypeReference,
 };
 
 #[allow(clippy::too_many_arguments)]
@@ -194,16 +195,16 @@ pub fn derive_contract_function_registration_ctor<'a>(
     crate_path: &Path,
     ty: &Type,
     trait_ident: Option<&Ident>,
-    methods: impl Iterator<Item = &'a syn::ImplItemFn>,
+    methods: impl Iterator<Item = &'a syn::Signature>,
 ) -> TokenStream2 {
     if cfg!(not(feature = "testutils")) {
         return quote!();
     }
 
     let (idents, wrap_idents): (Vec<_>, Vec<_>) = methods
-        .map(|m| {
-            let ident = format!("{}", m.sig.ident);
-            let wrap_ident = format_ident!("__{}", m.sig.ident);
+        .map(|Signature { ident, .. }| {
+            let ident = format!("{ident}");
+            let wrap_ident = format_ident!("__{}", ident);
             (ident, wrap_ident)
         })
         .multiunzip();

--- a/soroban-sdk-macros/src/lib.rs
+++ b/soroban-sdk-macros/src/lib.rs
@@ -291,7 +291,7 @@ pub fn contractimpl(metadata: TokenStream, input: TokenStream) -> TokenStream {
                     crate_path,
                     ty,
                     trait_ident,
-                    pub_methods.into_iter(),
+                    pub_methods.iter().map(|m| &m.sig),
                 )
             });
             output.extend(quote! { #cfs });


### PR DESCRIPTION
The contractimpl macro doesn't have all the info needed. So this makes it the responsibility of the trait macro to generate the ctor function.