### PR TITLE
Set empty top-level permissions in claude-review

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -7,6 +7,8 @@ concurrency:
   group: claude-review-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
+permissions: {}
+
 jobs:
   review:
     if: github.event.pull_request.draft == false && github.event.pull_request.head.repo.fork == false


### PR DESCRIPTION
### What

Add `permissions: {}` at the workflow top level in `.github/workflows/claude-review.yml`, after the `concurrency` block and before `jobs`.

### Why

Without an explicit top-level `permissions` block, jobs inherit whatever default `GITHUB_TOKEN` permissions the repository or organization grants. Setting `permissions: {}` at the workflow level enforces zero default permissions and forces every job to opt in to the exact scopes it needs (the `review` job already declares its own `contents: read`, `pull-requests: write`, `id-token: write`). This is the GitHub-recommended least-privilege hardening pattern and prevents future jobs added to this file from silently inheriting broad token scopes.