### PR TITLE
Update copilot-instructions.md

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -11,15 +11,11 @@ Always reference these instructions first and fallback to search or bash command
   - `curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh`
   - `rustup install stable`
   - `rustup +stable target add wasm32v1-none`
-  - `rustup +stable component add rust-src`
 - Install Rust nightly (required for documentation):
   - `rustup install nightly`
   - `rustup +nightly target add wasm32v1-none`
-  - `rustup +nightly component add rust-src`
 - Install required cargo tools:
   - `cargo install --locked cargo-hack`
-  - `cargo install --locked cargo-nextest`
-  - `cargo install --locked cargo-watch`
 
 ### Build Commands
 - **CRITICAL**: Format code first: `make fmt` -- takes ~1 second
@@ -54,7 +50,7 @@ After making changes to the SDK, always validate with these scenarios:
    - Use `log!` macro for debugging in tests
 
 3. **Contract Compilation Validation**:
-   - Build all test contracts: `make build` or `cargo hack build --target wasm32v1-none --release --workspace --exclude soroban-spec --exclude soroban-spec-rust --exclude soroban-ledger-snapshot`
+   - Build all test contracts: `make build`
    - Verify all Wasm files are generated correctly
    - Check that Wasm file sizes are reasonable (200B-3KB range)
    - Ensure no compilation warnings for the main SDK packages
@@ -111,8 +107,6 @@ After making changes to the SDK, always validate with these scenarios:
 
 ### Cargo Tools Usage
 - `cargo-hack` - Feature powerset testing and multi-target builds
-- `cargo-nextest` - Fast test execution (alternative to `cargo test`)
-- `cargo-watch` - File watching for development
 
 ### Build Artifacts
 - Wasm contracts output to `target/wasm32v1-none/release/*.wasm`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,26 +14,17 @@ Install rust stable:
 ```
 rustup install stable
 rustup +stable target add wasm32v1-none
-rustup +stable component add rust-src
 ```
 
 Install rust nightly:
 ```
 rustup install nightly
 rustup +nightly target add wasm32v1-none
-rustup +nightly component add rust-src
 ```
 
 Install cargo tools:
 ```
 cargo install --locked cargo-hack
-cargo install --locked cargo-nextest
-cargo install --locked cargo-watch
-```
-
-Install binaryen (for `wasm-opt`):
-```
-brew install binaryen
 ```
 
 ## Command Cheatsheet


### PR DESCRIPTION
### What

Remove unused deps from Copilot instructions: rust-src, cargo-watch, cargo-nextest.

### Why

They aren't required tools.

Telling Copilot to use rust-src is likely to send it on tangents we don't want it to take. Recompiling rust-src and relying on features that Rust provides only through rust-src would harm the developer experience of folks using the soroban-sdk, requiring them to also use rust-src which is a not a common Rust developer experience.

cargo-watch is a deprecated tool and not recommended to use. Unclear to me why Copilot would benefit from it since it is more likely to benefit from choosing to run appropriate test commands after each change, which the instructions already detail.

cargo-nextest is not needed. It may speed up test runs, but we don't use it in the Makefile and Copilot will benefit from using the test targets in the Makefile to ensure that the test vectors build before tests.