### PR TITLE
Add compile error for event names exceeding limit

### DIFF
--- a/soroban-sdk/src/tests/contract_event.rs
+++ b/soroban-sdk/src/tests/contract_event.rs
@@ -4,16 +4,6 @@ use crate::{
 };
 
 #[test]
-fn test_name_too_long() {
-    #[contractevent]
-    pub struct MyEventIsTooLongAndLongAndLongAndLongAndLong {
-        #[topic]
-        name: Symbol,
-        value: Symbol,
-    }
-}
-
-#[test]
 fn test_defaults() {
     let env = Env::default();
 


### PR DESCRIPTION
### What
  Add compile-time validation that event names do not exceed 32 characters. Return a descriptive error message showing the actual length and the limit when validation fails.
  
  #### Before
```
error: custom attribute panicked
  |
8 |     #[contractevent]
  |     ^^^^^^^^^^^^^^^^
  |
```

#### After
```
error: event name has length 44 greater than length limit of 32
  |
9 |     pub struct MyEventIsTooLongAndLongAndLongAndLongAndLong {
  |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

  ### Why
  Event names are constrained by the ScSymbol type to 32 characters maximum, but previously this constraint was only enforced by a call to .unwrap(), which emits a very unhelpful message.

### Testing
The SDK doesn't currently have the infra setup to do compile error testing. It used to. We removed it because it was crazy slow. It might come back as part of #1544. So no test is being included with this fix. However, in the first commit (1445bae4d9f8ce960ce478d6fe4b04b4b99e93e5) I am including a test that will fail at compile. Look at the logs for that commit and you'll see it. That test will be removed before merging.

Fix #1592