### PR TITLE
Harden Claude review workflow

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -38,5 +38,9 @@ jobs:
 
             Provide detailed feedback using inline comments for specific issues.
 
+          # --max-turns caps how many tool-use cycles Claude can run, which
+          # bounds token spend per invocation. The allowed `gh pr` commands are
+          # scoped to this PR's number so a misfire can't reach into another PR.
           claude_args: |
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
+            --max-turns 30
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment ${{ github.event.pull_request.number }}:*),Bash(gh pr diff ${{ github.event.pull_request.number }}:*),Bash(gh pr view ${{ github.event.pull_request.number }}:*)"


### PR DESCRIPTION
### What

Apply the best practices to the Claude review workflow:

- Add `--max-turns 30` to bound token spend per invocation.
- Scope the allowed `gh pr` commands to this PR's number so a misfire can't reach into another PR.

### Why

Brings this workflow in line with the Claude-action best practices: capped turns and per-PR-scoped tool patterns. Existing fork exclusion is preserved — fork PRs from outside contributors will not trigger Claude.