### PR TITLE
Bump stellar-xdr and soroban-env crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -643,9 +643,9 @@ checksum = "2bfcf67fea2815c2fc3b90873fae90957be12ff417335dfadc7f52927feb03b2"
 
 [[package]]
 name = "ethnum"
-version = "1.5.0"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b90ca2580b73ab6a1f724b76ca11ab632df820fd6040c336200d2c1df7b3c82c"
+checksum = "40404c3f5f511ec4da6fe866ddf6a717c309fdbb69fbbad7b0f3edab8f2e835f"
 
 [[package]]
 name = "expect-test"
@@ -1378,9 +1378,9 @@ checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "soroban-builtin-sdk-macros"
-version = "26.1.2"
+version = "26.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df78c69d87834af6a53e47323a8fa02d68d92ab233476c860db643f8d1801cfe"
+checksum = "35a3a2b57b132b800e132d2c81e1818359bb2cf787ca39c61c151d6bd0798403"
 dependencies = [
  "itertools",
  "proc-macro2",
@@ -1390,9 +1390,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-common"
-version = "26.1.2"
+version = "26.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08582c2c21bd3f7b737bcb76db9d4ca473f8349d65f8952a50eeed8823f44aef"
+checksum = "0c76fad735f9622d8aa0fa0c75838d2023a659a0c57638a783b8b2eb967f7822"
 dependencies = [
  "arbitrary",
  "crate-git-revision",
@@ -1409,9 +1409,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-guest"
-version = "26.1.2"
+version = "26.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aad436ff91576ce4c231b474aecd521ccf890df62042fc0234ffc2006b72fa1b"
+checksum = "15aeed6d7a4dc4d3bba65e2ac92f7eeaa664900bbc82e1055e024bf637d74ed3"
 dependencies = [
  "soroban-env-common",
  "static_assertions",
@@ -1419,9 +1419,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-host"
-version = "26.1.2"
+version = "26.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2662cd060f6a3be269e23d0611bd2ea9eb6a0e7db77e11427e09de0efe547f8b"
+checksum = "6fb523456b4efe9cdf869233cff5a2a1a5ebfae8c0acc405e57479c83781a20c"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -1456,9 +1456,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-macros"
-version = "26.1.2"
+version = "26.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d5489ee232e1fa56c817ac57e2cba8b788685c48902928fecbae05cba97f065"
+checksum = "2ada3449bb23c964a88a1bf633ac66ca3ebac2061693f53148b199ce816791d0"
 dependencies = [
  "itertools",
  "proc-macro2",
@@ -1658,9 +1658,9 @@ dependencies = [
 
 [[package]]
 name = "stellar-xdr"
-version = "26.0.0"
+version = "26.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fea3195594b044ea3a5b05906f81d945480825f00db4e3ae7d77526bf546ff3a"
+checksum = "ea6e29c7e1f071c2767916460d006668197843d5d93f0ec8893a26f72a14f595"
 dependencies = [
  "arbitrary",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,17 +30,17 @@ soroban-token-spec = { version = "26.0.0-rc.1", path = "soroban-token-spec" }
 stellar-asset-spec = { version = "26.0.0-rc.1", path = "stellar-asset-spec" }
 
 [workspace.dependencies.soroban-env-common]
-version = "=26.1.2"
+version = "=26.1.3"
 # git = "https://github.com/stellar/rs-soroban-env"
 # rev = "c0e58f94ff2983a09440cef6a54253349fd3c4db"
 
 [workspace.dependencies.soroban-env-guest]
-version = "=26.1.2"
+version = "=26.1.3"
 # git = "https://github.com/stellar/rs-soroban-env"
 # rev = "c0e58f94ff2983a09440cef6a54253349fd3c4db"
 
 [workspace.dependencies.soroban-env-host]
-version = "=26.1.2"
+version = "=26.1.3"
 # git = "https://github.com/stellar/rs-soroban-env"
 # rev = "c0e58f94ff2983a09440cef6a54253349fd3c4db"
 
@@ -48,7 +48,7 @@ version = "=26.1.2"
 version = "=0.0.16"
 
 [workspace.dependencies.stellar-xdr]
-version = "=26.0.0"
+version = "=26.0.1"
 # git = "https://github.com/stellar/rs-stellar-xdr"
 # rev = "dd7a165a193126fd37a751d867bee1cb8f3b55a6"
 default-features = false

--- a/tests/fuzz/fuzz/Cargo.lock
+++ b/tests/fuzz/fuzz/Cargo.lock
@@ -598,9 +598,9 @@ checksum = "2bfcf67fea2815c2fc3b90873fae90957be12ff417335dfadc7f52927feb03b2"
 
 [[package]]
 name = "ethnum"
-version = "1.5.0"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b90ca2580b73ab6a1f724b76ca11ab632df820fd6040c336200d2c1df7b3c82c"
+checksum = "40404c3f5f511ec4da6fe866ddf6a717c309fdbb69fbbad7b0f3edab8f2e835f"
 
 [[package]]
 name = "ff"
@@ -1196,9 +1196,9 @@ checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
 name = "soroban-builtin-sdk-macros"
-version = "26.1.2"
+version = "26.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df78c69d87834af6a53e47323a8fa02d68d92ab233476c860db643f8d1801cfe"
+checksum = "35a3a2b57b132b800e132d2c81e1818359bb2cf787ca39c61c151d6bd0798403"
 dependencies = [
  "itertools",
  "proc-macro2",
@@ -1208,9 +1208,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-common"
-version = "26.1.2"
+version = "26.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08582c2c21bd3f7b737bcb76db9d4ca473f8349d65f8952a50eeed8823f44aef"
+checksum = "0c76fad735f9622d8aa0fa0c75838d2023a659a0c57638a783b8b2eb967f7822"
 dependencies = [
  "arbitrary",
  "crate-git-revision",
@@ -1227,9 +1227,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-guest"
-version = "26.1.2"
+version = "26.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aad436ff91576ce4c231b474aecd521ccf890df62042fc0234ffc2006b72fa1b"
+checksum = "15aeed6d7a4dc4d3bba65e2ac92f7eeaa664900bbc82e1055e024bf637d74ed3"
 dependencies = [
  "soroban-env-common",
  "static_assertions",
@@ -1237,9 +1237,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-host"
-version = "26.1.2"
+version = "26.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2662cd060f6a3be269e23d0611bd2ea9eb6a0e7db77e11427e09de0efe547f8b"
+checksum = "6fb523456b4efe9cdf869233cff5a2a1a5ebfae8c0acc405e57479c83781a20c"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -1274,9 +1274,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-macros"
-version = "26.1.2"
+version = "26.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d5489ee232e1fa56c817ac57e2cba8b788685c48902928fecbae05cba97f065"
+checksum = "2ada3449bb23c964a88a1bf633ac66ca3ebac2061693f53148b199ce816791d0"
 dependencies = [
  "itertools",
  "proc-macro2",
@@ -1428,9 +1428,9 @@ dependencies = [
 
 [[package]]
 name = "stellar-xdr"
-version = "26.0.0"
+version = "26.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fea3195594b044ea3a5b05906f81d945480825f00db4e3ae7d77526bf546ff3a"
+checksum = "ea6e29c7e1f071c2767916460d006668197843d5d93f0ec8893a26f72a14f595"
 dependencies = [
  "arbitrary",
  "base64",


### PR DESCRIPTION
### What

Update the `stellar-xdr` crate to `26.0.1` and the `soroban-env-*` crates to `26.1.3`.

### Why

The crates contain dependency updates to `ethnum` that patch compiler errors introduced in a recent nightly version. See https://github.com/stellar/rs-stellar-xdr/pull/525 for details.

### Known limitations

None
