### PR TITLE
Run tests on macos and windows only on merge and push

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -65,7 +65,7 @@ jobs:
             }
           ]'
         fi
-        echo "sys=$sys" >> $GITHUB_OUTPUT
+        echo "sys=$(<<< $sys jq -c)" >> $GITHUB_OUTPUT
 
   fmt:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### What
  Add a setup job that dynamically generates the system matrix for the rust ci workflow. Use only ubuntu-latest for pull requests and the full set of targets (Linux, macOS, Windows across x86_64 and aarch64) for other events (merge group, push).

  ### Why
  Pull requests only need validation on a single platform to provide fast feedback, while the test runs on merge (the merge_group event) can catch any rare issues we create that are platform specific, and same with releases and main branch builds triggerd by push events.