### PR TITLE
Refactor out excessive borrowed value optimizations in macros

### DIFF
--- a/soroban-sdk-macros/src/lib.rs
+++ b/soroban-sdk-macros/src/lib.rs
@@ -95,7 +95,7 @@ pub fn contractspecfn(metadata: TokenStream, input: TokenStream) -> TokenStream 
 
     let derived: Result<proc_macro2::TokenStream, proc_macro2::TokenStream> = methods
         .iter()
-        .map(|m| derive_fn_spec(&args.name, m.ident, m.attrs, m.inputs, m.output, export))
+        .map(|m| derive_fn_spec(&args.name, &m.ident, &m.attrs, &m.inputs, &m.output, export))
         .collect();
 
     match derived {
@@ -239,7 +239,7 @@ pub fn contractimpl(metadata: TokenStream, input: TokenStream) -> TokenStream {
     }
     .unwrap_or_else(|| "Client".to_string());
 
-    let pub_methods: Vec<_> = syn_ext::impl_pub_methods(&imp).collect();
+    let pub_methods: Vec<_> = syn_ext::impl_pub_methods(&imp);
     let derived: Result<proc_macro2::TokenStream, proc_macro2::TokenStream> = pub_methods
         .iter()
         .map(|m| {
@@ -269,7 +269,7 @@ pub fn contractimpl(metadata: TokenStream, input: TokenStream) -> TokenStream {
                 crate_path,
                 ty,
                 trait_ident,
-                pub_methods.into_iter(),
+                pub_methods.iter(),
             );
             output.extend(quote! { #cfs });
             output.into()


### PR DESCRIPTION
### What
  Replace borrowed references with owned values in `impl_pub_methods` and `Fn`, which are internal functions and types in the soroban-sdk-macros.

  ### Why
  The excessive use of borrowed references and lifetime annotations was adding unnecessary complexity without meaningful performance benefits in macro expansion code that runs at compile time. Several times when I've worked with this code I have found it harder to evolve because of the limitation on data having to be owned externally to these functions.