### PR TITLE
Remove unnecessary clone in iterators

### DIFF
--- a/soroban-sdk/src/map.rs
+++ b/soroban-sdk/src/map.rs
@@ -519,7 +519,7 @@ where
         K: IntoVal<Env, Val> + TryFromVal<Env, Val> + Clone,
         V: IntoVal<Env, Val> + TryFromVal<Env, Val> + Clone,
     {
-        MapTryIter::new(self.clone())
+        MapTryIter::new(self)
     }
 }
 

--- a/soroban-sdk/src/vec.rs
+++ b/soroban-sdk/src/vec.rs
@@ -984,7 +984,7 @@ where
         T: IntoVal<Env, Val> + TryFromVal<Env, Val> + Clone,
         T::Error: Debug,
     {
-        VecTryIter::new(self.clone())
+        VecTryIter::new(self)
     }
 }
 


### PR DESCRIPTION
### What
Remove `.clone()` calls when passing `self` to `MapTryIter::new` and `VecTryIter::new` in the `try_iter` methods of `Map` and `Vec`.

### Why
The clone is redundant and unnecessary.