### PR TITLE
Work around rustdoc ICE caused by intra-doc links in deprecated notes

### DIFF
--- a/soroban-sdk/src/env.rs
+++ b/soroban-sdk/src/env.rs
@@ -450,7 +450,7 @@ impl Env {
 
     /// Get the [Logs] for logging debug events.
     #[inline(always)]
-    #[deprecated(note = "use [Env::logs]")]
+    #[deprecated(note = "use Env::logs")]
     #[doc(hidden)]
     pub fn logger(&self) -> Logs {
         self.logs()
@@ -1050,7 +1050,7 @@ impl Env {
     /// The contract will wrap a randomly-generated Stellar asset. This function
     /// is useful for using in the tests when an arbitrary token contract
     /// instance is needed.
-    #[deprecated(note = "use [Env::register_stellar_asset_contract_v2]")]
+    #[deprecated(note = "use Env::register_stellar_asset_contract_v2")]
     pub fn register_stellar_asset_contract(&self, admin: Address) -> Address {
         self.register_stellar_asset_contract_v2(admin).address()
     }

--- a/soroban-sdk/src/events.rs
+++ b/soroban-sdk/src/events.rs
@@ -121,7 +121,7 @@ impl Events {
     /// - [Map]
     /// - [Bytes]/[BytesN][crate::BytesN] longer than 32 bytes
     /// - [contracttype]
-    #[deprecated(note = "use the #[contractevent] macro on a contract event type")]
+    #[deprecated(note = "use the #\\[contractevent\\] macro on a contract event type")]
     #[inline(always)]
     pub fn publish<T, D>(&self, topics: T, data: D)
     where

--- a/soroban-sdk/src/logs.rs
+++ b/soroban-sdk/src/logs.rs
@@ -108,7 +108,7 @@ impl Logs {
         Logs(env.clone())
     }
 
-    #[deprecated(note = "use [Logs::add]")]
+    #[deprecated(note = "use Logs::add")]
     #[inline(always)]
     pub fn log(&self, msg: &'static str, args: &[Val]) {
         self.add(msg, args);

--- a/soroban-sdk/src/symbol.rs
+++ b/soroban-sdk/src/symbol.rs
@@ -249,7 +249,7 @@ impl Symbol {
     ///
     /// When the input string is not representable by Symbol.
     #[doc(hidden)]
-    #[deprecated(note = "use [symbol_short!()]")]
+    #[deprecated(note = "use symbol_short!()")]
     pub const fn short(s: &str) -> Self {
         if let Ok(sym) = SymbolSmall::try_from_str(s) {
             Symbol {

--- a/soroban-sdk/src/testutils/arbitrary.rs
+++ b/soroban-sdk/src/testutils/arbitrary.rs
@@ -1439,7 +1439,7 @@ mod fuzz_test_helpers {
     ///     let r = contract.try_deposit(deposit_address, input.deposit_amount);
     /// });
     /// ```
-    #[deprecated(note = "use [Env::try_invoke] or the try_ functions on a contract client")]
+    #[deprecated(note = "use Env::try_invoke or the try_ functions on a contract client")]
     pub fn fuzz_catch_panic<F, R>(f: F) -> std::thread::Result<R>
     where
         F: FnOnce() -> R,


### PR DESCRIPTION
### What

Remove or escape square brackets in `#[deprecated(note = "...")]` attributes that were being parsed as intra-doc links by rustdoc.

### Why

Running `cargo +nightly doc` causes an internal compiler error (ICE) in rustdoc when it attempts to resolve intra-doc links like `[Env::try_invoke]` within `#[deprecated]` attribute notes. When the deprecated item is re-exported via glob import (`pub use module::*`), rustdoc fails to resolve the link in the correct scope and panics instead of gracefully handling the unresolved link.

This is a workaround for a bug in rustdoc that has been reported upstream:
- https://github.com/rust-lang/rust/issues/151411

This workaround is to unblock PRs on this repo, such as:
- https://github.com/stellar/rs-soroban-sdk/pull/1687