### PR TITLE
Normalize raw identifiers (`r#`) in contract macros

### DIFF
--- a/soroban-sdk-macros/src/attribute.rs
+++ b/soroban-sdk-macros/src/attribute.rs
@@ -1,4 +1,6 @@
-use syn::{punctuated::Punctuated, Attribute, Data, Fields, FieldsNamed, FieldsUnnamed};
+use syn::{
+    ext::IdentExt as _, punctuated::Punctuated, Attribute, Data, Fields, FieldsNamed, FieldsUnnamed,
+};
 
 /// Returns true if the attribute is a doc attribute.
 pub fn is_attr_doc(attr: &Attribute) -> bool {
@@ -31,7 +33,7 @@ pub fn remove_attributes_from_item(data: &mut Data, attrs: &[&str]) {
             !attr
                 .path()
                 .get_ident()
-                .is_some_and(|ident| attrs.contains(&ident.to_string().as_str()))
+                .is_some_and(|ident| attrs.contains(&ident.unraw().to_string().as_str()))
         });
     }
 }

--- a/soroban-sdk-macros/src/derive_client.rs
+++ b/soroban-sdk-macros/src/derive_client.rs
@@ -3,9 +3,11 @@ use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
 use syn::{Error, FnArg, LitStr, Path, Type, TypePath, TypeReference};
 
+use syn::ext::IdentExt as _;
+
 use crate::{
     attribute::pass_through_attr_to_gen_code, map_type::map_type, stellar_xdr::ScSpecTypeDef,
-    symbol, syn_ext, syn_ext::IdentExt as _,
+    symbol, syn_ext,
 };
 
 fn is_muxed_address_type(arg: &FnArg) -> bool {
@@ -158,11 +160,11 @@ pub fn derive_client_impl(crate_path: &Path, name: &str, fns: &[syn_ext::Fn]) ->
             // and hooks. Check the Soroban-facing name so a raw-identifier
             // spelling like `r#__check_auth` can't slip past this filter and then
             // still export as `__check_auth`.
-            !f.ident.soroban_name().starts_with("__")
+            !f.ident.unraw().to_string().starts_with("__")
         })
         .map(|f| {
             let fn_ident = &f.ident;
-            let fn_name = fn_ident.soroban_name();
+            let fn_name = fn_ident.unraw().to_string();
             let fn_try_ident = format_ident!("try_{}", &fn_name);
             let fn_name_symbol = symbol::short_or_long(
                 crate_path,

--- a/soroban-sdk-macros/src/derive_client.rs
+++ b/soroban-sdk-macros/src/derive_client.rs
@@ -5,7 +5,7 @@ use syn::{Error, FnArg, LitStr, Path, Type, TypePath, TypeReference};
 
 use crate::{
     attribute::pass_through_attr_to_gen_code, map_type::map_type, stellar_xdr::ScSpecTypeDef,
-    symbol, syn_ext,
+    symbol, syn_ext, syn_ext::IdentExt as _,
 };
 
 fn is_muxed_address_type(arg: &FnArg) -> bool {
@@ -155,13 +155,15 @@ pub fn derive_client_impl(crate_path: &Path, name: &str, fns: &[syn_ext::Fn]) ->
             // Skip generating client functions for calling contract functions
             // that start with '__', because the Soroban Env won't let those
             // functions be invoked directly as they're reserved for callbacks
-            // and hooks.
-            !f.ident.to_string().starts_with("__")
+            // and hooks. Check the Soroban-facing name so a raw-identifier
+            // spelling like `r#__check_auth` can't slip past this filter and then
+            // still export as `__check_auth`.
+            !f.ident.soroban_name().starts_with("__")
         })
         .map(|f| {
             let fn_ident = &f.ident;
-            let fn_try_ident = format_ident!("try_{}", &f.ident);
-            let fn_name = fn_ident.to_string();
+            let fn_name = fn_ident.soroban_name();
+            let fn_try_ident = format_ident!("try_{}", &fn_name);
             let fn_name_symbol = symbol::short_or_long(
                 crate_path,
                 quote!(&self.env),

--- a/soroban-sdk-macros/src/derive_contractimpl_trait_default_fns_not_overridden.rs
+++ b/soroban-sdk-macros/src/derive_contractimpl_trait_default_fns_not_overridden.rs
@@ -10,7 +10,7 @@ use darling::{ast::NestedMeta, Error, FromMeta};
 use proc_macro2::{Ident, TokenStream as TokenStream2};
 use quote::quote;
 use std::collections::HashSet;
-use syn::{LitStr, Path, Type};
+use syn::{ext::IdentExt as _, LitStr, Path, Type};
 
 // See soroban-sdk/docs/contracttrait.md for documentation on how this works.
 
@@ -59,7 +59,7 @@ fn derive(args: &Args) -> Result<TokenStream2, Error> {
     // overridden in the input fns.
     let fns = trait_default_fns
         .into_iter()
-        .filter(|f| !impl_fn_idents.contains(&f.ident.to_string()))
+        .filter(|f| !impl_fn_idents.contains(&f.ident.unraw().to_string()))
         .collect::<Vec<_>>();
 
     let mut output = quote! {};

--- a/soroban-sdk-macros/src/derive_contractimpl_trait_macro.rs
+++ b/soroban-sdk-macros/src/derive_contractimpl_trait_macro.rs
@@ -4,7 +4,7 @@ use heck::ToSnakeCase;
 use proc_macro2::{Ident, TokenStream as TokenStream2};
 use quote::ToTokens;
 use quote::{format_ident, quote};
-use syn::{parse2, ImplItemFn, ItemTrait, Path, TraitItem, TraitItemFn, Type};
+use syn::{ext::IdentExt as _, parse2, ImplItemFn, ItemTrait, Path, TraitItem, TraitItemFn, Type};
 
 // See soroban-sdk/docs/contracttrait.md for documentation on how this works.
 
@@ -98,7 +98,7 @@ pub fn generate_call_to_contractimpl_for_trait(
     args_ident: &str,
     spec_ident: &str,
 ) -> TokenStream2 {
-    let impl_fn_idents = pub_methods.iter().map(|f| f.sig.ident.to_string());
+    let impl_fn_idents = pub_methods.iter().map(|f| f.sig.ident.unraw().to_string());
     quote! {
         #trait_ident!(
             #trait_ident,
@@ -112,6 +112,6 @@ pub fn generate_call_to_contractimpl_for_trait(
 }
 
 fn macro_ident(trait_ident: &Ident) -> Ident {
-    let lower = trait_ident.to_string().to_snake_case();
+    let lower = trait_ident.unraw().to_string().to_snake_case();
     format_ident!("__contractimpl_for_{lower}")
 }

--- a/soroban-sdk-macros/src/derive_enum.rs
+++ b/soroban-sdk-macros/src/derive_enum.rs
@@ -11,7 +11,7 @@ use stellar_xdr::{
 
 use crate::{
     doc::docs_from_attrs, map_type::map_type, shaking, spec_shaking_v2_enabled,
-    DEFAULT_XDR_RW_LIMITS,
+    syn_ext::IdentExt as _, DEFAULT_XDR_RW_LIMITS,
 };
 
 pub fn derive_type_enum(
@@ -48,7 +48,7 @@ pub fn derive_type_enum(
             // TODO: Choose discriminant type based on repr type of enum.
             // TODO: Use attributes tagged on variant to control whether field is included.
             let case_ident = &variant.ident;
-            let case_name = &case_ident.to_string();
+            let case_name = &case_ident.soroban_name();
             let case_name_str_lit = Literal::string(case_name);
             let case_num_lit = Literal::usize_unsuffixed(case_num);
             if case_name.len() > SCSYMBOL_LIMIT as usize {
@@ -151,7 +151,7 @@ pub fn derive_type_enum(
         let spec_entry = ScSpecEntry::UdtUnionV0(ScSpecUdtUnionV0 {
             doc: docs_from_attrs(attrs),
             lib: lib.as_deref().unwrap_or_default().try_into().unwrap(),
-            name: enum_ident.to_string().try_into().unwrap(),
+            name: enum_ident.soroban_name().try_into().unwrap(),
             cases: spec_cases.try_into().unwrap(),
         });
         Some(spec_entry.to_xdr(DEFAULT_XDR_RW_LIMITS).unwrap())
@@ -163,7 +163,10 @@ pub fn derive_type_enum(
     let spec_gen = if let Some(ref spec_xdr) = spec_xdr {
         let spec_xdr_lit = proc_macro2::Literal::byte_string(spec_xdr.as_slice());
         let spec_xdr_len = spec_xdr.len();
-        let spec_ident = format_ident!("__SPEC_XDR_TYPE_{}", enum_ident.to_string().to_uppercase());
+        let spec_ident = format_ident!(
+            "__SPEC_XDR_TYPE_{}",
+            enum_ident.soroban_name().to_uppercase()
+        );
         Some(quote! {
             #[cfg_attr(target_family = "wasm", link_section = "contractspecv0")]
             pub static #spec_ident: [u8; #spec_xdr_len] = #enum_ident::spec_xdr();

--- a/soroban-sdk-macros/src/derive_enum.rs
+++ b/soroban-sdk-macros/src/derive_enum.rs
@@ -1,7 +1,10 @@
 use itertools::MultiUnzip;
 use proc_macro2::{Literal, TokenStream as TokenStream2};
 use quote::{format_ident, quote, ToTokens};
-use syn::{spanned::Spanned, Attribute, DataEnum, Error, Fields, Ident, Path, Visibility};
+use syn::{
+    ext::IdentExt as _, spanned::Spanned, Attribute, DataEnum, Error, Fields, Ident, Path,
+    Visibility,
+};
 
 use stellar_xdr::curr as stellar_xdr;
 use stellar_xdr::{
@@ -11,7 +14,7 @@ use stellar_xdr::{
 
 use crate::{
     doc::docs_from_attrs, map_type::map_type, shaking, spec_shaking_v2_enabled,
-    syn_ext::IdentExt as _, DEFAULT_XDR_RW_LIMITS,
+    DEFAULT_XDR_RW_LIMITS,
 };
 
 pub fn derive_type_enum(
@@ -48,7 +51,7 @@ pub fn derive_type_enum(
             // TODO: Choose discriminant type based on repr type of enum.
             // TODO: Use attributes tagged on variant to control whether field is included.
             let case_ident = &variant.ident;
-            let case_name = &case_ident.soroban_name();
+            let case_name = &case_ident.unraw().to_string();
             let case_name_str_lit = Literal::string(case_name);
             let case_num_lit = Literal::usize_unsuffixed(case_num);
             if case_name.len() > SCSYMBOL_LIMIT as usize {
@@ -151,7 +154,7 @@ pub fn derive_type_enum(
         let spec_entry = ScSpecEntry::UdtUnionV0(ScSpecUdtUnionV0 {
             doc: docs_from_attrs(attrs),
             lib: lib.as_deref().unwrap_or_default().try_into().unwrap(),
-            name: enum_ident.soroban_name().try_into().unwrap(),
+            name: enum_ident.unraw().to_string().try_into().unwrap(),
             cases: spec_cases.try_into().unwrap(),
         });
         Some(spec_entry.to_xdr(DEFAULT_XDR_RW_LIMITS).unwrap())
@@ -165,7 +168,7 @@ pub fn derive_type_enum(
         let spec_xdr_len = spec_xdr.len();
         let spec_ident = format_ident!(
             "__SPEC_XDR_TYPE_{}",
-            enum_ident.soroban_name().to_uppercase()
+            enum_ident.unraw().to_string().to_uppercase()
         );
         Some(quote! {
             #[cfg_attr(target_family = "wasm", link_section = "contractspecv0")]

--- a/soroban-sdk-macros/src/derive_enum_int.rs
+++ b/soroban-sdk-macros/src/derive_enum_int.rs
@@ -7,7 +7,10 @@ use syn::{spanned::Spanned, Attribute, DataEnum, Error, ExprLit, Ident, Lit, Pat
 
 use stellar_xdr::{ScSpecEntry, ScSpecUdtEnumCaseV0, WriteXdr};
 
-use crate::{doc::docs_from_attrs, shaking, spec_shaking_v2_enabled, DEFAULT_XDR_RW_LIMITS};
+use crate::{
+    doc::docs_from_attrs, shaking, spec_shaking_v2_enabled, syn_ext::IdentExt as _,
+    DEFAULT_XDR_RW_LIMITS,
+};
 
 // TODO: Add conversions to/from ScVal types.
 
@@ -28,7 +31,7 @@ pub fn derive_type_enum_int(
         .iter()
         .map(|v| {
             let ident = &v.ident;
-            let name = &ident.to_string();
+            let name = &ident.soroban_name();
             let discriminant: u32 = if let syn::Expr::Lit(ExprLit {
                 lit: Lit::Int(ref lit_int),
                 ..
@@ -70,7 +73,7 @@ pub fn derive_type_enum_int(
         let spec_entry = ScSpecEntry::UdtEnumV0(ScSpecUdtEnumV0 {
             doc: docs_from_attrs(attrs),
             lib: lib.as_deref().unwrap_or_default().try_into().unwrap(),
-            name: enum_ident.to_string().try_into().unwrap(),
+            name: enum_ident.soroban_name().try_into().unwrap(),
             cases: spec_cases.try_into().unwrap(),
         });
         Some(spec_entry.to_xdr(DEFAULT_XDR_RW_LIMITS).unwrap())
@@ -82,7 +85,10 @@ pub fn derive_type_enum_int(
     let spec_gen = if let Some(ref spec_xdr) = spec_xdr {
         let spec_xdr_lit = proc_macro2::Literal::byte_string(spec_xdr.as_slice());
         let spec_xdr_len = spec_xdr.len();
-        let spec_ident = format_ident!("__SPEC_XDR_TYPE_{}", enum_ident.to_string().to_uppercase());
+        let spec_ident = format_ident!(
+            "__SPEC_XDR_TYPE_{}",
+            enum_ident.soroban_name().to_uppercase()
+        );
         Some(quote! {
             #[cfg_attr(target_family = "wasm", link_section = "contractspecv0")]
             pub static #spec_ident: [u8; #spec_xdr_len] = #enum_ident::spec_xdr();

--- a/soroban-sdk-macros/src/derive_enum_int.rs
+++ b/soroban-sdk-macros/src/derive_enum_int.rs
@@ -3,14 +3,14 @@ use proc_macro2::TokenStream as TokenStream2;
 use quote::{format_ident, quote};
 use stellar_xdr::curr as stellar_xdr;
 use stellar_xdr::{ScSpecUdtEnumV0, StringM};
-use syn::{spanned::Spanned, Attribute, DataEnum, Error, ExprLit, Ident, Lit, Path, Visibility};
+use syn::{
+    ext::IdentExt as _, spanned::Spanned, Attribute, DataEnum, Error, ExprLit, Ident, Lit, Path,
+    Visibility,
+};
 
 use stellar_xdr::{ScSpecEntry, ScSpecUdtEnumCaseV0, WriteXdr};
 
-use crate::{
-    doc::docs_from_attrs, shaking, spec_shaking_v2_enabled, syn_ext::IdentExt as _,
-    DEFAULT_XDR_RW_LIMITS,
-};
+use crate::{doc::docs_from_attrs, shaking, spec_shaking_v2_enabled, DEFAULT_XDR_RW_LIMITS};
 
 // TODO: Add conversions to/from ScVal types.
 
@@ -31,7 +31,7 @@ pub fn derive_type_enum_int(
         .iter()
         .map(|v| {
             let ident = &v.ident;
-            let name = &ident.soroban_name();
+            let name = &ident.unraw().to_string();
             let discriminant: u32 = if let syn::Expr::Lit(ExprLit {
                 lit: Lit::Int(ref lit_int),
                 ..
@@ -73,7 +73,7 @@ pub fn derive_type_enum_int(
         let spec_entry = ScSpecEntry::UdtEnumV0(ScSpecUdtEnumV0 {
             doc: docs_from_attrs(attrs),
             lib: lib.as_deref().unwrap_or_default().try_into().unwrap(),
-            name: enum_ident.soroban_name().try_into().unwrap(),
+            name: enum_ident.unraw().to_string().try_into().unwrap(),
             cases: spec_cases.try_into().unwrap(),
         });
         Some(spec_entry.to_xdr(DEFAULT_XDR_RW_LIMITS).unwrap())
@@ -87,7 +87,7 @@ pub fn derive_type_enum_int(
         let spec_xdr_len = spec_xdr.len();
         let spec_ident = format_ident!(
             "__SPEC_XDR_TYPE_{}",
-            enum_ident.soroban_name().to_uppercase()
+            enum_ident.unraw().to_string().to_uppercase()
         );
         Some(quote! {
             #[cfg_attr(target_family = "wasm", link_section = "contractspecv0")]

--- a/soroban-sdk-macros/src/derive_error_enum_int.rs
+++ b/soroban-sdk-macros/src/derive_error_enum_int.rs
@@ -3,12 +3,11 @@ use proc_macro2::TokenStream as TokenStream2;
 use quote::{format_ident, quote};
 use stellar_xdr::curr as stellar_xdr;
 use stellar_xdr::{ScSpecEntry, ScSpecUdtErrorEnumCaseV0, ScSpecUdtErrorEnumV0, StringM, WriteXdr};
-use syn::{spanned::Spanned, Attribute, DataEnum, Error, ExprLit, Ident, Lit, Path};
-
-use crate::{
-    doc::docs_from_attrs, shaking, spec_shaking_v2_enabled, syn_ext::IdentExt as _,
-    DEFAULT_XDR_RW_LIMITS,
+use syn::{
+    ext::IdentExt as _, spanned::Spanned, Attribute, DataEnum, Error, ExprLit, Ident, Lit, Path,
 };
+
+use crate::{doc::docs_from_attrs, shaking, spec_shaking_v2_enabled, DEFAULT_XDR_RW_LIMITS};
 
 pub fn derive_type_error_enum_int(
     path: &Path,
@@ -26,7 +25,7 @@ pub fn derive_type_error_enum_int(
         .iter()
         .map(|v| {
             let ident = &v.ident;
-            let name = &ident.soroban_name();
+            let name = &ident.unraw().to_string();
             let discriminant: u32 = if let syn::Expr::Lit(ExprLit {
                 lit: Lit::Int(ref lit_int),
                 ..
@@ -71,7 +70,7 @@ pub fn derive_type_error_enum_int(
         let spec_entry = ScSpecEntry::UdtErrorEnumV0(ScSpecUdtErrorEnumV0 {
             doc: docs_from_attrs(attrs),
             lib: lib.as_deref().unwrap_or_default().try_into().unwrap(),
-            name: enum_ident.soroban_name().try_into().unwrap(),
+            name: enum_ident.unraw().to_string().try_into().unwrap(),
             cases: spec_cases.try_into().unwrap(),
         });
         Some(spec_entry.to_xdr(DEFAULT_XDR_RW_LIMITS).unwrap())
@@ -85,7 +84,7 @@ pub fn derive_type_error_enum_int(
         let spec_xdr_len = spec_xdr.len();
         let spec_ident = format_ident!(
             "__SPEC_XDR_TYPE_{}",
-            enum_ident.soroban_name().to_uppercase()
+            enum_ident.unraw().to_string().to_uppercase()
         );
         Some(quote! {
             #[cfg_attr(target_family = "wasm", link_section = "contractspecv0")]

--- a/soroban-sdk-macros/src/derive_error_enum_int.rs
+++ b/soroban-sdk-macros/src/derive_error_enum_int.rs
@@ -5,7 +5,10 @@ use stellar_xdr::curr as stellar_xdr;
 use stellar_xdr::{ScSpecEntry, ScSpecUdtErrorEnumCaseV0, ScSpecUdtErrorEnumV0, StringM, WriteXdr};
 use syn::{spanned::Spanned, Attribute, DataEnum, Error, ExprLit, Ident, Lit, Path};
 
-use crate::{doc::docs_from_attrs, shaking, spec_shaking_v2_enabled, DEFAULT_XDR_RW_LIMITS};
+use crate::{
+    doc::docs_from_attrs, shaking, spec_shaking_v2_enabled, syn_ext::IdentExt as _,
+    DEFAULT_XDR_RW_LIMITS,
+};
 
 pub fn derive_type_error_enum_int(
     path: &Path,
@@ -23,7 +26,7 @@ pub fn derive_type_error_enum_int(
         .iter()
         .map(|v| {
             let ident = &v.ident;
-            let name = &ident.to_string();
+            let name = &ident.soroban_name();
             let discriminant: u32 = if let syn::Expr::Lit(ExprLit {
                 lit: Lit::Int(ref lit_int),
                 ..
@@ -68,7 +71,7 @@ pub fn derive_type_error_enum_int(
         let spec_entry = ScSpecEntry::UdtErrorEnumV0(ScSpecUdtErrorEnumV0 {
             doc: docs_from_attrs(attrs),
             lib: lib.as_deref().unwrap_or_default().try_into().unwrap(),
-            name: enum_ident.to_string().try_into().unwrap(),
+            name: enum_ident.soroban_name().try_into().unwrap(),
             cases: spec_cases.try_into().unwrap(),
         });
         Some(spec_entry.to_xdr(DEFAULT_XDR_RW_LIMITS).unwrap())
@@ -80,7 +83,10 @@ pub fn derive_type_error_enum_int(
     let spec_gen = if let Some(ref spec_xdr) = spec_xdr {
         let spec_xdr_lit = proc_macro2::Literal::byte_string(spec_xdr.as_slice());
         let spec_xdr_len = spec_xdr.len();
-        let spec_ident = format_ident!("__SPEC_XDR_TYPE_{}", enum_ident.to_string().to_uppercase());
+        let spec_ident = format_ident!(
+            "__SPEC_XDR_TYPE_{}",
+            enum_ident.soroban_name().to_uppercase()
+        );
         Some(quote! {
             #[cfg_attr(target_family = "wasm", link_section = "contractspecv0")]
             pub static #spec_ident: [u8; #spec_xdr_len] = #enum_ident::spec_xdr();

--- a/soroban-sdk-macros/src/derive_event.rs
+++ b/soroban-sdk-macros/src/derive_event.rs
@@ -1,10 +1,10 @@
 use crate::{
     attribute::remove_attributes_from_item, default_crate_path, doc::docs_from_attrs,
-    map_type::map_type, shaking, spec_shaking_v2_enabled, symbol, DEFAULT_XDR_RW_LIMITS,
+    map_type::map_type, shaking, spec_shaking_v2_enabled, symbol, syn_ext::IdentExt as _,
+    DEFAULT_XDR_RW_LIMITS,
 };
 use darling::{ast::NestedMeta, Error, FromMeta};
 use heck::ToSnakeCase;
-use itertools::Itertools as _;
 use proc_macro2::Span;
 use proc_macro2::TokenStream as TokenStream2;
 use quote::{format_ident, quote};
@@ -88,7 +88,7 @@ fn derive_impls(args: &ContractEventArgs, input: &DeriveInput) -> Result<TokenSt
 
     // Check event name length
     const EVENT_NAME_LENGTH: u32 = 32;
-    let event_name = input.ident.to_string();
+    let event_name = input.ident.soroban_name();
     let event_name_len = event_name.len();
     let event_name: StringM<EVENT_NAME_LENGTH> = errors
         .handle(event_name.try_into().map_err(|_| {
@@ -102,7 +102,7 @@ fn derive_impls(args: &ContractEventArgs, input: &DeriveInput) -> Result<TokenSt
     let prefix_topics = if let Some(prefix_topics) = &args.topics {
         prefix_topics.iter().map(|t| t.value()).collect()
     } else {
-        vec![input.ident.to_string().to_snake_case()]
+        vec![input.ident.soroban_name().to_snake_case()]
     };
 
     let fields =
@@ -127,8 +127,11 @@ fn derive_impls(args: &ContractEventArgs, input: &DeriveInput) -> Result<TokenSt
     // Collect field types for SpecShakingMarker
     let field_types: Vec<_> = fields.iter().map(|f| &f.ty).collect();
 
-    // Map each field of the struct to a spec for a param.
-    let params = fields
+    // Map each field of the struct to a spec for a param, keeping the original Ident
+    // alongside so it can still be used for `self.#ident` field access in the generated
+    // code (raw identifiers like `r#type` need to stay raw for Rust, while the spec name
+    // is the unraw form).
+    let params_with_idents = fields
         .iter()
         .map(|field| {
             let ident = field.ident.as_ref().unwrap();
@@ -140,7 +143,7 @@ fn derive_impls(args: &ContractEventArgs, input: &DeriveInput) -> Result<TokenSt
             };
             let doc = docs_from_attrs(&field.attrs);
             const NAME_LENGTH: u32 = 30;
-            let name = ident.to_string();
+            let name = ident.soroban_name();
             let name_len = name.len();
             let name: StringM<NAME_LENGTH> = errors
                 .handle(name.try_into().map_err(|_| {
@@ -153,12 +156,15 @@ fn derive_impls(args: &ContractEventArgs, input: &DeriveInput) -> Result<TokenSt
             let type_ = errors
                 .handle_in(|| Ok(map_type(&field.ty, true, false)?))
                 .unwrap_or_default();
-            ScSpecEventParamV0 {
-                location,
-                doc,
-                name,
-                type_,
-            }
+            (
+                ident.clone(),
+                ScSpecEventParamV0 {
+                    location,
+                    doc,
+                    name,
+                    type_,
+                },
+            )
         })
         .collect::<Vec<_>>();
 
@@ -183,9 +189,9 @@ fn derive_impls(args: &ContractEventArgs, input: &DeriveInput) -> Result<TokenSt
             .collect::<Vec<_>>()
             .try_into()
             .unwrap(),
-        params: params
+        params: params_with_idents
             .iter()
-            .map(|p| p.clone())
+            .map(|(_, p)| p.clone())
             .collect::<Vec<_>>()
             .try_into()
             .unwrap(),
@@ -195,7 +201,7 @@ fn derive_impls(args: &ContractEventArgs, input: &DeriveInput) -> Result<TokenSt
     let spec_xdr_len = spec_xdr.len();
     let spec_ident = format_ident!(
         "__SPEC_XDR_EVENT_{}",
-        input.ident.to_string().to_uppercase()
+        input.ident.soroban_name().to_uppercase()
     );
     let spec_shaking_call = if export && spec_shaking_v2_enabled() {
         Some(quote! { <Self as #path::SpecShakingMarker>::spec_shaking_marker(); })
@@ -239,10 +245,10 @@ fn derive_impls(args: &ContractEventArgs, input: &DeriveInput) -> Result<TokenSt
             &LitStr::new(&t, Span::call_site()),
         )
     });
-    let topic_idents = params
+    let topic_idents = params_with_idents
         .iter()
-        .filter(|p| p.location == ScSpecEventParamLocationV0::TopicList)
-        .map(|p| format_ident!("{}", p.name.to_string()))
+        .filter(|(_, p)| p.location == ScSpecEventParamLocationV0::TopicList)
+        .map(|(ident, _)| ident.clone())
         .collect::<Vec<_>>();
     let topics_to_vec_val = quote! {
         use #path::IntoVal;
@@ -253,14 +259,14 @@ fn derive_impls(args: &ContractEventArgs, input: &DeriveInput) -> Result<TokenSt
     };
 
     // Prepare Data Conversion to Val.
-    let data_params = params
+    let data_params = params_with_idents
         .iter()
-        .filter(|p| p.location == ScSpecEventParamLocationV0::Data)
+        .filter(|(_, p)| p.location == ScSpecEventParamLocationV0::Data)
         .collect::<Vec<_>>();
     let data_params_count = data_params.len();
     let data_idents = data_params
         .iter()
-        .map(|p| format_ident!("{}", p.name.to_string()))
+        .map(|(ident, _)| ident.clone())
         .collect::<Vec<_>>();
     let data_to_val = match args.data_format {
         DataFormat::SingleValue if data_params_count == 0 => quote! {
@@ -288,15 +294,18 @@ fn derive_impls(args: &ContractEventArgs, input: &DeriveInput) -> Result<TokenSt
             ).into_val(env)
         },
         DataFormat::Map => {
-            // Must be sorted for map_new_from_slices
-            let data_idents_sorted = data_params
+            // Must be sorted for map_new_from_slices. Sort by the spec name (the
+            // Soroban-facing Symbol string), and carry the original Ident alongside so
+            // that `self.#ident` still uses the raw form where needed.
+            let mut data_params_sorted = data_params.clone();
+            data_params_sorted.sort_by_key(|(_, p)| p.name.to_string());
+            let data_idents_sorted = data_params_sorted
                 .iter()
-                .sorted_by_key(|p| p.name.to_string())
-                .map(|p| format_ident!("{}", p.name.to_string()))
+                .map(|(ident, _)| ident.clone())
                 .collect::<Vec<_>>();
-            let data_strs_sorted = data_idents_sorted
+            let data_strs_sorted = data_params_sorted
                 .iter()
-                .map(|i| i.to_string())
+                .map(|(_, p)| p.name.to_string())
                 .collect::<Vec<_>>();
             quote! {
                 use #path::{EnvBase,IntoVal,unwrap::UnwrapInfallible};

--- a/soroban-sdk-macros/src/derive_event.rs
+++ b/soroban-sdk-macros/src/derive_event.rs
@@ -1,7 +1,6 @@
 use crate::{
     attribute::remove_attributes_from_item, default_crate_path, doc::docs_from_attrs,
-    map_type::map_type, shaking, spec_shaking_v2_enabled, symbol, syn_ext::IdentExt as _,
-    DEFAULT_XDR_RW_LIMITS,
+    map_type::map_type, shaking, spec_shaking_v2_enabled, symbol, DEFAULT_XDR_RW_LIMITS,
 };
 use darling::{ast::NestedMeta, Error, FromMeta};
 use heck::ToSnakeCase;
@@ -12,7 +11,7 @@ use stellar_xdr::curr::{
     ScSpecEntry, ScSpecEventDataFormat, ScSpecEventParamLocationV0, ScSpecEventParamV0,
     ScSpecEventV0, ScSymbol, StringM, WriteXdr,
 };
-use syn::{parse2, spanned::Spanned, Data, DeriveInput, Fields, LitStr, Path};
+use syn::{ext::IdentExt as _, parse2, spanned::Spanned, Data, DeriveInput, Fields, LitStr, Path};
 
 #[derive(Debug, FromMeta)]
 struct ContractEventArgs {
@@ -88,7 +87,7 @@ fn derive_impls(args: &ContractEventArgs, input: &DeriveInput) -> Result<TokenSt
 
     // Check event name length
     const EVENT_NAME_LENGTH: u32 = 32;
-    let event_name = input.ident.soroban_name();
+    let event_name = input.ident.unraw().to_string();
     let event_name_len = event_name.len();
     let event_name: StringM<EVENT_NAME_LENGTH> = errors
         .handle(event_name.try_into().map_err(|_| {
@@ -102,7 +101,7 @@ fn derive_impls(args: &ContractEventArgs, input: &DeriveInput) -> Result<TokenSt
     let prefix_topics = if let Some(prefix_topics) = &args.topics {
         prefix_topics.iter().map(|t| t.value()).collect()
     } else {
-        vec![input.ident.soroban_name().to_snake_case()]
+        vec![input.ident.unraw().to_string().to_snake_case()]
     };
 
     let fields =
@@ -143,7 +142,7 @@ fn derive_impls(args: &ContractEventArgs, input: &DeriveInput) -> Result<TokenSt
             };
             let doc = docs_from_attrs(&field.attrs);
             const NAME_LENGTH: u32 = 30;
-            let name = ident.soroban_name();
+            let name = ident.unraw().to_string();
             let name_len = name.len();
             let name: StringM<NAME_LENGTH> = errors
                 .handle(name.try_into().map_err(|_| {
@@ -201,7 +200,7 @@ fn derive_impls(args: &ContractEventArgs, input: &DeriveInput) -> Result<TokenSt
     let spec_xdr_len = spec_xdr.len();
     let spec_ident = format_ident!(
         "__SPEC_XDR_EVENT_{}",
-        input.ident.soroban_name().to_uppercase()
+        input.ident.unraw().to_string().to_uppercase()
     );
     let spec_shaking_call = if export && spec_shaking_v2_enabled() {
         Some(quote! { <Self as #path::SpecShakingMarker>::spec_shaking_marker(); })

--- a/soroban-sdk-macros/src/derive_fn.rs
+++ b/soroban-sdk-macros/src/derive_fn.rs
@@ -1,13 +1,14 @@
 use crate::{
     attribute::pass_through_attr_to_gen_code,
     map_type::map_type,
-    syn_ext::{self, fn_arg_type_validate_no_mut, ty_to_safe_ident_str, IdentExt as _},
+    syn_ext::{self, fn_arg_type_validate_no_mut, ty_to_safe_ident_str},
 };
 use itertools::MultiUnzip;
 use proc_macro2::TokenStream as TokenStream2;
 use quote::{format_ident, quote};
 use sha2::{Digest, Sha256};
 use syn::{
+    ext::IdentExt as _,
     punctuated::Punctuated,
     spanned::Spanned,
     token::{Colon, Comma},
@@ -93,7 +94,7 @@ pub fn derive_pub_fn(
                 // the Soroban-facing name so a raw-identifier spelling like
                 // `r#__check_auth` can't bypass this special-case and then still export
                 // as `__check_auth`.
-                let allow_hash = ident.soroban_name() == "__check_auth" && i == 0;
+                let allow_hash = ident.unraw().to_string() == "__check_auth" && i == 0;
 
                 // Error if the type of the fn arg is mutable.
                 if let Err(e) = fn_arg_type_validate_no_mut(&pat_ty.ty) {
@@ -144,7 +145,7 @@ pub fn derive_pub_fn(
 
     // Generated code parameters.
     let impl_ty_safe_str = ty_to_safe_ident_str(impl_ty);
-    let fn_name = ident.soroban_name();
+    let fn_name = ident.unraw().to_string();
     let wrap_export_name = &fn_name;
     let invoke_fn_prefix = format_ident!("__{}__{}", impl_ty_safe_str, fn_name);
     let invoke_raw = format_ident!("{}__invoke_raw", invoke_fn_prefix);
@@ -246,7 +247,7 @@ pub fn derive_contract_function_registration_ctor<'a>(
     let ty_str = ty_to_safe_ident_str(ty);
     let (idents, wrap_idents): (Vec<_>, Vec<_>) = method_idents
         .map(|ident| {
-            let ident_str = ident.soroban_name();
+            let ident_str = ident.unraw().to_string();
             let wrap_ident = format_ident!("__{}__{}__invoke_raw_slice", ty_str, ident_str);
             (ident_str, wrap_ident)
         })
@@ -256,7 +257,7 @@ pub fn derive_contract_function_registration_ctor<'a>(
         .map(|p| {
             p.segments
                 .iter()
-                .map(|s| s.ident.soroban_name())
+                .map(|s| s.ident.unraw().to_string())
                 .collect::<Vec<_>>()
                 .join("_")
         })

--- a/soroban-sdk-macros/src/derive_fn.rs
+++ b/soroban-sdk-macros/src/derive_fn.rs
@@ -1,7 +1,7 @@
 use crate::{
     attribute::pass_through_attr_to_gen_code,
     map_type::map_type,
-    syn_ext::{self, fn_arg_type_validate_no_mut, ty_to_safe_ident_str},
+    syn_ext::{self, fn_arg_type_validate_no_mut, ty_to_safe_ident_str, IdentExt as _},
 };
 use itertools::MultiUnzip;
 use proc_macro2::TokenStream as TokenStream2;
@@ -89,8 +89,11 @@ pub fn derive_pub_fn(
         .map(|(i, a)| match a {
             FnArg::Typed(pat_ty) => {
                 // If fn is a __check_auth implementation, allow the first argument,
-                // signature_payload of type Bytes (32 size), to be a Hash.
-                let allow_hash = ident == "__check_auth" && i == 0;
+                // signature_payload of type Bytes (32 size), to be a Hash. Compare on
+                // the Soroban-facing name so a raw-identifier spelling like
+                // `r#__check_auth` can't bypass this special-case and then still export
+                // as `__check_auth`.
+                let allow_hash = ident.soroban_name() == "__check_auth" && i == 0;
 
                 // Error if the type of the fn arg is mutable.
                 if let Err(e) = fn_arg_type_validate_no_mut(&pat_ty.ty) {
@@ -141,14 +144,15 @@ pub fn derive_pub_fn(
 
     // Generated code parameters.
     let impl_ty_safe_str = ty_to_safe_ident_str(impl_ty);
-    let wrap_export_name = &format!("{}", ident);
-    let invoke_fn_prefix = format_ident!("__{}__{}", impl_ty_safe_str, ident);
+    let fn_name = ident.soroban_name();
+    let wrap_export_name = &fn_name;
+    let invoke_fn_prefix = format_ident!("__{}__{}", impl_ty_safe_str, fn_name);
     let invoke_raw = format_ident!("{}__invoke_raw", invoke_fn_prefix);
     let invoke_raw_slice = format_ident!("{}__invoke_raw_slice", invoke_fn_prefix);
     let invoke_raw_extern = format_ident!("{}__invoke_raw_extern", invoke_fn_prefix);
     let deprecated_note = format!(
         "use `{}::new(&env, &contract_id).{}` instead",
-        client_ident, &ident
+        client_ident, &fn_name
     );
     let env_call = if let Some(is_ref) = env_input {
         if is_ref {
@@ -242,7 +246,7 @@ pub fn derive_contract_function_registration_ctor<'a>(
     let ty_str = ty_to_safe_ident_str(ty);
     let (idents, wrap_idents): (Vec<_>, Vec<_>) = method_idents
         .map(|ident| {
-            let ident_str = format!("{}", ident);
+            let ident_str = ident.soroban_name();
             let wrap_ident = format_ident!("__{}__{}__invoke_raw_slice", ty_str, ident_str);
             (ident_str, wrap_ident)
         })
@@ -252,7 +256,7 @@ pub fn derive_contract_function_registration_ctor<'a>(
         .map(|p| {
             p.segments
                 .iter()
-                .map(|s| s.ident.to_string())
+                .map(|s| s.ident.soroban_name())
                 .collect::<Vec<_>>()
                 .join("_")
         })

--- a/soroban-sdk-macros/src/derive_spec_fn.rs
+++ b/soroban-sdk-macros/src/derive_spec_fn.rs
@@ -12,7 +12,7 @@ use syn::{
 };
 
 use crate::attribute::pass_through_attr_to_gen_code;
-use crate::syn_ext::{self, ty_to_safe_ident_str};
+use crate::syn_ext::{self, ty_to_safe_ident_str, IdentExt as _};
 use crate::{doc::docs_from_attrs, map_type::map_type, DEFAULT_XDR_RW_LIMITS};
 
 pub fn derive_fns_spec<'a>(
@@ -69,7 +69,7 @@ pub fn derive_fn_spec(
         .map(|(i, a)| match a {
             FnArg::Typed(pat_type) => {
                 let name = if let Pat::Ident(pat_ident) = *pat_type.pat.clone() {
-                    pat_ident.ident.to_string()
+                    pat_ident.ident.soroban_name()
                 } else {
                     errors.push(Error::new(a.span(), "argument not supported"));
                     "".to_string()
@@ -86,8 +86,11 @@ pub fn derive_fn_spec(
                 let name = name.trim_start_matches("_");
 
                 // If fn is a __check_auth implementation, allow the first argument,
-                // signature_payload of type Bytes (32 size), to be a Hash.
-                let allow_hash = ident == "__check_auth" && i == 0;
+                // signature_payload of type Bytes (32 size), to be a Hash. Compare on
+                // the Soroban-facing name so a raw-identifier spelling like
+                // `r#__check_auth` can't bypass this special-case and then still export
+                // as `__check_auth`.
+                let allow_hash = ident.soroban_name() == "__check_auth" && i == 0;
 
                 match map_type(&pat_type.ty, true, allow_hash) {
                     Ok(type_) => {
@@ -139,7 +142,7 @@ pub fn derive_fn_spec(
     };
 
     // Generated code spec.
-    let name = &format!("{}", ident);
+    let name = &ident.soroban_name();
     let spec_entry = ScSpecEntry::FunctionV0(ScSpecFunctionV0 {
         doc: docs_from_attrs(attrs),
         name: name.try_into().unwrap_or_else(|_| {
@@ -159,8 +162,8 @@ pub fn derive_fn_spec(
     let spec_xdr = spec_entry.to_xdr(DEFAULT_XDR_RW_LIMITS).unwrap();
     let spec_xdr_lit = proc_macro2::Literal::byte_string(spec_xdr.as_slice());
     let spec_xdr_len = spec_xdr.len();
-    let spec_ident = format_ident!("__SPEC_XDR_FN_{}", ident.to_string().to_uppercase());
-    let spec_fn_ident = format_ident!("spec_xdr_{}", ident.to_string());
+    let spec_ident = format_ident!("__SPEC_XDR_FN_{}", ident.soroban_name().to_uppercase());
+    let spec_fn_ident = format_ident!("spec_xdr_{}", ident.soroban_name());
 
     // If errors have occurred, render them instead.
     if !errors.is_empty() {
@@ -175,7 +178,7 @@ pub fn derive_fn_spec(
         .collect::<Vec<_>>();
 
     let ty_str = ty_to_safe_ident_str(ty);
-    let hidden_mod_ident = format_ident!("__{}__{}__spec", ty_str, ident);
+    let hidden_mod_ident = format_ident!("__{}__{}__spec", ty_str, ident.soroban_name());
     let exported = if export {
         Some(quote! {
             #[doc(hidden)]

--- a/soroban-sdk-macros/src/derive_spec_fn.rs
+++ b/soroban-sdk-macros/src/derive_spec_fn.rs
@@ -7,12 +7,12 @@ use stellar_xdr::{
 };
 use syn::TypeReference;
 use syn::{
-    punctuated::Punctuated, spanned::Spanned, token::Comma, Attribute, Error, FnArg, Ident, Pat,
-    ReturnType, Type, TypePath,
+    ext::IdentExt as _, punctuated::Punctuated, spanned::Spanned, token::Comma, Attribute, Error,
+    FnArg, Ident, Pat, ReturnType, Type, TypePath,
 };
 
 use crate::attribute::pass_through_attr_to_gen_code;
-use crate::syn_ext::{self, ty_to_safe_ident_str, IdentExt as _};
+use crate::syn_ext::{self, ty_to_safe_ident_str};
 use crate::{doc::docs_from_attrs, map_type::map_type, DEFAULT_XDR_RW_LIMITS};
 
 pub fn derive_fns_spec<'a>(
@@ -69,7 +69,7 @@ pub fn derive_fn_spec(
         .map(|(i, a)| match a {
             FnArg::Typed(pat_type) => {
                 let name = if let Pat::Ident(pat_ident) = *pat_type.pat.clone() {
-                    pat_ident.ident.soroban_name()
+                    pat_ident.ident.unraw().to_string()
                 } else {
                     errors.push(Error::new(a.span(), "argument not supported"));
                     "".to_string()
@@ -90,7 +90,7 @@ pub fn derive_fn_spec(
                 // the Soroban-facing name so a raw-identifier spelling like
                 // `r#__check_auth` can't bypass this special-case and then still export
                 // as `__check_auth`.
-                let allow_hash = ident.soroban_name() == "__check_auth" && i == 0;
+                let allow_hash = ident.unraw().to_string() == "__check_auth" && i == 0;
 
                 match map_type(&pat_type.ty, true, allow_hash) {
                     Ok(type_) => {
@@ -142,7 +142,7 @@ pub fn derive_fn_spec(
     };
 
     // Generated code spec.
-    let name = &ident.soroban_name();
+    let name = &ident.unraw().to_string();
     let spec_entry = ScSpecEntry::FunctionV0(ScSpecFunctionV0 {
         doc: docs_from_attrs(attrs),
         name: name.try_into().unwrap_or_else(|_| {
@@ -162,8 +162,8 @@ pub fn derive_fn_spec(
     let spec_xdr = spec_entry.to_xdr(DEFAULT_XDR_RW_LIMITS).unwrap();
     let spec_xdr_lit = proc_macro2::Literal::byte_string(spec_xdr.as_slice());
     let spec_xdr_len = spec_xdr.len();
-    let spec_ident = format_ident!("__SPEC_XDR_FN_{}", ident.soroban_name().to_uppercase());
-    let spec_fn_ident = format_ident!("spec_xdr_{}", ident.soroban_name());
+    let spec_ident = format_ident!("__SPEC_XDR_FN_{}", ident.unraw().to_string().to_uppercase());
+    let spec_fn_ident = format_ident!("spec_xdr_{}", ident);
 
     // If errors have occurred, render them instead.
     if !errors.is_empty() {
@@ -178,7 +178,7 @@ pub fn derive_fn_spec(
         .collect::<Vec<_>>();
 
     let ty_str = ty_to_safe_ident_str(ty);
-    let hidden_mod_ident = format_ident!("__{}__{}__spec", ty_str, ident.soroban_name());
+    let hidden_mod_ident = format_ident!("__{}__{}__spec", ty_str, ident);
     let exported = if export {
         Some(quote! {
             #[doc(hidden)]

--- a/soroban-sdk-macros/src/derive_struct.rs
+++ b/soroban-sdk-macros/src/derive_struct.rs
@@ -1,7 +1,7 @@
 use itertools::Itertools;
 use proc_macro2::{Literal, TokenStream as TokenStream2};
 use quote::{format_ident, quote};
-use syn::{Attribute, DataStruct, Error, Ident, Path, Visibility};
+use syn::{ext::IdentExt as _, Attribute, DataStruct, Error, Ident, Path, Visibility};
 
 use stellar_xdr::curr as stellar_xdr;
 use stellar_xdr::{
@@ -10,7 +10,7 @@ use stellar_xdr::{
 
 use crate::{
     doc::docs_from_attrs, map_type::map_type, shaking, spec_shaking_v2_enabled,
-    syn_ext::IdentExt as _, DEFAULT_XDR_RW_LIMITS,
+    DEFAULT_XDR_RW_LIMITS,
 };
 
 // TODO: Add field attribute for including/excluding fields in types.
@@ -32,11 +32,11 @@ pub fn derive_type_struct(
     let field_count_usize: usize = fields.len();
     let (spec_fields, field_idents, field_names, field_idx_lits, field_types, try_from_xdrs, try_into_xdrs): (Vec<_>, Vec<_>, Vec<_>, Vec<_>, Vec<_>, Vec<_>, Vec<_>) = fields
         .iter()
-        .sorted_by_key(|field| field.ident.as_ref().unwrap().soroban_name())
+        .sorted_by_key(|field| field.ident.as_ref().unwrap().unraw().to_string())
         .enumerate()
         .map(|(field_num, field)| {
             let field_ident = field.ident.as_ref().unwrap();
-            let field_name = field_ident.soroban_name();
+            let field_name = field_ident.unraw().to_string();
             let field_idx_lit = Literal::usize_unsuffixed(field_num);
             let field_type = &field.ty;
             let spec_field = ScSpecUdtStructFieldV0 {
@@ -83,7 +83,7 @@ pub fn derive_type_struct(
         let spec_entry = ScSpecEntry::UdtStructV0(ScSpecUdtStructV0 {
             doc: docs_from_attrs(attrs),
             lib: lib.as_deref().unwrap_or_default().try_into().unwrap(),
-            name: ident.soroban_name().try_into().unwrap(),
+            name: ident.unraw().to_string().try_into().unwrap(),
             fields: spec_fields.try_into().unwrap(),
         });
         Some(spec_entry.to_xdr(DEFAULT_XDR_RW_LIMITS).unwrap())
@@ -95,7 +95,10 @@ pub fn derive_type_struct(
     let spec_gen = if let Some(ref spec_xdr) = spec_xdr {
         let spec_xdr_lit = proc_macro2::Literal::byte_string(spec_xdr.as_slice());
         let spec_xdr_len = spec_xdr.len();
-        let spec_ident = format_ident!("__SPEC_XDR_TYPE_{}", ident.soroban_name().to_uppercase());
+        let spec_ident = format_ident!(
+            "__SPEC_XDR_TYPE_{}",
+            ident.unraw().to_string().to_uppercase()
+        );
         Some(quote! {
             #[cfg_attr(target_family = "wasm", link_section = "contractspecv0")]
             pub static #spec_ident: [u8; #spec_xdr_len] = #ident::spec_xdr();

--- a/soroban-sdk-macros/src/derive_struct.rs
+++ b/soroban-sdk-macros/src/derive_struct.rs
@@ -10,7 +10,7 @@ use stellar_xdr::{
 
 use crate::{
     doc::docs_from_attrs, map_type::map_type, shaking, spec_shaking_v2_enabled,
-    DEFAULT_XDR_RW_LIMITS,
+    syn_ext::IdentExt as _, DEFAULT_XDR_RW_LIMITS,
 };
 
 // TODO: Add field attribute for including/excluding fields in types.
@@ -32,11 +32,11 @@ pub fn derive_type_struct(
     let field_count_usize: usize = fields.len();
     let (spec_fields, field_idents, field_names, field_idx_lits, field_types, try_from_xdrs, try_into_xdrs): (Vec<_>, Vec<_>, Vec<_>, Vec<_>, Vec<_>, Vec<_>, Vec<_>) = fields
         .iter()
-        .sorted_by_key(|field| field.ident.as_ref().unwrap().to_string())
+        .sorted_by_key(|field| field.ident.as_ref().unwrap().soroban_name())
         .enumerate()
         .map(|(field_num, field)| {
             let field_ident = field.ident.as_ref().unwrap();
-            let field_name = field_ident.to_string();
+            let field_name = field_ident.soroban_name();
             let field_idx_lit = Literal::usize_unsuffixed(field_num);
             let field_type = &field.ty;
             let spec_field = ScSpecUdtStructFieldV0 {
@@ -83,7 +83,7 @@ pub fn derive_type_struct(
         let spec_entry = ScSpecEntry::UdtStructV0(ScSpecUdtStructV0 {
             doc: docs_from_attrs(attrs),
             lib: lib.as_deref().unwrap_or_default().try_into().unwrap(),
-            name: ident.to_string().try_into().unwrap(),
+            name: ident.soroban_name().try_into().unwrap(),
             fields: spec_fields.try_into().unwrap(),
         });
         Some(spec_entry.to_xdr(DEFAULT_XDR_RW_LIMITS).unwrap())
@@ -95,7 +95,7 @@ pub fn derive_type_struct(
     let spec_gen = if let Some(ref spec_xdr) = spec_xdr {
         let spec_xdr_lit = proc_macro2::Literal::byte_string(spec_xdr.as_slice());
         let spec_xdr_len = spec_xdr.len();
-        let spec_ident = format_ident!("__SPEC_XDR_TYPE_{}", ident.to_string().to_uppercase());
+        let spec_ident = format_ident!("__SPEC_XDR_TYPE_{}", ident.soroban_name().to_uppercase());
         Some(quote! {
             #[cfg_attr(target_family = "wasm", link_section = "contractspecv0")]
             pub static #spec_ident: [u8; #spec_xdr_len] = #ident::spec_xdr();

--- a/soroban-sdk-macros/src/derive_struct_tuple.rs
+++ b/soroban-sdk-macros/src/derive_struct_tuple.rs
@@ -1,7 +1,7 @@
 use itertools::MultiUnzip;
 use proc_macro2::{Literal, TokenStream as TokenStream2};
 use quote::{format_ident, quote};
-use syn::{Attribute, DataStruct, Error, Ident, Path, Visibility};
+use syn::{ext::IdentExt as _, Attribute, DataStruct, Error, Ident, Path, Visibility};
 
 use stellar_xdr::curr as stellar_xdr;
 use stellar_xdr::{
@@ -10,7 +10,7 @@ use stellar_xdr::{
 
 use crate::{
     doc::docs_from_attrs, map_type::map_type, shaking, spec_shaking_v2_enabled,
-    syn_ext::IdentExt as _, DEFAULT_XDR_RW_LIMITS,
+    DEFAULT_XDR_RW_LIMITS,
 };
 
 pub fn derive_type_struct_tuple(
@@ -72,7 +72,7 @@ pub fn derive_type_struct_tuple(
         let spec_entry = ScSpecEntry::UdtStructV0(ScSpecUdtStructV0 {
             doc: docs_from_attrs(attrs),
             lib: lib.as_deref().unwrap_or_default().try_into().unwrap(),
-            name: ident.soroban_name().try_into().unwrap(),
+            name: ident.unraw().to_string().try_into().unwrap(),
             fields: field_specs.try_into().unwrap(),
         });
         Some(spec_entry.to_xdr(DEFAULT_XDR_RW_LIMITS).unwrap())
@@ -84,7 +84,10 @@ pub fn derive_type_struct_tuple(
     let spec_gen = if let Some(ref spec_xdr) = spec_xdr {
         let spec_xdr_lit = proc_macro2::Literal::byte_string(spec_xdr.as_slice());
         let spec_xdr_len = spec_xdr.len();
-        let spec_ident = format_ident!("__SPEC_XDR_TYPE_{}", ident.soroban_name().to_uppercase());
+        let spec_ident = format_ident!(
+            "__SPEC_XDR_TYPE_{}",
+            ident.unraw().to_string().to_uppercase()
+        );
         Some(quote! {
             #[cfg_attr(target_family = "wasm", link_section = "contractspecv0")]
             pub static #spec_ident: [u8; #spec_xdr_len] = #ident::spec_xdr();

--- a/soroban-sdk-macros/src/derive_struct_tuple.rs
+++ b/soroban-sdk-macros/src/derive_struct_tuple.rs
@@ -10,7 +10,7 @@ use stellar_xdr::{
 
 use crate::{
     doc::docs_from_attrs, map_type::map_type, shaking, spec_shaking_v2_enabled,
-    DEFAULT_XDR_RW_LIMITS,
+    syn_ext::IdentExt as _, DEFAULT_XDR_RW_LIMITS,
 };
 
 pub fn derive_type_struct_tuple(
@@ -72,7 +72,7 @@ pub fn derive_type_struct_tuple(
         let spec_entry = ScSpecEntry::UdtStructV0(ScSpecUdtStructV0 {
             doc: docs_from_attrs(attrs),
             lib: lib.as_deref().unwrap_or_default().try_into().unwrap(),
-            name: ident.to_string().try_into().unwrap(),
+            name: ident.soroban_name().try_into().unwrap(),
             fields: field_specs.try_into().unwrap(),
         });
         Some(spec_entry.to_xdr(DEFAULT_XDR_RW_LIMITS).unwrap())
@@ -84,7 +84,7 @@ pub fn derive_type_struct_tuple(
     let spec_gen = if let Some(ref spec_xdr) = spec_xdr {
         let spec_xdr_lit = proc_macro2::Literal::byte_string(spec_xdr.as_slice());
         let spec_xdr_len = spec_xdr.len();
-        let spec_ident = format_ident!("__SPEC_XDR_TYPE_{}", ident.to_string().to_uppercase());
+        let spec_ident = format_ident!("__SPEC_XDR_TYPE_{}", ident.soroban_name().to_uppercase());
         Some(quote! {
             #[cfg_attr(target_family = "wasm", link_section = "contractspecv0")]
             pub static #spec_ident: [u8; #spec_xdr_len] = #ident::spec_xdr();

--- a/soroban-sdk-macros/src/derive_trait.rs
+++ b/soroban-sdk-macros/src/derive_trait.rs
@@ -38,11 +38,17 @@ fn derive_or_err(metadata: TokenStream2, input: TokenStream2) -> Result<TokenStr
     let input: ItemTrait = parse2(input)?;
 
     let path = &args.crate_path;
-    let spec_name = args.spec_name.unwrap_or(format!("{}Spec", input.ident));
+    let spec_name = args
+        .spec_name
+        .unwrap_or_else(|| format_ident!("{}Spec", input.ident).to_string());
     let spec_ident = format_ident!("{spec_name}");
     let spec_export = args.spec_export;
-    let args_name = args.args_name.unwrap_or(format!("{}Args", input.ident));
-    let client_name = args.client_name.unwrap_or(format!("{}Client", input.ident));
+    let args_name = args
+        .args_name
+        .unwrap_or_else(|| format_ident!("{}Args", input.ident).to_string());
+    let client_name = args
+        .client_name
+        .unwrap_or_else(|| format_ident!("{}Client", input.ident).to_string());
 
     Ok(quote! {
         pub struct #spec_ident;

--- a/soroban-sdk-macros/src/derive_trait.rs
+++ b/soroban-sdk-macros/src/derive_trait.rs
@@ -2,7 +2,7 @@ use crate::default_crate_path;
 use darling::{ast::NestedMeta, Error, FromMeta};
 use proc_macro2::TokenStream as TokenStream2;
 use quote::{format_ident, quote};
-use syn::{parse2, ItemTrait, Path};
+use syn::{ext::IdentExt as _, parse2, ItemTrait, Path};
 
 // See soroban-sdk/docs/contracttrait.md for documentation on how this works.
 
@@ -40,15 +40,15 @@ fn derive_or_err(metadata: TokenStream2, input: TokenStream2) -> Result<TokenStr
     let path = &args.crate_path;
     let spec_name = args
         .spec_name
-        .unwrap_or_else(|| format_ident!("{}Spec", input.ident).to_string());
+        .unwrap_or_else(|| format!("{}Spec", input.ident.unraw()));
     let spec_ident = format_ident!("{spec_name}");
     let spec_export = args.spec_export;
     let args_name = args
         .args_name
-        .unwrap_or_else(|| format_ident!("{}Args", input.ident).to_string());
+        .unwrap_or_else(|| format!("{}Args", input.ident.unraw()));
     let client_name = args
         .client_name
-        .unwrap_or_else(|| format_ident!("{}Client", input.ident).to_string());
+        .unwrap_or_else(|| format!("{}Client", input.ident.unraw()));
 
     Ok(quote! {
         pub struct #spec_ident;

--- a/soroban-sdk-macros/src/lib.rs
+++ b/soroban-sdk-macros/src/lib.rs
@@ -47,8 +47,8 @@ use quote::{format_ident, quote, ToTokens};
 use sha2::{Digest, Sha256};
 use std::{fmt::Write, fs};
 use syn::{
-    parse_macro_input, parse_str, spanned::Spanned, Data, DeriveInput, Error, Expr, Fields,
-    ItemImpl, ItemStruct, LitStr, Path, Type, Visibility,
+    ext::IdentExt as _, parse_macro_input, parse_str, spanned::Spanned, Data, DeriveInput, Error,
+    Expr, Fields, ItemImpl, ItemStruct, LitStr, Path, Type, Visibility,
 };
 use syn_ext::HasFnsItem;
 
@@ -152,13 +152,13 @@ pub fn contract(metadata: TokenStream, input: TokenStream) -> TokenStream {
     let item = parse_macro_input!(input as ItemStruct);
 
     let ty = &item.ident;
-    let ty_str = quote!(#ty).to_string();
+    let ty_str = ty.unraw().to_string();
 
-    let client_ident = format!("{ty_str}Client");
+    let client_ident = format_ident!("{}Client", ty).to_string();
     let fn_set_registry_ident = format_ident!("__{}_fn_set_registry", ty_str.to_lowercase());
     let crate_path = &args.crate_path;
     let client = derive_client_type(&args.crate_path, &ty_str, &client_ident);
-    let args_ident = format!("{ty_str}Args");
+    let args_ident = format_ident!("{}Args", ty).to_string();
     let contract_args = derive_args_type(&ty_str, &args_ident);
     let mut output = quote! {
         #input2
@@ -239,7 +239,7 @@ pub fn contractimpl(metadata: TokenStream, input: TokenStream) -> TokenStream {
         path.path
             .segments
             .last()
-            .map(|name| format!("{}Args", name.ident))
+            .map(|name| format_ident!("{}Args", name.ident).to_string())
     } else {
         None
     }
@@ -251,7 +251,7 @@ pub fn contractimpl(metadata: TokenStream, input: TokenStream) -> TokenStream {
         path.path
             .segments
             .last()
-            .map(|name| format!("{}Client", name.ident))
+            .map(|name| format_ident!("{}Client", name.ident).to_string())
     } else {
         None
     }

--- a/soroban-sdk-macros/src/lib.rs
+++ b/soroban-sdk-macros/src/lib.rs
@@ -154,11 +154,11 @@ pub fn contract(metadata: TokenStream, input: TokenStream) -> TokenStream {
     let ty = &item.ident;
     let ty_str = ty.unraw().to_string();
 
-    let client_ident = format_ident!("{}Client", ty).to_string();
+    let client_ident = format!("{ty_str}Client");
     let fn_set_registry_ident = format_ident!("__{}_fn_set_registry", ty_str.to_lowercase());
     let crate_path = &args.crate_path;
     let client = derive_client_type(&args.crate_path, &ty_str, &client_ident);
-    let args_ident = format_ident!("{}Args", ty).to_string();
+    let args_ident = format!("{ty_str}Args");
     let contract_args = derive_args_type(&ty_str, &args_ident);
     let mut output = quote! {
         #input2
@@ -239,7 +239,7 @@ pub fn contractimpl(metadata: TokenStream, input: TokenStream) -> TokenStream {
         path.path
             .segments
             .last()
-            .map(|name| format_ident!("{}Args", name.ident).to_string())
+            .map(|name| format!("{}Args", name.ident.unraw()))
     } else {
         None
     }
@@ -251,7 +251,7 @@ pub fn contractimpl(metadata: TokenStream, input: TokenStream) -> TokenStream {
         path.path
             .segments
             .last()
-            .map(|name| format_ident!("{}Client", name.ident).to_string())
+            .map(|name| format!("{}Client", name.ident.unraw()))
     } else {
         None
     }

--- a/soroban-sdk-macros/src/map_type.rs
+++ b/soroban-sdk-macros/src/map_type.rs
@@ -5,10 +5,12 @@ use stellar_xdr::{
     ScSpecTypeTuple, ScSpecTypeUdt, ScSpecTypeVec,
 };
 use syn::{
-    spanned::Spanned, Error, Expr, ExprLit, GenericArgument, Ident, Lit, Path, PathArguments,
-    PathSegment, Type, TypePath, TypeTuple,
+    ext::IdentExt as _, spanned::Spanned, Error, Expr, ExprLit, GenericArgument, Ident, Lit, Path,
+    PathArguments, PathSegment, Type, TypePath, TypeTuple,
 };
 use syn::{Generics, TypeReference};
+
+use crate::syn_ext::ident_to_type;
 
 // These constants' values must match the definitions of the constants with the
 // same names in soroban_sdk::crypto::bls12_381.
@@ -35,13 +37,10 @@ pub const BN254_G2_SERIALIZED_SIZE: u32 = BN254_G1_SERIALIZED_SIZE * 2; // 128
 /// - If the type mapped from `ident` is not a UDT
 /// - If `generics` has any parameters, as UDTs don't support generics
 pub fn is_mapped_type_udt(ident: &Ident, generics: &Generics) -> Result<(), Error> {
-    let name = ident.to_string();
-    let ty: Type = syn::parse_str(&name).map_err(|e| {
-        Error::new(
-            ident.span(),
-            format!("type `{}` cannot be used in XDR spec: {}", ident, e),
-        )
-    })?;
+    // Wrap the Ident directly into a Type rather than stringifying and
+    // re-parsing — the latter would fail for raw keyword idents like `r#type`
+    // because the unraw'd form (`type`) isn't a valid Rust Type.
+    let ty = ident_to_type(ident.clone());
     match map_type(&ty, false, false) {
         Ok(ScSpecTypeDef::Udt(_)) => {
             // `ty` does not contain the generics, so check manually here
@@ -56,6 +55,7 @@ pub fn is_mapped_type_udt(ident: &Ident, generics: &Generics) -> Result<(), Erro
         }
         _ => {
             // Check if the error originated from the UDT-arm of `map_type`
+            let name = ident.unraw().to_string();
             let _ = ScSpecTypeDef::Udt(ScSpecTypeUdt {
                 name: name.try_into().map_err(|e| {
                     Error::new(
@@ -90,7 +90,7 @@ pub fn map_type(t: &Type, allow_ref: bool, allow_hash: bool) -> Result<ScSpecTyp
                 Some(PathSegment {
                     ident,
                     arguments: PathArguments::None,
-                }) => match &ident.to_string()[..] {
+                }) => match &ident.unraw().to_string()[..] {
                     "Val" => Ok(ScSpecTypeDef::Val),
                     "u64" => Ok(ScSpecTypeDef::U64),
                     "i64" => Ok(ScSpecTypeDef::I64),
@@ -193,7 +193,7 @@ pub fn map_type(t: &Type, allow_ref: bool, allow_hash: bool) -> Result<ScSpecTyp
                     arguments: PathArguments::AngleBracketed(angle_bracketed),
                 }) => {
                     let args = angle_bracketed.args.iter().collect::<Vec<_>>();
-                    match &ident.to_string()[..] {
+                    match &ident.unraw().to_string()[..] {
                         "Result" => {
                             let (ok, err) = match args.as_slice() {
                                 [GenericArgument::Type(ok), GenericArgument::Type(err)] => (ok, err),

--- a/soroban-sdk-macros/src/syn_ext.rs
+++ b/soroban-sdk-macros/src/syn_ext.rs
@@ -2,15 +2,16 @@ use proc_macro2::{Span, TokenStream};
 use quote::{format_ident, quote, ToTokens};
 use std::collections::HashMap;
 use syn::{
+    ext::IdentExt as _, spanned::Spanned, token::And, Error, FnArg, Ident, ImplItem, ImplItemFn,
+    ItemImpl, ItemTrait, Lifetime, Pat, PatIdent, PatType, TraitItem, TraitItemFn, Type,
+    TypeReference, Visibility,
+};
+use syn::{
     parse::{Parse, ParseStream},
     punctuated::Punctuated,
     token::Comma,
     AngleBracketedGenericArguments, Attribute, GenericArgument, LitStr, Path, PathArguments,
     PathSegment, ReturnType, Signature, Token, TypePath,
-};
-use syn::{
-    spanned::Spanned, token::And, Error, FnArg, Ident, ImplItem, ImplItemFn, ItemImpl, ItemTrait,
-    Lifetime, Pat, PatIdent, PatType, TraitItem, TraitItemFn, Type, TypeReference, Visibility,
 };
 
 /// Gets methods from the implementation that have public visibility. For
@@ -47,27 +48,6 @@ pub fn fn_arg_ident(arg: &FnArg) -> Result<Ident, Error> {
         arg.span(),
         "argument in this form is not supported, use simple named arguments only",
     ))
-}
-
-/// Extension methods on `syn::Ident` used across the derive macros.
-pub trait IdentExt {
-    /// Returns the identifier's name for use in generated Soroban-facing names
-    /// (spec XDR entries, runtime `Symbol`s, map keys, discriminants, and the
-    /// internal static idents derived from them).
-    ///
-    /// Raw identifiers like `r#type` return the unraw form (`"type"`). `Symbol`'s
-    /// charset (`[_0-9A-Za-z]`) does not permit the `#` character.
-    ///
-    /// Call sites that emit Rust tokens referring back to the original field or
-    /// variant must still use the original `Ident` so that raw identifiers remain
-    /// valid Rust.
-    fn soroban_name(&self) -> String;
-}
-
-impl IdentExt for Ident {
-    fn soroban_name(&self) -> String {
-        syn::ext::IdentExt::unraw(self).to_string()
-    }
 }
 
 /// Validate that the function argument type is not a mutable reference.
@@ -175,7 +155,7 @@ pub enum HasFnsItem {
 impl HasFnsItem {
     pub fn name(&'_ self) -> String {
         match self {
-            HasFnsItem::Trait(t) => t.ident.to_string(),
+            HasFnsItem::Trait(t) => t.ident.unraw().to_string(),
             HasFnsItem::Impl(i) => {
                 let ty = &i.self_ty;
                 quote!(#ty).to_string()
@@ -313,7 +293,7 @@ fn unpack_result(typ: &Type) -> Option<(Type, Type)> {
             }) = path.segments.last()
             {
                 let args = args.iter().collect::<Vec<_>>();
-                match (&ident.to_string()[..], args.as_slice()) {
+                match (&ident.unraw().to_string()[..], args.as_slice()) {
                     ("Result", [GenericArgument::Type(t), GenericArgument::Type(e)]) => {
                         Some((t.clone(), e.clone()))
                     }
@@ -444,7 +424,11 @@ fn self_type_ident(ty: &Type) -> Result<Option<&Ident>, Error> {
 }
 
 pub fn ty_to_safe_ident_str(ty: &Type) -> String {
-    quote!(#ty).to_string().replace(' ', "").replace(':', "_")
+    quote!(#ty)
+        .to_string()
+        .replace(' ', "")
+        .replace(':', "_")
+        .replace("r#", "")
 }
 
 pub fn ident_to_type(ident: Ident) -> Type {

--- a/soroban-sdk-macros/src/syn_ext.rs
+++ b/soroban-sdk-macros/src/syn_ext.rs
@@ -49,6 +49,27 @@ pub fn fn_arg_ident(arg: &FnArg) -> Result<Ident, Error> {
     ))
 }
 
+/// Extension methods on `syn::Ident` used across the derive macros.
+pub trait IdentExt {
+    /// Returns the identifier's name for use in generated Soroban-facing names
+    /// (spec XDR entries, runtime `Symbol`s, map keys, discriminants, and the
+    /// internal static idents derived from them).
+    ///
+    /// Raw identifiers like `r#type` return the unraw form (`"type"`). `Symbol`'s
+    /// charset (`[_0-9A-Za-z]`) does not permit the `#` character.
+    ///
+    /// Call sites that emit Rust tokens referring back to the original field or
+    /// variant must still use the original `Ident` so that raw identifiers remain
+    /// valid Rust.
+    fn soroban_name(&self) -> String;
+}
+
+impl IdentExt for Ident {
+    fn soroban_name(&self) -> String {
+        syn::ext::IdentExt::unraw(self).to_string()
+    }
+}
+
 /// Validate that the function argument type is not a mutable reference.
 ///
 /// Returns an error indicating that contract functions arguments cannot be a mutable reference.

--- a/soroban-sdk/src/tests.rs
+++ b/soroban-sdk/src/tests.rs
@@ -27,6 +27,7 @@ mod contract_udt_enum_error;
 mod contract_udt_enum_int;
 mod contract_udt_enum_option;
 mod contract_udt_option;
+mod contract_udt_raw_identifier;
 mod contract_udt_struct;
 mod contract_udt_struct_tuple;
 mod contractimpl_trait_call_resolution;

--- a/soroban-sdk/src/tests/contract_udt_raw_identifier.rs
+++ b/soroban-sdk/src/tests/contract_udt_raw_identifier.rs
@@ -31,6 +31,10 @@ pub struct TestEvent {
 #[derive(Debug)]
 pub struct TestType {
     pub r#type: u32,
+    // `rank` is intentionally non-raw and starts with `r` so that its sort
+    // position differs between the raw form (`r#type`,`r#value`,`raw`) and
+    // unraw form (`raw`,`type`,`value`) of the other fields.
+    pub rank: u32,
     pub r#value: u32,
 }
 
@@ -52,6 +56,7 @@ impl Contract {
 
         match a {
             TestEnum::r#Enum => Ok(TestType {
+                rank: 7,
                 r#type: a as u32,
                 r#value: 42,
             }),
@@ -67,6 +72,7 @@ fn test_functional() {
     let client = ContractClient::new(&env, &contract_id);
 
     let res = client.r#type(&TestEnum::r#Enum);
+    assert_eq!(res.rank, 7);
     assert_eq!(res.r#type, 0);
     assert_eq!(res.value, 42);
 
@@ -120,6 +126,11 @@ fn test_spec() {
             lib: "".try_into().unwrap(),
             name: "TestType".try_into().unwrap(),
             fields: [
+                ScSpecUdtStructFieldV0 {
+                    doc: "".try_into().unwrap(),
+                    name: "rank".try_into().unwrap(),
+                    type_: ScSpecTypeDef::U32,
+                },
                 ScSpecUdtStructFieldV0 {
                     doc: "".try_into().unwrap(),
                     name: "type".try_into().unwrap(),

--- a/soroban-sdk/src/tests/contract_udt_raw_identifier.rs
+++ b/soroban-sdk/src/tests/contract_udt_raw_identifier.rs
@@ -1,0 +1,215 @@
+use crate::{self as soroban_sdk, Event};
+use soroban_sdk::{
+    contract, contracterror, contractevent, contractimpl, contracttype, testutils::Events as _, Env,
+};
+use stellar_xdr::curr as stellar_xdr;
+use stellar_xdr::{
+    Limits, ReadXdr, ScSpecEntry, ScSpecEventDataFormat, ScSpecEventParamLocationV0,
+    ScSpecEventParamV0, ScSpecEventV0, ScSpecFunctionInputV0, ScSpecFunctionV0, ScSpecTypeDef,
+    ScSpecTypeResult, ScSpecTypeUdt, ScSpecUdtEnumCaseV0, ScSpecUdtEnumV0,
+    ScSpecUdtErrorEnumCaseV0, ScSpecUdtErrorEnumV0, ScSpecUdtStructFieldV0, ScSpecUdtStructV0,
+    ScSymbol,
+};
+
+#[contract]
+pub struct Contract;
+
+#[contracterror]
+#[derive(Debug, Eq, PartialEq)]
+pub enum TestError {
+    r#Error = 1,
+}
+
+#[contractevent]
+pub struct TestEvent {
+    #[topic]
+    pub r#type: u32,
+    pub r#fn: u32,
+}
+
+#[contracttype]
+#[derive(Debug)]
+pub struct TestType {
+    pub r#type: u32,
+    pub r#value: u32,
+}
+
+#[contracttype]
+#[derive(Clone, Debug)]
+pub enum TestEnum {
+    r#Enum = 0,
+    TestError = 1,
+}
+
+#[contractimpl]
+impl Contract {
+    pub fn r#type(env: Env, a: TestEnum) -> Result<TestType, TestError> {
+        TestEvent {
+            r#type: a.clone() as u32,
+            r#fn: 1,
+        }
+        .publish(&env);
+
+        match a {
+            TestEnum::r#Enum => Ok(TestType {
+                r#type: a as u32,
+                r#value: 42,
+            }),
+            TestEnum::TestError => Err(TestError::r#Error),
+        }
+    }
+}
+
+#[test]
+fn test_functional() {
+    let env = Env::default();
+    let contract_id = env.register(Contract, ());
+    let client = ContractClient::new(&env, &contract_id);
+
+    let res = client.r#type(&TestEnum::r#Enum);
+    assert_eq!(res.r#type, 0);
+    assert_eq!(res.value, 42);
+
+    assert_eq!(
+        env.events().all(),
+        std::vec![TestEvent { r#type: 0, r#fn: 1 }.to_xdr(&env, &contract_id)],
+    );
+
+    let err = client.try_type(&TestEnum::TestError);
+    assert_eq!(err.unwrap_err().unwrap(), TestError::r#Error);
+}
+
+#[test]
+fn test_spec() {
+    // `r#type` function must emit as "type", with inputs and outputs unraw'd.
+    let fn_entry = ScSpecEntry::from_xdr(Contract::spec_xdr_type(), Limits::none()).unwrap();
+    assert_eq!(
+        fn_entry,
+        ScSpecEntry::FunctionV0(ScSpecFunctionV0 {
+            doc: "".try_into().unwrap(),
+            name: "type".try_into().unwrap(),
+            inputs: [ScSpecFunctionInputV0 {
+                doc: "".try_into().unwrap(),
+                name: "a".try_into().unwrap(),
+                type_: ScSpecTypeDef::Udt(ScSpecTypeUdt {
+                    name: "TestEnum".try_into().unwrap(),
+                }),
+            }]
+            .try_into()
+            .unwrap(),
+            outputs: [ScSpecTypeDef::Result(Box::new(ScSpecTypeResult {
+                ok_type: Box::new(ScSpecTypeDef::Udt(ScSpecTypeUdt {
+                    name: "TestType".try_into().unwrap(),
+                })),
+                error_type: Box::new(ScSpecTypeDef::Udt(ScSpecTypeUdt {
+                    name: "TestError".try_into().unwrap(),
+                })),
+            }))]
+            .try_into()
+            .unwrap(),
+        }),
+    );
+
+    // `TestType` struct fields `r#type` and `r#value` must emit as "type" and
+    // "value" and appear sorted by the unraw'd name.
+    let type_entry = ScSpecEntry::from_xdr(TestType::spec_xdr(), Limits::none()).unwrap();
+    assert_eq!(
+        type_entry,
+        ScSpecEntry::UdtStructV0(ScSpecUdtStructV0 {
+            doc: "".try_into().unwrap(),
+            lib: "".try_into().unwrap(),
+            name: "TestType".try_into().unwrap(),
+            fields: [
+                ScSpecUdtStructFieldV0 {
+                    doc: "".try_into().unwrap(),
+                    name: "type".try_into().unwrap(),
+                    type_: ScSpecTypeDef::U32,
+                },
+                ScSpecUdtStructFieldV0 {
+                    doc: "".try_into().unwrap(),
+                    name: "value".try_into().unwrap(),
+                    type_: ScSpecTypeDef::U32,
+                },
+            ]
+            .try_into()
+            .unwrap(),
+        }),
+    );
+
+    // `TestEnum` variant `r#Enum` must emit as "Enum"; the non-raw `TestError`
+    // variant is unchanged.
+    let enum_entry = ScSpecEntry::from_xdr(TestEnum::spec_xdr(), Limits::none()).unwrap();
+    assert_eq!(
+        enum_entry,
+        ScSpecEntry::UdtEnumV0(ScSpecUdtEnumV0 {
+            doc: "".try_into().unwrap(),
+            lib: "".try_into().unwrap(),
+            name: "TestEnum".try_into().unwrap(),
+            cases: [
+                ScSpecUdtEnumCaseV0 {
+                    doc: "".try_into().unwrap(),
+                    name: "Enum".try_into().unwrap(),
+                    value: 0,
+                },
+                ScSpecUdtEnumCaseV0 {
+                    doc: "".try_into().unwrap(),
+                    name: "TestError".try_into().unwrap(),
+                    value: 1,
+                },
+            ]
+            .try_into()
+            .unwrap(),
+        }),
+    );
+
+    // `TestError` variant `r#Error` must emit as "Error".
+    let error_entry = ScSpecEntry::from_xdr(TestError::spec_xdr(), Limits::none()).unwrap();
+    assert_eq!(
+        error_entry,
+        ScSpecEntry::UdtErrorEnumV0(ScSpecUdtErrorEnumV0 {
+            doc: "".try_into().unwrap(),
+            lib: "".try_into().unwrap(),
+            name: "TestError".try_into().unwrap(),
+            cases: [ScSpecUdtErrorEnumCaseV0 {
+                doc: "".try_into().unwrap(),
+                name: "Error".try_into().unwrap(),
+                value: 1,
+            }]
+            .try_into()
+            .unwrap(),
+        }),
+    );
+
+    // `TestEvent` must emit its prefix topic as snake_case of the unraw'd
+    // struct name ("test_event"), and its fields `r#type` and `r#fn` as "type"
+    // and "fn" in declaration order.
+    let event_entry = ScSpecEntry::from_xdr(TestEvent::spec_xdr(), Limits::none()).unwrap();
+    assert_eq!(
+        event_entry,
+        ScSpecEntry::EventV0(ScSpecEventV0 {
+            doc: "".try_into().unwrap(),
+            lib: "".try_into().unwrap(),
+            name: ScSymbol("TestEvent".try_into().unwrap()),
+            prefix_topics: [ScSymbol("test_event".try_into().unwrap())]
+                .try_into()
+                .unwrap(),
+            params: [
+                ScSpecEventParamV0 {
+                    doc: "".try_into().unwrap(),
+                    name: "type".try_into().unwrap(),
+                    type_: ScSpecTypeDef::U32,
+                    location: ScSpecEventParamLocationV0::TopicList,
+                },
+                ScSpecEventParamV0 {
+                    doc: "".try_into().unwrap(),
+                    name: "fn".try_into().unwrap(),
+                    type_: ScSpecTypeDef::U32,
+                    location: ScSpecEventParamLocationV0::Data,
+                },
+            ]
+            .try_into()
+            .unwrap(),
+            data_format: ScSpecEventDataFormat::Map,
+        }),
+    );
+}

--- a/soroban-sdk/src/tests/contract_udt_raw_identifier.rs
+++ b/soroban-sdk/src/tests/contract_udt_raw_identifier.rs
@@ -1,6 +1,7 @@
 use crate::{self as soroban_sdk, Event};
 use soroban_sdk::{
-    contract, contracterror, contractevent, contractimpl, contracttype, testutils::Events as _, Env,
+    contract, contracterror, contractevent, contractimpl, contracttrait, contracttype,
+    testutils::Events as _, Env,
 };
 use stellar_xdr::curr as stellar_xdr;
 use stellar_xdr::{
@@ -8,20 +9,20 @@ use stellar_xdr::{
     ScSpecEventParamV0, ScSpecEventV0, ScSpecFunctionInputV0, ScSpecFunctionV0, ScSpecTypeDef,
     ScSpecTypeResult, ScSpecTypeUdt, ScSpecUdtEnumCaseV0, ScSpecUdtEnumV0,
     ScSpecUdtErrorEnumCaseV0, ScSpecUdtErrorEnumV0, ScSpecUdtStructFieldV0, ScSpecUdtStructV0,
-    ScSymbol,
+    ScSpecUdtUnionCaseTupleV0, ScSpecUdtUnionCaseV0, ScSpecUdtUnionV0, ScSymbol,
 };
 
 #[contract]
-pub struct Contract;
+pub struct r#Contract;
 
 #[contracterror]
 #[derive(Debug, Eq, PartialEq)]
-pub enum TestError {
+pub enum r#TestError {
     r#Error = 1,
 }
 
 #[contractevent]
-pub struct TestEvent {
+pub struct r#TestEvent {
     #[topic]
     pub r#type: u32,
     pub r#fn: u32,
@@ -29,7 +30,7 @@ pub struct TestEvent {
 
 #[contracttype]
 #[derive(Debug)]
-pub struct TestType {
+pub struct r#TestType {
     pub r#type: u32,
     // `rank` is intentionally non-raw and starts with `r` so that its sort
     // position differs between the raw form (`r#type`,`r#value`,`raw`) and
@@ -39,25 +40,49 @@ pub struct TestType {
 }
 
 #[contracttype]
-#[derive(Clone, Debug)]
-pub enum TestEnum {
+#[derive(Clone)]
+pub enum r#TestEnum {
     r#Enum = 0,
     TestError = 1,
 }
 
+#[contracttype]
+#[derive(Clone)]
+pub enum r#TestTupleEnum {
+    r#Tuple(u32),
+    TestTuple(i32),
+}
+
+#[contracttrait]
+pub trait r#RawTrait {
+    fn r#method(env: &Env) -> u32 {
+        let _ = env;
+        42
+    }
+}
+
+#[contracttype]
+#[allow(non_camel_case_types)]
+pub struct r#type {
+    pub value: u32,
+}
+
+#[contracttype]
+pub struct r#TupleStruct(u32, u32);
+
 #[contractimpl]
-impl Contract {
-    pub fn r#type(env: Env, a: TestEnum) -> Result<TestType, TestError> {
+impl r#Contract {
+    pub fn r#type(env: Env, r#fn: TestEnum) -> Result<TestType, TestError> {
         TestEvent {
-            r#type: a.clone() as u32,
+            r#type: r#fn.clone() as u32,
             r#fn: 1,
         }
         .publish(&env);
 
-        match a {
+        match r#fn {
             TestEnum::r#Enum => Ok(TestType {
                 rank: 7,
-                r#type: a as u32,
+                r#type: r#fn as u32,
                 r#value: 42,
             }),
             TestEnum::TestError => Err(TestError::r#Error),
@@ -65,10 +90,13 @@ impl Contract {
     }
 }
 
+#[contractimpl(contracttrait)]
+impl r#RawTrait for r#Contract {}
+
 #[test]
 fn test_functional() {
     let env = Env::default();
-    let contract_id = env.register(Contract, ());
+    let contract_id = env.register(r#Contract, ());
     let client = ContractClient::new(&env, &contract_id);
 
     let res = client.r#type(&TestEnum::r#Enum);
@@ -83,12 +111,13 @@ fn test_functional() {
 
     let err = client.try_type(&TestEnum::TestError);
     assert_eq!(err.unwrap_err().unwrap(), TestError::r#Error);
+
+    assert_eq!(client.method(), 42);
 }
 
 #[test]
-fn test_spec() {
-    // `r#type` function must emit as "type", with inputs and outputs unraw'd.
-    let fn_entry = ScSpecEntry::from_xdr(Contract::spec_xdr_type(), Limits::none()).unwrap();
+fn test_spec_contract() {
+    let fn_entry = ScSpecEntry::from_xdr(r#Contract::spec_xdr_type(), Limits::none()).unwrap();
     assert_eq!(
         fn_entry,
         ScSpecEntry::FunctionV0(ScSpecFunctionV0 {
@@ -96,7 +125,7 @@ fn test_spec() {
             name: "type".try_into().unwrap(),
             inputs: [ScSpecFunctionInputV0 {
                 doc: "".try_into().unwrap(),
-                name: "a".try_into().unwrap(),
+                name: "fn".try_into().unwrap(),
                 type_: ScSpecTypeDef::Udt(ScSpecTypeUdt {
                     name: "TestEnum".try_into().unwrap(),
                 }),
@@ -116,8 +145,35 @@ fn test_spec() {
         }),
     );
 
-    // `TestType` struct fields `r#type` and `r#value` must emit as "type" and
-    // "value" and appear sorted by the unraw'd name.
+    let trait_fn_entry =
+        ScSpecEntry::from_xdr(r#Contract::spec_xdr_method(), Limits::none()).unwrap();
+    assert_eq!(
+        trait_fn_entry,
+        ScSpecEntry::FunctionV0(ScSpecFunctionV0 {
+            doc: "".try_into().unwrap(),
+            name: "method".try_into().unwrap(),
+            inputs: [].try_into().unwrap(),
+            outputs: [ScSpecTypeDef::U32].try_into().unwrap(),
+        }),
+    );
+
+    let trait_method_spec =
+        ScSpecEntry::from_xdr(RawTraitSpec::spec_xdr_method(), Limits::none()).unwrap();
+    assert_eq!(
+        trait_method_spec,
+        ScSpecEntry::FunctionV0(ScSpecFunctionV0 {
+            doc: "".try_into().unwrap(),
+            name: "method".try_into().unwrap(),
+            inputs: [].try_into().unwrap(),
+            outputs: [ScSpecTypeDef::U32].try_into().unwrap(),
+        }),
+    );
+}
+
+#[test]
+fn test_spec_struct() {
+    // `r#TestType` with raw fields `r#type` and `r#value` must emit with its
+    // name unraw'd, fields unraw'd, and sorted by the unraw'd field name.
     let type_entry = ScSpecEntry::from_xdr(TestType::spec_xdr(), Limits::none()).unwrap();
     assert_eq!(
         type_entry,
@@ -147,8 +203,51 @@ fn test_spec() {
         }),
     );
 
-    // `TestEnum` variant `r#Enum` must emit as "Enum"; the non-raw `TestError`
-    // variant is unchanged.
+    let keyword_struct_entry = ScSpecEntry::from_xdr(r#type::spec_xdr(), Limits::none()).unwrap();
+    assert_eq!(
+        keyword_struct_entry,
+        ScSpecEntry::UdtStructV0(ScSpecUdtStructV0 {
+            doc: "".try_into().unwrap(),
+            lib: "".try_into().unwrap(),
+            name: "type".try_into().unwrap(),
+            fields: [ScSpecUdtStructFieldV0 {
+                doc: "".try_into().unwrap(),
+                name: "value".try_into().unwrap(),
+                type_: ScSpecTypeDef::U32,
+            }]
+            .try_into()
+            .unwrap(),
+        }),
+    );
+
+    let tuple_struct_entry =
+        ScSpecEntry::from_xdr(r#TupleStruct::spec_xdr(), Limits::none()).unwrap();
+    assert_eq!(
+        tuple_struct_entry,
+        ScSpecEntry::UdtStructV0(ScSpecUdtStructV0 {
+            doc: "".try_into().unwrap(),
+            lib: "".try_into().unwrap(),
+            name: "TupleStruct".try_into().unwrap(),
+            fields: [
+                ScSpecUdtStructFieldV0 {
+                    doc: "".try_into().unwrap(),
+                    name: "0".try_into().unwrap(),
+                    type_: ScSpecTypeDef::U32,
+                },
+                ScSpecUdtStructFieldV0 {
+                    doc: "".try_into().unwrap(),
+                    name: "1".try_into().unwrap(),
+                    type_: ScSpecTypeDef::U32,
+                },
+            ]
+            .try_into()
+            .unwrap(),
+        }),
+    );
+}
+
+#[test]
+fn test_spec_enum() {
     let enum_entry = ScSpecEntry::from_xdr(TestEnum::spec_xdr(), Limits::none()).unwrap();
     assert_eq!(
         enum_entry,
@@ -173,7 +272,6 @@ fn test_spec() {
         }),
     );
 
-    // `TestError` variant `r#Error` must emit as "Error".
     let error_entry = ScSpecEntry::from_xdr(TestError::spec_xdr(), Limits::none()).unwrap();
     assert_eq!(
         error_entry,
@@ -191,7 +289,35 @@ fn test_spec() {
         }),
     );
 
-    // `TestEvent` must emit its prefix topic as snake_case of the unraw'd
+    let tuple_enum_entry =
+        ScSpecEntry::from_xdr(TestTupleEnum::spec_xdr(), Limits::none()).unwrap();
+    assert_eq!(
+        tuple_enum_entry,
+        ScSpecEntry::UdtUnionV0(ScSpecUdtUnionV0 {
+            doc: "".try_into().unwrap(),
+            lib: "".try_into().unwrap(),
+            name: "TestTupleEnum".try_into().unwrap(),
+            cases: [
+                ScSpecUdtUnionCaseV0::TupleV0(ScSpecUdtUnionCaseTupleV0 {
+                    doc: "".try_into().unwrap(),
+                    name: "Tuple".try_into().unwrap(),
+                    type_: [ScSpecTypeDef::U32].try_into().unwrap(),
+                }),
+                ScSpecUdtUnionCaseV0::TupleV0(ScSpecUdtUnionCaseTupleV0 {
+                    doc: "".try_into().unwrap(),
+                    name: "TestTuple".try_into().unwrap(),
+                    type_: [ScSpecTypeDef::I32].try_into().unwrap(),
+                }),
+            ]
+            .try_into()
+            .unwrap(),
+        }),
+    );
+}
+
+#[test]
+fn test_spec_event() {
+    // `r#TestEvent` must emit its prefix topic as snake_case of the unraw'd
     // struct name ("test_event"), and its fields `r#type` and `r#fn` as "type"
     // and "fn" in declaration order.
     let event_entry = ScSpecEntry::from_xdr(TestEvent::spec_xdr(), Limits::none()).unwrap();

--- a/soroban-sdk/test_snapshots/tests/contract_udt_raw_identifier/test_functional.1.json
+++ b/soroban-sdk/test_snapshots/tests/contract_udt_raw_identifier/test_functional.1.json
@@ -7,6 +7,7 @@
   "auth": [
     [],
     [],
+    [],
     []
   ],
   "ledger": {
@@ -58,38 +59,5 @@
       }
     ]
   },
-  "events": [
-    {
-      "event": {
-        "ext": "v0",
-        "contract_id": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-        "type_": "contract",
-        "body": {
-          "v0": {
-            "topics": [
-              {
-                "symbol": "test_event"
-              },
-              {
-                "u32": 1
-              }
-            ],
-            "data": {
-              "map": [
-                {
-                  "key": {
-                    "symbol": "fn"
-                  },
-                  "val": {
-                    "u32": 1
-                  }
-                }
-              ]
-            }
-          }
-        }
-      },
-      "failed_call": true
-    }
-  ]
+  "events": []
 }

--- a/soroban-sdk/test_snapshots/tests/contract_udt_raw_identifier/test_functional.1.json
+++ b/soroban-sdk/test_snapshots/tests/contract_udt_raw_identifier/test_functional.1.json
@@ -1,0 +1,95 @@
+{
+  "generators": {
+    "address": 1,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 26,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": "ledger_key_contract_instance",
+              "durability": "persistent",
+              "val": {
+                "contract_instance": {
+                  "executable": {
+                    "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  },
+                  "storage": null
+                }
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_code": {
+              "ext": "v0",
+              "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+              "code": ""
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      }
+    ]
+  },
+  "events": [
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+        "type_": "contract",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "test_event"
+              },
+              {
+                "u32": 1
+              }
+            ],
+            "data": {
+              "map": [
+                {
+                  "key": {
+                    "symbol": "fn"
+                  },
+                  "val": {
+                    "u32": 1
+                  }
+                }
+              ]
+            }
+          }
+        }
+      },
+      "failed_call": true
+    }
+  ]
+}


### PR DESCRIPTION
### What

Normalizes raw identifiers (r#) across the Soroban macros so that every name, generated Rust ident, and downstream comparison/sort key uses the unraw'd form of a user's Ident.

For tokens that must refer back to the user's field / variant / fn, the raw Ident is preserved, so it remains valid Rust.

### Why

Fixes #1836 

### Known limitations

None
