### PR TITLE
Add reference to the org contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,10 @@
-# Contributing
+# How to contribute
 
-Contributions are welcome to the soroban-sdk. Please discuss issues to be solved
-and potential solutions on issues ahead of opening a pull request.
+Check out the [Stellar Contribution Guide](https://github.com/stellar/.github/blob/master/CONTRIBUTING.md) that applies to all Stellar projects.
+
+## Contributing to soroban-sdk
+
+Please discuss issues to be solved and potential solutions on issues ahead of opening a pull request.
 
 ## Development Environment Setup
 


### PR DESCRIPTION
### What
Add reference to the CONTRIBUTING.md to link to the Stellar organization-wide contribution guide.

### Why
Repositories in the org are intended to link to the main shared contributing guide.