### PR TITLE
Use compile-time assert in BigInt::from

### DIFF
--- a/soroban-sdk/src/crypto/utils.rs
+++ b/soroban-sdk/src/crypto/utils.rs
@@ -44,8 +44,10 @@ impl<const N: usize> BigInt<N> {
 
 impl<const N: usize, const M: usize> From<&BytesN<M>> for BigInt<N> {
     fn from(bytes: &BytesN<M>) -> Self {
-        if M != N * 8 {
-            panic!("BytesN::Into<BigInt> - length mismatch")
+        const {
+            if M != N * 8 {
+                panic!("BytesN::Into<BigInt> - length mismatch")
+            }
         }
 
         let array = bytes.to_array();


### PR DESCRIPTION
### What
Wrap the length mismatch check in `BigInt::From<&BytesN<M>>` in a `const` block to evaluate it at compile time instead of runtime.

### Why
Both `M` and `N` are const generics, so the `M != N * 8` check can be a compile-time assertion. The nearby `copy_into_array` method already uses this pattern. This makes a mismatched conversion a compile error rather than a runtime panic.
