### PR TITLE
Add comment for future EnvTestConfig API privatization

### DIFF
--- a/soroban-sdk/src/env.rs
+++ b/soroban-sdk/src/env.rs
@@ -270,7 +270,6 @@ pub struct EnvTestConfig {
     /// JSON file to be written to disk when the Env is no longer referenced.
     /// Defaults to true.
     pub capture_snapshot_at_drop: bool,
-
     // NOTE: Next time a field needs to be added to EnvTestConfig it will be a breaking change,
     // take the opportunity to make the current field private, new fields private, and settable via
     // functions. Why: So that it is the last time a breaking change is needed to the type.


### PR DESCRIPTION
### What
Add a comment to `EnvTestConfig` noting that the next time a field is added, which requires a breaking change, the fields should be made private and settable via builder-style functions.

### Why
`EnvTestConfig` has public fields, which makes adding new fields a breaking change due to struct literal construction and exhaustive pattern matching. The refactor is deferred to the next unavoidable breaking change to avoid introducing one unnecessarily, and the comment ensures the opportunity is not missed.

Close #1419