### PR TITLE
Expose `Executable` from the SDK module.

### DIFF
--- a/soroban-sdk/src/lib.rs
+++ b/soroban-sdk/src/lib.rs
@@ -1022,7 +1022,7 @@ pub mod prng;
 pub mod storage;
 pub mod token;
 mod vec;
-pub use address::Address;
+pub use address::{Address, Executable};
 pub use bytes::{Bytes, BytesN};
 pub use map::Map;
 pub use muxed_address::MuxedAddress;


### PR DESCRIPTION
### What

Expose `Executable` from the SDK module.

### Why

Make it usable.

### Known limitations

N/A
