### PR TITLE
Write to a temp file first during snapshot write_file

### DIFF
--- a/soroban-ledger-snapshot/src/lib.rs
+++ b/soroban-ledger-snapshot/src/lib.rs
@@ -1,10 +1,9 @@
 use serde::Deserialize;
 use serde_with::{serde_as, DeserializeAs, SerializeAs};
 use std::{
-    ffi::OsString,
     fs::{create_dir_all, remove_file, rename, File},
     io::{self, BufReader, Read, Write},
-    path::{Path, PathBuf},
+    path::Path,
     rc::Rc,
 };
 


### PR DESCRIPTION
### What

`LedgerSnapshot::write_file` writes to a tempfile first before overwriting the destination file.

### Why

This prevents errors during serialization from leaving the destination file in a corrupted state.

Closes #1795

### Known limitations

None
