### PR TITLE
Add ScVal conversion and SorobanArbitrary impls for MuxedAddress

### DIFF
--- a/soroban-sdk/src/muxed_address.rs
+++ b/soroban-sdk/src/muxed_address.rs
@@ -354,6 +354,25 @@ impl MuxedAddress {
 }
 
 #[cfg(not(target_family = "wasm"))]
+impl From<&MuxedAddress> for ScVal {
+    fn from(v: &MuxedAddress) -> Self {
+        // This conversion occurs only in test utilities, and theoretically all
+        // values should convert to an ScVal because the Env won't let the host
+        // type to exist otherwise, unwrapping. Even if there are edge cases
+        // that don't, this is a trade off for a better test developer
+        // experience.
+        ScVal::try_from_val(&v.env, &v.to_val()).unwrap()
+    }
+}
+
+#[cfg(not(target_family = "wasm"))]
+impl From<MuxedAddress> for ScVal {
+    fn from(v: MuxedAddress) -> Self {
+        (&v).into()
+    }
+}
+
+#[cfg(not(target_family = "wasm"))]
 impl TryFromVal<Env, ScVal> for MuxedAddress {
     type Error = ConversionError;
     fn try_from_val(env: &Env, val: &ScVal) -> Result<Self, Self::Error> {

--- a/soroban-sdk/src/tests/muxed_address.rs
+++ b/soroban-sdk/src/tests/muxed_address.rs
@@ -1,4 +1,4 @@
-use soroban_sdk_macros::{contract, contractimpl};
+use soroban_sdk_macros::{contract, contractimpl, contracttype};
 
 use crate::testutils::{Address as _, MuxedAddress as _};
 use crate::{self as soroban_sdk, Bytes, String};
@@ -6,6 +6,13 @@ use crate::{
     env::xdr::{AccountId, ScAddress, Uint256},
     Address, Env, MuxedAddress, TryFromVal,
 };
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[contracttype]
+pub struct Udt {
+    pub address: MuxedAddress,
+    pub amount: i128,
+}
 
 #[contract]
 pub struct MuxedAddressContract;
@@ -18,6 +25,10 @@ impl MuxedAddressContract {
         b: soroban_sdk::MuxedAddress,
     ) -> (Option<u64>, Option<u64>) {
         (a.id(), b.id())
+    }
+
+    pub fn echo_udt(_e: Env, udt: Udt) -> Udt {
+        udt
     }
 }
 
@@ -107,6 +118,32 @@ fn test_accept_muxed_address_argument_in_contract() {
         client.get_muxed_ids(non_muxed_address, muxed_address2),
         (None, Some(2))
     );
+}
+
+#[test]
+fn test_contracttype_struct_with_address_backed_muxed_address() {
+    let env = Env::default();
+    let contract_id = env.register(MuxedAddressContract, ());
+    let client = MuxedAddressContractClient::new(&env, &contract_id);
+
+    let udt = Udt {
+        address: Address::generate(&env).into(),
+        amount: 42,
+    };
+    assert_eq!(client.echo_udt(&udt), udt.clone());
+}
+
+#[test]
+fn test_contracttype_struct_with_muxed_address() {
+    let env = Env::default();
+    let contract_id = env.register(MuxedAddressContract, ());
+    let client = MuxedAddressContractClient::new(&env, &contract_id);
+
+    let udt = Udt {
+        address: MuxedAddress::generate(&env),
+        amount: 42,
+    };
+    assert_eq!(client.echo_udt(&udt), udt.clone());
 }
 
 #[test]

--- a/soroban-sdk/src/testutils/arbitrary.rs
+++ b/soroban-sdk/src/testutils/arbitrary.rs
@@ -328,7 +328,8 @@ mod objects {
             Fp, Fp2, Fr, G1Affine, G2Affine, FP2_SERIALIZED_SIZE, FP_SERIALIZED_SIZE,
             G1_SERIALIZED_SIZE, G2_SERIALIZED_SIZE,
         },
-        Address, Bytes, BytesN, Duration, Map, String, Symbol, Timepoint, Val, Vec, I256, U256,
+        Address, Bytes, BytesN, Duration, Map, MuxedAddress, String, Symbol, Timepoint, Val, Vec,
+        I256, U256,
     };
 
     use std::string::String as RustString;
@@ -647,6 +648,39 @@ mod objects {
             use crate::env::xdr::{ContractId, Hash, ScAddress};
 
             let sc_addr = ScVal::Address(ScAddress::Contract(ContractId(Hash(v.inner))));
+            Ok(sc_addr.into_val(env))
+        }
+    }
+
+    //////////////////////////////////
+
+    #[derive(Arbitrary, Debug, Clone, Eq, PartialEq, Ord, PartialOrd)]
+    pub enum ArbitraryMuxedAddress {
+        Address(ArbitraryAddress),
+        Muxed { ed25519: [u8; 32], id: u64 },
+    }
+
+    impl SorobanArbitrary for MuxedAddress {
+        type Prototype = ArbitraryMuxedAddress;
+    }
+
+    impl TryFromVal<Env, ArbitraryMuxedAddress> for MuxedAddress {
+        type Error = ConversionError;
+        fn try_from_val(env: &Env, v: &ArbitraryMuxedAddress) -> Result<Self, Self::Error> {
+            use crate::env::xdr::{MuxedEd25519Account, ScAddress, Uint256};
+
+            let sc_addr = match v {
+                ArbitraryMuxedAddress::Address(v) => {
+                    let address = Address::try_from_val(env, v)?;
+                    return Ok(address.into());
+                }
+                ArbitraryMuxedAddress::Muxed { ed25519, id } => {
+                    ScVal::Address(ScAddress::MuxedAccount(MuxedEd25519Account {
+                        ed25519: Uint256(*ed25519),
+                        id: *id,
+                    }))
+                }
+            };
             Ok(sc_addr.into_val(env))
         }
     }

--- a/soroban-sdk/test_snapshots/tests/muxed_address/test_contracttype_struct_with_address_backed_muxed_address.1.json
+++ b/soroban-sdk/test_snapshots/tests/muxed_address/test_contracttype_struct_with_address_backed_muxed_address.1.json
@@ -1,0 +1,61 @@
+{
+  "generators": {
+    "address": 2,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 25,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": "ledger_key_contract_instance",
+              "durability": "persistent",
+              "val": {
+                "contract_instance": {
+                  "executable": {
+                    "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  },
+                  "storage": null
+                }
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_code": {
+              "ext": "v0",
+              "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+              "code": ""
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      }
+    ]
+  },
+  "events": []
+}

--- a/soroban-sdk/test_snapshots/tests/muxed_address/test_contracttype_struct_with_muxed_address.1.json
+++ b/soroban-sdk/test_snapshots/tests/muxed_address/test_contracttype_struct_with_muxed_address.1.json
@@ -1,0 +1,61 @@
+{
+  "generators": {
+    "address": 2,
+    "nonce": 0,
+    "mux_id": 1
+  },
+  "auth": [
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 25,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": "ledger_key_contract_instance",
+              "durability": "persistent",
+              "val": {
+                "contract_instance": {
+                  "executable": {
+                    "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  },
+                  "storage": null
+                }
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_code": {
+              "ext": "v0",
+              "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+              "code": ""
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      }
+    ]
+  },
+  "events": []
+}


### PR DESCRIPTION
### What

Add the missing `ScVal` conversion impls and `SorobanArbitrary` support for `MuxedAddress`.

### Why

`#[contracttype]` generates test-only code paths that require field types to support conversion to and from `ScVal`, and to implement `SorobanArbitrary`.

Without these impls, `MuxedAddress` cannot be used as a field in a `#[contracttype]` struct.

Closes #1772

### Known limitations

None