### PR TITLE
Remove all permissions in test with soroban-examples workflow

### DIFF
--- a/.github/workflows/test-with-soroban-examples.yml
+++ b/.github/workflows/test-with-soroban-examples.yml
@@ -9,7 +9,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref_protected == 'true' && github.sha || github.ref }}-{{ github.event_name }}
   cancel-in-progress: true
 
-permissions: {} # No permissions
+# No permissions. This workflow downloads code from outside this repository and
+# compiles it. No permissions ensures that any exploit in an external
+# repository does not gain access to anything in this repo.
+permissions: {}
 
 jobs:
   collect-examples:


### PR DESCRIPTION
### What
  Remove all permissions in the test with soroban-examples workflow file.

  ### Why
  This explicitly declares that the workflow requires no GitHub token permissions, following security best practices by applying the principle of least privilege. The workflow pulls code from another repo and builds it. That other repo is an internal @stellar repo, but it has a different set of permissions and access and so nothing in that repo should be able to escalate into this repo.