### PR TITLE
Add soroban-meta package for wasm meta parsing

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -57,10 +57,10 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - run: rustup update
-    - uses: stellar/binaries@v40
+    - uses: stellar/binaries@v41
       with:
         name: cargo-semver-checks
-        version: 0.42.0
+        version: 0.44.0
     - run: >
         cargo semver-checks
         --exclude soroban-token-spec

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -115,7 +115,7 @@ jobs:
       name: Clear test snapshots for checking no diffs exists after test run
       run: rm -fr **/test_snapshots
     - name: Build for wasm
-      run: cargo-hack hack build --target wasm32v1-none --profile release --workspace --exclude soroban-spec --exclude soroban-spec-rust --exclude soroban-ledger-snapshot
+      run: cargo-hack hack build --target wasm32v1-none --profile release --workspace --exclude soroban-meta --exclude soroban-spec --exclude soroban-spec-rust --exclude soroban-ledger-snapshot
     - name: Wasm Size
       run: |
         cd target/wasm32v1-none/release/ && \
@@ -186,7 +186,7 @@ jobs:
         sys:
         - os: ubuntu-latest
           target: wasm32v1-none
-          cargo-hack-feature-options: --manifest-path Cargo.toml --exclude soroban-spec --exclude soroban-spec-rust --exclude soroban-ledger-snapshot --exclude-features testutils,docs,default,std --feature-powerset
+          cargo-hack-feature-options: --manifest-path Cargo.toml --exclude soroban-meta --exclude soroban-spec --exclude soroban-spec-rust --exclude soroban-ledger-snapshot --exclude-features testutils,docs,default,std --feature-powerset
         - os: ubuntu-latest
           target: x86_64-unknown-linux-gnu
           cargo-hack-feature-options: '--feature-powerset --exclude-features docs'

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -63,6 +63,7 @@ jobs:
         version: 0.44.0
     - run: >
         cargo semver-checks
+        --exclude soroban-meta
         --exclude soroban-token-spec
         --exclude stellar-asset-spec
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1391,6 +1391,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "soroban-meta"
+version = "23.0.2"
+dependencies = [
+ "stellar-xdr",
+ "thiserror",
+ "wasmparser",
+]
+
+[[package]]
 name = "soroban-sdk"
 version = "23.0.2"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ resolver = "2"
 members = [
     "soroban-sdk",
     "soroban-sdk-macros",
+    "soroban-meta",
     "soroban-spec",
     "soroban-spec-rust",
     "soroban-ledger-snapshot",
@@ -20,6 +21,7 @@ rust-version = "1.84.0"
 [workspace.dependencies]
 soroban-sdk = { version = "23.0.2", path = "soroban-sdk" }
 soroban-sdk-macros = { version = "23.0.2", path = "soroban-sdk-macros" }
+soroban-meta = { version = "23.0.2", path = "soroban-meta" }
 soroban-spec = { version = "23.0.2", path = "soroban-spec" }
 soroban-spec-rust = { version = "23.0.2", path = "soroban-spec-rust" }
 soroban-ledger-snapshot = { version = "23.0.2", path = "soroban-ledger-snapshot" }

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ all: check test
 export RUSTFLAGS=-Dwarnings
 
 CARGO_DOC_ARGS?=--open
-NATIVE_ONLY_CRATES:=soroban-spec soroban-spec-rust soroban-ledger-snapshot
+NATIVE_ONLY_CRATES:=soroban-meta soroban-spec soroban-spec-rust soroban-ledger-snapshot
 NATIVE_PACKAGE_ARGS:=$(foreach i,$(NATIVE_ONLY_CRATES), --package $(i))
 WASM_EXCLUDE_ARGS:=$(foreach i,$(NATIVE_ONLY_CRATES), --exclude $(i))
 

--- a/soroban-meta/Cargo.toml
+++ b/soroban-meta/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "soroban-meta"
+description = "Soroban contract meta utilities."
+homepage = "https://github.com/stellar/rs-soroban-sdk"
+repository = "https://github.com/stellar/rs-soroban-sdk"
+authors = ["Stellar Development Foundation <info@stellar.org>"]
+readme = "../README.md"
+license = "Apache-2.0"
+version.workspace = true
+edition = "2021"
+rust-version.workspace = true
+
+[dependencies]
+stellar-xdr = { workspace = true, features = ["curr", "std"] }
+thiserror = "1.0.32"
+wasmparser = "0.116.1"

--- a/soroban-meta/src/lib.rs
+++ b/soroban-meta/src/lib.rs
@@ -1,3 +1,4 @@
 pub mod read;
 
+#[cfg(test)]
 mod tests;

--- a/soroban-meta/src/lib.rs
+++ b/soroban-meta/src/lib.rs
@@ -1,0 +1,3 @@
+pub mod read;
+
+mod tests;

--- a/soroban-meta/src/read.rs
+++ b/soroban-meta/src/read.rs
@@ -1,0 +1,45 @@
+use std::io::Cursor;
+
+use stellar_xdr::curr as stellar_xdr;
+use stellar_xdr::{Limited, Limits, ReadXdr, ScMetaEntry};
+use wasmparser::{BinaryReaderError, Parser, Payload};
+
+pub fn parse_raw(meta: &[u8]) -> Result<Vec<ScMetaEntry>, stellar_xdr::Error> {
+    let cursor = Cursor::new(meta);
+    let entries = ScMetaEntry::read_xdr_iter(&mut Limited::new(
+        cursor,
+        Limits {
+            depth: 500,
+            len: 0x1000000,
+        },
+    ))
+    .collect::<Result<Vec<_>, _>>()?;
+    Ok(entries)
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum FromWasmError {
+    #[error("reading wasm")]
+    Read(BinaryReaderError),
+    #[error("parsing contract meta")]
+    Parse(stellar_xdr::Error),
+    #[error("contract meta not found")]
+    NotFound,
+}
+
+pub fn raw_from_wasm(wasm: &[u8]) -> Result<Vec<u8>, FromWasmError> {
+    for payload in Parser::new(0).parse_all(wasm) {
+        let payload = payload.map_err(FromWasmError::Read)?;
+        if let Payload::CustomSection(section) = payload {
+            if section.name() == "contractmetav0" {
+                return Ok(section.data().to_vec());
+            }
+        };
+    }
+    Err(FromWasmError::NotFound)
+}
+
+pub fn from_wasm(wasm: &[u8]) -> Result<Vec<ScMetaEntry>, FromWasmError> {
+    let meta = raw_from_wasm(wasm)?;
+    parse_raw(&meta).map_err(FromWasmError::Parse)
+}

--- a/soroban-meta/src/read.rs
+++ b/soroban-meta/src/read.rs
@@ -9,8 +9,8 @@ pub fn parse_raw(meta: &[u8]) -> Result<Vec<ScMetaEntry>, stellar_xdr::Error> {
     let entries = ScMetaEntry::read_xdr_iter(&mut Limited::new(
         cursor,
         Limits {
-            depth: 500,
-            len: 0x1000000,
+            depth: 5,
+            len: meta.len(),
         },
     ))
     .collect::<Result<Vec<_>, _>>()?;

--- a/soroban-meta/src/read.rs
+++ b/soroban-meta/src/read.rs
@@ -21,17 +21,7 @@ pub enum FromWasmError {
 }
 
 pub fn raw_from_wasm(wasm: &[u8]) -> Result<Vec<u8>, FromWasmError> {
-    let mut total_len = 0;
-    for payload in Parser::new(0).parse_all(wasm) {
-        let payload = payload.map_err(FromWasmError::Read)?;
-        if let Payload::CustomSection(section) = payload {
-            if section.name() == "contractmetav0" {
-                total_len += section.data().len();
-            }
-        }
-    }
-
-    let mut meta = Vec::with_capacity(total_len);
+    let mut meta = Vec::new();
     for payload in Parser::new(0).parse_all(wasm) {
         let payload = payload.map_err(FromWasmError::Read)?;
         if let Payload::CustomSection(section) = payload {

--- a/soroban-meta/src/read.rs
+++ b/soroban-meta/src/read.rs
@@ -5,15 +5,10 @@ use stellar_xdr::{Limited, Limits, ReadXdr, ScMetaEntry};
 use wasmparser::{BinaryReaderError, Parser, Payload};
 
 pub fn parse_raw(meta: &[u8]) -> Result<Vec<ScMetaEntry>, stellar_xdr::Error> {
-    let cursor = Cursor::new(meta);
-    let entries = ScMetaEntry::read_xdr_iter(&mut Limited::new(
-        cursor,
-        Limits {
-            depth: 5,
-            len: meta.len(),
-        },
-    ))
-    .collect::<Result<Vec<_>, _>>()?;
+    let limits = Limits::len(meta.len());
+    let reader = Cursor::new(meta);
+    let mut limited_reader = Limited::new(reader, limits);
+    let entries = ScMetaEntry::read_xdr_iter(&mut limited_reader).collect::<Result<Vec<_>, _>>()?;
     Ok(entries)
 }
 

--- a/soroban-meta/src/tests.rs
+++ b/soroban-meta/src/tests.rs
@@ -1,7 +1,6 @@
-#![cfg(test)]
 use crate::read;
 use std::fs;
-use stellar_xdr::curr::ScMetaEntry;
+use stellar_xdr::curr::{Limits, ScMetaEntry, ScMetaV0, StringM, WriteXdr};
 
 #[test]
 fn test_from_wasm() {
@@ -18,8 +17,44 @@ fn test_from_wasm() {
 
 #[test]
 fn test_from_wasm_no_metadata() {
-    // Create a simple Wasm file without metadata
+    // Create a simple Wasm file without meta
     let wasm = vec![0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00]; // minimal Wasm header
-    let result = read::from_wasm(&wasm);
-    assert!(matches!(result, Err(read::FromWasmError::NotFound)));
+    let result = read::from_wasm(&wasm).unwrap();
+    assert_eq!(result.len(), 0);
+}
+
+#[test]
+fn test_multiple_metadata_sections() {
+    // Read the original test_zero.wasm
+    let mut wasm = fs::read("../target/wasm32v1-none/release/test_zero.wasm").unwrap();
+
+    // Add on an additional contract meta section
+    let section_name = b"contractmetav0";
+    let section_content = ScMetaEntry::ScMetaV0(ScMetaV0 {
+        key: StringM::try_from("mykey").unwrap(),
+        val: StringM::try_from("myval").unwrap(),
+    }).to_xdr(Limits::none()).unwrap();
+
+    // Encode custom section
+    let mut custom_section = Vec::new();
+    custom_section.push(0); // 0 = custom section
+    custom_section.push((1 + section_name.len() + section_content.len()) as u8);
+    custom_section.push(section_name.len() as u8);
+    custom_section.extend_from_slice(section_name);
+    custom_section.extend_from_slice(&section_content);
+
+    // Append the custom section to the WASM file
+    wasm.extend_from_slice(&custom_section);
+
+    // Parse the new wasm
+    let meta = read::from_wasm(&wasm).unwrap();
+
+    // Should have the original entries plus the new one
+    let keys = meta
+        .iter()
+        .map(|e| match e {
+            ScMetaEntry::ScMetaV0(v0) => v0.key.to_string(),
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(keys, ["rsver", "rssdkver", "mykey"]);
 }

--- a/soroban-meta/src/tests.rs
+++ b/soroban-meta/src/tests.rs
@@ -33,7 +33,9 @@ fn test_multiple_metadata_sections() {
     let section_content = ScMetaEntry::ScMetaV0(ScMetaV0 {
         key: StringM::try_from("mykey").unwrap(),
         val: StringM::try_from("myval").unwrap(),
-    }).to_xdr(Limits::none()).unwrap();
+    })
+    .to_xdr(Limits::none())
+    .unwrap();
 
     // Encode custom section
     let mut custom_section = Vec::new();

--- a/soroban-meta/src/tests.rs
+++ b/soroban-meta/src/tests.rs
@@ -17,37 +17,9 @@ fn test_from_wasm() {
 }
 
 #[test]
-fn test_raw_from_wasm() {
-    let wasm = fs::read("../target/wasm32v1-none/release/test_zero.wasm").unwrap();
-    let raw_meta = read::raw_from_wasm(&wasm).unwrap();
-    assert!(!raw_meta.is_empty());
-}
-
-#[test]
-fn test_parse_raw() {
-    let wasm = fs::read("../target/wasm32v1-none/release/test_zero.wasm").unwrap();
-    let raw_meta = read::raw_from_wasm(&wasm).unwrap();
-    let meta = read::parse_raw(&raw_meta).unwrap();
-    assert!(!meta.is_empty());
-}
-
-#[test]
 fn test_from_wasm_no_metadata() {
     // Create a simple Wasm file without metadata
     let wasm = vec![0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00]; // minimal Wasm header
     let result = read::from_wasm(&wasm);
     assert!(matches!(result, Err(read::FromWasmError::NotFound)));
-}
-
-#[test]
-fn test_raw_from_wasm_no_metadata() {
-    let wasm = vec![0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00];
-    let result = read::raw_from_wasm(&wasm);
-    assert!(matches!(result, Err(read::FromWasmError::NotFound)));
-}
-
-#[test]
-fn test_parse_raw_invalid() {
-    let result = read::parse_raw(b"invalid xdr data");
-    assert!(matches!(result, Err(_)));
 }

--- a/soroban-meta/src/tests.rs
+++ b/soroban-meta/src/tests.rs
@@ -1,0 +1,53 @@
+#![cfg(test)]
+use crate::read;
+use std::fs;
+use stellar_xdr::curr::ScMetaEntry;
+
+#[test]
+fn test_from_wasm() {
+    let wasm = fs::read("../target/wasm32v1-none/release/test_zero.wasm").unwrap();
+    let meta = read::from_wasm(&wasm).unwrap();
+    let keys = meta
+        .iter()
+        .map(|e| match e {
+            ScMetaEntry::ScMetaV0(v0) => v0.key.to_string(),
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(keys, ["rsver", "rssdkver"]);
+}
+
+#[test]
+fn test_raw_from_wasm() {
+    let wasm = fs::read("../target/wasm32v1-none/release/test_zero.wasm").unwrap();
+    let raw_meta = read::raw_from_wasm(&wasm).unwrap();
+    assert!(!raw_meta.is_empty());
+}
+
+#[test]
+fn test_parse_raw() {
+    let wasm = fs::read("../target/wasm32v1-none/release/test_zero.wasm").unwrap();
+    let raw_meta = read::raw_from_wasm(&wasm).unwrap();
+    let meta = read::parse_raw(&raw_meta).unwrap();
+    assert!(!meta.is_empty());
+}
+
+#[test]
+fn test_from_wasm_no_metadata() {
+    // Create a simple Wasm file without metadata
+    let wasm = vec![0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00]; // minimal Wasm header
+    let result = read::from_wasm(&wasm);
+    assert!(matches!(result, Err(read::FromWasmError::NotFound)));
+}
+
+#[test]
+fn test_raw_from_wasm_no_metadata() {
+    let wasm = vec![0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00];
+    let result = read::raw_from_wasm(&wasm);
+    assert!(matches!(result, Err(read::FromWasmError::NotFound)));
+}
+
+#[test]
+fn test_parse_raw_invalid() {
+    let result = read::parse_raw(b"invalid xdr data");
+    assert!(matches!(result, Err(_)));
+}


### PR DESCRIPTION
### What
  Add soroban-meta package with wasm meta parsing.

  ### Why
  Mirror the soroban-spec crate providing the same functionality for extracting meta from contract wasm files. I was writing a utility that interacted with both contract specs and contract meta, and it was convenient to be able to use the soroban-spec crate to extract the spec, and I was having to rewrite the same logic for the meta. It's been rare, but someone else asked me in the past how to extract meta and I had to tell them to do it manually because this crate didn't exist. The crate API surface area matches that of soroban-spec minus the base64 functions because the base64 functions don't get any use.