### PR TITLE
Add workflow to test with soroban-examples

### DIFF
--- a/.github/workflows/test-with-soroban-examples.yml
+++ b/.github/workflows/test-with-soroban-examples.yml
@@ -62,6 +62,7 @@ jobs:
 
     - name: Patch SDK versions
       run: |
+        # TODO: Update this patch logic to use `cargo add` once this issue is resolved: https://github.com/rust-lang/cargo/issues/16101
         crates=$(cd ${{ github.workspace }}/rs-soroban-sdk && cargo metadata --format-version 1 --no-deps | jq -r '.packages[] | select(.publish != []) | .name')
         find . -name Cargo.toml | while read file; do
           echo Patching "$file" ...


### PR DESCRIPTION
### What
  Add a GitHub Actions workflow that tests rs-soroban-sdk changes against the soroban-examples repository by patching the SDK dependency, building, and running tests.

  ### Why
  This ensures SDK changes don't break existing example contracts and provides early detection of compatibility issues before release.

The soroban-examples are a good extended set of test vectors to test upcoming changes in the sdk. I often manually test PRs against soroban-examples looking for breakages. This codifies that process.

Deprecations are allowed via an env var when runnin the builds and tests in soroban-examples, because it is permitted for the sdk to deprecate functionality and later remove that functionality. The soroban-examples should always stay within at least one major version, and the sdk should generally try to give deprecations at least one full major version before being removed. Meaning that the sdk should generally never break soroban-examples as long as they are within one major version.

The new workflow does not block pull request merges, giving us an opportunity to see how practical it is to run these tests with sdk changes. We can make it a required build when we're happy with how the initial period goes.

For #1544 