### PR TITLE
chore: use saturating sub with max_ttl computation

### DIFF
--- a/soroban-sdk/src/storage.rs
+++ b/soroban-sdk/src/storage.rs
@@ -153,7 +153,7 @@ impl Storage {
     pub fn max_ttl(&self) -> u32 {
         let seq = self.env.ledger().sequence();
         let max = self.env.ledger().max_live_until_ledger();
-        max - seq
+        max.saturating_sub(seq)
     }
 
     /// Returns if there is a value stored for the given key in the currently


### PR DESCRIPTION
### What

Use `saturating_sub` when computing `max_ttl`.

### Why

Add another defense layer to potential misconfigurations, and improve consistency with math usage in the repository.

Closes #1791

### Known limitations

None