### PR TITLE
Make event publish method public

### DIFF
--- a/soroban-sdk-macros/src/derive_event.rs
+++ b/soroban-sdk-macros/src/derive_event.rs
@@ -269,7 +269,7 @@ fn derive_impls(args: &ContractEventArgs, input: &DeriveInput) -> Result<TokenSt
         }
 
         impl #gen_impl #ident #gen_types #gen_where {
-            fn publish(&self, env: &#path::Env) {
+            pub fn publish(&self, env: &#path::Env) {
                 <_ as #path::Event>::publish(self, env);
             }
         }

--- a/soroban-sdk/src/tests/token_events.rs
+++ b/soroban-sdk/src/tests/token_events.rs
@@ -4,7 +4,7 @@ use soroban_sdk::{
     contract, symbol_short,
     testutils::{Address as _, Events as _},
     token::{Approve, Burn, Clawback, Mint, Transfer, TransferMuxed},
-    vec, Address, Env, Event, Map, Symbol, Val,
+    vec, Address, Env, Map, Symbol, Val,
 };
 
 #[contract]

--- a/soroban-sdk/src/tests/token_events_stellar_asset.rs
+++ b/soroban-sdk/src/tests/token_events_stellar_asset.rs
@@ -4,7 +4,7 @@ use soroban_sdk::{
     contract, symbol_short,
     testutils::{Address as _, Events as _},
     token::{SetAdmin, SetAuthorized},
-    vec, Address, Env, Event, Symbol,
+    vec, Address, Env, Symbol,
 };
 
 #[contract]


### PR DESCRIPTION
### What
  Make code generated inherent event publish method public.

  ### Why
  The function is intended to be callable. While the trait method is public, it is mirror by an inherent function so that users of the code generated implemenation do not need to import the trait to use the function, but the inherent function isn't public.