### PR TITLE
Fix BytesN::is_empty to check const length

### DIFF
--- a/soroban-sdk/src/bytes.rs
+++ b/soroban-sdk/src/bytes.rs
@@ -1229,7 +1229,7 @@ impl<const N: usize> BytesN<N> {
     /// Returns true if the Bytes is empty and has a length of zero.
     #[inline(always)]
     pub fn is_empty(&self) -> bool {
-        false
+        N == 0
     }
 
     /// Returns the number of bytes are in the Bytes.

--- a/soroban-sdk/src/tests.rs
+++ b/soroban-sdk/src/tests.rs
@@ -6,6 +6,7 @@ mod auth;
 mod bytes_alloc_vec;
 mod bytes_buffer;
 mod bytes_slice;
+mod bytesn;
 mod cmp_across_env_in_tests;
 mod contract_add_i32;
 mod contract_assert;

--- a/soroban-sdk/src/tests/bytesn.rs
+++ b/soroban-sdk/src/tests/bytesn.rs
@@ -1,0 +1,17 @@
+use crate::{BytesN, Env};
+
+#[test]
+fn test_bytesn_is_empty_zero_length() {
+    let env = Env::default();
+    let b: BytesN<0> = BytesN::from_array(&env, &[]);
+    assert_eq!(b.len(), 0);
+    assert!(b.is_empty());
+}
+
+#[test]
+fn test_bytesn_is_empty_nonzero_length() {
+    let env = Env::default();
+    let b: BytesN<4> = BytesN::from_array(&env, &[1, 2, 3, 4]);
+    assert_eq!(b.len(), 4);
+    assert!(!b.is_empty());
+}


### PR DESCRIPTION
### What
Change `BytesN::is_empty` to return `N == 0` instead of unconditionally returning `false`. Add tests for zero-length and nonzero-length `BytesN` values.

### Why
`BytesN::is_empty` hardcodes `false`, which is incorrect for `BytesN<0>`. The const generic parameter `N` already encodes the length, so the check should compare against it.

It's unclear to me how or why this came about. The hardcoded false value goes as far back as the v0.0.3 build of soroban-sdk in 2022 when still in early development. Back then the Bytes and BytesN types did not exist but their counter parts from which they evolved did. It is possible through host behaviour that an empty fixed array size was not possible and that was why the value was hardcoded. Since then the function was moved about when the BytesN type was introduced.

The utility of a `BytesN<0>` value is near zero so its use in a contract is unlikely. None-the-less this is being fixed.