### PR TITLE
Fix permissions from bump-version workflow

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -7,6 +7,11 @@ on:
         description: 'Version to bump to'
         required: true
 
+permissions:
+  actions: write
+  contents: write
+  pull-requests: write
+
 jobs:
 
   bump-version:


### PR DESCRIPTION
### What

Added required permissions for version bumping.

### Why

This failure: https://github.com/stellar/rs-soroban-sdk/actions/runs/21274277606.

In the past these permissions were enabled implicitly, but when we introduced the contents: write line here, it disabled all the default permissions including the action and pull-request permissions that the bump version workflow requires and previously had access to.

### Known limitations

There's limited testing I can do without merging this to main because the permissions work different on the default branch (main) compared to other branches.