### PR TITLE
Update transitive dependency `ethnum` to 1.5.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -643,9 +643,9 @@ checksum = "2bfcf67fea2815c2fc3b90873fae90957be12ff417335dfadc7f52927feb03b2"
 
 [[package]]
 name = "ethnum"
-version = "1.5.0"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b90ca2580b73ab6a1f724b76ca11ab632df820fd6040c336200d2c1df7b3c82c"
+checksum = "40404c3f5f511ec4da6fe866ddf6a717c309fdbb69fbbad7b0f3edab8f2e835f"
 
 [[package]]
 name = "expect-test"

--- a/tests/fuzz/fuzz/Cargo.lock
+++ b/tests/fuzz/fuzz/Cargo.lock
@@ -598,9 +598,9 @@ checksum = "2bfcf67fea2815c2fc3b90873fae90957be12ff417335dfadc7f52927feb03b2"
 
 [[package]]
 name = "ethnum"
-version = "1.5.0"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b90ca2580b73ab6a1f724b76ca11ab632df820fd6040c336200d2c1df7b3c82c"
+checksum = "40404c3f5f511ec4da6fe866ddf6a717c309fdbb69fbbad7b0f3edab8f2e835f"
 
 [[package]]
 name = "ff"


### PR DESCRIPTION
### What

Update transitive dependency `ethnum` to 1.5.3

### Why

This includes a fix for new compiler errors introduce in `nightly-2026-04-18`. [ethnum-rs/pull/58](https://github.com/nlordell/ethnum-rs/pull/58)

### Known limitations

This dependency originates in `rs-stellar-xdr`. We could opt to release a patch version there instead.
