### PR TITLE
Fix contractevent vec data format to preserve field declaration order

### DIFF
--- a/soroban-sdk-macros/src/derive_event.rs
+++ b/soroban-sdk-macros/src/derive_event.rs
@@ -229,16 +229,11 @@ fn derive_impls(args: &ContractEventArgs, input: &DeriveInput) -> Result<TokenSt
     let data_params = params
         .iter()
         .filter(|p| p.location == ScSpecEventParamLocationV0::Data)
-        .sorted_by_key(|p| p.name.to_string()) // must be sorted for map_new_from_slices
         .collect::<Vec<_>>();
     let data_params_count = data_params.len();
     let data_idents = data_params
         .iter()
         .map(|p| format_ident!("{}", p.name.to_string()))
-        .collect::<Vec<_>>();
-    let data_strs = data_idents
-        .iter()
-        .map(|i| i.to_string())
         .collect::<Vec<_>>();
     let data_to_val = match args.data_format {
         DataFormat::SingleValue if data_params_count == 0 => quote! {
@@ -258,14 +253,26 @@ fn derive_impls(args: &ContractEventArgs, input: &DeriveInput) -> Result<TokenSt
                 #({ let v: #path::Val = self.#data_idents.into_val(env); v },)*
             ).into_val(env)
         },
-        DataFormat::Map => quote! {
-            use #path::{EnvBase,IntoVal,unwrap::UnwrapInfallible};
-            const KEYS: [&'static str; #data_params_count] = [#(#data_strs),*];
-            let vals: [#path::Val; #data_params_count] = [
-                #(self.#data_idents.into_val(env)),*
-            ];
-            env.map_new_from_slices(&KEYS, &vals).unwrap_infallible().into()
-        },
+        DataFormat::Map => {
+            // Must be sorted for map_new_from_slices
+            let data_idents_sorted = data_params
+                .iter()
+                .sorted_by_key(|p| p.name.to_string())
+                .map(|p| format_ident!("{}", p.name.to_string()))
+                .collect::<Vec<_>>();
+            let data_strs_sorted = data_idents_sorted
+                .iter()
+                .map(|i| i.to_string())
+                .collect::<Vec<_>>();
+            quote! {
+                use #path::{EnvBase,IntoVal,unwrap::UnwrapInfallible};
+                const KEYS: [&'static str; #data_params_count] = [#(#data_strs_sorted),*];
+                let vals: [#path::Val; #data_params_count] = [
+                    #(self.#data_idents_sorted.into_val(env)),*
+                ];
+                env.map_new_from_slices(&KEYS, &vals).unwrap_infallible().into()
+            }
+        }
     };
 
     // Output.

--- a/soroban-sdk/test_snapshots/tests/contract_event/test_data_map_sorts_fields.1.json
+++ b/soroban-sdk/test_snapshots/tests/contract_event/test_data_map_sorts_fields.1.json
@@ -1,0 +1,102 @@
+{
+  "generators": {
+    "address": 1,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 25,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": "ledger_key_contract_instance",
+              "durability": "persistent",
+              "val": {
+                "contract_instance": {
+                  "executable": {
+                    "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  },
+                  "storage": null
+                }
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_code": {
+              "ext": "v0",
+              "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+              "code": ""
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      }
+    ]
+  },
+  "events": [
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+        "type_": "contract",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "deposit"
+              },
+              {
+                "symbol": "user"
+              }
+            ],
+            "data": {
+              "map": [
+                {
+                  "key": {
+                    "symbol": "amount"
+                  },
+                  "val": {
+                    "i128": "500"
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "time"
+                  },
+                  "val": {
+                    "u64": "1000"
+                  }
+                }
+              ]
+            }
+          }
+        }
+      },
+      "failed_call": false
+    }
+  ]
+}

--- a/soroban-sdk/test_snapshots/tests/contract_event/test_data_vec_preserves_field_order.1.json
+++ b/soroban-sdk/test_snapshots/tests/contract_event/test_data_vec_preserves_field_order.1.json
@@ -1,0 +1,92 @@
+{
+  "generators": {
+    "address": 1,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 25,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": "ledger_key_contract_instance",
+              "durability": "persistent",
+              "val": {
+                "contract_instance": {
+                  "executable": {
+                    "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  },
+                  "storage": null
+                }
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_code": {
+              "ext": "v0",
+              "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+              "code": ""
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      }
+    ]
+  },
+  "events": [
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+        "type_": "contract",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "deposit"
+              },
+              {
+                "symbol": "user"
+              }
+            ],
+            "data": {
+              "vec": [
+                {
+                  "u64": "1000"
+                },
+                {
+                  "i128": "500"
+                }
+              ]
+            }
+          }
+        }
+      },
+      "failed_call": false
+    }
+  ]
+}


### PR DESCRIPTION
### What

Only sort contractevent fields when building events where the data format is `map`.

### Why

For contractevents with a data_format of vec, sorting the fields caused the data to be published in a different order than what the event defined, which is not expected.

Closes https://github.com/stellar/rs-soroban-sdk/issues/1679

### Known limitations

N/A
