### PR TITLE
Make contract spec inject only on actual use

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1736,6 +1736,7 @@ name = "test_empty"
 version = "23.4.0"
 dependencies = [
  "soroban-sdk",
+ "soroban-token-sdk",
 ]
 
 [[package]]

--- a/soroban-sdk-macros/src/derive_enum.rs
+++ b/soroban-sdk-macros/src/derive_enum.rs
@@ -149,15 +149,30 @@ pub fn derive_type_enum(
         let spec_xdr_len = spec_xdr.len();
         let spec_ident = format_ident!("__SPEC_XDR_TYPE_{}", enum_ident.to_string().to_uppercase());
         Some(quote! {
-            #[cfg_attr(target_family = "wasm", link_section = "contractspecv0")]
-            pub static #spec_ident: [u8; #spec_xdr_len] = #enum_ident::spec_xdr();
-
             impl #enum_ident {
                 pub const fn spec_xdr() -> [u8; #spec_xdr_len] {
                     *#spec_xdr_lit
                 }
+
+                #[doc(hidden)]
+                #[inline(always)]
+                fn __include_spec() {
+                    #[cfg(target_family = "wasm")]
+                    {
+                        #[link_section = "contractspecv0"]
+                        static #spec_ident: [u8; #spec_xdr_len] = #enum_ident::spec_xdr();
+                        let _ = unsafe { ::core::ptr::read_volatile(#spec_ident.as_ptr()) };
+                    }
+                }
             }
         })
+    } else {
+        None
+    };
+
+    // Call to include spec in the WASM if the type is used.
+    let include_spec_call = if spec {
+        Some(quote! { #enum_ident::__include_spec(); })
     } else {
         None
     };
@@ -170,6 +185,7 @@ pub fn derive_type_enum(
             type Error = #path::ConversionError;
             #[inline(always)]
             fn try_from_val(env: &#path::Env, val: &#path::Val) -> Result<Self, #path::ConversionError> {
+                #include_spec_call
                 use #path::{EnvBase,TryIntoVal,TryFromVal};
                 const CASES: &'static [&'static str] = &[#(#case_name_str_lits),*];
                 let vec: #path::Vec<#path::Val> = val.try_into_val(env)?;
@@ -186,6 +202,7 @@ pub fn derive_type_enum(
             type Error = #path::ConversionError;
             #[inline(always)]
             fn try_from_val(env: &#path::Env, val: &#enum_ident) -> Result<Self, #path::ConversionError> {
+                #include_spec_call
                 use #path::{TryIntoVal,TryFromVal};
                 match val {
                     #(#try_intos,)*

--- a/soroban-sdk-macros/src/derive_enum_int.rs
+++ b/soroban-sdk-macros/src/derive_enum_int.rs
@@ -78,15 +78,30 @@ pub fn derive_type_enum_int(
         let spec_xdr_len = spec_xdr.len();
         let spec_ident = format_ident!("__SPEC_XDR_TYPE_{}", enum_ident.to_string().to_uppercase());
         Some(quote! {
-            #[cfg_attr(target_family = "wasm", link_section = "contractspecv0")]
-            pub static #spec_ident: [u8; #spec_xdr_len] = #enum_ident::spec_xdr();
-
             impl #enum_ident {
                 pub const fn spec_xdr() -> [u8; #spec_xdr_len] {
                     *#spec_xdr_lit
                 }
+
+                #[doc(hidden)]
+                #[inline(always)]
+                fn __include_spec() {
+                    #[cfg(target_family = "wasm")]
+                    {
+                        #[link_section = "contractspecv0"]
+                        static #spec_ident: [u8; #spec_xdr_len] = #enum_ident::spec_xdr();
+                        let _ = unsafe { ::core::ptr::read_volatile(#spec_ident.as_ptr()) };
+                    }
+                }
             }
         })
+    } else {
+        None
+    };
+
+    // Call to include spec in the WASM if the type is used.
+    let include_spec_call = if spec {
+        Some(quote! { #enum_ident::__include_spec(); })
     } else {
         None
     };
@@ -99,6 +114,7 @@ pub fn derive_type_enum_int(
             type Error = #path::ConversionError;
             #[inline(always)]
             fn try_from_val(env: &#path::Env, val: &#path::Val) -> Result<Self, #path::ConversionError> {
+                #include_spec_call
                 use #path::TryIntoVal;
                 let discriminant: u32 = val.try_into_val(env)?;
                 Ok(match discriminant {
@@ -112,6 +128,7 @@ pub fn derive_type_enum_int(
             type Error = #path::ConversionError;
             #[inline(always)]
             fn try_from_val(env: &#path::Env, val: &#enum_ident) -> Result<Self, #path::ConversionError> {
+                #include_spec_call
                 Ok(match val {
                     #(#try_intos,)*
                 })

--- a/soroban-sdk-macros/src/derive_struct_tuple.rs
+++ b/soroban-sdk-macros/src/derive_struct_tuple.rs
@@ -76,15 +76,30 @@ pub fn derive_type_struct_tuple(
         let spec_xdr_len = spec_xdr.len();
         let spec_ident = format_ident!("__SPEC_XDR_TYPE_{}", ident.to_string().to_uppercase());
         Some(quote! {
-            #[cfg_attr(target_family = "wasm", link_section = "contractspecv0")]
-            pub static #spec_ident: [u8; #spec_xdr_len] = #ident::spec_xdr();
-
             impl #ident {
                 pub const fn spec_xdr() -> [u8; #spec_xdr_len] {
                     *#spec_xdr_lit
                 }
+
+                #[doc(hidden)]
+                #[inline(always)]
+                fn __include_spec() {
+                    #[cfg(target_family = "wasm")]
+                    {
+                        #[link_section = "contractspecv0"]
+                        static #spec_ident: [u8; #spec_xdr_len] = #ident::spec_xdr();
+                        let _ = unsafe { ::core::ptr::read_volatile(#spec_ident.as_ptr()) };
+                    }
+                }
             }
         })
+    } else {
+        None
+    };
+
+    // Call to include spec in the WASM if the type is used.
+    let include_spec_call = if spec {
+        Some(quote! { #ident::__include_spec(); })
     } else {
         None
     };
@@ -97,6 +112,7 @@ pub fn derive_type_struct_tuple(
             type Error = #path::ConversionError;
             #[inline(always)]
             fn try_from_val(env: &#path::Env, val: &#path::Val) -> Result<Self, #path::ConversionError> {
+                #include_spec_call
                 use #path::{TryIntoVal,EnvBase,ConversionError,VecObject,Val};
                 let vec: VecObject = (*val).try_into().map_err(|_| ConversionError)?;
                 let mut vals: [Val; #field_count_usize] = [Val::VOID.to_val(); #field_count_usize];
@@ -111,6 +127,7 @@ pub fn derive_type_struct_tuple(
             type Error = #path::ConversionError;
             #[inline(always)]
             fn try_from_val(env: &#path::Env, val: &#ident) -> Result<Self, #path::ConversionError> {
+                #include_spec_call
                 use #path::{TryIntoVal,EnvBase,ConversionError,Val};
                 let vals: [Val; #field_count_usize] = [
                     #((&val.#field_idx_lits).try_into_val(env).map_err(|_| ConversionError)?),*

--- a/soroban-sdk/src/tests/contract_docs.rs
+++ b/soroban-sdk/src/tests/contract_docs.rs
@@ -56,7 +56,7 @@ mod struct_ {
 
     #[test]
     fn test_spec() {
-        let entry = ScSpecEntry::from_xdr(__SPEC_XDR_TYPE_S, Limits::none()).unwrap();
+        let entry = ScSpecEntry::from_xdr(S::spec_xdr(), Limits::none()).unwrap();
         let expect = ScSpecEntry::UdtStructV0(ScSpecUdtStructV0 {
             doc: "S holds a and\nb.".try_into().unwrap(),
             name: "S".try_into().unwrap(),
@@ -98,7 +98,7 @@ mod struct_tuple {
 
     #[test]
     fn test_spec() {
-        let entry = ScSpecEntry::from_xdr(__SPEC_XDR_TYPE_S, Limits::none()).unwrap();
+        let entry = ScSpecEntry::from_xdr(S::spec_xdr(), Limits::none()).unwrap();
         let expect = ScSpecEntry::UdtStructV0(ScSpecUdtStructV0 {
             doc: "S holds two u64s.".try_into().unwrap(),
             name: "S".try_into().unwrap(),
@@ -145,7 +145,7 @@ mod enum_ {
 
     #[test]
     fn test_spec() {
-        let entry = ScSpecEntry::from_xdr(__SPEC_XDR_TYPE_E, Limits::none()).unwrap();
+        let entry = ScSpecEntry::from_xdr(E::spec_xdr(), Limits::none()).unwrap();
         let expect = ScSpecEntry::UdtUnionV0(ScSpecUdtUnionV0 {
             doc: "E has variants A and B.".try_into().unwrap(),
             lib: "".try_into().unwrap(),
@@ -193,7 +193,7 @@ mod enum_int {
 
     #[test]
     fn test_spec() {
-        let entry = ScSpecEntry::from_xdr(__SPEC_XDR_TYPE_E, Limits::none()).unwrap();
+        let entry = ScSpecEntry::from_xdr(E::spec_xdr(), Limits::none()).unwrap();
         let expect = ScSpecEntry::UdtEnumV0(ScSpecUdtEnumV0 {
             doc: "E has variants A and B.".try_into().unwrap(),
             name: "E".try_into().unwrap(),
@@ -238,7 +238,7 @@ mod enum_error_int {
 
     #[test]
     fn test_spec() {
-        let entry = ScSpecEntry::from_xdr(__SPEC_XDR_TYPE_E, Limits::none()).unwrap();
+        let entry = ScSpecEntry::from_xdr(E::spec_xdr(), Limits::none()).unwrap();
         let expect = ScSpecEntry::UdtErrorEnumV0(ScSpecUdtErrorEnumV0 {
             doc: "E has variants A and B.".try_into().unwrap(),
             name: "E".try_into().unwrap(),


### PR DESCRIPTION
### What
Change contract spec XDR from being unconditionally exported via static link sections to lazy-loading via hidden `__include_spec()` methods. Spec data is only included in the WASM when types are actually used through conversion trait implementations or event publishing.

### Why
Prevent library type specs from leaking into contract WASM builds. Previously, all spec data from dependencies was exported regardless of whether types were used, causing contracts to inherit unused exports from libraries like OpenZeppelin stellar-contracts.

Close #1569