### PR TITLE
Update fuzz Cargo.lock in bump-version workflow

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -7,9 +7,31 @@ on:
         description: 'Version to bump to'
         required: true
 
+permissions:
+  contents: write
+
 jobs:
 
   bump-version:
     uses: stellar/actions/.github/workflows/rust-bump-version.yml@main
     with:
       version: ${{ inputs.version }}
+
+  bump-fuzz-lock:
+    needs: bump-version
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v6
+      with:
+        ref: 'release/v${{ inputs.version }}'
+    - run: rustup update
+    - run: rustup install nightly
+    - name: Update fuzz Cargo.lock
+      run: cargo +nightly update --manifest-path tests/fuzz/fuzz/Cargo.toml soroban-sdk
+    - name: Commit fuzz Cargo.lock
+      run: |
+        git config user.name 'github-actions[bot]'
+        git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+        git add tests/fuzz/fuzz/Cargo.lock
+        git commit -m 'Update fuzz Cargo.lock for ${{ inputs.version }}' || echo 'No changes to commit'
+        git push


### PR DESCRIPTION
### What
Add a new `bump-fuzz-lock` job to the bump-version workflow that updates `tests/fuzz/fuzz/Cargo.lock` after the version bump completes. The job checks out the release branch, runs `cargo +nightly update` targeting only the `soroban-sdk` package to conservatively update the lock file, then commits and pushes the change.

### Why
The fuzz crate at `tests/fuzz/fuzz/` has its own `Cargo.lock` separate from the workspace and depends on `soroban-sdk` via a path dependency. When versions are bumped, only the root `Cargo.lock` gets updated, leaving the fuzz lock file referencing the old version. This causes the `build-fuzz` CI job to fail. We've been manually updating this during releases, but this was accidentally missed during the v23.4.1 release. The release process shouldn't require manual steps.

Close #1683