### PR TITLE
Use ubuntu-slim for complete job runner

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -22,7 +22,7 @@ jobs:
   complete:
     if: always()
     needs: [fmt, check-git-rev-deps, semver-checks, build, test, build-fuzz, docs, readme, migration-docs]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
     - if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
       run: exit 1


### PR DESCRIPTION
### What
Change the CI complete job runner from ubuntu-latest to ubuntu-slim.

### Why
Reduce CI resource usage for a job that only checks the status of other jobs. Ubuntu-slim is a super lightweight runner.