### PR TITLE
Combine the build and test jobs in the ci workflow

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -74,6 +74,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        rust: [msrv, latest]
         sys:
         - os: ubuntu-latest
           target: x86_64-unknown-linux-gnu
@@ -89,36 +90,34 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: stellar/actions/rust-cache@main
-    - name: Install msrv
+    - name: Use the minimum supported Rust version
+      if: matrix.rust == 'msrv'
       run: |
-        msrv="$(make msrv)"
-        rustup install $msrv
-        rustup target add --toolchain $msrv ${{ matrix.sys.target }}
-        rustup target add --toolchain $msrv wasm32v1-none
-    - name: Install latest
-      run: |
-        rustup update
-        rustup target add ${{ matrix.sys.target }}
-        rustup target add wasm32v1-none
+        msrv="$(cargo metadata --format-version 1 --no-deps | jq -r '.packages | map(.rust_version) | map(values) | min')"
+        rustup override set $msrv
+        rustup component add clippy rustfmt
+    - name: Error on warnings only for msrv
+      if: matrix.rust == 'msrv'
+      run: echo RUSTFLAGS='-Dwarnings' >> $GITHUB_ENV
+    - run: rustup update
+    - run: cargo version
+    - run: rustup target add ${{ matrix.sys.target }}
+    - run: rustup target add wasm32v1-none
     - run: echo CARGO_BUILD_TARGET='${{ matrix.sys.target }}' >> $GITHUB_ENV
     - uses: stellar/binaries@v45
       with:
         name: cargo-hack
         version: 0.5.28
-    # Build with latest Rust
-    - run: make build-libs
-    - run: make build-test-wasms
-    # Build with MSRV Rust
-    - run: make build-libs RUST=msrv
-    - run: make build-test-wasms RUST=msrv
-    # Run tests with latest
-    - run: rm -fr **/test_snapshots
-    - run: make test
-    - run: git add -N . && git diff HEAD --exit-code
-    # Run tests with MSRV
-    - run: rm -fr **/test_snapshots
-    - run: make test RUST=msrv
-    - run: git add -N . && git diff HEAD --exit-code
+    - name: Build libs with current rust toolchain
+      run: make build-libs
+    - name: Build test wasms with current rust toolchain
+      run: make build-test-wasms TEST_CRATES_RUSTUP_TOOLCHAIN=
+    - name: Clear test snapshots for checking no diffs exists after test run
+      run: rm -fr **/test_snapshots
+    - name: Run test with current rust toolchain (will also rebuild test wasms with msrv rust toolchain for test reproducibility)
+      run: make build-test-wasms test
+    - name: Check no diffs exist
+      run: git add -N . && git diff HEAD --exit-code
 
   build-fuzz:
     runs-on: ubuntu-latest

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -93,16 +93,16 @@ jobs:
     - name: Use the minimum supported Rust version
       if: matrix.rust == 'msrv'
       run: |
-        msrv="$(cargo metadata --format-version 1 --no-deps | jq -r '.packages | map(.rust_version) | map(values) | min')"
+        msrv="$(make msrv)"
         rustup override set $msrv
         rustup component add clippy rustfmt
+    - run: |
+        rustup update
+        rustup target add ${{ matrix.sys.target }}
+        rustup target add wasm32v1-none
     - name: Error on warnings only for msrv
       if: matrix.rust == 'msrv'
       run: echo RUSTFLAGS='-Dwarnings' >> $GITHUB_ENV
-    - run: rustup update
-    - run: cargo version
-    - run: rustup target add ${{ matrix.sys.target }}
-    - run: rustup target add wasm32v1-none
     - run: echo CARGO_BUILD_TARGET='${{ matrix.sys.target }}' >> $GITHUB_ENV
     - uses: stellar/binaries@v45
       with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -21,7 +21,7 @@ jobs:
 
   complete:
     if: always()
-    needs: [fmt, check-git-rev-deps, semver-checks, build, test, build-fuzz, docs, readme, migration-docs]
+    needs: [fmt, check-git-rev-deps, semver-checks, build-and-test, build-fuzz, docs, readme, migration-docs]
     runs-on: ubuntu-latest
     steps:
     - if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
@@ -70,7 +70,7 @@ jobs:
         --exclude soroban-token-spec
         --exclude stellar-asset-spec
 
-  build:
+  build-and-test:
     strategy:
       fail-fast: false
       matrix:
@@ -108,62 +108,14 @@ jobs:
       with:
         name: cargo-hack
         version: 0.5.28
-    - run: make build-libs
-    - run: make build-test-wasms TEST_CRATES_RUSTUP_TOOLCHAIN=
-    - name: Upload test wasms
-      uses: actions/upload-artifact@v4
-      with:
-        name: test-wasms-${{ matrix.rust }}-${{ matrix.sys.target }}
-        path: target/wasm32v1-none/release/test_*.wasm
-        retention-days: ${{ env.ARTIFACT_RETENTION_DAYS_FOR_TEST_WASMS }}
-
-  test:
-    needs: build
-    strategy:
-      fail-fast: false
-      matrix:
-        rust: [msrv, latest]
-        sys:
-        - os: ubuntu-latest
-          target: x86_64-unknown-linux-gnu
-        - os: ubuntu-24.04-arm
-          target: aarch64-unknown-linux-gnu
-        - os: macos-15-intel
-          target: x86_64-apple-darwin
-        - os: macos-latest
-          target: aarch64-apple-darwin
-        - os: windows-latest
-          target: x86_64-pc-windows-msvc
-    runs-on: ${{ matrix.sys.os }}
-    steps:
-    - uses: actions/checkout@v3
-    - uses: stellar/actions/rust-cache@main
-    - name: Use the minimum supported Rust version
-      if: matrix.rust == 'msrv'
-      run: |
-        msrv="$(cargo metadata --format-version 1 --no-deps | jq -r '.packages | map(.rust_version) | map(values) | min')"
-        rustup override set $msrv
-        rustup component add clippy rustfmt
-    - name: Error on warnings only for msrv
-      if: matrix.rust == 'msrv'
-      run: echo RUSTFLAGS='-Dwarnings' >> $GITHUB_ENV
-    - run: rustup update
-    - run: cargo version
-    - run: rustup target add ${{ matrix.sys.target }}
-    - run: rustup target add wasm32v1-none
-    - run: echo CARGO_BUILD_TARGET='${{ matrix.sys.target }}' >> $GITHUB_ENV
-    - uses: stellar/binaries@v45
-      with:
-        name: cargo-hack
-        version: 0.5.28
-    - name: Restore test wasms for tests from one of the msrv builds
-      uses: actions/download-artifact@v5
-      with:
-        name: test-wasms-msrv-x86_64-unknown-linux-gnu
-        path: target/wasm32v1-none/release/
+    - name: Build libs with current rust toolchain
+      run: make build-libs
+    - name: Build test wasms with current rust toolchain
+      run: make build-test-wasms TEST_CRATES_RUSTUP_TOOLCHAIN=
     - name: Clear test snapshots for checking no diffs exists after test run
       run: rm -fr **/test_snapshots
-    - run: make test
+    - name: Run test with current rust toolchain (will also rebuild test wasms with msrv rust toolchain for test reproducibility)
+      run: make build-test-wasms test
     - name: Check no diffs exist
       run: git add -N . && git diff HEAD --exit-code
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -74,7 +74,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rust: [msrv, latest]
         sys:
         - os: ubuntu-latest
           target: x86_64-unknown-linux-gnu
@@ -90,34 +89,36 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: stellar/actions/rust-cache@main
-    - name: Use the minimum supported Rust version
-      if: matrix.rust == 'msrv'
+    - name: Install msrv
       run: |
-        msrv="$(cargo metadata --format-version 1 --no-deps | jq -r '.packages | map(.rust_version) | map(values) | min')"
-        rustup override set $msrv
-        rustup component add clippy rustfmt
-    - name: Error on warnings only for msrv
-      if: matrix.rust == 'msrv'
-      run: echo RUSTFLAGS='-Dwarnings' >> $GITHUB_ENV
-    - run: rustup update
-    - run: cargo version
-    - run: rustup target add ${{ matrix.sys.target }}
-    - run: rustup target add wasm32v1-none
+        msrv="$(make msrv)"
+        rustup install $msrv
+        rustup target add --toolchain $msrv ${{ matrix.sys.target }}
+        rustup target add --toolchain $msrv wasm32v1-none
+    - name: Install latest
+      run: |
+        rustup update
+        rustup target add ${{ matrix.sys.target }}
+        rustup target add wasm32v1-none
     - run: echo CARGO_BUILD_TARGET='${{ matrix.sys.target }}' >> $GITHUB_ENV
     - uses: stellar/binaries@v45
       with:
         name: cargo-hack
         version: 0.5.28
-    - name: Build libs with current rust toolchain
-      run: make build-libs
-    - name: Build test wasms with current rust toolchain
-      run: make build-test-wasms TEST_CRATES_RUSTUP_TOOLCHAIN=
-    - name: Clear test snapshots for checking no diffs exists after test run
-      run: rm -fr **/test_snapshots
-    - name: Run test with current rust toolchain (will also rebuild test wasms with msrv rust toolchain for test reproducibility)
-      run: make build-test-wasms test
-    - name: Check no diffs exist
-      run: git add -N . && git diff HEAD --exit-code
+    # Build with latest Rust
+    - run: make build-libs
+    - run: make build-test-wasms
+    # Build with MSRV Rust
+    - run: make build-libs RUST=msrv
+    - run: make build-test-wasms RUST=msrv
+    # Run tests with latest
+    - run: rm -fr **/test_snapshots
+    - run: make test
+    - run: git add -N . && git diff HEAD --exit-code
+    # Run tests with MSRV
+    - run: rm -fr **/test_snapshots
+    - run: make test RUST=msrv
+    - run: git add -N . && git diff HEAD --exit-code
 
   build-fuzz:
     runs-on: ubuntu-latest

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -90,16 +90,22 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: stellar/actions/rust-cache@main
-    - name: Use the minimum supported Rust version
+    - name: Install minimum supported Rust version
       if: matrix.rust == 'msrv'
       run: |
         msrv="$(make msrv)"
-        rustup override set $msrv
+        rustup install $msrv
         rustup component add clippy rustfmt
-    - run: |
+        rustup target add --toolchain $msrv ${{ matrix.sys.target }}
+        rustup target add --toolchain $msrv wasm32v1-none
+    - name: Install latest Rust version
+      run: |
         rustup update
         rustup target add ${{ matrix.sys.target }}
         rustup target add wasm32v1-none
+    - name: Use the minimum supported Rust version
+      if: matrix.rust == 'msrv'
+      run: echo RUSTUP_TOOLCHAIN="$(make msrv) >> $GITHUB_ENV
     - name: Error on warnings only for msrv
       if: matrix.rust == 'msrv'
       run: echo RUSTFLAGS='-Dwarnings' >> $GITHUB_ENV

--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,6 @@ TEST_CRATES_RUSTUP_TOOLCHAIN?=$(MSRV)
 
 all: check test
 
-export RUSTFLAGS=-Dwarnings
-
 CARGO_DOC_ARGS?=--open
 
 doc: fmt
@@ -48,3 +46,6 @@ fmt:
 
 clean:
 	cargo clean
+
+msrv:
+	@echo $(MSRV)

--- a/Makefile
+++ b/Makefile
@@ -2,13 +2,21 @@ LIB_CRATES = $(shell cargo metadata --no-deps --format-version 1 | jq -r '.packa
 TEST_CRATES = $(shell cargo metadata --no-deps --format-version 1 | jq -r '.packages[] | select(.name | startswith("test_")) | .name' | tr '\n' ' ')
 
 MSRV = $(shell cargo metadata --no-deps --format-version 1 | jq -r '.packages[] | select(.name == "soroban-sdk") | .rust_version')
-TEST_CRATES_RUSTUP_TOOLCHAIN?=$(MSRV)
 
-all: check test
+RUST?=
+ifeq ($(RUST),msrv)
+export RUSTUP_TOOLCHAIN=$(MSRV)
+else
+export RUSTUP_TOOLCHAIN=$(RUST)
+endif
 
+ifeq ($(RUSTUP_TOOLCHAIN),$(MSRV))
 export RUSTFLAGS=-Dwarnings
+endif
 
 CARGO_DOC_ARGS?=--open
+
+default: test
 
 doc: fmt
 	cargo test --doc $(foreach c,$(LIB_CRATES),--package $(c)) --features testutils,alloc,hazmat
@@ -23,9 +31,7 @@ build-libs: fmt
 	cargo hack build --release $(foreach c,$(LIB_CRATES),--package $(c))
 
 build-test-wasms: fmt
-	# Build the test wasms with MSRV by default, with some meta disabled for
-	# binary stability for tests.
-	RUSTUP_TOOLCHAIN=$(TEST_CRATES_RUSTUP_TOOLCHAIN) \
+	# Build the test wasms with some meta disabled for binary stability for tests.
 	RUSTFLAGS='--cfg soroban_sdk_internal_no_rssdkver_meta' \
 		cargo hack build --release --target wasm32v1-none $(foreach c,$(TEST_CRATES),--package $(c)) ; \
 	cd target/wasm32v1-none/release/ && \
@@ -48,3 +54,6 @@ fmt:
 
 clean:
 	cargo clean
+
+msrv:
+	@echo $(MSRV)


### PR DESCRIPTION
### What
  Combine the build and test jobs in the ci workflow.

  ### Why
  In #1576 I separated the build and test workflows as part of improving the reliability of the wasm builds, because I thought that the wasm builds used in tests would need to be produced by one host. But it turns out the wasm is stable on all of the hosts we build on. Also, even though the builds and tests were happening separately, the wasms were still being rebuilt in the tests, so it wasn't as effecient as I thought it would be.