### PR TITLE
Small refactor to move call generation inside derive_pub_fn

### DIFF
--- a/soroban-sdk-macros/src/derive_fn.rs
+++ b/soroban-sdk-macros/src/derive_fn.rs
@@ -18,7 +18,6 @@ use syn::{
 pub fn derive_pub_fn(
     crate_path: &Path,
     impl_ty: &Type,
-    call: &TokenStream2,
     ident: &Ident,
     attrs: &[Attribute],
     inputs: &Punctuated<FnArg, Comma>,
@@ -27,6 +26,8 @@ pub fn derive_pub_fn(
 ) -> Result<TokenStream2, TokenStream2> {
     // Collect errors as they are encountered and emit them at the end.
     let mut errors = Vec::<Error>::new();
+
+    let call = quote! { <super::#impl_ty>::#ident };
 
     // Prepare the env input.
     let env_input = inputs.first().and_then(|a| match a {

--- a/soroban-sdk-macros/src/lib.rs
+++ b/soroban-sdk-macros/src/lib.rs
@@ -244,11 +244,9 @@ pub fn contractimpl(metadata: TokenStream, input: TokenStream) -> TokenStream {
         .iter()
         .map(|m| {
             let ident = &m.sig.ident;
-            let call = quote! { <super::#ty>::#ident };
             derive_pub_fn(
                 crate_path,
                 &ty,
-                &call,
                 ident,
                 &m.attrs,
                 &m.sig.inputs,


### PR DESCRIPTION
### What
  Move the token stream generation for function calls from the caller into the derive_pub_fn function itself, eliminating the call parameter from the function signature.

  ### Why
  This encapsulates the call generation logic within derive_pub_fn, reducing coupling and simplifying the function interface for callers. In a future change I'm working on where derive_pub_fn gets used in more places this will simplify the additional call sites not having to also define the call tokens. Minor refactor here in this PR rather than including it later to keep the later PRs hyperfocused on new functionality rather than a myriad of refactors.