### PR TITLE
Fix #[cfg(test)] methods in #[contractimpl] blocks failing to compile with testutils

### DIFF
--- a/soroban-sdk-macros/src/derive_contractimpl_trait_default_fns_not_overridden.rs
+++ b/soroban-sdk-macros/src/derive_contractimpl_trait_default_fns_not_overridden.rs
@@ -81,7 +81,7 @@ fn derive(args: &Args) -> Result<TokenStream2, Error> {
         &args.crate_path,
         &impl_ty,
         Some(trait_ident),
-        fns.iter().map(|f| &f.ident),
+        fns.iter().map(|f| (&f.ident, f.attrs.as_slice())),
     ));
 
     Ok(output)

--- a/soroban-sdk-macros/src/derive_fn.rs
+++ b/soroban-sdk-macros/src/derive_fn.rs
@@ -233,18 +233,22 @@ pub fn derive_contract_function_registration_ctor<'a>(
     crate_path: &Path,
     ty: &Type,
     trait_ident: Option<&Path>,
-    method_idents: impl Iterator<Item = &'a Ident>,
+    method_idents: impl Iterator<Item = (&'a Ident, &'a [Attribute])>,
 ) -> TokenStream2 {
     if cfg!(not(feature = "testutils")) {
         return quote!();
     }
 
     let ty_str = ty_to_safe_ident_str(ty);
-    let (idents, wrap_idents): (Vec<_>, Vec<_>) = method_idents
-        .map(|ident| {
+    let (idents, wrap_idents, cfg_attrs): (Vec<_>, Vec<_>, Vec<_>) = method_idents
+        .map(|(ident, attrs)| {
             let ident_str = format!("{}", ident);
             let wrap_ident = format_ident!("__{}__{}__invoke_raw_slice", ty_str, ident_str);
-            (ident_str, wrap_ident)
+            let cfg_attrs: Vec<_> = attrs
+                .iter()
+                .filter(|attr| attr.path().is_ident("cfg"))
+                .collect();
+            (ident_str, wrap_ident, cfg_attrs)
         })
         .multiunzip();
 
@@ -266,6 +270,7 @@ pub fn derive_contract_function_registration_ctor<'a>(
         #[allow(non_snake_case)]
         fn #ctor_ident() {
             #(
+                #(#cfg_attrs)*
                 <#ty as #crate_path::testutils::ContractFunctionRegister>::register(
                     #idents,
                     #[allow(deprecated)]

--- a/soroban-sdk-macros/src/lib.rs
+++ b/soroban-sdk-macros/src/lib.rs
@@ -287,7 +287,9 @@ pub fn contractimpl(metadata: TokenStream, input: TokenStream) -> TokenStream {
                 crate_path,
                 ty,
                 trait_ident,
-                pub_methods.iter().map(|m| &m.sig.ident),
+                pub_methods
+                    .iter()
+                    .map(|m| (&m.sig.ident, m.attrs.as_slice())),
             );
             output.extend(quote! { #cfs });
 


### PR DESCRIPTION
## Summary

When a `pub fn` inside a `#[contractimpl]` block is annotated with `#[cfg(test)]`, the macro correctly propagates that attribute onto the generated `__Contract__<method>__invoke_raw_slice` function (via `#(#attrs)*` passthrough in `derive_fn`). However, `derive_contract_function_registration_ctor` only received method idents — not their attributes — so the generated registration ctor referenced `__Contract__<method>__invoke_raw_slice` unconditionally. In a non-test build with the `testutils` feature enabled, this produces:

```
error[E0425]: cannot find value `__Contract__persisted__invoke_raw_slice` in this scope
```

## Fix

Change `derive_contract_function_registration_ctor` to accept `(&Ident, &[Attribute])` pairs instead of just `&Ident`. For each method, extract any `cfg` attributes and emit them on the corresponding registration call in the ctor body, so `#[cfg(test)]` (and other cfg guards) are respected.

## Impact

Narrow compile-time only: any crate with a `#[cfg(test)]` public method inside `#[contractimpl]` would fail to compile with `testutils` enabled. No runtime behavior is affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)