### PR TITLE
Fix patch logic to include workspace root Cargo.toml

### DIFF
--- a/.github/workflows/test-with-soroban-examples.yml
+++ b/.github/workflows/test-with-soroban-examples.yml
@@ -82,7 +82,7 @@ jobs:
         files=$(echo "$local_files"; echo "$workspace_root/Cargo.toml")
 
         # Patch local files and workspace root (sort -u to deduplicate)
-        echo "$files" | sort -u | while read file; do
+        echo "$files" | sort -u | while read -r file; do
           echo Patching "$file" ...
           dir=$(dirname "$file")
           for crate in $crates; do


### PR DESCRIPTION
### What
Update the soroban examples test workflow to patch both local Cargo.toml files and the workspace root Cargo.toml.

### Why
The previous logic only patched local Cargo.toml files found by find, missing the workspace root Cargo.toml which may be located outside the search path.

Related:
- https://github.com/stellar/soroban-examples/pull/391