### PR TITLE
Simplify hazmat feature docs

### DIFF
--- a/soroban-sdk/src/address.rs
+++ b/soroban-sdk/src/address.rs
@@ -394,10 +394,7 @@ impl Address {
     /// custom Ed25519 signature verification as a form of authentication
     /// because the master key may not be configured the signer of the account.
     #[cfg(any(test, feature = "hazmat-address"))]
-    #[cfg_attr(
-        feature = "docs",
-        doc(cfg(any(feature = "hazmat", feature = "hazmat-address")))
-    )]
+    #[cfg_attr(feature = "docs", doc(cfg(feature = "hazmat-address")))]
     pub fn to_payload(&self) -> Option<AddressPayload> {
         AddressPayload::from_address(self)
     }
@@ -414,10 +411,7 @@ impl Address {
     /// custom Ed25519 signature verification as a form of authentication
     /// because the master key may not be configured the signer of the account.
     #[cfg(any(test, feature = "hazmat-address"))]
-    #[cfg_attr(
-        feature = "docs",
-        doc(cfg(any(feature = "hazmat", feature = "hazmat-address")))
-    )]
+    #[cfg_attr(feature = "docs", doc(cfg(feature = "hazmat-address")))]
     pub fn from_payload(env: &Env, payload: AddressPayload) -> Address {
         payload.to_address(env)
     }

--- a/soroban-sdk/src/address_payload.rs
+++ b/soroban-sdk/src/address_payload.rs
@@ -1,8 +1,5 @@
 #![cfg(any(test, feature = "hazmat-address"))]
-#![cfg_attr(
-    feature = "docs",
-    doc(cfg(any(feature = "hazmat", feature = "hazmat-address")))
-)]
+#![cfg_attr(feature = "docs", doc(cfg(feature = "hazmat-address")))]
 
 //! Address payload extraction and construction.
 //!

--- a/soroban-sdk/src/crypto.rs
+++ b/soroban-sdk/src/crypto.rs
@@ -191,10 +191,7 @@ impl Crypto {
 /// incorrectly can introduce security vulnerabilities. Please use [Crypto] if
 /// possible.
 #[cfg_attr(any(test, feature = "hazmat-crypto"), visibility::make(pub))]
-#[cfg_attr(
-    feature = "docs",
-    doc(cfg(any(feature = "hazmat", feature = "hazmat-crypto")))
-)]
+#[cfg_attr(feature = "docs", doc(cfg(feature = "hazmat-crypto")))]
 pub(crate) struct CryptoHazmat {
     env: Env,
 }

--- a/soroban-sdk/src/env.rs
+++ b/soroban-sdk/src/env.rs
@@ -334,10 +334,7 @@ impl Env {
     /// incorrectly can introduce security vulnerabilities. Use [Crypto] if
     /// possible.
     #[cfg_attr(any(test, feature = "hazmat-crypto"), visibility::make(pub))]
-    #[cfg_attr(
-        feature = "docs",
-        doc(cfg(any(feature = "hazmat", feature = "hazmat-crypto")))
-    )]
+    #[cfg_attr(feature = "docs", doc(cfg(feature = "hazmat-crypto")))]
     #[inline(always)]
     pub(crate) fn crypto_hazmat(&self) -> crate::crypto::CryptoHazmat {
         crate::crypto::CryptoHazmat::new(self)


### PR DESCRIPTION
### What
Remove `hazmat` feature from doc cfg attributes, keeping only the specific `hazmat-address` and `hazmat-crypto` features in documentation.

#### Before
<img width="461" height="214" alt="Screenshot 2025-12-15 at 4 05 12 pm" src="https://github.com/user-attachments/assets/3e00c4da-cf53-4b34-924f-b8f913bfc1c5" />

#### After
<img width="461" height="214" alt="Screenshot 2025-12-15 at 4 05 58 pm" src="https://github.com/user-attachments/assets/8229806b-22ab-4e76-bd93-aa1f3a57654c" />

### Why
The generic `hazmat` feature is used for compilation gating, but really only exists historically for backwards compatibility and as something used for testing during development of the SDK. Generally folks should use the narrower scoped hazmat features, so showing it in documentation guides folks to do the not best practice, which results in enabling more hazmat APIs than are necessary.