### PR TITLE
Bring back token event fns but deprecated

### DIFF
--- a/soroban-sdk/src/_migrating/v23_token_transfer.rs
+++ b/soroban-sdk/src/_migrating/v23_token_transfer.rs
@@ -78,5 +78,3 @@
 //! [`Address`]: crate::MuxedAddress
 //! [`MuxedAddress`]: crate::MuxedAddress
 //! [`contractevent`]: crate::contractevent
-
-

--- a/soroban-sdk/src/_migrating/v23_token_transfer.rs
+++ b/soroban-sdk/src/_migrating/v23_token_transfer.rs
@@ -57,7 +57,7 @@
 //!    token_impl::move_balance(&env, &from, &to, amount);
 //!    // Publish an appropriate transfer event that includes the muxed ID
 //!    // when it's non-None.
-//!    token::publish_transfer_to_muxed_address_event(&env, &from, &muxed_to, amount);
+//!    token::publish_transfer_event(&env, &from, &muxed_to, amount);
 //! }
 //!
 //! mod token_impl {
@@ -78,3 +78,5 @@
 //! [`Address`]: crate::MuxedAddress
 //! [`MuxedAddress`]: crate::MuxedAddress
 //! [`contractevent`]: crate::contractevent
+
+

--- a/soroban-sdk/src/token.rs
+++ b/soroban-sdk/src/token.rs
@@ -288,10 +288,12 @@ pub struct Clawback {
     pub amount: i128,
 }
 
-/// This is a helper function to publish either a `Transfer` or `TransferMuxed`
-/// event based on whether the `to` address is a muxed address or not (i.e.
-/// whether it has non-None ID).
-pub fn publish_transfer_to_muxed_address_event(
+/// Publish a `transfer` event.
+///
+/// Publishes a [`Transfer`] event if the `to` has no muxed ID.
+///
+/// Publishes a [`TransferMuxed`] event if the `to` has a muxed ID.
+pub fn publish_transfer_event(
     env: &Env,
     from: &Address,
     to: &MuxedAddress,

--- a/soroban-sdk/src/token.rs
+++ b/soroban-sdk/src/token.rs
@@ -293,12 +293,7 @@ pub struct Clawback {
 /// Publishes a [`Transfer`] event if the `to` has no muxed ID.
 ///
 /// Publishes a [`TransferMuxed`] event if the `to` has a muxed ID.
-pub fn publish_transfer_event(
-    env: &Env,
-    from: &Address,
-    to: &MuxedAddress,
-    amount: i128,
-) {
+pub fn publish_transfer_event(env: &Env, from: &Address, to: &MuxedAddress, amount: i128) {
     if let Some(to_muxed_id) = to.id() {
         TransferMuxed {
             from: from.clone(),

--- a/soroban-token-sdk/src/event.rs
+++ b/soroban-token-sdk/src/event.rs
@@ -1,9 +1,10 @@
-use soroban_sdk::{symbol_short, Address, Env, EnvBase, IntoVal, MuxedAddress, Symbol};
+use soroban_sdk::{symbol_short, Address, Env, Symbol};
 
 pub struct Events {
     env: Env,
 }
 
+#[allow(deprecated)]
 impl Events {
     #[inline(always)]
     pub fn new(env: &Env) -> Events {

--- a/soroban-token-sdk/src/event.rs
+++ b/soroban-token-sdk/src/event.rs
@@ -10,6 +10,7 @@ impl Events {
         Events { env: env.clone() }
     }
 
+    #[deprecated = "use soroban_sdk::token::Approve::publish"]
     pub fn approve(&self, from: Address, to: Address, amount: i128, expiration_ledger: u32) {
         let topics = (Symbol::new(&self.env, "approve"), from, to);
         self.env
@@ -17,49 +18,37 @@ impl Events {
             .publish(topics, (amount, expiration_ledger));
     }
 
+    #[deprecated = "use soroban_sdk::token::publish_transfer_event"]
     pub fn transfer(&self, from: Address, to: Address, amount: i128) {
         let topics = (symbol_short!("transfer"), from, to);
         self.env.events().publish(topics, amount);
     }
 
-    pub fn transfer_with_muxed_address(&self, from: Address, to: MuxedAddress, amount: i128) {
-        let to_muxed_id = to.id();
-        let topics = (symbol_short!("transfer"), from, to);
-        let amount_val = amount.into_val(&self.env);
-        let data = match to_muxed_id {
-            None => amount_val,
-            Some(to_muxed_id) => self
-                .env
-                .map_new_from_slices(
-                    &["amount", "to_muxed_id"],
-                    &[amount_val, to_muxed_id.into_val(&self.env)],
-                )
-                .unwrap()
-                .into(),
-        };
-        self.env.events().publish(topics, data);
-    }
-
+    #[deprecated = "use soroban_sdk::token::Mint::publish"]
     pub fn mint(&self, admin: Address, to: Address, amount: i128) {
         let topics = (symbol_short!("mint"), admin, to);
         self.env.events().publish(topics, amount);
     }
 
+    #[deprecated = "use soroban_sdk::token::Clawback::publish"]
     pub fn clawback(&self, admin: Address, from: Address, amount: i128) {
         let topics = (symbol_short!("clawback"), admin, from);
         self.env.events().publish(topics, amount);
     }
 
+    #[deprecated = "use soroban_sdk::token::SetAuthorized::publish"]
     pub fn set_authorized(&self, admin: Address, id: Address, authorize: bool) {
         let topics = (Symbol::new(&self.env, "set_authorized"), admin, id);
         self.env.events().publish(topics, authorize);
     }
 
+    #[deprecated = "use soroban_sdk::token::SetAdmin::publish"]
     pub fn set_admin(&self, admin: Address, new_admin: Address) {
         let topics = (symbol_short!("set_admin"), admin);
         self.env.events().publish(topics, new_admin);
     }
 
+    #[deprecated = "use soroban_sdk::token::Burn::publish"]
     pub fn burn(&self, from: Address, amount: i128) {
         let topics = (symbol_short!("burn"), from);
         self.env.events().publish(topics, amount);

--- a/soroban-token-sdk/src/event.rs
+++ b/soroban-token-sdk/src/event.rs
@@ -1,0 +1,67 @@
+use soroban_sdk::{symbol_short, Address, Env, EnvBase, IntoVal, MuxedAddress, Symbol};
+
+pub struct Events {
+    env: Env,
+}
+
+impl Events {
+    #[inline(always)]
+    pub fn new(env: &Env) -> Events {
+        Events { env: env.clone() }
+    }
+
+    pub fn approve(&self, from: Address, to: Address, amount: i128, expiration_ledger: u32) {
+        let topics = (Symbol::new(&self.env, "approve"), from, to);
+        self.env
+            .events()
+            .publish(topics, (amount, expiration_ledger));
+    }
+
+    pub fn transfer(&self, from: Address, to: Address, amount: i128) {
+        let topics = (symbol_short!("transfer"), from, to);
+        self.env.events().publish(topics, amount);
+    }
+
+    pub fn transfer_with_muxed_address(&self, from: Address, to: MuxedAddress, amount: i128) {
+        let to_muxed_id = to.id();
+        let topics = (symbol_short!("transfer"), from, to);
+        let amount_val = amount.into_val(&self.env);
+        let data = match to_muxed_id {
+            None => amount_val,
+            Some(to_muxed_id) => self
+                .env
+                .map_new_from_slices(
+                    &["amount", "to_muxed_id"],
+                    &[amount_val, to_muxed_id.into_val(&self.env)],
+                )
+                .unwrap()
+                .into(),
+        };
+        self.env.events().publish(topics, data);
+    }
+
+    pub fn mint(&self, admin: Address, to: Address, amount: i128) {
+        let topics = (symbol_short!("mint"), admin, to);
+        self.env.events().publish(topics, amount);
+    }
+
+    pub fn clawback(&self, admin: Address, from: Address, amount: i128) {
+        let topics = (symbol_short!("clawback"), admin, from);
+        self.env.events().publish(topics, amount);
+    }
+
+    pub fn set_authorized(&self, admin: Address, id: Address, authorize: bool) {
+        let topics = (Symbol::new(&self.env, "set_authorized"), admin, id);
+        self.env.events().publish(topics, authorize);
+    }
+
+    pub fn set_admin(&self, admin: Address, new_admin: Address) {
+        let topics = (symbol_short!("set_admin"), admin);
+        self.env.events().publish(topics, new_admin);
+    }
+
+    pub fn burn(&self, from: Address, amount: i128) {
+        let topics = (symbol_short!("burn"), from);
+        self.env.events().publish(topics, amount);
+    }
+}

--- a/soroban-token-sdk/src/lib.rs
+++ b/soroban-token-sdk/src/lib.rs
@@ -1,8 +1,10 @@
 #![no_std]
 
+use crate::event::Events;
 use crate::metadata::Metadata;
 use soroban_sdk::Env;
 
+pub mod event;
 pub mod metadata;
 
 #[derive(Clone)]
@@ -16,5 +18,9 @@ impl TokenUtils {
 
     pub fn metadata(&self) -> Metadata {
         Metadata::new(&self.0)
+    }
+
+    pub fn events(&self) -> Events {
+        Events::new(&self.0)
     }
 }


### PR DESCRIPTION
### What
  Bring back the token event fns but marked deprecated instead of deleted.

  ### Why
  I deleted the event functions in #1489 to encourage use of the new event types, however they should be at least marked deprecated to soften the upgrade path, and help developers immediately find through meaningful deprecated notices what they need to use instead.