### PR TITLE
Preserve cfg attrs for contracttrait default functions

### DIFF
--- a/soroban-sdk-macros/src/derive_args.rs
+++ b/soroban-sdk-macros/src/derive_args.rs
@@ -3,7 +3,7 @@ use proc_macro2::{Span, TokenStream};
 use quote::{format_ident, quote};
 use syn::{Error, FnArg, Lifetime, Type, TypePath, TypeReference};
 
-use crate::syn_ext;
+use crate::{attribute::pass_through_attr_to_gen_code, syn_ext};
 
 pub fn derive_args_type(ty: &str, name: &str) -> TokenStream {
     let ty_str = quote!(#ty).to_string();
@@ -23,6 +23,11 @@ pub fn derive_args_impl(name: &str, fns: &[syn_ext::Fn]) -> TokenStream {
         .iter()
         .map(|f| {
             let fn_ident = &f.ident;
+            let fn_attrs = f
+                .attrs
+                .iter()
+                .filter(|attr| pass_through_attr_to_gen_code(attr))
+                .collect::<Vec<_>>();
 
             // Check for the Env argument.
             let env_input = f.inputs.first().and_then(|a| match a {
@@ -78,6 +83,7 @@ pub fn derive_args_impl(name: &str, fns: &[syn_ext::Fn]) -> TokenStream {
                 .multiunzip();
 
             quote! {
+                #(#fn_attrs)*
                 #[inline(always)]
                 #[allow(clippy::unused_unit)]
                 pub fn #fn_ident<#fn_input_lifetime>(#(#fn_input_fn_args),*)

--- a/soroban-sdk-macros/src/derive_contractimpl_trait_default_fns_not_overridden.rs
+++ b/soroban-sdk-macros/src/derive_contractimpl_trait_default_fns_not_overridden.rs
@@ -9,8 +9,7 @@ use crate::{
 use darling::{ast::NestedMeta, Error, FromMeta};
 use proc_macro2::{Ident, TokenStream as TokenStream2};
 use quote::quote;
-use std::collections::HashSet;
-use syn::{ext::IdentExt as _, LitStr, Path, Type};
+use syn::{parse_quote, Attribute, LitStr, Path, Type};
 
 // See soroban-sdk/docs/contracttrait.md for documentation on how this works.
 
@@ -53,14 +52,40 @@ fn derive(args: &Args) -> Result<TokenStream2, Error> {
     let spec_export = args.spec_export.unwrap_or(true);
 
     let trait_default_fns = syn_ext::strs_to_fns(&args.trait_default_fns)?;
-    let impl_fn_idents: HashSet<_> = args.impl_fns.iter().map(|s| s.value()).collect();
+    let impl_fns = syn_ext::strs_to_fns(&args.impl_fns)?;
 
     // Filter the list of default fns down to only default fns that have not been redefined /
     // overridden in the input fns.
     let fns = trait_default_fns
         .into_iter()
-        .filter(|f| !impl_fn_idents.contains(&f.ident.unraw().to_string()))
-        .collect::<Vec<_>>();
+        .filter_map(|mut f| {
+            // No matching impl means keep the default. An unconditional impl drops it.
+            // Cfg-gated impls only override the default when their cfg is active, so the
+            // default is kept behind `not(cfg)` to remain available when the impl is absent.
+            let impl_fns = impl_fns
+                .iter()
+                .filter(|impl_fn| impl_fn.ident == f.ident)
+                .collect::<Vec<_>>();
+            if impl_fns.is_empty() {
+                return Some(Ok(f));
+            }
+
+            let mut cfgs = Vec::new();
+            for impl_fn in impl_fns {
+                match cfg_condition(&impl_fn.attrs) {
+                    Ok(Some(cfg)) => cfgs.push(cfg),
+                    Ok(None) => return None,
+                    Err(e) => return Some(Err(e)),
+                }
+            }
+            f.attrs
+                .extend(cfgs.into_iter().map(|cfg| parse_quote!(#[cfg(not(#cfg))])));
+            Some(Ok(f))
+        })
+        .collect::<Result<Vec<_>, Error>>()?;
+    if fns.is_empty() {
+        return Ok(quote! {});
+    }
 
     let mut output = quote! {};
     output.extend(derive_pub_fns(
@@ -81,8 +106,21 @@ fn derive(args: &Args) -> Result<TokenStream2, Error> {
         &args.crate_path,
         &impl_ty,
         Some(trait_ident),
-        fns.iter().map(|f| &f.ident),
+        &fns,
     ));
 
     Ok(output)
+}
+
+fn cfg_condition(attrs: &[Attribute]) -> Result<Option<TokenStream2>, Error> {
+    let cfgs = attrs
+        .iter()
+        .filter(|a| a.path().is_ident("cfg"))
+        .map(|a| a.parse_args::<TokenStream2>().map_err(Error::from))
+        .collect::<Result<Vec<_>, Error>>()?;
+    Ok(match cfgs.as_slice() {
+        [] => None,
+        [cfg] => Some(quote! { #cfg }),
+        _ => Some(quote! { all(#(#cfgs),*) }),
+    })
 }

--- a/soroban-sdk-macros/src/derive_contractimpl_trait_macro.rs
+++ b/soroban-sdk-macros/src/derive_contractimpl_trait_macro.rs
@@ -1,10 +1,13 @@
-use crate::{attribute::is_attr_doc, default_crate_path, syn_ext};
+use crate::{attribute::pass_through_attr_to_gen_code, default_crate_path, syn_ext};
 use darling::{ast::NestedMeta, Error, FromMeta};
 use heck::ToSnakeCase;
 use proc_macro2::{Ident, TokenStream as TokenStream2};
 use quote::ToTokens;
 use quote::{format_ident, quote};
-use syn::{ext::IdentExt as _, parse2, ImplItemFn, ItemTrait, Path, TraitItem, TraitItemFn, Type};
+use syn::{
+    ext::IdentExt as _, parse2, Attribute, ImplItemFn, ItemTrait, Path, TraitItem, TraitItemFn,
+    Type,
+};
 
 // See soroban-sdk/docs/contracttrait.md for documentation on how this works.
 
@@ -49,10 +52,7 @@ fn derive(args: &Args, input: &ItemTrait) -> Result<TokenStream2, Error> {
             sig,
             attrs,
             ..
-        }) => {
-            let doc_attrs: Vec<_> = attrs.iter().filter(|a| is_attr_doc(a)).collect();
-            Some(quote!(#(#doc_attrs)* #sig).to_token_stream().to_string())
-        }
+        }) => Some(fn_string(sig, attrs)),
         _ => None,
     });
 
@@ -90,6 +90,11 @@ fn derive(args: &Args, input: &ItemTrait) -> Result<TokenStream2, Error> {
     Ok(output)
 }
 
+fn fn_string(sig: &syn::Signature, attrs: &[Attribute]) -> String {
+    let attrs = attrs.iter().filter(|a| pass_through_attr_to_gen_code(a));
+    quote!(#(#attrs)* #sig).to_token_stream().to_string()
+}
+
 pub fn generate_call_to_contractimpl_for_trait(
     trait_ident: &Path,
     impl_ident: &Type,
@@ -98,17 +103,24 @@ pub fn generate_call_to_contractimpl_for_trait(
     args_ident: &str,
     spec_ident: &str,
 ) -> TokenStream2 {
-    let impl_fn_idents = pub_methods.iter().map(|f| f.sig.ident.unraw().to_string());
+    let impl_fns = pub_methods.iter().map(impl_fn_string);
     quote! {
         #trait_ident!(
             #trait_ident,
             #impl_ident,
-            [#(#impl_fn_idents),*],
+            [#(#impl_fns),*],
             #client_ident,
             #args_ident,
             #spec_ident,
         );
     }
+}
+
+fn impl_fn_string(f: &ImplItemFn) -> String {
+    let attrs = f.attrs.iter().filter(|a| pass_through_attr_to_gen_code(a));
+    let ident = &f.sig.ident;
+    // Args and return type are stripped; the receiver only needs attrs and ident for override matching.
+    quote!(#(#attrs)* fn #ident()).to_token_stream().to_string()
 }
 
 fn macro_ident(trait_ident: &Ident) -> Ident {

--- a/soroban-sdk-macros/src/derive_fn.rs
+++ b/soroban-sdk-macros/src/derive_fn.rs
@@ -238,21 +238,13 @@ pub fn derive_contract_function_registration_ctor<'a>(
     crate_path: &Path,
     ty: &Type,
     trait_ident: Option<&Path>,
-    method_idents: impl Iterator<Item = &'a Ident>,
+    fns: impl IntoIterator<Item = &'a syn_ext::Fn>,
 ) -> TokenStream2 {
     if cfg!(not(feature = "testutils")) {
         return quote!();
     }
 
     let ty_str = ty_to_safe_ident_str(ty);
-    let (idents, wrap_idents): (Vec<_>, Vec<_>) = method_idents
-        .map(|ident| {
-            let ident_str = ident.unraw().to_string();
-            let wrap_ident = format_ident!("__{}__{}__invoke_raw_slice", ty_str, ident_str);
-            (ident_str, wrap_ident)
-        })
-        .multiunzip();
-
     let trait_str = trait_ident
         .map(|p| {
             p.segments
@@ -262,21 +254,37 @@ pub fn derive_contract_function_registration_ctor<'a>(
                 .join("_")
         })
         .unwrap_or_else(|| "".to_string());
-    let methods_hash = format!("{:x}", Sha256::digest(idents.join(",").as_bytes()));
-    let ctor_ident = format_ident!("__{ty_str}__{trait_str}__{methods_hash}_ctor");
+
+    let ctors = fns
+        .into_iter()
+        .map(|f| {
+            let ident = f.ident.unraw().to_string();
+            let wrap_ident = format_ident!("__{}__{}__invoke_raw_slice", ty_str, ident);
+            let attrs = f
+                .attrs
+                .iter()
+                .filter(|attr| pass_through_attr_to_gen_code(attr) && !attr.path().is_ident("doc"))
+                .collect::<Vec<_>>();
+            let methods_hash =
+                format!("{:x}", Sha256::digest(quote!(#ident #(#attrs)*).to_string()));
+            let ctor_ident = format_ident!("__{ty_str}__{trait_str}__{methods_hash}_ctor");
+            quote! {
+                #[doc(hidden)]
+                #(#attrs)*
+                #[#crate_path::reexports_for_macros::ctor::ctor(crate_path=#crate_path::reexports_for_macros::ctor)]
+                #[allow(non_snake_case)]
+                fn #ctor_ident() {
+                    <#ty as #crate_path::testutils::ContractFunctionRegister>::register(
+                        #ident,
+                        #[allow(deprecated)]
+                        &#wrap_ident,
+                    );
+                }
+            }
+        })
+        .collect::<Vec<_>>();
 
     quote! {
-        #[doc(hidden)]
-        #[#crate_path::reexports_for_macros::ctor::ctor(crate_path=#crate_path::reexports_for_macros::ctor)]
-        #[allow(non_snake_case)]
-        fn #ctor_ident() {
-            #(
-                <#ty as #crate_path::testutils::ContractFunctionRegister>::register(
-                    #idents,
-                    #[allow(deprecated)]
-                    &#wrap_idents,
-                );
-            )*
-        }
+        #(#ctors)*
     }
 }

--- a/soroban-sdk-macros/src/lib.rs
+++ b/soroban-sdk-macros/src/lib.rs
@@ -289,7 +289,7 @@ pub fn contractimpl(metadata: TokenStream, input: TokenStream) -> TokenStream {
                 crate_path,
                 ty,
                 trait_ident,
-                pub_methods.iter().map(|m| &m.sig.ident),
+                &pub_methods_fns,
             );
             output.extend(quote! { #cfs });
 

--- a/soroban-sdk/docs/contracttrait.md
+++ b/soroban-sdk/docs/contracttrait.md
@@ -87,7 +87,11 @@ macro_rules! __contractimpl_for_pause {
 pub use __contractimpl_for_pause as Pause;
 ```
 
-The `trait_default_fns` contains stringified signatures (and documentation) of all functions with default implementations. We serialize function signatures and their documentation into strings because the tooling used to parse macros and values doesn't handle raw tokens well as parameters. This information is "remembered" by the declarative macro for later comparison.
+The `trait_default_fns` contains stringified signatures and pass-through attributes of all functions with default implementations. We serialize function signatures and supported attributes into strings because the tooling used to parse macros and values doesn't handle raw tokens well as parameters. This information is "remembered" by the declarative macro for later comparison.
+
+Direct `#[cfg(...)]` attributes on default functions are preserved in the generated code. For cross-crate traits, function-level cfgs inside a `#[contracttrait]` are evaluated in the implementing contract crate's configuration context when generating wrappers. Shared trait crates should prefer applying cfg to the whole trait item, or require implementing contracts to define matching features when function-level cfgs are needed.
+
+`cfg_attr` is not interpreted by the bridge. Avoid using `cfg_attr` to conditionally add `cfg` to `#[contracttrait]` default functions or `#[contractimpl]` functions, because generated wrappers may not agree with whether Rust compiles the original function. Use direct `#[cfg(...)]` instead.
 
 ### Stage 3: `#[contractimpl(contracttrait)]` calls the trait macro
 
@@ -114,6 +118,8 @@ Pause!(
     //...
 );
 ```
+
+Direct `#[cfg(...)]` attributes on overriding impl functions are preserved, so a cfg-disabled override does not suppress the trait default function.
 
 ### Stage 4: The trait macro calls `contractimpl_trait_default_fns_not_overridden`
 

--- a/tests-expanded/test_account_tests.rs
+++ b/tests-expanded/test_account_tests.rs
@@ -328,6 +328,7 @@ impl Contract {
 }
 impl<'a> ContractClient<'a> {}
 impl ContractArgs {
+    #[allow(non_snake_case)]
     #[inline(always)]
     #[allow(clippy::unused_unit)]
     pub fn __check_auth<'i>(
@@ -408,8 +409,9 @@ pub extern "C" fn __Contract____check_auth__invoke_raw_extern(
 }
 #[doc(hidden)]
 #[allow(non_snake_case)]
+#[allow(non_snake_case)]
 #[allow(unused)]
-fn __Contract__CustomAccountInterface__d465b6861ce11142d9f64c1622e1ad88ae003d910de0a8493889a96a23449736_ctor(
+fn __Contract__CustomAccountInterface__1cb152b3d7e456ec2ef6550a76691e16248c4973551c0ab421ef85c852910b2a_ctor(
 ) {
     #[allow(unsafe_code)]
     {
@@ -422,7 +424,7 @@ fn __Contract__CustomAccountInterface__d465b6861ce11142d9f64c1622e1ad88ae003d910
             #[allow(non_snake_case)]
             extern "C" fn f() -> ::ctor::__support::CtorRetType {
                 unsafe {
-                    __Contract__CustomAccountInterface__d465b6861ce11142d9f64c1622e1ad88ae003d910de0a8493889a96a23449736_ctor();
+                    __Contract__CustomAccountInterface__1cb152b3d7e456ec2ef6550a76691e16248c4973551c0ab421ef85c852910b2a_ctor();
                 };
                 core::default::Default::default()
             }

--- a/tests-expanded/test_account_wasm32v1-none.rs
+++ b/tests-expanded/test_account_wasm32v1-none.rs
@@ -223,6 +223,7 @@ impl Contract {
 }
 impl<'a> ContractClient<'a> {}
 impl ContractArgs {
+    #[allow(non_snake_case)]
     #[inline(always)]
     #[allow(clippy::unused_unit)]
     pub fn __check_auth<'i>(

--- a/tests-expanded/test_add_i128_tests.rs
+++ b/tests-expanded/test_add_i128_tests.rs
@@ -310,7 +310,7 @@ pub extern "C" fn __Contract__add__invoke_raw_extern(
 #[doc(hidden)]
 #[allow(non_snake_case)]
 #[allow(unused)]
-fn __Contract____7e9e5ac30f2216fd0fd6f5faed316f2d5983361a4203c3330cfa46ef65bb4767_ctor() {
+fn __Contract____7b8a6f33b43ca26a3f2aa73e408748f9ceb391ac21dfe746c94563016ab72f85_ctor() {
     #[allow(unsafe_code)]
     {
         #[link_section = ".init_array"]
@@ -322,7 +322,7 @@ fn __Contract____7e9e5ac30f2216fd0fd6f5faed316f2d5983361a4203c3330cfa46ef65bb476
             #[allow(non_snake_case)]
             extern "C" fn f() -> ::ctor::__support::CtorRetType {
                 unsafe {
-                    __Contract____7e9e5ac30f2216fd0fd6f5faed316f2d5983361a4203c3330cfa46ef65bb4767_ctor();
+                    __Contract____7b8a6f33b43ca26a3f2aa73e408748f9ceb391ac21dfe746c94563016ab72f85_ctor();
                 };
                 core::default::Default::default()
             }

--- a/tests-expanded/test_add_u128_tests.rs
+++ b/tests-expanded/test_add_u128_tests.rs
@@ -310,7 +310,7 @@ pub extern "C" fn __Contract__add__invoke_raw_extern(
 #[doc(hidden)]
 #[allow(non_snake_case)]
 #[allow(unused)]
-fn __Contract____7e9e5ac30f2216fd0fd6f5faed316f2d5983361a4203c3330cfa46ef65bb4767_ctor() {
+fn __Contract____7b8a6f33b43ca26a3f2aa73e408748f9ceb391ac21dfe746c94563016ab72f85_ctor() {
     #[allow(unsafe_code)]
     {
         #[link_section = ".init_array"]
@@ -322,7 +322,7 @@ fn __Contract____7e9e5ac30f2216fd0fd6f5faed316f2d5983361a4203c3330cfa46ef65bb476
             #[allow(non_snake_case)]
             extern "C" fn f() -> ::ctor::__support::CtorRetType {
                 unsafe {
-                    __Contract____7e9e5ac30f2216fd0fd6f5faed316f2d5983361a4203c3330cfa46ef65bb4767_ctor();
+                    __Contract____7b8a6f33b43ca26a3f2aa73e408748f9ceb391ac21dfe746c94563016ab72f85_ctor();
                 };
                 core::default::Default::default()
             }

--- a/tests-expanded/test_add_u64_tests.rs
+++ b/tests-expanded/test_add_u64_tests.rs
@@ -898,7 +898,7 @@ pub extern "C" fn __Contract__safe_add_two__invoke_raw_extern(
 #[doc(hidden)]
 #[allow(non_snake_case)]
 #[allow(unused)]
-fn __Contract____6ecf4b81a1826b186b96027a980a40b74ef0e4056b0b7fa44cfd522125765f33_ctor() {
+fn __Contract____7b8a6f33b43ca26a3f2aa73e408748f9ceb391ac21dfe746c94563016ab72f85_ctor() {
     #[allow(unsafe_code)]
     {
         #[link_section = ".init_array"]
@@ -910,7 +910,7 @@ fn __Contract____6ecf4b81a1826b186b96027a980a40b74ef0e4056b0b7fa44cfd522125765f3
             #[allow(non_snake_case)]
             extern "C" fn f() -> ::ctor::__support::CtorRetType {
                 unsafe {
-                    __Contract____6ecf4b81a1826b186b96027a980a40b74ef0e4056b0b7fa44cfd522125765f33_ctor();
+                    __Contract____7b8a6f33b43ca26a3f2aa73e408748f9ceb391ac21dfe746c94563016ab72f85_ctor();
                 };
                 core::default::Default::default()
             }
@@ -923,11 +923,61 @@ fn __Contract____6ecf4b81a1826b186b96027a980a40b74ef0e4056b0b7fa44cfd522125765f3
             #[allow(deprecated)]
             &__Contract__add__invoke_raw_slice,
         );
+    }
+}
+#[doc(hidden)]
+#[allow(non_snake_case)]
+#[allow(unused)]
+fn __Contract____500743733ed8387e9796d514f49ab61d7937c32d85b9f23c7ca3c111acb79236_ctor() {
+    #[allow(unsafe_code)]
+    {
+        #[link_section = ".init_array"]
+        #[used]
+        #[allow(non_upper_case_globals, non_snake_case)]
+        #[doc(hidden)]
+        static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
+            #[link_section = ".text.startup"]
+            #[allow(non_snake_case)]
+            extern "C" fn f() -> ::ctor::__support::CtorRetType {
+                unsafe {
+                    __Contract____500743733ed8387e9796d514f49ab61d7937c32d85b9f23c7ca3c111acb79236_ctor();
+                };
+                core::default::Default::default()
+            }
+            f
+        };
+    }
+    {
         <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
             "safe_add",
             #[allow(deprecated)]
             &__Contract__safe_add__invoke_raw_slice,
         );
+    }
+}
+#[doc(hidden)]
+#[allow(non_snake_case)]
+#[allow(unused)]
+fn __Contract____9b71487e78b9827e35d57f964ccd4eef7015240ed004fda3c6b0b9eca5f79db0_ctor() {
+    #[allow(unsafe_code)]
+    {
+        #[link_section = ".init_array"]
+        #[used]
+        #[allow(non_upper_case_globals, non_snake_case)]
+        #[doc(hidden)]
+        static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
+            #[link_section = ".text.startup"]
+            #[allow(non_snake_case)]
+            extern "C" fn f() -> ::ctor::__support::CtorRetType {
+                unsafe {
+                    __Contract____9b71487e78b9827e35d57f964ccd4eef7015240ed004fda3c6b0b9eca5f79db0_ctor();
+                };
+                core::default::Default::default()
+            }
+            f
+        };
+    }
+    {
         <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
             "safe_add_two",
             #[allow(deprecated)]

--- a/tests-expanded/test_associated_type_chained_tests.rs
+++ b/tests-expanded/test_associated_type_chained_tests.rs
@@ -1372,7 +1372,7 @@ pub extern "C" fn __Contract__valref__invoke_raw_extern(
 #[doc(hidden)]
 #[allow(non_snake_case)]
 #[allow(unused)]
-fn __Contract__AssociatedType__43ee96751c899ff0e1a286858793b710aeacd1f5d72c118904d14312012a0923_ctor(
+fn __Contract__AssociatedType__043c3d7722d3bf11133b7c59f0762088dd24e872b8f205012c43694389734000_ctor(
 ) {
     #[allow(unsafe_code)]
     {
@@ -1385,7 +1385,7 @@ fn __Contract__AssociatedType__43ee96751c899ff0e1a286858793b710aeacd1f5d72c11890
             #[allow(non_snake_case)]
             extern "C" fn f() -> ::ctor::__support::CtorRetType {
                 unsafe {
-                    __Contract__AssociatedType__43ee96751c899ff0e1a286858793b710aeacd1f5d72c118904d14312012a0923_ctor();
+                    __Contract__AssociatedType__043c3d7722d3bf11133b7c59f0762088dd24e872b8f205012c43694389734000_ctor();
                 };
                 core::default::Default::default()
             }
@@ -1398,36 +1398,218 @@ fn __Contract__AssociatedType__43ee96751c899ff0e1a286858793b710aeacd1f5d72c11890
             #[allow(deprecated)]
             &__Contract__set_val__invoke_raw_slice,
         );
+    }
+}
+#[doc(hidden)]
+#[allow(non_snake_case)]
+#[allow(unused)]
+fn __Contract__AssociatedType__046f11281157e6161f86c17a4fd81c73d4a1850f61644945dce482cbfed55104_ctor(
+) {
+    #[allow(unsafe_code)]
+    {
+        #[link_section = ".init_array"]
+        #[used]
+        #[allow(non_upper_case_globals, non_snake_case)]
+        #[doc(hidden)]
+        static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
+            #[link_section = ".text.startup"]
+            #[allow(non_snake_case)]
+            extern "C" fn f() -> ::ctor::__support::CtorRetType {
+                unsafe {
+                    __Contract__AssociatedType__046f11281157e6161f86c17a4fd81c73d4a1850f61644945dce482cbfed55104_ctor();
+                };
+                core::default::Default::default()
+            }
+            f
+        };
+    }
+    {
         <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
             "get_val",
             #[allow(deprecated)]
             &__Contract__get_val__invoke_raw_slice,
         );
+    }
+}
+#[doc(hidden)]
+#[allow(non_snake_case)]
+#[allow(unused)]
+fn __Contract__AssociatedType__6a4adbca11192a326f61110cda055762eb10de529ff037da568d56e23724242d_ctor(
+) {
+    #[allow(unsafe_code)]
+    {
+        #[link_section = ".init_array"]
+        #[used]
+        #[allow(non_upper_case_globals, non_snake_case)]
+        #[doc(hidden)]
+        static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
+            #[link_section = ".text.startup"]
+            #[allow(non_snake_case)]
+            extern "C" fn f() -> ::ctor::__support::CtorRetType {
+                unsafe {
+                    __Contract__AssociatedType__6a4adbca11192a326f61110cda055762eb10de529ff037da568d56e23724242d_ctor();
+                };
+                core::default::Default::default()
+            }
+            f
+        };
+    }
+    {
         <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
             "both",
             #[allow(deprecated)]
             &__Contract__both__invoke_raw_slice,
         );
+    }
+}
+#[doc(hidden)]
+#[allow(non_snake_case)]
+#[allow(unused)]
+fn __Contract__AssociatedType__90670cd5403f9fb2b5808b5ec7b86a35ca487c545db8b4811d7ecfa3ed865b0e_ctor(
+) {
+    #[allow(unsafe_code)]
+    {
+        #[link_section = ".init_array"]
+        #[used]
+        #[allow(non_upper_case_globals, non_snake_case)]
+        #[doc(hidden)]
+        static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
+            #[link_section = ".text.startup"]
+            #[allow(non_snake_case)]
+            extern "C" fn f() -> ::ctor::__support::CtorRetType {
+                unsafe {
+                    __Contract__AssociatedType__90670cd5403f9fb2b5808b5ec7b86a35ca487c545db8b4811d7ecfa3ed865b0e_ctor();
+                };
+                core::default::Default::default()
+            }
+            f
+        };
+    }
+    {
         <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
             "wrapped",
             #[allow(deprecated)]
             &__Contract__wrapped__invoke_raw_slice,
         );
+    }
+}
+#[doc(hidden)]
+#[allow(non_snake_case)]
+#[allow(unused)]
+fn __Contract__AssociatedType__0a6346b590ec54ae0ea2c12e8434f4b54754a90e5014cb1c3e7d34114e12bf06_ctor(
+) {
+    #[allow(unsafe_code)]
+    {
+        #[link_section = ".init_array"]
+        #[used]
+        #[allow(non_upper_case_globals, non_snake_case)]
+        #[doc(hidden)]
+        static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
+            #[link_section = ".text.startup"]
+            #[allow(non_snake_case)]
+            extern "C" fn f() -> ::ctor::__support::CtorRetType {
+                unsafe {
+                    __Contract__AssociatedType__0a6346b590ec54ae0ea2c12e8434f4b54754a90e5014cb1c3e7d34114e12bf06_ctor();
+                };
+                core::default::Default::default()
+            }
+            f
+        };
+    }
+    {
         <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
             "double_wrapped",
             #[allow(deprecated)]
             &__Contract__double_wrapped__invoke_raw_slice,
         );
+    }
+}
+#[doc(hidden)]
+#[allow(non_snake_case)]
+#[allow(unused)]
+fn __Contract__AssociatedType__0340c9867947c79320688763a69ddbf0216e7ee101c4dc188f98ae5d9f506623_ctor(
+) {
+    #[allow(unsafe_code)]
+    {
+        #[link_section = ".init_array"]
+        #[used]
+        #[allow(non_upper_case_globals, non_snake_case)]
+        #[doc(hidden)]
+        static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
+            #[link_section = ".text.startup"]
+            #[allow(non_snake_case)]
+            extern "C" fn f() -> ::ctor::__support::CtorRetType {
+                unsafe {
+                    __Contract__AssociatedType__0340c9867947c79320688763a69ddbf0216e7ee101c4dc188f98ae5d9f506623_ctor();
+                };
+                core::default::Default::default()
+            }
+            f
+        };
+    }
+    {
         <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
             "valval",
             #[allow(deprecated)]
             &__Contract__valval__invoke_raw_slice,
         );
+    }
+}
+#[doc(hidden)]
+#[allow(non_snake_case)]
+#[allow(unused)]
+fn __Contract__AssociatedType__f614f097777ac2441e247db87db9301019e86205ddff588b16dca24ea5560240_ctor(
+) {
+    #[allow(unsafe_code)]
+    {
+        #[link_section = ".init_array"]
+        #[used]
+        #[allow(non_upper_case_globals, non_snake_case)]
+        #[doc(hidden)]
+        static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
+            #[link_section = ".text.startup"]
+            #[allow(non_snake_case)]
+            extern "C" fn f() -> ::ctor::__support::CtorRetType {
+                unsafe {
+                    __Contract__AssociatedType__f614f097777ac2441e247db87db9301019e86205ddff588b16dca24ea5560240_ctor();
+                };
+                core::default::Default::default()
+            }
+            f
+        };
+    }
+    {
         <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
             "tuple",
             #[allow(deprecated)]
             &__Contract__tuple__invoke_raw_slice,
         );
+    }
+}
+#[doc(hidden)]
+#[allow(non_snake_case)]
+#[allow(unused)]
+fn __Contract__AssociatedType__4a93da409cb3081e4ff7ba10a0aca0c1fd9ab13110aae4b03e5b0010226be89a_ctor(
+) {
+    #[allow(unsafe_code)]
+    {
+        #[link_section = ".init_array"]
+        #[used]
+        #[allow(non_upper_case_globals, non_snake_case)]
+        #[doc(hidden)]
+        static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
+            #[link_section = ".text.startup"]
+            #[allow(non_snake_case)]
+            extern "C" fn f() -> ::ctor::__support::CtorRetType {
+                unsafe {
+                    __Contract__AssociatedType__4a93da409cb3081e4ff7ba10a0aca0c1fd9ab13110aae4b03e5b0010226be89a_ctor();
+                };
+                core::default::Default::default()
+            }
+            f
+        };
+    }
+    {
         <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
             "valref",
             #[allow(deprecated)]

--- a/tests-expanded/test_associated_types_contracttrait_tests.rs
+++ b/tests-expanded/test_associated_types_contracttrait_tests.rs
@@ -493,7 +493,7 @@ impl ContractArgs {
 #[doc(hidden)]
 #[allow(non_snake_case)]
 #[allow(unused)]
-fn __Contract__Trait__2706c619fe73f0cf112473c6ee02e66c04e1c01c110b0c37b88d8eb509630c9f_ctor() {
+fn __Contract__Trait__37c9a5bba64484ff1971b80862a96916501e4624e59e717e16e7686f6f41be73_ctor() {
     #[allow(unsafe_code)]
     {
         #[link_section = ".init_array"]
@@ -505,7 +505,7 @@ fn __Contract__Trait__2706c619fe73f0cf112473c6ee02e66c04e1c01c110b0c37b88d8eb509
             #[allow(non_snake_case)]
             extern "C" fn f() -> ::ctor::__support::CtorRetType {
                 unsafe {
-                    __Contract__Trait__2706c619fe73f0cf112473c6ee02e66c04e1c01c110b0c37b88d8eb509630c9f_ctor();
+                    __Contract__Trait__37c9a5bba64484ff1971b80862a96916501e4624e59e717e16e7686f6f41be73_ctor();
                 };
                 core::default::Default::default()
             }
@@ -519,30 +519,6 @@ fn __Contract__Trait__2706c619fe73f0cf112473c6ee02e66c04e1c01c110b0c37b88d8eb509
             &__Contract__exec__invoke_raw_slice,
         );
     }
-}
-#[doc(hidden)]
-#[allow(non_snake_case)]
-#[allow(unused)]
-fn __Contract__Trait__e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855_ctor() {
-    #[allow(unsafe_code)]
-    {
-        #[link_section = ".init_array"]
-        #[used]
-        #[allow(non_upper_case_globals, non_snake_case)]
-        #[doc(hidden)]
-        static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
-            #[link_section = ".text.startup"]
-            #[allow(non_snake_case)]
-            extern "C" fn f() -> ::ctor::__support::CtorRetType {
-                unsafe {
-                    __Contract__Trait__e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855_ctor();
-                };
-                core::default::Default::default()
-            }
-            f
-        };
-    }
-    {}
 }
 pub trait TraitWithoutContractTrait {
     type Impl: Trait;
@@ -706,7 +682,7 @@ pub extern "C" fn __Contract__exec2__invoke_raw_extern() -> soroban_sdk::Val {
 #[doc(hidden)]
 #[allow(non_snake_case)]
 #[allow(unused)]
-fn __Contract__TraitWithoutContractTrait__b85cb430838ad2be2940af63cd34aab7c962ea8738ef61b7759fbac5a916bc1c_ctor(
+fn __Contract__TraitWithoutContractTrait__942987ac160acf81de596b765a56290d5629304f9b57083258d78e8ba633ab49_ctor(
 ) {
     #[allow(unsafe_code)]
     {
@@ -719,7 +695,7 @@ fn __Contract__TraitWithoutContractTrait__b85cb430838ad2be2940af63cd34aab7c962ea
             #[allow(non_snake_case)]
             extern "C" fn f() -> ::ctor::__support::CtorRetType {
                 unsafe {
-                    __Contract__TraitWithoutContractTrait__b85cb430838ad2be2940af63cd34aab7c962ea8738ef61b7759fbac5a916bc1c_ctor();
+                    __Contract__TraitWithoutContractTrait__942987ac160acf81de596b765a56290d5629304f9b57083258d78e8ba633ab49_ctor();
                 };
                 core::default::Default::default()
             }

--- a/tests-expanded/test_associated_types_tests.rs
+++ b/tests-expanded/test_associated_types_tests.rs
@@ -299,7 +299,7 @@ pub extern "C" fn __Contract__exec__invoke_raw_extern() -> soroban_sdk::Val {
 #[doc(hidden)]
 #[allow(non_snake_case)]
 #[allow(unused)]
-fn __Contract__Trait__2706c619fe73f0cf112473c6ee02e66c04e1c01c110b0c37b88d8eb509630c9f_ctor() {
+fn __Contract__Trait__37c9a5bba64484ff1971b80862a96916501e4624e59e717e16e7686f6f41be73_ctor() {
     #[allow(unsafe_code)]
     {
         #[link_section = ".init_array"]
@@ -311,7 +311,7 @@ fn __Contract__Trait__2706c619fe73f0cf112473c6ee02e66c04e1c01c110b0c37b88d8eb509
             #[allow(non_snake_case)]
             extern "C" fn f() -> ::ctor::__support::CtorRetType {
                 unsafe {
-                    __Contract__Trait__2706c619fe73f0cf112473c6ee02e66c04e1c01c110b0c37b88d8eb509630c9f_ctor();
+                    __Contract__Trait__37c9a5bba64484ff1971b80862a96916501e4624e59e717e16e7686f6f41be73_ctor();
                 };
                 core::default::Default::default()
             }

--- a/tests-expanded/test_auth_tests.rs
+++ b/tests-expanded/test_auth_tests.rs
@@ -294,7 +294,7 @@ pub extern "C" fn __ContractA__fn1__invoke_raw_extern(arg_0: soroban_sdk::Val) -
 #[doc(hidden)]
 #[allow(non_snake_case)]
 #[allow(unused)]
-fn __ContractA____7c3764b58a7ababbe8a6b452f6a400d8ae3704b80f8c5ea1b251eebbc8698020_ctor() {
+fn __ContractA____24d525105ae50e25bf56fee614149028cd5fe74524b7274b058a180444f2778a_ctor() {
     #[allow(unsafe_code)]
     {
         #[link_section = ".init_array"]
@@ -306,7 +306,7 @@ fn __ContractA____7c3764b58a7ababbe8a6b452f6a400d8ae3704b80f8c5ea1b251eebbc86980
             #[allow(non_snake_case)]
             extern "C" fn f() -> ::ctor::__support::CtorRetType {
                 unsafe {
-                    __ContractA____7c3764b58a7ababbe8a6b452f6a400d8ae3704b80f8c5ea1b251eebbc8698020_ctor();
+                    __ContractA____24d525105ae50e25bf56fee614149028cd5fe74524b7274b058a180444f2778a_ctor();
                 };
                 core::default::Default::default()
             }
@@ -821,6 +821,7 @@ mod test_a {
         }
         impl<'a> ContractClient<'a> {}
         impl ContractArgs {
+            #[allow(non_snake_case)]
             #[inline(always)]
             #[allow(clippy::unused_unit)]
             pub fn __check_auth<'i>(
@@ -900,8 +901,9 @@ mod test_a {
         }
         #[doc(hidden)]
         #[allow(non_snake_case)]
+        #[allow(non_snake_case)]
         #[allow(unused)]
-        fn __Contract____d465b6861ce11142d9f64c1622e1ad88ae003d910de0a8493889a96a23449736_ctor() {
+        fn __Contract____1cb152b3d7e456ec2ef6550a76691e16248c4973551c0ab421ef85c852910b2a_ctor() {
             #[allow(unsafe_code)]
             {
                 #[link_section = ".init_array"]
@@ -913,7 +915,7 @@ mod test_a {
                     #[allow(non_snake_case)]
                     extern "C" fn f() -> ::ctor::__support::CtorRetType {
                         unsafe {
-                            __Contract____d465b6861ce11142d9f64c1622e1ad88ae003d910de0a8493889a96a23449736_ctor();
+                            __Contract____1cb152b3d7e456ec2ef6550a76691e16248c4973551c0ab421ef85c852910b2a_ctor();
                         };
                         core::default::Default::default()
                     }
@@ -1264,6 +1266,7 @@ mod test_a {
         }
         impl<'a> ContractClient<'a> {}
         impl ContractArgs {
+            #[allow(non_snake_case)]
             #[inline(always)]
             #[allow(clippy::unused_unit)]
             pub fn __check_auth<'i>(
@@ -1343,8 +1346,9 @@ mod test_a {
         }
         #[doc(hidden)]
         #[allow(non_snake_case)]
+        #[allow(non_snake_case)]
         #[allow(unused)]
-        fn __Contract____d465b6861ce11142d9f64c1622e1ad88ae003d910de0a8493889a96a23449736_ctor() {
+        fn __Contract____1cb152b3d7e456ec2ef6550a76691e16248c4973551c0ab421ef85c852910b2a_ctor() {
             #[allow(unsafe_code)]
             {
                 #[link_section = ".init_array"]
@@ -1356,7 +1360,7 @@ mod test_a {
                     #[allow(non_snake_case)]
                     extern "C" fn f() -> ::ctor::__support::CtorRetType {
                         unsafe {
-                            __Contract____d465b6861ce11142d9f64c1622e1ad88ae003d910de0a8493889a96a23449736_ctor();
+                            __Contract____1cb152b3d7e456ec2ef6550a76691e16248c4973551c0ab421ef85c852910b2a_ctor();
                         };
                         core::default::Default::default()
                     }
@@ -1681,7 +1685,7 @@ pub extern "C" fn __ContractB__fn2__invoke_raw_extern(
 #[doc(hidden)]
 #[allow(non_snake_case)]
 #[allow(unused)]
-fn __ContractB____389cfcb1cb10680376b4cd5cf632e6b11c3e59494c10e1d42514faf6c4c21b84_ctor() {
+fn __ContractB____278958ee50661aa4b4af9b0b91a68df2da10001cf396d44f9b886953ed383cb1_ctor() {
     #[allow(unsafe_code)]
     {
         #[link_section = ".init_array"]
@@ -1693,7 +1697,7 @@ fn __ContractB____389cfcb1cb10680376b4cd5cf632e6b11c3e59494c10e1d42514faf6c4c21b
             #[allow(non_snake_case)]
             extern "C" fn f() -> ::ctor::__support::CtorRetType {
                 unsafe {
-                    __ContractB____389cfcb1cb10680376b4cd5cf632e6b11c3e59494c10e1d42514faf6c4c21b84_ctor();
+                    __ContractB____278958ee50661aa4b4af9b0b91a68df2da10001cf396d44f9b886953ed383cb1_ctor();
                 };
                 core::default::Default::default()
             }
@@ -2303,6 +2307,7 @@ mod test_b {
         }
         impl<'a> ContractClient<'a> {}
         impl ContractArgs {
+            #[allow(non_snake_case)]
             #[inline(always)]
             #[allow(clippy::unused_unit)]
             pub fn __check_auth<'i>(
@@ -2382,8 +2387,9 @@ mod test_b {
         }
         #[doc(hidden)]
         #[allow(non_snake_case)]
+        #[allow(non_snake_case)]
         #[allow(unused)]
-        fn __Contract____d465b6861ce11142d9f64c1622e1ad88ae003d910de0a8493889a96a23449736_ctor() {
+        fn __Contract____1cb152b3d7e456ec2ef6550a76691e16248c4973551c0ab421ef85c852910b2a_ctor() {
             #[allow(unsafe_code)]
             {
                 #[link_section = ".init_array"]
@@ -2395,7 +2401,7 @@ mod test_b {
                     #[allow(non_snake_case)]
                     extern "C" fn f() -> ::ctor::__support::CtorRetType {
                         unsafe {
-                            __Contract____d465b6861ce11142d9f64c1622e1ad88ae003d910de0a8493889a96a23449736_ctor();
+                            __Contract____1cb152b3d7e456ec2ef6550a76691e16248c4973551c0ab421ef85c852910b2a_ctor();
                         };
                         core::default::Default::default()
                     }
@@ -2746,6 +2752,7 @@ mod test_b {
         }
         impl<'a> ContractClient<'a> {}
         impl ContractArgs {
+            #[allow(non_snake_case)]
             #[inline(always)]
             #[allow(clippy::unused_unit)]
             pub fn __check_auth<'i>(
@@ -2825,8 +2832,9 @@ mod test_b {
         }
         #[doc(hidden)]
         #[allow(non_snake_case)]
+        #[allow(non_snake_case)]
         #[allow(unused)]
-        fn __Contract____d465b6861ce11142d9f64c1622e1ad88ae003d910de0a8493889a96a23449736_ctor() {
+        fn __Contract____1cb152b3d7e456ec2ef6550a76691e16248c4973551c0ab421ef85c852910b2a_ctor() {
             #[allow(unsafe_code)]
             {
                 #[link_section = ".init_array"]
@@ -2838,7 +2846,7 @@ mod test_b {
                     #[allow(non_snake_case)]
                     extern "C" fn f() -> ::ctor::__support::CtorRetType {
                         unsafe {
-                            __Contract____d465b6861ce11142d9f64c1622e1ad88ae003d910de0a8493889a96a23449736_ctor();
+                            __Contract____1cb152b3d7e456ec2ef6550a76691e16248c4973551c0ab421ef85c852910b2a_ctor();
                         };
                         core::default::Default::default()
                     }

--- a/tests-expanded/test_bls_tests.rs
+++ b/tests-expanded/test_bls_tests.rs
@@ -1390,7 +1390,7 @@ pub extern "C" fn __Contract__fr_vec_get__invoke_raw_extern(
 #[doc(hidden)]
 #[allow(non_snake_case)]
 #[allow(unused)]
-fn __Contract____9d5f96fce19df1a5d4c4527aba1995b76016454af03e47b778c4fa6ece8e5b9c_ctor() {
+fn __Contract____b10987513f5f289c00c1fa940eefae15ed515f17a01abaa2e239e3baec02e07c_ctor() {
     #[allow(unsafe_code)]
     {
         #[link_section = ".init_array"]
@@ -1402,7 +1402,7 @@ fn __Contract____9d5f96fce19df1a5d4c4527aba1995b76016454af03e47b778c4fa6ece8e5b9
             #[allow(non_snake_case)]
             extern "C" fn f() -> ::ctor::__support::CtorRetType {
                 unsafe {
-                    __Contract____9d5f96fce19df1a5d4c4527aba1995b76016454af03e47b778c4fa6ece8e5b9c_ctor();
+                    __Contract____b10987513f5f289c00c1fa940eefae15ed515f17a01abaa2e239e3baec02e07c_ctor();
                 };
                 core::default::Default::default()
             }
@@ -1415,16 +1415,91 @@ fn __Contract____9d5f96fce19df1a5d4c4527aba1995b76016454af03e47b778c4fa6ece8e5b9
             #[allow(deprecated)]
             &__Contract__g1_mul__invoke_raw_slice,
         );
+    }
+}
+#[doc(hidden)]
+#[allow(non_snake_case)]
+#[allow(unused)]
+fn __Contract____73ebb0f786bcc1e173e57bf24b866a057e03f9195497e4871925a5a2870dda0e_ctor() {
+    #[allow(unsafe_code)]
+    {
+        #[link_section = ".init_array"]
+        #[used]
+        #[allow(non_upper_case_globals, non_snake_case)]
+        #[doc(hidden)]
+        static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
+            #[link_section = ".text.startup"]
+            #[allow(non_snake_case)]
+            extern "C" fn f() -> ::ctor::__support::CtorRetType {
+                unsafe {
+                    __Contract____73ebb0f786bcc1e173e57bf24b866a057e03f9195497e4871925a5a2870dda0e_ctor();
+                };
+                core::default::Default::default()
+            }
+            f
+        };
+    }
+    {
         <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
             "g2_mul",
             #[allow(deprecated)]
             &__Contract__g2_mul__invoke_raw_slice,
         );
+    }
+}
+#[doc(hidden)]
+#[allow(non_snake_case)]
+#[allow(unused)]
+fn __Contract____3a30246396cd1073f0d8225163c8f745aeb73b84289f3d8dc0351eefa7c6067b_ctor() {
+    #[allow(unsafe_code)]
+    {
+        #[link_section = ".init_array"]
+        #[used]
+        #[allow(non_upper_case_globals, non_snake_case)]
+        #[doc(hidden)]
+        static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
+            #[link_section = ".text.startup"]
+            #[allow(non_snake_case)]
+            extern "C" fn f() -> ::ctor::__support::CtorRetType {
+                unsafe {
+                    __Contract____3a30246396cd1073f0d8225163c8f745aeb73b84289f3d8dc0351eefa7c6067b_ctor();
+                };
+                core::default::Default::default()
+            }
+            f
+        };
+    }
+    {
         <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
             "dummy_verify",
             #[allow(deprecated)]
             &__Contract__dummy_verify__invoke_raw_slice,
         );
+    }
+}
+#[doc(hidden)]
+#[allow(non_snake_case)]
+#[allow(unused)]
+fn __Contract____9e3ade73ce788482ef84cd70cd45cedcef549f87a320b687c5994af7c34c4303_ctor() {
+    #[allow(unsafe_code)]
+    {
+        #[link_section = ".init_array"]
+        #[used]
+        #[allow(non_upper_case_globals, non_snake_case)]
+        #[doc(hidden)]
+        static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
+            #[link_section = ".text.startup"]
+            #[allow(non_snake_case)]
+            extern "C" fn f() -> ::ctor::__support::CtorRetType {
+                unsafe {
+                    __Contract____9e3ade73ce788482ef84cd70cd45cedcef549f87a320b687c5994af7c34c4303_ctor();
+                };
+                core::default::Default::default()
+            }
+            f
+        };
+    }
+    {
         <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
             "fr_vec_get",
             #[allow(deprecated)]

--- a/tests-expanded/test_bn254_tests.rs
+++ b/tests-expanded/test_bn254_tests.rs
@@ -1189,7 +1189,7 @@ pub extern "C" fn __Contract__fr_vec_get__invoke_raw_extern(
 #[doc(hidden)]
 #[allow(non_snake_case)]
 #[allow(unused)]
-fn __Contract____791f30cbe20fdd8dd82fcdc2b6465e800581173658019a4bee49e2305925f4e0_ctor() {
+fn __Contract____f69211349cf2de87142804f4ac6227eb957692ae7546be6b71d31056efe84dfd_ctor() {
     #[allow(unsafe_code)]
     {
         #[link_section = ".init_array"]
@@ -1201,7 +1201,7 @@ fn __Contract____791f30cbe20fdd8dd82fcdc2b6465e800581173658019a4bee49e2305925f4e
             #[allow(non_snake_case)]
             extern "C" fn f() -> ::ctor::__support::CtorRetType {
                 unsafe {
-                    __Contract____791f30cbe20fdd8dd82fcdc2b6465e800581173658019a4bee49e2305925f4e0_ctor();
+                    __Contract____f69211349cf2de87142804f4ac6227eb957692ae7546be6b71d31056efe84dfd_ctor();
                 };
                 core::default::Default::default()
             }
@@ -1214,16 +1214,91 @@ fn __Contract____791f30cbe20fdd8dd82fcdc2b6465e800581173658019a4bee49e2305925f4e
             #[allow(deprecated)]
             &__Contract__verify_pairing__invoke_raw_slice,
         );
+    }
+}
+#[doc(hidden)]
+#[allow(non_snake_case)]
+#[allow(unused)]
+fn __Contract____a856e59ee4bfca9be0abaf00e3db6a350099780034adb12c8c5f5e97e9a71180_ctor() {
+    #[allow(unsafe_code)]
+    {
+        #[link_section = ".init_array"]
+        #[used]
+        #[allow(non_upper_case_globals, non_snake_case)]
+        #[doc(hidden)]
+        static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
+            #[link_section = ".text.startup"]
+            #[allow(non_snake_case)]
+            extern "C" fn f() -> ::ctor::__support::CtorRetType {
+                unsafe {
+                    __Contract____a856e59ee4bfca9be0abaf00e3db6a350099780034adb12c8c5f5e97e9a71180_ctor();
+                };
+                core::default::Default::default()
+            }
+            f
+        };
+    }
+    {
         <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
             "g1_add",
             #[allow(deprecated)]
             &__Contract__g1_add__invoke_raw_slice,
         );
+    }
+}
+#[doc(hidden)]
+#[allow(non_snake_case)]
+#[allow(unused)]
+fn __Contract____b10987513f5f289c00c1fa940eefae15ed515f17a01abaa2e239e3baec02e07c_ctor() {
+    #[allow(unsafe_code)]
+    {
+        #[link_section = ".init_array"]
+        #[used]
+        #[allow(non_upper_case_globals, non_snake_case)]
+        #[doc(hidden)]
+        static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
+            #[link_section = ".text.startup"]
+            #[allow(non_snake_case)]
+            extern "C" fn f() -> ::ctor::__support::CtorRetType {
+                unsafe {
+                    __Contract____b10987513f5f289c00c1fa940eefae15ed515f17a01abaa2e239e3baec02e07c_ctor();
+                };
+                core::default::Default::default()
+            }
+            f
+        };
+    }
+    {
         <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
             "g1_mul",
             #[allow(deprecated)]
             &__Contract__g1_mul__invoke_raw_slice,
         );
+    }
+}
+#[doc(hidden)]
+#[allow(non_snake_case)]
+#[allow(unused)]
+fn __Contract____9e3ade73ce788482ef84cd70cd45cedcef549f87a320b687c5994af7c34c4303_ctor() {
+    #[allow(unsafe_code)]
+    {
+        #[link_section = ".init_array"]
+        #[used]
+        #[allow(non_upper_case_globals, non_snake_case)]
+        #[doc(hidden)]
+        static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
+            #[link_section = ".text.startup"]
+            #[allow(non_snake_case)]
+            extern "C" fn f() -> ::ctor::__support::CtorRetType {
+                unsafe {
+                    __Contract____9e3ade73ce788482ef84cd70cd45cedcef549f87a320b687c5994af7c34c4303_ctor();
+                };
+                core::default::Default::default()
+            }
+            f
+        };
+    }
+    {
         <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
             "fr_vec_get",
             #[allow(deprecated)]

--- a/tests-expanded/test_constructor_tests.rs
+++ b/tests-expanded/test_constructor_tests.rs
@@ -944,7 +944,7 @@ pub extern "C" fn __Contract__get_data__invoke_raw_extern(
 #[doc(hidden)]
 #[allow(non_snake_case)]
 #[allow(unused)]
-fn __Contract____99dc7227b32e52c8d11ead5dec3dd80bafdad62d74493e7341c782fd8cb13593_ctor() {
+fn __Contract____61fe4c71dfe26cd6b323dcd34e237c382eb546b841486cb4f1cfe9d81adf2047_ctor() {
     #[allow(unsafe_code)]
     {
         #[link_section = ".init_array"]
@@ -956,7 +956,7 @@ fn __Contract____99dc7227b32e52c8d11ead5dec3dd80bafdad62d74493e7341c782fd8cb1359
             #[allow(non_snake_case)]
             extern "C" fn f() -> ::ctor::__support::CtorRetType {
                 unsafe {
-                    __Contract____99dc7227b32e52c8d11ead5dec3dd80bafdad62d74493e7341c782fd8cb13593_ctor();
+                    __Contract____61fe4c71dfe26cd6b323dcd34e237c382eb546b841486cb4f1cfe9d81adf2047_ctor();
                 };
                 core::default::Default::default()
             }
@@ -969,6 +969,31 @@ fn __Contract____99dc7227b32e52c8d11ead5dec3dd80bafdad62d74493e7341c782fd8cb1359
             #[allow(deprecated)]
             &__Contract____constructor__invoke_raw_slice,
         );
+    }
+}
+#[doc(hidden)]
+#[allow(non_snake_case)]
+#[allow(unused)]
+fn __Contract____400134394a744d5eba8572e931ffe5685eeeef6f0a23dc3398f205a1915e2b4f_ctor() {
+    #[allow(unsafe_code)]
+    {
+        #[link_section = ".init_array"]
+        #[used]
+        #[allow(non_upper_case_globals, non_snake_case)]
+        #[doc(hidden)]
+        static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
+            #[link_section = ".text.startup"]
+            #[allow(non_snake_case)]
+            extern "C" fn f() -> ::ctor::__support::CtorRetType {
+                unsafe {
+                    __Contract____400134394a744d5eba8572e931ffe5685eeeef6f0a23dc3398f205a1915e2b4f_ctor();
+                };
+                core::default::Default::default()
+            }
+            f
+        };
+    }
+    {
         <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
             "get_data",
             #[allow(deprecated)]

--- a/tests-expanded/test_contract_data_tests.rs
+++ b/tests-expanded/test_contract_data_tests.rs
@@ -612,7 +612,7 @@ pub extern "C" fn __Contract__del__invoke_raw_extern(arg_0: soroban_sdk::Val) ->
 #[doc(hidden)]
 #[allow(non_snake_case)]
 #[allow(unused)]
-fn __Contract____0e764744b384ee8739a8810d2509da0f2e8c1cbf45b7a6de3d69726f824c2c8c_ctor() {
+fn __Contract____904a70f064c7bdd5d5cef32143c0ed851472d294f92d14620f76d0ba45f5fad1_ctor() {
     #[allow(unsafe_code)]
     {
         #[link_section = ".init_array"]
@@ -624,7 +624,7 @@ fn __Contract____0e764744b384ee8739a8810d2509da0f2e8c1cbf45b7a6de3d69726f824c2c8
             #[allow(non_snake_case)]
             extern "C" fn f() -> ::ctor::__support::CtorRetType {
                 unsafe {
-                    __Contract____0e764744b384ee8739a8810d2509da0f2e8c1cbf45b7a6de3d69726f824c2c8c_ctor();
+                    __Contract____904a70f064c7bdd5d5cef32143c0ed851472d294f92d14620f76d0ba45f5fad1_ctor();
                 };
                 core::default::Default::default()
             }
@@ -637,11 +637,61 @@ fn __Contract____0e764744b384ee8739a8810d2509da0f2e8c1cbf45b7a6de3d69726f824c2c8
             #[allow(deprecated)]
             &__Contract__put__invoke_raw_slice,
         );
+    }
+}
+#[doc(hidden)]
+#[allow(non_snake_case)]
+#[allow(unused)]
+fn __Contract____306bcefe5205e5b49a6fdf4319882100f94f12fbb4559d1c94bd72c090cea6ee_ctor() {
+    #[allow(unsafe_code)]
+    {
+        #[link_section = ".init_array"]
+        #[used]
+        #[allow(non_upper_case_globals, non_snake_case)]
+        #[doc(hidden)]
+        static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
+            #[link_section = ".text.startup"]
+            #[allow(non_snake_case)]
+            extern "C" fn f() -> ::ctor::__support::CtorRetType {
+                unsafe {
+                    __Contract____306bcefe5205e5b49a6fdf4319882100f94f12fbb4559d1c94bd72c090cea6ee_ctor();
+                };
+                core::default::Default::default()
+            }
+            f
+        };
+    }
+    {
         <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
             "get",
             #[allow(deprecated)]
             &__Contract__get__invoke_raw_slice,
         );
+    }
+}
+#[doc(hidden)]
+#[allow(non_snake_case)]
+#[allow(unused)]
+fn __Contract____6e4b9bd6602e2306d7bc6d4578eb30cd1bae66faac67d4e18e89b29ca27ce6c8_ctor() {
+    #[allow(unsafe_code)]
+    {
+        #[link_section = ".init_array"]
+        #[used]
+        #[allow(non_upper_case_globals, non_snake_case)]
+        #[doc(hidden)]
+        static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
+            #[link_section = ".text.startup"]
+            #[allow(non_snake_case)]
+            extern "C" fn f() -> ::ctor::__support::CtorRetType {
+                unsafe {
+                    __Contract____6e4b9bd6602e2306d7bc6d4578eb30cd1bae66faac67d4e18e89b29ca27ce6c8_ctor();
+                };
+                core::default::Default::default()
+            }
+            f
+        };
+    }
+    {
         <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
             "del",
             #[allow(deprecated)]

--- a/tests-expanded/test_contracttrait_impl_full_tests.rs
+++ b/tests-expanded/test_contracttrait_impl_full_tests.rs
@@ -8,7 +8,7 @@ use soroban_sdk::{
     contract, contractimpl, Address, Bytes, BytesN, Duration, Map, String, Symbol, Timepoint, Vec,
     I256, U256,
 };
-use test_contracttrait_trait::{AllTypes, MyEnumUnit, MyEnumVariants, MyStruct};
+use test_contracttrait_trait::{AllTypes, CfgGated, MyEnumUnit, MyEnumVariants, MyStruct};
 pub struct Contract;
 ///ContractArgs is a type for building arg lists for functions defined in "Contract".
 pub struct ContractArgs;
@@ -3234,11 +3234,14 @@ impl<'a> ContractClient<'a> {
     }
 }
 impl ContractArgs {
+    /// Test u32 values.
+    /// Returns the input unchanged.
     #[inline(always)]
     #[allow(clippy::unused_unit)]
     pub fn test_u32<'i>(v: &'i u32) -> (&'i u32,) {
         (v,)
     }
+    /// Test i32 values.
     #[inline(always)]
     #[allow(clippy::unused_unit)]
     pub fn test_i32<'i>(v: &'i i32) -> (&'i i32,) {
@@ -3348,7 +3351,7 @@ impl ContractArgs {
 #[doc(hidden)]
 #[allow(non_snake_case)]
 #[allow(unused)]
-fn __Contract__AllTypes__959aee9d42336ade92416504111dfbb4e37b0472bbb1e487310c05a170c39d28_ctor() {
+fn __Contract__AllTypes__53d758cb364e30212244bac7f86701cb2cd52ec2d1e81aa422edf52088793ca1_ctor() {
     #[allow(unsafe_code)]
     {
         #[link_section = ".init_array"]
@@ -3360,7 +3363,7 @@ fn __Contract__AllTypes__959aee9d42336ade92416504111dfbb4e37b0472bbb1e487310c05a
             #[allow(non_snake_case)]
             extern "C" fn f() -> ::ctor::__support::CtorRetType {
                 unsafe {
-                    __Contract__AllTypes__959aee9d42336ade92416504111dfbb4e37b0472bbb1e487310c05a170c39d28_ctor();
+                    __Contract__AllTypes__53d758cb364e30212244bac7f86701cb2cd52ec2d1e81aa422edf52088793ca1_ctor();
                 };
                 core::default::Default::default()
             }
@@ -3373,117 +3376,12 @@ fn __Contract__AllTypes__959aee9d42336ade92416504111dfbb4e37b0472bbb1e487310c05a
             #[allow(deprecated)]
             &__Contract__test_u32__invoke_raw_slice,
         );
-        <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
-            "test_i32",
-            #[allow(deprecated)]
-            &__Contract__test_i32__invoke_raw_slice,
-        );
-        <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
-            "test_u64",
-            #[allow(deprecated)]
-            &__Contract__test_u64__invoke_raw_slice,
-        );
-        <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
-            "test_i64",
-            #[allow(deprecated)]
-            &__Contract__test_i64__invoke_raw_slice,
-        );
-        <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
-            "test_u128",
-            #[allow(deprecated)]
-            &__Contract__test_u128__invoke_raw_slice,
-        );
-        <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
-            "test_i128",
-            #[allow(deprecated)]
-            &__Contract__test_i128__invoke_raw_slice,
-        );
-        <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
-            "test_bool",
-            #[allow(deprecated)]
-            &__Contract__test_bool__invoke_raw_slice,
-        );
-        <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
-            "test_address",
-            #[allow(deprecated)]
-            &__Contract__test_address__invoke_raw_slice,
-        );
-        <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
-            "test_bytes",
-            #[allow(deprecated)]
-            &__Contract__test_bytes__invoke_raw_slice,
-        );
-        <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
-            "test_bytes_n",
-            #[allow(deprecated)]
-            &__Contract__test_bytes_n__invoke_raw_slice,
-        );
-        <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
-            "test_string",
-            #[allow(deprecated)]
-            &__Contract__test_string__invoke_raw_slice,
-        );
-        <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
-            "test_symbol",
-            #[allow(deprecated)]
-            &__Contract__test_symbol__invoke_raw_slice,
-        );
-        <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
-            "test_vec",
-            #[allow(deprecated)]
-            &__Contract__test_vec__invoke_raw_slice,
-        );
-        <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
-            "test_map",
-            #[allow(deprecated)]
-            &__Contract__test_map__invoke_raw_slice,
-        );
-        <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
-            "test_duration",
-            #[allow(deprecated)]
-            &__Contract__test_duration__invoke_raw_slice,
-        );
-        <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
-            "test_timepoint",
-            #[allow(deprecated)]
-            &__Contract__test_timepoint__invoke_raw_slice,
-        );
-        <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
-            "test_i256",
-            #[allow(deprecated)]
-            &__Contract__test_i256__invoke_raw_slice,
-        );
-        <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
-            "test_u256",
-            #[allow(deprecated)]
-            &__Contract__test_u256__invoke_raw_slice,
-        );
-        <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
-            "test_env_param",
-            #[allow(deprecated)]
-            &__Contract__test_env_param__invoke_raw_slice,
-        );
-        <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
-            "test_struct",
-            #[allow(deprecated)]
-            &__Contract__test_struct__invoke_raw_slice,
-        );
-        <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
-            "test_enum_unit",
-            #[allow(deprecated)]
-            &__Contract__test_enum_unit__invoke_raw_slice,
-        );
-        <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
-            "test_enum_variants",
-            #[allow(deprecated)]
-            &__Contract__test_enum_variants__invoke_raw_slice,
-        );
     }
 }
 #[doc(hidden)]
 #[allow(non_snake_case)]
 #[allow(unused)]
-fn __Contract__AllTypes__e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855_ctor() {
+fn __Contract__AllTypes__fc0e53ecfa4163838da8f2017151f32594d5d3960028ec820f6052edb4a84059_ctor() {
     #[allow(unsafe_code)]
     {
         #[link_section = ".init_array"]
@@ -3495,14 +3393,925 @@ fn __Contract__AllTypes__e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991
             #[allow(non_snake_case)]
             extern "C" fn f() -> ::ctor::__support::CtorRetType {
                 unsafe {
-                    __Contract__AllTypes__e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855_ctor();
+                    __Contract__AllTypes__fc0e53ecfa4163838da8f2017151f32594d5d3960028ec820f6052edb4a84059_ctor();
                 };
                 core::default::Default::default()
             }
             f
         };
     }
-    {}
+    {
+        <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
+            "test_i32",
+            #[allow(deprecated)]
+            &__Contract__test_i32__invoke_raw_slice,
+        );
+    }
+}
+#[doc(hidden)]
+#[allow(non_snake_case)]
+#[allow(unused)]
+fn __Contract__AllTypes__b770dfe9b2adeb806c45d6b5ef3d31c7b9c987740d9a583ed8e1683b5debdb75_ctor() {
+    #[allow(unsafe_code)]
+    {
+        #[link_section = ".init_array"]
+        #[used]
+        #[allow(non_upper_case_globals, non_snake_case)]
+        #[doc(hidden)]
+        static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
+            #[link_section = ".text.startup"]
+            #[allow(non_snake_case)]
+            extern "C" fn f() -> ::ctor::__support::CtorRetType {
+                unsafe {
+                    __Contract__AllTypes__b770dfe9b2adeb806c45d6b5ef3d31c7b9c987740d9a583ed8e1683b5debdb75_ctor();
+                };
+                core::default::Default::default()
+            }
+            f
+        };
+    }
+    {
+        <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
+            "test_u64",
+            #[allow(deprecated)]
+            &__Contract__test_u64__invoke_raw_slice,
+        );
+    }
+}
+#[doc(hidden)]
+#[allow(non_snake_case)]
+#[allow(unused)]
+fn __Contract__AllTypes__c7e2f7ef9f571dc3460d8b374883a38011169cfe419aa02ad69ddbff73b746d7_ctor() {
+    #[allow(unsafe_code)]
+    {
+        #[link_section = ".init_array"]
+        #[used]
+        #[allow(non_upper_case_globals, non_snake_case)]
+        #[doc(hidden)]
+        static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
+            #[link_section = ".text.startup"]
+            #[allow(non_snake_case)]
+            extern "C" fn f() -> ::ctor::__support::CtorRetType {
+                unsafe {
+                    __Contract__AllTypes__c7e2f7ef9f571dc3460d8b374883a38011169cfe419aa02ad69ddbff73b746d7_ctor();
+                };
+                core::default::Default::default()
+            }
+            f
+        };
+    }
+    {
+        <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
+            "test_i64",
+            #[allow(deprecated)]
+            &__Contract__test_i64__invoke_raw_slice,
+        );
+    }
+}
+#[doc(hidden)]
+#[allow(non_snake_case)]
+#[allow(unused)]
+fn __Contract__AllTypes__1f04aa8787240d34edecbbf647ed2ed836655df078df79a8b7d5840e300aae9d_ctor() {
+    #[allow(unsafe_code)]
+    {
+        #[link_section = ".init_array"]
+        #[used]
+        #[allow(non_upper_case_globals, non_snake_case)]
+        #[doc(hidden)]
+        static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
+            #[link_section = ".text.startup"]
+            #[allow(non_snake_case)]
+            extern "C" fn f() -> ::ctor::__support::CtorRetType {
+                unsafe {
+                    __Contract__AllTypes__1f04aa8787240d34edecbbf647ed2ed836655df078df79a8b7d5840e300aae9d_ctor();
+                };
+                core::default::Default::default()
+            }
+            f
+        };
+    }
+    {
+        <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
+            "test_u128",
+            #[allow(deprecated)]
+            &__Contract__test_u128__invoke_raw_slice,
+        );
+    }
+}
+#[doc(hidden)]
+#[allow(non_snake_case)]
+#[allow(unused)]
+fn __Contract__AllTypes__21c197ddff91b560d684eefa2ec923ac1edb7ba246d887790999555f1f1082b4_ctor() {
+    #[allow(unsafe_code)]
+    {
+        #[link_section = ".init_array"]
+        #[used]
+        #[allow(non_upper_case_globals, non_snake_case)]
+        #[doc(hidden)]
+        static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
+            #[link_section = ".text.startup"]
+            #[allow(non_snake_case)]
+            extern "C" fn f() -> ::ctor::__support::CtorRetType {
+                unsafe {
+                    __Contract__AllTypes__21c197ddff91b560d684eefa2ec923ac1edb7ba246d887790999555f1f1082b4_ctor();
+                };
+                core::default::Default::default()
+            }
+            f
+        };
+    }
+    {
+        <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
+            "test_i128",
+            #[allow(deprecated)]
+            &__Contract__test_i128__invoke_raw_slice,
+        );
+    }
+}
+#[doc(hidden)]
+#[allow(non_snake_case)]
+#[allow(unused)]
+fn __Contract__AllTypes__4b66c68c88167c0df99dce45fb5157ceb3781fd75f46e2d96e1313a46c234164_ctor() {
+    #[allow(unsafe_code)]
+    {
+        #[link_section = ".init_array"]
+        #[used]
+        #[allow(non_upper_case_globals, non_snake_case)]
+        #[doc(hidden)]
+        static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
+            #[link_section = ".text.startup"]
+            #[allow(non_snake_case)]
+            extern "C" fn f() -> ::ctor::__support::CtorRetType {
+                unsafe {
+                    __Contract__AllTypes__4b66c68c88167c0df99dce45fb5157ceb3781fd75f46e2d96e1313a46c234164_ctor();
+                };
+                core::default::Default::default()
+            }
+            f
+        };
+    }
+    {
+        <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
+            "test_bool",
+            #[allow(deprecated)]
+            &__Contract__test_bool__invoke_raw_slice,
+        );
+    }
+}
+#[doc(hidden)]
+#[allow(non_snake_case)]
+#[allow(unused)]
+fn __Contract__AllTypes__d78659c68ad1cfce2ad440653013d25977b451539dd6f219c8e1e8b875d23c14_ctor() {
+    #[allow(unsafe_code)]
+    {
+        #[link_section = ".init_array"]
+        #[used]
+        #[allow(non_upper_case_globals, non_snake_case)]
+        #[doc(hidden)]
+        static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
+            #[link_section = ".text.startup"]
+            #[allow(non_snake_case)]
+            extern "C" fn f() -> ::ctor::__support::CtorRetType {
+                unsafe {
+                    __Contract__AllTypes__d78659c68ad1cfce2ad440653013d25977b451539dd6f219c8e1e8b875d23c14_ctor();
+                };
+                core::default::Default::default()
+            }
+            f
+        };
+    }
+    {
+        <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
+            "test_address",
+            #[allow(deprecated)]
+            &__Contract__test_address__invoke_raw_slice,
+        );
+    }
+}
+#[doc(hidden)]
+#[allow(non_snake_case)]
+#[allow(unused)]
+fn __Contract__AllTypes__d8369e1d7eccf342204ebd3114d6abb3261652c93b0722901964ebc9a2b869ac_ctor() {
+    #[allow(unsafe_code)]
+    {
+        #[link_section = ".init_array"]
+        #[used]
+        #[allow(non_upper_case_globals, non_snake_case)]
+        #[doc(hidden)]
+        static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
+            #[link_section = ".text.startup"]
+            #[allow(non_snake_case)]
+            extern "C" fn f() -> ::ctor::__support::CtorRetType {
+                unsafe {
+                    __Contract__AllTypes__d8369e1d7eccf342204ebd3114d6abb3261652c93b0722901964ebc9a2b869ac_ctor();
+                };
+                core::default::Default::default()
+            }
+            f
+        };
+    }
+    {
+        <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
+            "test_bytes",
+            #[allow(deprecated)]
+            &__Contract__test_bytes__invoke_raw_slice,
+        );
+    }
+}
+#[doc(hidden)]
+#[allow(non_snake_case)]
+#[allow(unused)]
+fn __Contract__AllTypes__4263283d1487792fb25a9666db2bcf4b7cb85d1596eddd530b28e3dea11ca98e_ctor() {
+    #[allow(unsafe_code)]
+    {
+        #[link_section = ".init_array"]
+        #[used]
+        #[allow(non_upper_case_globals, non_snake_case)]
+        #[doc(hidden)]
+        static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
+            #[link_section = ".text.startup"]
+            #[allow(non_snake_case)]
+            extern "C" fn f() -> ::ctor::__support::CtorRetType {
+                unsafe {
+                    __Contract__AllTypes__4263283d1487792fb25a9666db2bcf4b7cb85d1596eddd530b28e3dea11ca98e_ctor();
+                };
+                core::default::Default::default()
+            }
+            f
+        };
+    }
+    {
+        <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
+            "test_bytes_n",
+            #[allow(deprecated)]
+            &__Contract__test_bytes_n__invoke_raw_slice,
+        );
+    }
+}
+#[doc(hidden)]
+#[allow(non_snake_case)]
+#[allow(unused)]
+fn __Contract__AllTypes__a1a211ad36b73f745fe11cbbe5a3b7111710436824119d305f34af1842e457c4_ctor() {
+    #[allow(unsafe_code)]
+    {
+        #[link_section = ".init_array"]
+        #[used]
+        #[allow(non_upper_case_globals, non_snake_case)]
+        #[doc(hidden)]
+        static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
+            #[link_section = ".text.startup"]
+            #[allow(non_snake_case)]
+            extern "C" fn f() -> ::ctor::__support::CtorRetType {
+                unsafe {
+                    __Contract__AllTypes__a1a211ad36b73f745fe11cbbe5a3b7111710436824119d305f34af1842e457c4_ctor();
+                };
+                core::default::Default::default()
+            }
+            f
+        };
+    }
+    {
+        <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
+            "test_string",
+            #[allow(deprecated)]
+            &__Contract__test_string__invoke_raw_slice,
+        );
+    }
+}
+#[doc(hidden)]
+#[allow(non_snake_case)]
+#[allow(unused)]
+fn __Contract__AllTypes__d218b946ac71446987caada5b1ddd9a88071593dc7947a9b5e0c9684f58016d1_ctor() {
+    #[allow(unsafe_code)]
+    {
+        #[link_section = ".init_array"]
+        #[used]
+        #[allow(non_upper_case_globals, non_snake_case)]
+        #[doc(hidden)]
+        static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
+            #[link_section = ".text.startup"]
+            #[allow(non_snake_case)]
+            extern "C" fn f() -> ::ctor::__support::CtorRetType {
+                unsafe {
+                    __Contract__AllTypes__d218b946ac71446987caada5b1ddd9a88071593dc7947a9b5e0c9684f58016d1_ctor();
+                };
+                core::default::Default::default()
+            }
+            f
+        };
+    }
+    {
+        <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
+            "test_symbol",
+            #[allow(deprecated)]
+            &__Contract__test_symbol__invoke_raw_slice,
+        );
+    }
+}
+#[doc(hidden)]
+#[allow(non_snake_case)]
+#[allow(unused)]
+fn __Contract__AllTypes__3dab3b2e67a5258edc6046d3b3cb677c43a508a69de5786d8a34361ad5c12e80_ctor() {
+    #[allow(unsafe_code)]
+    {
+        #[link_section = ".init_array"]
+        #[used]
+        #[allow(non_upper_case_globals, non_snake_case)]
+        #[doc(hidden)]
+        static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
+            #[link_section = ".text.startup"]
+            #[allow(non_snake_case)]
+            extern "C" fn f() -> ::ctor::__support::CtorRetType {
+                unsafe {
+                    __Contract__AllTypes__3dab3b2e67a5258edc6046d3b3cb677c43a508a69de5786d8a34361ad5c12e80_ctor();
+                };
+                core::default::Default::default()
+            }
+            f
+        };
+    }
+    {
+        <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
+            "test_vec",
+            #[allow(deprecated)]
+            &__Contract__test_vec__invoke_raw_slice,
+        );
+    }
+}
+#[doc(hidden)]
+#[allow(non_snake_case)]
+#[allow(unused)]
+fn __Contract__AllTypes__26529164027f0c953c7b3a907b09c5e144a82b6430185ad98603b636b4b3b349_ctor() {
+    #[allow(unsafe_code)]
+    {
+        #[link_section = ".init_array"]
+        #[used]
+        #[allow(non_upper_case_globals, non_snake_case)]
+        #[doc(hidden)]
+        static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
+            #[link_section = ".text.startup"]
+            #[allow(non_snake_case)]
+            extern "C" fn f() -> ::ctor::__support::CtorRetType {
+                unsafe {
+                    __Contract__AllTypes__26529164027f0c953c7b3a907b09c5e144a82b6430185ad98603b636b4b3b349_ctor();
+                };
+                core::default::Default::default()
+            }
+            f
+        };
+    }
+    {
+        <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
+            "test_map",
+            #[allow(deprecated)]
+            &__Contract__test_map__invoke_raw_slice,
+        );
+    }
+}
+#[doc(hidden)]
+#[allow(non_snake_case)]
+#[allow(unused)]
+fn __Contract__AllTypes__152e048563476cac8dd28938f3c41518456072e651f690c6b1ea6814466aea27_ctor() {
+    #[allow(unsafe_code)]
+    {
+        #[link_section = ".init_array"]
+        #[used]
+        #[allow(non_upper_case_globals, non_snake_case)]
+        #[doc(hidden)]
+        static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
+            #[link_section = ".text.startup"]
+            #[allow(non_snake_case)]
+            extern "C" fn f() -> ::ctor::__support::CtorRetType {
+                unsafe {
+                    __Contract__AllTypes__152e048563476cac8dd28938f3c41518456072e651f690c6b1ea6814466aea27_ctor();
+                };
+                core::default::Default::default()
+            }
+            f
+        };
+    }
+    {
+        <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
+            "test_duration",
+            #[allow(deprecated)]
+            &__Contract__test_duration__invoke_raw_slice,
+        );
+    }
+}
+#[doc(hidden)]
+#[allow(non_snake_case)]
+#[allow(unused)]
+fn __Contract__AllTypes__6ab993c9945db4a3067443e6b98939664c9b314387f62bdaaccf83a79f172330_ctor() {
+    #[allow(unsafe_code)]
+    {
+        #[link_section = ".init_array"]
+        #[used]
+        #[allow(non_upper_case_globals, non_snake_case)]
+        #[doc(hidden)]
+        static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
+            #[link_section = ".text.startup"]
+            #[allow(non_snake_case)]
+            extern "C" fn f() -> ::ctor::__support::CtorRetType {
+                unsafe {
+                    __Contract__AllTypes__6ab993c9945db4a3067443e6b98939664c9b314387f62bdaaccf83a79f172330_ctor();
+                };
+                core::default::Default::default()
+            }
+            f
+        };
+    }
+    {
+        <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
+            "test_timepoint",
+            #[allow(deprecated)]
+            &__Contract__test_timepoint__invoke_raw_slice,
+        );
+    }
+}
+#[doc(hidden)]
+#[allow(non_snake_case)]
+#[allow(unused)]
+fn __Contract__AllTypes__720f8551818518259a0743a812712dcfb905b3c817117e017891bbf6229633f2_ctor() {
+    #[allow(unsafe_code)]
+    {
+        #[link_section = ".init_array"]
+        #[used]
+        #[allow(non_upper_case_globals, non_snake_case)]
+        #[doc(hidden)]
+        static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
+            #[link_section = ".text.startup"]
+            #[allow(non_snake_case)]
+            extern "C" fn f() -> ::ctor::__support::CtorRetType {
+                unsafe {
+                    __Contract__AllTypes__720f8551818518259a0743a812712dcfb905b3c817117e017891bbf6229633f2_ctor();
+                };
+                core::default::Default::default()
+            }
+            f
+        };
+    }
+    {
+        <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
+            "test_i256",
+            #[allow(deprecated)]
+            &__Contract__test_i256__invoke_raw_slice,
+        );
+    }
+}
+#[doc(hidden)]
+#[allow(non_snake_case)]
+#[allow(unused)]
+fn __Contract__AllTypes__c11a38375965f06d3e70c95d14652a94d7d10c85964c69ff29449fd1fdd684df_ctor() {
+    #[allow(unsafe_code)]
+    {
+        #[link_section = ".init_array"]
+        #[used]
+        #[allow(non_upper_case_globals, non_snake_case)]
+        #[doc(hidden)]
+        static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
+            #[link_section = ".text.startup"]
+            #[allow(non_snake_case)]
+            extern "C" fn f() -> ::ctor::__support::CtorRetType {
+                unsafe {
+                    __Contract__AllTypes__c11a38375965f06d3e70c95d14652a94d7d10c85964c69ff29449fd1fdd684df_ctor();
+                };
+                core::default::Default::default()
+            }
+            f
+        };
+    }
+    {
+        <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
+            "test_u256",
+            #[allow(deprecated)]
+            &__Contract__test_u256__invoke_raw_slice,
+        );
+    }
+}
+#[doc(hidden)]
+#[allow(non_snake_case)]
+#[allow(unused)]
+fn __Contract__AllTypes__d66789a1d5c62b2e13ce77eb51642b42a21d817718902956ded0ca9720c4f2c2_ctor() {
+    #[allow(unsafe_code)]
+    {
+        #[link_section = ".init_array"]
+        #[used]
+        #[allow(non_upper_case_globals, non_snake_case)]
+        #[doc(hidden)]
+        static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
+            #[link_section = ".text.startup"]
+            #[allow(non_snake_case)]
+            extern "C" fn f() -> ::ctor::__support::CtorRetType {
+                unsafe {
+                    __Contract__AllTypes__d66789a1d5c62b2e13ce77eb51642b42a21d817718902956ded0ca9720c4f2c2_ctor();
+                };
+                core::default::Default::default()
+            }
+            f
+        };
+    }
+    {
+        <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
+            "test_env_param",
+            #[allow(deprecated)]
+            &__Contract__test_env_param__invoke_raw_slice,
+        );
+    }
+}
+#[doc(hidden)]
+#[allow(non_snake_case)]
+#[allow(unused)]
+fn __Contract__AllTypes__8eddde8d361a1a64147292e9556cb28d1efeec7df66b8064c5cc8af95e9b9bad_ctor() {
+    #[allow(unsafe_code)]
+    {
+        #[link_section = ".init_array"]
+        #[used]
+        #[allow(non_upper_case_globals, non_snake_case)]
+        #[doc(hidden)]
+        static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
+            #[link_section = ".text.startup"]
+            #[allow(non_snake_case)]
+            extern "C" fn f() -> ::ctor::__support::CtorRetType {
+                unsafe {
+                    __Contract__AllTypes__8eddde8d361a1a64147292e9556cb28d1efeec7df66b8064c5cc8af95e9b9bad_ctor();
+                };
+                core::default::Default::default()
+            }
+            f
+        };
+    }
+    {
+        <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
+            "test_struct",
+            #[allow(deprecated)]
+            &__Contract__test_struct__invoke_raw_slice,
+        );
+    }
+}
+#[doc(hidden)]
+#[allow(non_snake_case)]
+#[allow(unused)]
+fn __Contract__AllTypes__4a069ddc7591bc91505072ab63fbb531eadd377db8acb22014e849a66a1e26e0_ctor() {
+    #[allow(unsafe_code)]
+    {
+        #[link_section = ".init_array"]
+        #[used]
+        #[allow(non_upper_case_globals, non_snake_case)]
+        #[doc(hidden)]
+        static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
+            #[link_section = ".text.startup"]
+            #[allow(non_snake_case)]
+            extern "C" fn f() -> ::ctor::__support::CtorRetType {
+                unsafe {
+                    __Contract__AllTypes__4a069ddc7591bc91505072ab63fbb531eadd377db8acb22014e849a66a1e26e0_ctor();
+                };
+                core::default::Default::default()
+            }
+            f
+        };
+    }
+    {
+        <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
+            "test_enum_unit",
+            #[allow(deprecated)]
+            &__Contract__test_enum_unit__invoke_raw_slice,
+        );
+    }
+}
+#[doc(hidden)]
+#[allow(non_snake_case)]
+#[allow(unused)]
+fn __Contract__AllTypes__d2b0ba6d429ff899ab7fa1f5126ecddb66bdaec3f51d9aabaa916af14c3079a8_ctor() {
+    #[allow(unsafe_code)]
+    {
+        #[link_section = ".init_array"]
+        #[used]
+        #[allow(non_upper_case_globals, non_snake_case)]
+        #[doc(hidden)]
+        static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
+            #[link_section = ".text.startup"]
+            #[allow(non_snake_case)]
+            extern "C" fn f() -> ::ctor::__support::CtorRetType {
+                unsafe {
+                    __Contract__AllTypes__d2b0ba6d429ff899ab7fa1f5126ecddb66bdaec3f51d9aabaa916af14c3079a8_ctor();
+                };
+                core::default::Default::default()
+            }
+            f
+        };
+    }
+    {
+        <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
+            "test_enum_variants",
+            #[allow(deprecated)]
+            &__Contract__test_enum_variants__invoke_raw_slice,
+        );
+    }
+}
+pub struct CfgGatedContract;
+///CfgGatedContractArgs is a type for building arg lists for functions defined in "CfgGatedContract".
+pub struct CfgGatedContractArgs;
+///CfgGatedContractClient is a client for calling the contract defined in "CfgGatedContract".
+pub struct CfgGatedContractClient<'a> {
+    pub env: soroban_sdk::Env,
+    pub address: soroban_sdk::Address,
+    #[doc(hidden)]
+    set_auths: Option<&'a [soroban_sdk::xdr::SorobanAuthorizationEntry]>,
+    #[doc(hidden)]
+    mock_auths: Option<&'a [soroban_sdk::testutils::MockAuth<'a>]>,
+    #[doc(hidden)]
+    mock_all_auths: bool,
+    #[doc(hidden)]
+    allow_non_root_auth: bool,
+}
+impl<'a> CfgGatedContractClient<'a> {
+    pub fn new(env: &soroban_sdk::Env, address: &soroban_sdk::Address) -> Self {
+        Self {
+            env: env.clone(),
+            address: address.clone(),
+            set_auths: None,
+            mock_auths: None,
+            mock_all_auths: false,
+            allow_non_root_auth: false,
+        }
+    }
+    /// Set authorizations in the environment which will be consumed by
+    /// contracts when they invoke `Address::require_auth` or
+    /// `Address::require_auth_for_args` functions.
+    ///
+    /// Requires valid signatures for the authorization to be successful.
+    /// To mock auth without requiring valid signatures, use `mock_auths`.
+    ///
+    /// See `soroban_sdk::Env::set_auths` for more details and examples.
+    pub fn set_auths(&self, auths: &'a [soroban_sdk::xdr::SorobanAuthorizationEntry]) -> Self {
+        Self {
+            env: self.env.clone(),
+            address: self.address.clone(),
+            set_auths: Some(auths),
+            mock_auths: self.mock_auths.clone(),
+            mock_all_auths: false,
+            allow_non_root_auth: false,
+        }
+    }
+    /// Mock authorizations in the environment which will cause matching invokes
+    /// of `Address::require_auth` and `Address::require_auth_for_args` to
+    /// pass.
+    ///
+    /// See `soroban_sdk::Env::set_auths` for more details and examples.
+    pub fn mock_auths(&self, mock_auths: &'a [soroban_sdk::testutils::MockAuth<'a>]) -> Self {
+        Self {
+            env: self.env.clone(),
+            address: self.address.clone(),
+            set_auths: self.set_auths.clone(),
+            mock_auths: Some(mock_auths),
+            mock_all_auths: false,
+            allow_non_root_auth: false,
+        }
+    }
+    /// Mock all calls to the `Address::require_auth` and
+    /// `Address::require_auth_for_args` functions in invoked contracts,
+    /// having them succeed as if authorization was provided.
+    ///
+    /// See `soroban_sdk::Env::mock_all_auths` for more details and
+    /// examples.
+    pub fn mock_all_auths(&self) -> Self {
+        Self {
+            env: self.env.clone(),
+            address: self.address.clone(),
+            set_auths: None,
+            mock_auths: None,
+            mock_all_auths: true,
+            allow_non_root_auth: false,
+        }
+    }
+    /// A version of `mock_all_auths` that allows authorizations that
+    /// are not present in the root invocation.
+    ///
+    /// Refer to `mock_all_auths` documentation for details and
+    /// prefer using `mock_all_auths` unless non-root authorization is
+    /// required.
+    ///
+    /// See `soroban_sdk::Env::mock_all_auths_allowing_non_root_auth`
+    /// for more details and examples.
+    pub fn mock_all_auths_allowing_non_root_auth(&self) -> Self {
+        Self {
+            env: self.env.clone(),
+            address: self.address.clone(),
+            set_auths: None,
+            mock_auths: None,
+            mock_all_auths: true,
+            allow_non_root_auth: true,
+        }
+    }
+}
+mod __cfggatedcontract_fn_set_registry {
+    use super::*;
+    extern crate std;
+    use std::collections::BTreeMap;
+    use std::sync::Mutex;
+    pub type F = soroban_sdk::testutils::ContractFunctionF;
+    static FUNCS: Mutex<BTreeMap<&'static str, &'static F>> = Mutex::new(BTreeMap::new());
+    pub fn register(name: &'static str, func: &'static F) {
+        FUNCS.lock().unwrap().insert(name, func);
+    }
+    pub fn call(
+        name: &str,
+        env: soroban_sdk::Env,
+        args: &[soroban_sdk::Val],
+    ) -> Option<soroban_sdk::Val> {
+        let fopt: Option<&'static F> = FUNCS.lock().unwrap().get(name).map(|f| f.clone());
+        fopt.map(|f| f(env, args))
+    }
+}
+impl soroban_sdk::testutils::ContractFunctionRegister for CfgGatedContract {
+    fn register(name: &'static str, func: &'static __cfggatedcontract_fn_set_registry::F) {
+        __cfggatedcontract_fn_set_registry::register(name, func);
+    }
+}
+#[doc(hidden)]
+impl soroban_sdk::testutils::ContractFunctionSet for CfgGatedContract {
+    fn call(
+        &self,
+        func: &str,
+        env: soroban_sdk::Env,
+        args: &[soroban_sdk::Val],
+    ) -> Option<soroban_sdk::Val> {
+        __cfggatedcontract_fn_set_registry::call(func, env, args)
+    }
+}
+impl CfgGated for CfgGatedContract {}
+impl<'a> CfgGatedContractClient<'a> {}
+impl CfgGatedContractArgs {}
+#[doc(hidden)]
+#[allow(non_snake_case)]
+#[deprecated(note = "use `CfgGatedContractClient::new(&env, &contract_id).shown` instead")]
+#[allow(deprecated)]
+pub fn __CfgGatedContract__shown__invoke_raw(env: soroban_sdk::Env) -> soroban_sdk::Val {
+    soroban_sdk::IntoValForContractFn::into_val_for_contract_fn(
+        <CfgGatedContract as CfgGated>::shown(env.clone()),
+        &env,
+    )
+}
+#[doc(hidden)]
+#[allow(non_snake_case)]
+#[deprecated(note = "use `CfgGatedContractClient::new(&env, &contract_id).shown` instead")]
+pub fn __CfgGatedContract__shown__invoke_raw_slice(
+    env: soroban_sdk::Env,
+    args: &[soroban_sdk::Val],
+) -> soroban_sdk::Val {
+    if args.len() != 0usize {
+        {
+            ::core::panicking::panic_fmt(format_args!(
+                "invalid number of input arguments: {0} expected, got {1}",
+                0usize,
+                args.len(),
+            ));
+        };
+    }
+    #[allow(deprecated)]
+    __CfgGatedContract__shown__invoke_raw(env)
+}
+#[doc(hidden)]
+#[allow(non_snake_case)]
+#[deprecated(note = "use `CfgGatedContractClient::new(&env, &contract_id).shown` instead")]
+pub extern "C" fn __CfgGatedContract__shown__invoke_raw_extern() -> soroban_sdk::Val {
+    #[allow(deprecated)]
+    __CfgGatedContract__shown__invoke_raw(soroban_sdk::Env::default())
+}
+impl CfgGatedContract {}
+#[doc(hidden)]
+#[allow(non_snake_case)]
+pub mod __CfgGatedContract__shown__spec {
+    #[doc(hidden)]
+    #[allow(non_snake_case)]
+    #[allow(non_upper_case_globals)]
+    pub static __SPEC_XDR_FN_SHOWN: [u8; 32usize] = super::CfgGatedContract::spec_xdr_shown();
+}
+impl CfgGatedContract {
+    #[allow(non_snake_case)]
+    pub const fn spec_xdr_shown() -> [u8; 32usize] {
+        *b"\0\0\0\0\0\0\0\0\0\0\0\x05shown\0\0\0\0\0\0\0\0\0\0\x01\0\0\0\x04"
+    }
+}
+impl CfgGatedContract {}
+impl<'a> CfgGatedContractClient<'a> {
+    pub fn shown(&self) -> u32 {
+        use core::ops::Not;
+        let old_auth_manager = self
+            .env
+            .in_contract()
+            .not()
+            .then(|| self.env.host().snapshot_auth_manager().unwrap());
+        {
+            if let Some(set_auths) = self.set_auths {
+                self.env.set_auths(set_auths);
+            }
+            if let Some(mock_auths) = self.mock_auths {
+                self.env.mock_auths(mock_auths);
+            }
+            if self.mock_all_auths {
+                if self.allow_non_root_auth {
+                    self.env.mock_all_auths_allowing_non_root_auth();
+                } else {
+                    self.env.mock_all_auths();
+                }
+            }
+        }
+        use soroban_sdk::{FromVal, IntoVal};
+        let res = self.env.invoke_contract(
+            &self.address,
+            &{
+                #[allow(deprecated)]
+                const SYMBOL: soroban_sdk::Symbol = soroban_sdk::Symbol::short("shown");
+                SYMBOL
+            },
+            ::soroban_sdk::Vec::new(&self.env),
+        );
+        if let Some(old_auth_manager) = old_auth_manager {
+            self.env.host().set_auth_manager(old_auth_manager).unwrap();
+        }
+        res
+    }
+    pub fn try_shown(
+        &self,
+    ) -> Result<
+        Result<u32, <u32 as soroban_sdk::TryFromVal<soroban_sdk::Env, soroban_sdk::Val>>::Error>,
+        Result<soroban_sdk::Error, soroban_sdk::InvokeError>,
+    > {
+        use core::ops::Not;
+        let old_auth_manager = self
+            .env
+            .in_contract()
+            .not()
+            .then(|| self.env.host().snapshot_auth_manager().unwrap());
+        {
+            if let Some(set_auths) = self.set_auths {
+                self.env.set_auths(set_auths);
+            }
+            if let Some(mock_auths) = self.mock_auths {
+                self.env.mock_auths(mock_auths);
+            }
+            if self.mock_all_auths {
+                if self.allow_non_root_auth {
+                    self.env.mock_all_auths_allowing_non_root_auth();
+                } else {
+                    self.env.mock_all_auths();
+                }
+            }
+        }
+        use soroban_sdk::{FromVal, IntoVal};
+        let res = self.env.try_invoke_contract(
+            &self.address,
+            &{
+                #[allow(deprecated)]
+                const SYMBOL: soroban_sdk::Symbol = soroban_sdk::Symbol::short("shown");
+                SYMBOL
+            },
+            ::soroban_sdk::Vec::new(&self.env),
+        );
+        if let Some(old_auth_manager) = old_auth_manager {
+            self.env.host().set_auth_manager(old_auth_manager).unwrap();
+        }
+        res
+    }
+}
+impl CfgGatedContractArgs {
+    #[inline(always)]
+    #[allow(clippy::unused_unit)]
+    pub fn shown<'i>() -> () {
+        ()
+    }
+}
+#[doc(hidden)]
+#[allow(non_snake_case)]
+#[allow(unused)]
+fn __CfgGatedContract__CfgGated__f4db9ab03a219f9ef1cecf98c7ccfdc83419274753acb76e2f464116514bd341_ctor(
+) {
+    #[allow(unsafe_code)]
+    {
+        #[link_section = ".init_array"]
+        #[used]
+        #[allow(non_upper_case_globals, non_snake_case)]
+        #[doc(hidden)]
+        static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
+            #[link_section = ".text.startup"]
+            #[allow(non_snake_case)]
+            extern "C" fn f() -> ::ctor::__support::CtorRetType {
+                unsafe {
+                    __CfgGatedContract__CfgGated__f4db9ab03a219f9ef1cecf98c7ccfdc83419274753acb76e2f464116514bd341_ctor();
+                };
+                core::default::Default::default()
+            }
+            f
+        };
+    }
+    {
+        <CfgGatedContract as soroban_sdk::testutils::ContractFunctionRegister>::register(
+            "shown",
+            #[allow(deprecated)]
+            &__CfgGatedContract__shown__invoke_raw_slice,
+        );
+    }
 }
 mod test {
     use super::*;
@@ -3516,9 +4325,9 @@ mod test {
             ignore: false,
             ignore_message: ::core::option::Option::None,
             source_file: "tests/contracttrait_impl_full/src/lib.rs",
-            start_line: 20usize,
+            start_line: 26usize,
             start_col: 8usize,
-            end_line: 20usize,
+            end_line: 26usize,
             end_col: 36usize,
             compile_fail: false,
             no_run: false,
@@ -3838,11 +4647,55 @@ mod test {
             }
         };
     }
+    extern crate test;
+    #[rustc_test_marker = "test::test_cross_crate_cfg_gated_default_fn"]
+    #[doc(hidden)]
+    pub const test_cross_crate_cfg_gated_default_fn: test::TestDescAndFn = test::TestDescAndFn {
+        desc: test::TestDesc {
+            name: test::StaticTestName("test::test_cross_crate_cfg_gated_default_fn"),
+            ignore: false,
+            ignore_message: ::core::option::Option::None,
+            source_file: "tests/contracttrait_impl_full/src/lib.rs",
+            start_line: 89usize,
+            start_col: 8usize,
+            end_line: 89usize,
+            end_col: 45usize,
+            compile_fail: false,
+            no_run: false,
+            should_panic: test::ShouldPanic::No,
+            test_type: test::TestType::UnitTest,
+        },
+        testfn: test::StaticTestFn(
+            #[coverage(off)]
+            || test::assert_test_result(test_cross_crate_cfg_gated_default_fn()),
+        ),
+    };
+    fn test_cross_crate_cfg_gated_default_fn() {
+        let e = Env::default();
+        let contract_id = e.register(CfgGatedContract, ());
+        let client = CfgGatedContractClient::new(&e, &contract_id);
+        match (&client.shown(), &8) {
+            (left_val, right_val) => {
+                if !(*left_val == *right_val) {
+                    let kind = ::core::panicking::AssertKind::Eq;
+                    ::core::panicking::assert_failed(
+                        kind,
+                        &*left_val,
+                        &*right_val,
+                        ::core::option::Option::None,
+                    );
+                }
+            }
+        };
+    }
 }
 #[rustc_main]
 #[coverage(off)]
 #[doc(hidden)]
 pub fn main() -> () {
     extern crate test;
-    test::test_main_static(&[&test_cross_crate_default_fns])
+    test::test_main_static(&[
+        &test_cross_crate_cfg_gated_default_fn,
+        &test_cross_crate_default_fns,
+    ])
 }

--- a/tests-expanded/test_contracttrait_impl_full_wasm32v1-none.rs
+++ b/tests-expanded/test_contracttrait_impl_full_wasm32v1-none.rs
@@ -8,7 +8,7 @@ use soroban_sdk::{
     contract, contractimpl, Address, Bytes, BytesN, Duration, Map, String, Symbol, Timepoint, Vec,
     I256, U256,
 };
-use test_contracttrait_trait::{AllTypes, MyEnumUnit, MyEnumVariants, MyStruct};
+use test_contracttrait_trait::{AllTypes, CfgGated, MyEnumUnit, MyEnumVariants, MyStruct};
 pub struct Contract;
 ///ContractArgs is a type for building arg lists for functions defined in "Contract".
 pub struct ContractArgs;
@@ -1711,11 +1711,14 @@ impl<'a> ContractClient<'a> {
     }
 }
 impl ContractArgs {
+    /// Test u32 values.
+    /// Returns the input unchanged.
     #[inline(always)]
     #[allow(clippy::unused_unit)]
     pub fn test_u32<'i>(v: &'i u32) -> (&'i u32,) {
         (v,)
     }
+    /// Test i32 values.
     #[inline(always)]
     #[allow(clippy::unused_unit)]
     pub fn test_i32<'i>(v: &'i i32) -> (&'i i32,) {
@@ -1820,5 +1823,103 @@ impl ContractArgs {
     #[allow(clippy::unused_unit)]
     pub fn test_enum_variants<'i>(v: &'i MyEnumVariants) -> (&'i MyEnumVariants,) {
         (v,)
+    }
+}
+pub struct CfgGatedContract;
+///CfgGatedContractArgs is a type for building arg lists for functions defined in "CfgGatedContract".
+pub struct CfgGatedContractArgs;
+///CfgGatedContractClient is a client for calling the contract defined in "CfgGatedContract".
+pub struct CfgGatedContractClient<'a> {
+    pub env: soroban_sdk::Env,
+    pub address: soroban_sdk::Address,
+    #[doc(hidden)]
+    _phantom: core::marker::PhantomData<&'a ()>,
+}
+impl<'a> CfgGatedContractClient<'a> {
+    pub fn new(env: &soroban_sdk::Env, address: &soroban_sdk::Address) -> Self {
+        Self {
+            env: env.clone(),
+            address: address.clone(),
+            _phantom: core::marker::PhantomData,
+        }
+    }
+}
+impl CfgGated for CfgGatedContract {}
+impl<'a> CfgGatedContractClient<'a> {}
+impl CfgGatedContractArgs {}
+#[doc(hidden)]
+#[allow(non_snake_case)]
+#[deprecated(note = "use `CfgGatedContractClient::new(&env, &contract_id).shown` instead")]
+#[allow(deprecated)]
+pub fn __CfgGatedContract__shown__invoke_raw(env: soroban_sdk::Env) -> soroban_sdk::Val {
+    soroban_sdk::IntoValForContractFn::into_val_for_contract_fn(
+        <CfgGatedContract as CfgGated>::shown(env.clone()),
+        &env,
+    )
+}
+#[doc(hidden)]
+#[allow(non_snake_case)]
+#[deprecated(note = "use `CfgGatedContractClient::new(&env, &contract_id).shown` instead")]
+#[export_name = "shown"]
+pub extern "C" fn __CfgGatedContract__shown__invoke_raw_extern() -> soroban_sdk::Val {
+    #[allow(deprecated)]
+    __CfgGatedContract__shown__invoke_raw(soroban_sdk::Env::default())
+}
+impl CfgGatedContract {}
+#[doc(hidden)]
+#[allow(non_snake_case)]
+pub mod __CfgGatedContract__shown__spec {
+    #[doc(hidden)]
+    #[allow(non_snake_case)]
+    #[allow(non_upper_case_globals)]
+    #[link_section = "contractspecv0"]
+    pub static __SPEC_XDR_FN_SHOWN: [u8; 32usize] = super::CfgGatedContract::spec_xdr_shown();
+}
+impl CfgGatedContract {
+    #[allow(non_snake_case)]
+    pub const fn spec_xdr_shown() -> [u8; 32usize] {
+        *b"\0\0\0\0\0\0\0\0\0\0\0\x05shown\0\0\0\0\0\0\0\0\0\0\x01\0\0\0\x04"
+    }
+}
+impl CfgGatedContract {}
+impl<'a> CfgGatedContractClient<'a> {
+    pub fn shown(&self) -> u32 {
+        use core::ops::Not;
+        use soroban_sdk::{FromVal, IntoVal};
+        let res = self.env.invoke_contract(
+            &self.address,
+            &{
+                #[allow(deprecated)]
+                const SYMBOL: soroban_sdk::Symbol = soroban_sdk::Symbol::short("shown");
+                SYMBOL
+            },
+            ::soroban_sdk::Vec::new(&self.env),
+        );
+        res
+    }
+    pub fn try_shown(
+        &self,
+    ) -> Result<
+        Result<u32, <u32 as soroban_sdk::TryFromVal<soroban_sdk::Env, soroban_sdk::Val>>::Error>,
+        Result<soroban_sdk::Error, soroban_sdk::InvokeError>,
+    > {
+        use soroban_sdk::{FromVal, IntoVal};
+        let res = self.env.try_invoke_contract(
+            &self.address,
+            &{
+                #[allow(deprecated)]
+                const SYMBOL: soroban_sdk::Symbol = soroban_sdk::Symbol::short("shown");
+                SYMBOL
+            },
+            ::soroban_sdk::Vec::new(&self.env),
+        );
+        res
+    }
+}
+impl CfgGatedContractArgs {
+    #[inline(always)]
+    #[allow(clippy::unused_unit)]
+    pub fn shown<'i>() -> () {
+        ()
     }
 }

--- a/tests-expanded/test_contracttrait_impl_partial_tests.rs
+++ b/tests-expanded/test_contracttrait_impl_partial_tests.rs
@@ -3256,6 +3256,7 @@ impl<'a> ContractClient<'a> {
     }
 }
 impl ContractArgs {
+    /// Test i32 values.
     #[inline(always)]
     #[allow(clippy::unused_unit)]
     pub fn test_i32<'i>(v: &'i i32) -> (&'i i32,) {
@@ -3350,7 +3351,7 @@ impl ContractArgs {
 #[doc(hidden)]
 #[allow(non_snake_case)]
 #[allow(unused)]
-fn __Contract__AllTypes__447a3d427d821f62365afd21ac9b6fa9597c9d71324b5cba7631f732f3b74d84_ctor() {
+fn __Contract__AllTypes__fc0e53ecfa4163838da8f2017151f32594d5d3960028ec820f6052edb4a84059_ctor() {
     #[allow(unsafe_code)]
     {
         #[link_section = ".init_array"]
@@ -3362,7 +3363,7 @@ fn __Contract__AllTypes__447a3d427d821f62365afd21ac9b6fa9597c9d71324b5cba7631f73
             #[allow(non_snake_case)]
             extern "C" fn f() -> ::ctor::__support::CtorRetType {
                 unsafe {
-                    __Contract__AllTypes__447a3d427d821f62365afd21ac9b6fa9597c9d71324b5cba7631f732f3b74d84_ctor();
+                    __Contract__AllTypes__fc0e53ecfa4163838da8f2017151f32594d5d3960028ec820f6052edb4a84059_ctor();
                 };
                 core::default::Default::default()
             }
@@ -3375,97 +3376,12 @@ fn __Contract__AllTypes__447a3d427d821f62365afd21ac9b6fa9597c9d71324b5cba7631f73
             #[allow(deprecated)]
             &__Contract__test_i32__invoke_raw_slice,
         );
-        <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
-            "test_u64",
-            #[allow(deprecated)]
-            &__Contract__test_u64__invoke_raw_slice,
-        );
-        <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
-            "test_i64",
-            #[allow(deprecated)]
-            &__Contract__test_i64__invoke_raw_slice,
-        );
-        <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
-            "test_u128",
-            #[allow(deprecated)]
-            &__Contract__test_u128__invoke_raw_slice,
-        );
-        <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
-            "test_i128",
-            #[allow(deprecated)]
-            &__Contract__test_i128__invoke_raw_slice,
-        );
-        <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
-            "test_bool",
-            #[allow(deprecated)]
-            &__Contract__test_bool__invoke_raw_slice,
-        );
-        <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
-            "test_address",
-            #[allow(deprecated)]
-            &__Contract__test_address__invoke_raw_slice,
-        );
-        <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
-            "test_bytes",
-            #[allow(deprecated)]
-            &__Contract__test_bytes__invoke_raw_slice,
-        );
-        <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
-            "test_bytes_n",
-            #[allow(deprecated)]
-            &__Contract__test_bytes_n__invoke_raw_slice,
-        );
-        <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
-            "test_symbol",
-            #[allow(deprecated)]
-            &__Contract__test_symbol__invoke_raw_slice,
-        );
-        <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
-            "test_vec",
-            #[allow(deprecated)]
-            &__Contract__test_vec__invoke_raw_slice,
-        );
-        <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
-            "test_map",
-            #[allow(deprecated)]
-            &__Contract__test_map__invoke_raw_slice,
-        );
-        <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
-            "test_duration",
-            #[allow(deprecated)]
-            &__Contract__test_duration__invoke_raw_slice,
-        );
-        <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
-            "test_timepoint",
-            #[allow(deprecated)]
-            &__Contract__test_timepoint__invoke_raw_slice,
-        );
-        <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
-            "test_i256",
-            #[allow(deprecated)]
-            &__Contract__test_i256__invoke_raw_slice,
-        );
-        <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
-            "test_u256",
-            #[allow(deprecated)]
-            &__Contract__test_u256__invoke_raw_slice,
-        );
-        <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
-            "test_enum_unit",
-            #[allow(deprecated)]
-            &__Contract__test_enum_unit__invoke_raw_slice,
-        );
-        <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
-            "test_enum_variants",
-            #[allow(deprecated)]
-            &__Contract__test_enum_variants__invoke_raw_slice,
-        );
     }
 }
 #[doc(hidden)]
 #[allow(non_snake_case)]
 #[allow(unused)]
-fn __Contract__AllTypes__1eb9a6a69c5f732bd78e03e0fa5ea9d0a5c925757f7a5e53cd10ccd57b3e027d_ctor() {
+fn __Contract__AllTypes__b770dfe9b2adeb806c45d6b5ef3d31c7b9c987740d9a583ed8e1683b5debdb75_ctor() {
     #[allow(unsafe_code)]
     {
         #[link_section = ".init_array"]
@@ -3477,7 +3393,517 @@ fn __Contract__AllTypes__1eb9a6a69c5f732bd78e03e0fa5ea9d0a5c925757f7a5e53cd10ccd
             #[allow(non_snake_case)]
             extern "C" fn f() -> ::ctor::__support::CtorRetType {
                 unsafe {
-                    __Contract__AllTypes__1eb9a6a69c5f732bd78e03e0fa5ea9d0a5c925757f7a5e53cd10ccd57b3e027d_ctor();
+                    __Contract__AllTypes__b770dfe9b2adeb806c45d6b5ef3d31c7b9c987740d9a583ed8e1683b5debdb75_ctor();
+                };
+                core::default::Default::default()
+            }
+            f
+        };
+    }
+    {
+        <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
+            "test_u64",
+            #[allow(deprecated)]
+            &__Contract__test_u64__invoke_raw_slice,
+        );
+    }
+}
+#[doc(hidden)]
+#[allow(non_snake_case)]
+#[allow(unused)]
+fn __Contract__AllTypes__c7e2f7ef9f571dc3460d8b374883a38011169cfe419aa02ad69ddbff73b746d7_ctor() {
+    #[allow(unsafe_code)]
+    {
+        #[link_section = ".init_array"]
+        #[used]
+        #[allow(non_upper_case_globals, non_snake_case)]
+        #[doc(hidden)]
+        static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
+            #[link_section = ".text.startup"]
+            #[allow(non_snake_case)]
+            extern "C" fn f() -> ::ctor::__support::CtorRetType {
+                unsafe {
+                    __Contract__AllTypes__c7e2f7ef9f571dc3460d8b374883a38011169cfe419aa02ad69ddbff73b746d7_ctor();
+                };
+                core::default::Default::default()
+            }
+            f
+        };
+    }
+    {
+        <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
+            "test_i64",
+            #[allow(deprecated)]
+            &__Contract__test_i64__invoke_raw_slice,
+        );
+    }
+}
+#[doc(hidden)]
+#[allow(non_snake_case)]
+#[allow(unused)]
+fn __Contract__AllTypes__1f04aa8787240d34edecbbf647ed2ed836655df078df79a8b7d5840e300aae9d_ctor() {
+    #[allow(unsafe_code)]
+    {
+        #[link_section = ".init_array"]
+        #[used]
+        #[allow(non_upper_case_globals, non_snake_case)]
+        #[doc(hidden)]
+        static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
+            #[link_section = ".text.startup"]
+            #[allow(non_snake_case)]
+            extern "C" fn f() -> ::ctor::__support::CtorRetType {
+                unsafe {
+                    __Contract__AllTypes__1f04aa8787240d34edecbbf647ed2ed836655df078df79a8b7d5840e300aae9d_ctor();
+                };
+                core::default::Default::default()
+            }
+            f
+        };
+    }
+    {
+        <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
+            "test_u128",
+            #[allow(deprecated)]
+            &__Contract__test_u128__invoke_raw_slice,
+        );
+    }
+}
+#[doc(hidden)]
+#[allow(non_snake_case)]
+#[allow(unused)]
+fn __Contract__AllTypes__21c197ddff91b560d684eefa2ec923ac1edb7ba246d887790999555f1f1082b4_ctor() {
+    #[allow(unsafe_code)]
+    {
+        #[link_section = ".init_array"]
+        #[used]
+        #[allow(non_upper_case_globals, non_snake_case)]
+        #[doc(hidden)]
+        static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
+            #[link_section = ".text.startup"]
+            #[allow(non_snake_case)]
+            extern "C" fn f() -> ::ctor::__support::CtorRetType {
+                unsafe {
+                    __Contract__AllTypes__21c197ddff91b560d684eefa2ec923ac1edb7ba246d887790999555f1f1082b4_ctor();
+                };
+                core::default::Default::default()
+            }
+            f
+        };
+    }
+    {
+        <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
+            "test_i128",
+            #[allow(deprecated)]
+            &__Contract__test_i128__invoke_raw_slice,
+        );
+    }
+}
+#[doc(hidden)]
+#[allow(non_snake_case)]
+#[allow(unused)]
+fn __Contract__AllTypes__4b66c68c88167c0df99dce45fb5157ceb3781fd75f46e2d96e1313a46c234164_ctor() {
+    #[allow(unsafe_code)]
+    {
+        #[link_section = ".init_array"]
+        #[used]
+        #[allow(non_upper_case_globals, non_snake_case)]
+        #[doc(hidden)]
+        static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
+            #[link_section = ".text.startup"]
+            #[allow(non_snake_case)]
+            extern "C" fn f() -> ::ctor::__support::CtorRetType {
+                unsafe {
+                    __Contract__AllTypes__4b66c68c88167c0df99dce45fb5157ceb3781fd75f46e2d96e1313a46c234164_ctor();
+                };
+                core::default::Default::default()
+            }
+            f
+        };
+    }
+    {
+        <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
+            "test_bool",
+            #[allow(deprecated)]
+            &__Contract__test_bool__invoke_raw_slice,
+        );
+    }
+}
+#[doc(hidden)]
+#[allow(non_snake_case)]
+#[allow(unused)]
+fn __Contract__AllTypes__d78659c68ad1cfce2ad440653013d25977b451539dd6f219c8e1e8b875d23c14_ctor() {
+    #[allow(unsafe_code)]
+    {
+        #[link_section = ".init_array"]
+        #[used]
+        #[allow(non_upper_case_globals, non_snake_case)]
+        #[doc(hidden)]
+        static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
+            #[link_section = ".text.startup"]
+            #[allow(non_snake_case)]
+            extern "C" fn f() -> ::ctor::__support::CtorRetType {
+                unsafe {
+                    __Contract__AllTypes__d78659c68ad1cfce2ad440653013d25977b451539dd6f219c8e1e8b875d23c14_ctor();
+                };
+                core::default::Default::default()
+            }
+            f
+        };
+    }
+    {
+        <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
+            "test_address",
+            #[allow(deprecated)]
+            &__Contract__test_address__invoke_raw_slice,
+        );
+    }
+}
+#[doc(hidden)]
+#[allow(non_snake_case)]
+#[allow(unused)]
+fn __Contract__AllTypes__d8369e1d7eccf342204ebd3114d6abb3261652c93b0722901964ebc9a2b869ac_ctor() {
+    #[allow(unsafe_code)]
+    {
+        #[link_section = ".init_array"]
+        #[used]
+        #[allow(non_upper_case_globals, non_snake_case)]
+        #[doc(hidden)]
+        static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
+            #[link_section = ".text.startup"]
+            #[allow(non_snake_case)]
+            extern "C" fn f() -> ::ctor::__support::CtorRetType {
+                unsafe {
+                    __Contract__AllTypes__d8369e1d7eccf342204ebd3114d6abb3261652c93b0722901964ebc9a2b869ac_ctor();
+                };
+                core::default::Default::default()
+            }
+            f
+        };
+    }
+    {
+        <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
+            "test_bytes",
+            #[allow(deprecated)]
+            &__Contract__test_bytes__invoke_raw_slice,
+        );
+    }
+}
+#[doc(hidden)]
+#[allow(non_snake_case)]
+#[allow(unused)]
+fn __Contract__AllTypes__4263283d1487792fb25a9666db2bcf4b7cb85d1596eddd530b28e3dea11ca98e_ctor() {
+    #[allow(unsafe_code)]
+    {
+        #[link_section = ".init_array"]
+        #[used]
+        #[allow(non_upper_case_globals, non_snake_case)]
+        #[doc(hidden)]
+        static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
+            #[link_section = ".text.startup"]
+            #[allow(non_snake_case)]
+            extern "C" fn f() -> ::ctor::__support::CtorRetType {
+                unsafe {
+                    __Contract__AllTypes__4263283d1487792fb25a9666db2bcf4b7cb85d1596eddd530b28e3dea11ca98e_ctor();
+                };
+                core::default::Default::default()
+            }
+            f
+        };
+    }
+    {
+        <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
+            "test_bytes_n",
+            #[allow(deprecated)]
+            &__Contract__test_bytes_n__invoke_raw_slice,
+        );
+    }
+}
+#[doc(hidden)]
+#[allow(non_snake_case)]
+#[allow(unused)]
+fn __Contract__AllTypes__d218b946ac71446987caada5b1ddd9a88071593dc7947a9b5e0c9684f58016d1_ctor() {
+    #[allow(unsafe_code)]
+    {
+        #[link_section = ".init_array"]
+        #[used]
+        #[allow(non_upper_case_globals, non_snake_case)]
+        #[doc(hidden)]
+        static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
+            #[link_section = ".text.startup"]
+            #[allow(non_snake_case)]
+            extern "C" fn f() -> ::ctor::__support::CtorRetType {
+                unsafe {
+                    __Contract__AllTypes__d218b946ac71446987caada5b1ddd9a88071593dc7947a9b5e0c9684f58016d1_ctor();
+                };
+                core::default::Default::default()
+            }
+            f
+        };
+    }
+    {
+        <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
+            "test_symbol",
+            #[allow(deprecated)]
+            &__Contract__test_symbol__invoke_raw_slice,
+        );
+    }
+}
+#[doc(hidden)]
+#[allow(non_snake_case)]
+#[allow(unused)]
+fn __Contract__AllTypes__3dab3b2e67a5258edc6046d3b3cb677c43a508a69de5786d8a34361ad5c12e80_ctor() {
+    #[allow(unsafe_code)]
+    {
+        #[link_section = ".init_array"]
+        #[used]
+        #[allow(non_upper_case_globals, non_snake_case)]
+        #[doc(hidden)]
+        static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
+            #[link_section = ".text.startup"]
+            #[allow(non_snake_case)]
+            extern "C" fn f() -> ::ctor::__support::CtorRetType {
+                unsafe {
+                    __Contract__AllTypes__3dab3b2e67a5258edc6046d3b3cb677c43a508a69de5786d8a34361ad5c12e80_ctor();
+                };
+                core::default::Default::default()
+            }
+            f
+        };
+    }
+    {
+        <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
+            "test_vec",
+            #[allow(deprecated)]
+            &__Contract__test_vec__invoke_raw_slice,
+        );
+    }
+}
+#[doc(hidden)]
+#[allow(non_snake_case)]
+#[allow(unused)]
+fn __Contract__AllTypes__26529164027f0c953c7b3a907b09c5e144a82b6430185ad98603b636b4b3b349_ctor() {
+    #[allow(unsafe_code)]
+    {
+        #[link_section = ".init_array"]
+        #[used]
+        #[allow(non_upper_case_globals, non_snake_case)]
+        #[doc(hidden)]
+        static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
+            #[link_section = ".text.startup"]
+            #[allow(non_snake_case)]
+            extern "C" fn f() -> ::ctor::__support::CtorRetType {
+                unsafe {
+                    __Contract__AllTypes__26529164027f0c953c7b3a907b09c5e144a82b6430185ad98603b636b4b3b349_ctor();
+                };
+                core::default::Default::default()
+            }
+            f
+        };
+    }
+    {
+        <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
+            "test_map",
+            #[allow(deprecated)]
+            &__Contract__test_map__invoke_raw_slice,
+        );
+    }
+}
+#[doc(hidden)]
+#[allow(non_snake_case)]
+#[allow(unused)]
+fn __Contract__AllTypes__152e048563476cac8dd28938f3c41518456072e651f690c6b1ea6814466aea27_ctor() {
+    #[allow(unsafe_code)]
+    {
+        #[link_section = ".init_array"]
+        #[used]
+        #[allow(non_upper_case_globals, non_snake_case)]
+        #[doc(hidden)]
+        static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
+            #[link_section = ".text.startup"]
+            #[allow(non_snake_case)]
+            extern "C" fn f() -> ::ctor::__support::CtorRetType {
+                unsafe {
+                    __Contract__AllTypes__152e048563476cac8dd28938f3c41518456072e651f690c6b1ea6814466aea27_ctor();
+                };
+                core::default::Default::default()
+            }
+            f
+        };
+    }
+    {
+        <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
+            "test_duration",
+            #[allow(deprecated)]
+            &__Contract__test_duration__invoke_raw_slice,
+        );
+    }
+}
+#[doc(hidden)]
+#[allow(non_snake_case)]
+#[allow(unused)]
+fn __Contract__AllTypes__6ab993c9945db4a3067443e6b98939664c9b314387f62bdaaccf83a79f172330_ctor() {
+    #[allow(unsafe_code)]
+    {
+        #[link_section = ".init_array"]
+        #[used]
+        #[allow(non_upper_case_globals, non_snake_case)]
+        #[doc(hidden)]
+        static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
+            #[link_section = ".text.startup"]
+            #[allow(non_snake_case)]
+            extern "C" fn f() -> ::ctor::__support::CtorRetType {
+                unsafe {
+                    __Contract__AllTypes__6ab993c9945db4a3067443e6b98939664c9b314387f62bdaaccf83a79f172330_ctor();
+                };
+                core::default::Default::default()
+            }
+            f
+        };
+    }
+    {
+        <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
+            "test_timepoint",
+            #[allow(deprecated)]
+            &__Contract__test_timepoint__invoke_raw_slice,
+        );
+    }
+}
+#[doc(hidden)]
+#[allow(non_snake_case)]
+#[allow(unused)]
+fn __Contract__AllTypes__720f8551818518259a0743a812712dcfb905b3c817117e017891bbf6229633f2_ctor() {
+    #[allow(unsafe_code)]
+    {
+        #[link_section = ".init_array"]
+        #[used]
+        #[allow(non_upper_case_globals, non_snake_case)]
+        #[doc(hidden)]
+        static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
+            #[link_section = ".text.startup"]
+            #[allow(non_snake_case)]
+            extern "C" fn f() -> ::ctor::__support::CtorRetType {
+                unsafe {
+                    __Contract__AllTypes__720f8551818518259a0743a812712dcfb905b3c817117e017891bbf6229633f2_ctor();
+                };
+                core::default::Default::default()
+            }
+            f
+        };
+    }
+    {
+        <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
+            "test_i256",
+            #[allow(deprecated)]
+            &__Contract__test_i256__invoke_raw_slice,
+        );
+    }
+}
+#[doc(hidden)]
+#[allow(non_snake_case)]
+#[allow(unused)]
+fn __Contract__AllTypes__c11a38375965f06d3e70c95d14652a94d7d10c85964c69ff29449fd1fdd684df_ctor() {
+    #[allow(unsafe_code)]
+    {
+        #[link_section = ".init_array"]
+        #[used]
+        #[allow(non_upper_case_globals, non_snake_case)]
+        #[doc(hidden)]
+        static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
+            #[link_section = ".text.startup"]
+            #[allow(non_snake_case)]
+            extern "C" fn f() -> ::ctor::__support::CtorRetType {
+                unsafe {
+                    __Contract__AllTypes__c11a38375965f06d3e70c95d14652a94d7d10c85964c69ff29449fd1fdd684df_ctor();
+                };
+                core::default::Default::default()
+            }
+            f
+        };
+    }
+    {
+        <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
+            "test_u256",
+            #[allow(deprecated)]
+            &__Contract__test_u256__invoke_raw_slice,
+        );
+    }
+}
+#[doc(hidden)]
+#[allow(non_snake_case)]
+#[allow(unused)]
+fn __Contract__AllTypes__4a069ddc7591bc91505072ab63fbb531eadd377db8acb22014e849a66a1e26e0_ctor() {
+    #[allow(unsafe_code)]
+    {
+        #[link_section = ".init_array"]
+        #[used]
+        #[allow(non_upper_case_globals, non_snake_case)]
+        #[doc(hidden)]
+        static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
+            #[link_section = ".text.startup"]
+            #[allow(non_snake_case)]
+            extern "C" fn f() -> ::ctor::__support::CtorRetType {
+                unsafe {
+                    __Contract__AllTypes__4a069ddc7591bc91505072ab63fbb531eadd377db8acb22014e849a66a1e26e0_ctor();
+                };
+                core::default::Default::default()
+            }
+            f
+        };
+    }
+    {
+        <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
+            "test_enum_unit",
+            #[allow(deprecated)]
+            &__Contract__test_enum_unit__invoke_raw_slice,
+        );
+    }
+}
+#[doc(hidden)]
+#[allow(non_snake_case)]
+#[allow(unused)]
+fn __Contract__AllTypes__d2b0ba6d429ff899ab7fa1f5126ecddb66bdaec3f51d9aabaa916af14c3079a8_ctor() {
+    #[allow(unsafe_code)]
+    {
+        #[link_section = ".init_array"]
+        #[used]
+        #[allow(non_upper_case_globals, non_snake_case)]
+        #[doc(hidden)]
+        static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
+            #[link_section = ".text.startup"]
+            #[allow(non_snake_case)]
+            extern "C" fn f() -> ::ctor::__support::CtorRetType {
+                unsafe {
+                    __Contract__AllTypes__d2b0ba6d429ff899ab7fa1f5126ecddb66bdaec3f51d9aabaa916af14c3079a8_ctor();
+                };
+                core::default::Default::default()
+            }
+            f
+        };
+    }
+    {
+        <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
+            "test_enum_variants",
+            #[allow(deprecated)]
+            &__Contract__test_enum_variants__invoke_raw_slice,
+        );
+    }
+}
+#[doc(hidden)]
+#[allow(non_snake_case)]
+#[allow(unused)]
+fn __Contract__AllTypes__53d758cb364e30212244bac7f86701cb2cd52ec2d1e81aa422edf52088793ca1_ctor() {
+    #[allow(unsafe_code)]
+    {
+        #[link_section = ".init_array"]
+        #[used]
+        #[allow(non_upper_case_globals, non_snake_case)]
+        #[doc(hidden)]
+        static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
+            #[link_section = ".text.startup"]
+            #[allow(non_snake_case)]
+            extern "C" fn f() -> ::ctor::__support::CtorRetType {
+                unsafe {
+                    __Contract__AllTypes__53d758cb364e30212244bac7f86701cb2cd52ec2d1e81aa422edf52088793ca1_ctor();
                 };
                 core::default::Default::default()
             }
@@ -3490,16 +3916,91 @@ fn __Contract__AllTypes__1eb9a6a69c5f732bd78e03e0fa5ea9d0a5c925757f7a5e53cd10ccd
             #[allow(deprecated)]
             &__Contract__test_u32__invoke_raw_slice,
         );
+    }
+}
+#[doc(hidden)]
+#[allow(non_snake_case)]
+#[allow(unused)]
+fn __Contract__AllTypes__a1a211ad36b73f745fe11cbbe5a3b7111710436824119d305f34af1842e457c4_ctor() {
+    #[allow(unsafe_code)]
+    {
+        #[link_section = ".init_array"]
+        #[used]
+        #[allow(non_upper_case_globals, non_snake_case)]
+        #[doc(hidden)]
+        static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
+            #[link_section = ".text.startup"]
+            #[allow(non_snake_case)]
+            extern "C" fn f() -> ::ctor::__support::CtorRetType {
+                unsafe {
+                    __Contract__AllTypes__a1a211ad36b73f745fe11cbbe5a3b7111710436824119d305f34af1842e457c4_ctor();
+                };
+                core::default::Default::default()
+            }
+            f
+        };
+    }
+    {
         <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
             "test_string",
             #[allow(deprecated)]
             &__Contract__test_string__invoke_raw_slice,
         );
+    }
+}
+#[doc(hidden)]
+#[allow(non_snake_case)]
+#[allow(unused)]
+fn __Contract__AllTypes__d66789a1d5c62b2e13ce77eb51642b42a21d817718902956ded0ca9720c4f2c2_ctor() {
+    #[allow(unsafe_code)]
+    {
+        #[link_section = ".init_array"]
+        #[used]
+        #[allow(non_upper_case_globals, non_snake_case)]
+        #[doc(hidden)]
+        static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
+            #[link_section = ".text.startup"]
+            #[allow(non_snake_case)]
+            extern "C" fn f() -> ::ctor::__support::CtorRetType {
+                unsafe {
+                    __Contract__AllTypes__d66789a1d5c62b2e13ce77eb51642b42a21d817718902956ded0ca9720c4f2c2_ctor();
+                };
+                core::default::Default::default()
+            }
+            f
+        };
+    }
+    {
         <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
             "test_env_param",
             #[allow(deprecated)]
             &__Contract__test_env_param__invoke_raw_slice,
         );
+    }
+}
+#[doc(hidden)]
+#[allow(non_snake_case)]
+#[allow(unused)]
+fn __Contract__AllTypes__8eddde8d361a1a64147292e9556cb28d1efeec7df66b8064c5cc8af95e9b9bad_ctor() {
+    #[allow(unsafe_code)]
+    {
+        #[link_section = ".init_array"]
+        #[used]
+        #[allow(non_upper_case_globals, non_snake_case)]
+        #[doc(hidden)]
+        static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
+            #[link_section = ".text.startup"]
+            #[allow(non_snake_case)]
+            extern "C" fn f() -> ::ctor::__support::CtorRetType {
+                unsafe {
+                    __Contract__AllTypes__8eddde8d361a1a64147292e9556cb28d1efeec7df66b8064c5cc8af95e9b9bad_ctor();
+                };
+                core::default::Default::default()
+            }
+            f
+        };
+    }
+    {
         <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
             "test_struct",
             #[allow(deprecated)]

--- a/tests-expanded/test_contracttrait_impl_partial_wasm32v1-none.rs
+++ b/tests-expanded/test_contracttrait_impl_partial_wasm32v1-none.rs
@@ -1735,6 +1735,7 @@ impl<'a> ContractClient<'a> {
     }
 }
 impl ContractArgs {
+    /// Test i32 values.
     #[inline(always)]
     #[allow(clippy::unused_unit)]
     pub fn test_i32<'i>(v: &'i i32) -> (&'i i32,) {

--- a/tests-expanded/test_contracttrait_path_crate_tests.rs
+++ b/tests-expanded/test_contracttrait_path_crate_tests.rs
@@ -477,7 +477,7 @@ impl ContractCratePathArgs {
 #[doc(hidden)]
 #[allow(non_snake_case)]
 #[allow(unused)]
-fn __ContractCratePath__crate_traits_CratePathTrait__1eead55085fa77445f5d7af954169483008ff4874e183c7854e538dc896fb975_ctor(
+fn __ContractCratePath__crate_traits_CratePathTrait__bb56e4f980d333c8ac8c90e324dc9deff7747ee2354dd96432316232a5bcb9b6_ctor(
 ) {
     #[allow(unsafe_code)]
     {
@@ -490,7 +490,7 @@ fn __ContractCratePath__crate_traits_CratePathTrait__1eead55085fa77445f5d7af9541
             #[allow(non_snake_case)]
             extern "C" fn f() -> ::ctor::__support::CtorRetType {
                 unsafe {
-                    __ContractCratePath__crate_traits_CratePathTrait__1eead55085fa77445f5d7af954169483008ff4874e183c7854e538dc896fb975_ctor();
+                    __ContractCratePath__crate_traits_CratePathTrait__bb56e4f980d333c8ac8c90e324dc9deff7747ee2354dd96432316232a5bcb9b6_ctor();
                 };
                 core::default::Default::default()
             }
@@ -504,31 +504,6 @@ fn __ContractCratePath__crate_traits_CratePathTrait__1eead55085fa77445f5d7af9541
             &__ContractCratePath__crate_path_method__invoke_raw_slice,
         );
     }
-}
-#[doc(hidden)]
-#[allow(non_snake_case)]
-#[allow(unused)]
-fn __ContractCratePath__crate_traits_CratePathTrait__e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855_ctor(
-) {
-    #[allow(unsafe_code)]
-    {
-        #[link_section = ".init_array"]
-        #[used]
-        #[allow(non_upper_case_globals, non_snake_case)]
-        #[doc(hidden)]
-        static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
-            #[link_section = ".text.startup"]
-            #[allow(non_snake_case)]
-            extern "C" fn f() -> ::ctor::__support::CtorRetType {
-                unsafe {
-                    __ContractCratePath__crate_traits_CratePathTrait__e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855_ctor();
-                };
-                core::default::Default::default()
-            }
-            f
-        };
-    }
-    {}
 }
 mod test {
     use super::*;

--- a/tests-expanded/test_contracttrait_path_global_tests.rs
+++ b/tests-expanded/test_contracttrait_path_global_tests.rs
@@ -3281,11 +3281,14 @@ impl<'a> ContractGlobalPathClient<'a> {
     }
 }
 impl ContractGlobalPathArgs {
+    /// Test u32 values.
+    /// Returns the input unchanged.
     #[inline(always)]
     #[allow(clippy::unused_unit)]
     pub fn test_u32<'i>(v: &'i u32) -> (&'i u32,) {
         (v,)
     }
+    /// Test i32 values.
     #[inline(always)]
     #[allow(clippy::unused_unit)]
     pub fn test_i32<'i>(v: &'i i32) -> (&'i i32,) {
@@ -3395,7 +3398,7 @@ impl ContractGlobalPathArgs {
 #[doc(hidden)]
 #[allow(non_snake_case)]
 #[allow(unused)]
-fn __ContractGlobalPath__test_contracttrait_trait_AllTypes__959aee9d42336ade92416504111dfbb4e37b0472bbb1e487310c05a170c39d28_ctor(
+fn __ContractGlobalPath__test_contracttrait_trait_AllTypes__53d758cb364e30212244bac7f86701cb2cd52ec2d1e81aa422edf52088793ca1_ctor(
 ) {
     #[allow(unsafe_code)]
     {
@@ -3408,7 +3411,7 @@ fn __ContractGlobalPath__test_contracttrait_trait_AllTypes__959aee9d42336ade9241
             #[allow(non_snake_case)]
             extern "C" fn f() -> ::ctor::__support::CtorRetType {
                 unsafe {
-                    __ContractGlobalPath__test_contracttrait_trait_AllTypes__959aee9d42336ade92416504111dfbb4e37b0472bbb1e487310c05a170c39d28_ctor();
+                    __ContractGlobalPath__test_contracttrait_trait_AllTypes__53d758cb364e30212244bac7f86701cb2cd52ec2d1e81aa422edf52088793ca1_ctor();
                 };
                 core::default::Default::default()
             }
@@ -3421,117 +3424,12 @@ fn __ContractGlobalPath__test_contracttrait_trait_AllTypes__959aee9d42336ade9241
             #[allow(deprecated)]
             &__ContractGlobalPath__test_u32__invoke_raw_slice,
         );
-        <ContractGlobalPath as soroban_sdk::testutils::ContractFunctionRegister>::register(
-            "test_i32",
-            #[allow(deprecated)]
-            &__ContractGlobalPath__test_i32__invoke_raw_slice,
-        );
-        <ContractGlobalPath as soroban_sdk::testutils::ContractFunctionRegister>::register(
-            "test_u64",
-            #[allow(deprecated)]
-            &__ContractGlobalPath__test_u64__invoke_raw_slice,
-        );
-        <ContractGlobalPath as soroban_sdk::testutils::ContractFunctionRegister>::register(
-            "test_i64",
-            #[allow(deprecated)]
-            &__ContractGlobalPath__test_i64__invoke_raw_slice,
-        );
-        <ContractGlobalPath as soroban_sdk::testutils::ContractFunctionRegister>::register(
-            "test_u128",
-            #[allow(deprecated)]
-            &__ContractGlobalPath__test_u128__invoke_raw_slice,
-        );
-        <ContractGlobalPath as soroban_sdk::testutils::ContractFunctionRegister>::register(
-            "test_i128",
-            #[allow(deprecated)]
-            &__ContractGlobalPath__test_i128__invoke_raw_slice,
-        );
-        <ContractGlobalPath as soroban_sdk::testutils::ContractFunctionRegister>::register(
-            "test_bool",
-            #[allow(deprecated)]
-            &__ContractGlobalPath__test_bool__invoke_raw_slice,
-        );
-        <ContractGlobalPath as soroban_sdk::testutils::ContractFunctionRegister>::register(
-            "test_address",
-            #[allow(deprecated)]
-            &__ContractGlobalPath__test_address__invoke_raw_slice,
-        );
-        <ContractGlobalPath as soroban_sdk::testutils::ContractFunctionRegister>::register(
-            "test_bytes",
-            #[allow(deprecated)]
-            &__ContractGlobalPath__test_bytes__invoke_raw_slice,
-        );
-        <ContractGlobalPath as soroban_sdk::testutils::ContractFunctionRegister>::register(
-            "test_bytes_n",
-            #[allow(deprecated)]
-            &__ContractGlobalPath__test_bytes_n__invoke_raw_slice,
-        );
-        <ContractGlobalPath as soroban_sdk::testutils::ContractFunctionRegister>::register(
-            "test_string",
-            #[allow(deprecated)]
-            &__ContractGlobalPath__test_string__invoke_raw_slice,
-        );
-        <ContractGlobalPath as soroban_sdk::testutils::ContractFunctionRegister>::register(
-            "test_symbol",
-            #[allow(deprecated)]
-            &__ContractGlobalPath__test_symbol__invoke_raw_slice,
-        );
-        <ContractGlobalPath as soroban_sdk::testutils::ContractFunctionRegister>::register(
-            "test_vec",
-            #[allow(deprecated)]
-            &__ContractGlobalPath__test_vec__invoke_raw_slice,
-        );
-        <ContractGlobalPath as soroban_sdk::testutils::ContractFunctionRegister>::register(
-            "test_map",
-            #[allow(deprecated)]
-            &__ContractGlobalPath__test_map__invoke_raw_slice,
-        );
-        <ContractGlobalPath as soroban_sdk::testutils::ContractFunctionRegister>::register(
-            "test_duration",
-            #[allow(deprecated)]
-            &__ContractGlobalPath__test_duration__invoke_raw_slice,
-        );
-        <ContractGlobalPath as soroban_sdk::testutils::ContractFunctionRegister>::register(
-            "test_timepoint",
-            #[allow(deprecated)]
-            &__ContractGlobalPath__test_timepoint__invoke_raw_slice,
-        );
-        <ContractGlobalPath as soroban_sdk::testutils::ContractFunctionRegister>::register(
-            "test_i256",
-            #[allow(deprecated)]
-            &__ContractGlobalPath__test_i256__invoke_raw_slice,
-        );
-        <ContractGlobalPath as soroban_sdk::testutils::ContractFunctionRegister>::register(
-            "test_u256",
-            #[allow(deprecated)]
-            &__ContractGlobalPath__test_u256__invoke_raw_slice,
-        );
-        <ContractGlobalPath as soroban_sdk::testutils::ContractFunctionRegister>::register(
-            "test_env_param",
-            #[allow(deprecated)]
-            &__ContractGlobalPath__test_env_param__invoke_raw_slice,
-        );
-        <ContractGlobalPath as soroban_sdk::testutils::ContractFunctionRegister>::register(
-            "test_struct",
-            #[allow(deprecated)]
-            &__ContractGlobalPath__test_struct__invoke_raw_slice,
-        );
-        <ContractGlobalPath as soroban_sdk::testutils::ContractFunctionRegister>::register(
-            "test_enum_unit",
-            #[allow(deprecated)]
-            &__ContractGlobalPath__test_enum_unit__invoke_raw_slice,
-        );
-        <ContractGlobalPath as soroban_sdk::testutils::ContractFunctionRegister>::register(
-            "test_enum_variants",
-            #[allow(deprecated)]
-            &__ContractGlobalPath__test_enum_variants__invoke_raw_slice,
-        );
     }
 }
 #[doc(hidden)]
 #[allow(non_snake_case)]
 #[allow(unused)]
-fn __ContractGlobalPath__test_contracttrait_trait_AllTypes__e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855_ctor(
+fn __ContractGlobalPath__test_contracttrait_trait_AllTypes__fc0e53ecfa4163838da8f2017151f32594d5d3960028ec820f6052edb4a84059_ctor(
 ) {
     #[allow(unsafe_code)]
     {
@@ -3544,14 +3442,640 @@ fn __ContractGlobalPath__test_contracttrait_trait_AllTypes__e3b0c44298fc1c149afb
             #[allow(non_snake_case)]
             extern "C" fn f() -> ::ctor::__support::CtorRetType {
                 unsafe {
-                    __ContractGlobalPath__test_contracttrait_trait_AllTypes__e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855_ctor();
+                    __ContractGlobalPath__test_contracttrait_trait_AllTypes__fc0e53ecfa4163838da8f2017151f32594d5d3960028ec820f6052edb4a84059_ctor();
                 };
                 core::default::Default::default()
             }
             f
         };
     }
-    {}
+    {
+        <ContractGlobalPath as soroban_sdk::testutils::ContractFunctionRegister>::register(
+            "test_i32",
+            #[allow(deprecated)]
+            &__ContractGlobalPath__test_i32__invoke_raw_slice,
+        );
+    }
+}
+#[doc(hidden)]
+#[allow(non_snake_case)]
+#[allow(unused)]
+fn __ContractGlobalPath__test_contracttrait_trait_AllTypes__b770dfe9b2adeb806c45d6b5ef3d31c7b9c987740d9a583ed8e1683b5debdb75_ctor(
+) {
+    #[allow(unsafe_code)]
+    {
+        #[link_section = ".init_array"]
+        #[used]
+        #[allow(non_upper_case_globals, non_snake_case)]
+        #[doc(hidden)]
+        static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
+            #[link_section = ".text.startup"]
+            #[allow(non_snake_case)]
+            extern "C" fn f() -> ::ctor::__support::CtorRetType {
+                unsafe {
+                    __ContractGlobalPath__test_contracttrait_trait_AllTypes__b770dfe9b2adeb806c45d6b5ef3d31c7b9c987740d9a583ed8e1683b5debdb75_ctor();
+                };
+                core::default::Default::default()
+            }
+            f
+        };
+    }
+    {
+        <ContractGlobalPath as soroban_sdk::testutils::ContractFunctionRegister>::register(
+            "test_u64",
+            #[allow(deprecated)]
+            &__ContractGlobalPath__test_u64__invoke_raw_slice,
+        );
+    }
+}
+#[doc(hidden)]
+#[allow(non_snake_case)]
+#[allow(unused)]
+fn __ContractGlobalPath__test_contracttrait_trait_AllTypes__c7e2f7ef9f571dc3460d8b374883a38011169cfe419aa02ad69ddbff73b746d7_ctor(
+) {
+    #[allow(unsafe_code)]
+    {
+        #[link_section = ".init_array"]
+        #[used]
+        #[allow(non_upper_case_globals, non_snake_case)]
+        #[doc(hidden)]
+        static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
+            #[link_section = ".text.startup"]
+            #[allow(non_snake_case)]
+            extern "C" fn f() -> ::ctor::__support::CtorRetType {
+                unsafe {
+                    __ContractGlobalPath__test_contracttrait_trait_AllTypes__c7e2f7ef9f571dc3460d8b374883a38011169cfe419aa02ad69ddbff73b746d7_ctor();
+                };
+                core::default::Default::default()
+            }
+            f
+        };
+    }
+    {
+        <ContractGlobalPath as soroban_sdk::testutils::ContractFunctionRegister>::register(
+            "test_i64",
+            #[allow(deprecated)]
+            &__ContractGlobalPath__test_i64__invoke_raw_slice,
+        );
+    }
+}
+#[doc(hidden)]
+#[allow(non_snake_case)]
+#[allow(unused)]
+fn __ContractGlobalPath__test_contracttrait_trait_AllTypes__1f04aa8787240d34edecbbf647ed2ed836655df078df79a8b7d5840e300aae9d_ctor(
+) {
+    #[allow(unsafe_code)]
+    {
+        #[link_section = ".init_array"]
+        #[used]
+        #[allow(non_upper_case_globals, non_snake_case)]
+        #[doc(hidden)]
+        static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
+            #[link_section = ".text.startup"]
+            #[allow(non_snake_case)]
+            extern "C" fn f() -> ::ctor::__support::CtorRetType {
+                unsafe {
+                    __ContractGlobalPath__test_contracttrait_trait_AllTypes__1f04aa8787240d34edecbbf647ed2ed836655df078df79a8b7d5840e300aae9d_ctor();
+                };
+                core::default::Default::default()
+            }
+            f
+        };
+    }
+    {
+        <ContractGlobalPath as soroban_sdk::testutils::ContractFunctionRegister>::register(
+            "test_u128",
+            #[allow(deprecated)]
+            &__ContractGlobalPath__test_u128__invoke_raw_slice,
+        );
+    }
+}
+#[doc(hidden)]
+#[allow(non_snake_case)]
+#[allow(unused)]
+fn __ContractGlobalPath__test_contracttrait_trait_AllTypes__21c197ddff91b560d684eefa2ec923ac1edb7ba246d887790999555f1f1082b4_ctor(
+) {
+    #[allow(unsafe_code)]
+    {
+        #[link_section = ".init_array"]
+        #[used]
+        #[allow(non_upper_case_globals, non_snake_case)]
+        #[doc(hidden)]
+        static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
+            #[link_section = ".text.startup"]
+            #[allow(non_snake_case)]
+            extern "C" fn f() -> ::ctor::__support::CtorRetType {
+                unsafe {
+                    __ContractGlobalPath__test_contracttrait_trait_AllTypes__21c197ddff91b560d684eefa2ec923ac1edb7ba246d887790999555f1f1082b4_ctor();
+                };
+                core::default::Default::default()
+            }
+            f
+        };
+    }
+    {
+        <ContractGlobalPath as soroban_sdk::testutils::ContractFunctionRegister>::register(
+            "test_i128",
+            #[allow(deprecated)]
+            &__ContractGlobalPath__test_i128__invoke_raw_slice,
+        );
+    }
+}
+#[doc(hidden)]
+#[allow(non_snake_case)]
+#[allow(unused)]
+fn __ContractGlobalPath__test_contracttrait_trait_AllTypes__4b66c68c88167c0df99dce45fb5157ceb3781fd75f46e2d96e1313a46c234164_ctor(
+) {
+    #[allow(unsafe_code)]
+    {
+        #[link_section = ".init_array"]
+        #[used]
+        #[allow(non_upper_case_globals, non_snake_case)]
+        #[doc(hidden)]
+        static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
+            #[link_section = ".text.startup"]
+            #[allow(non_snake_case)]
+            extern "C" fn f() -> ::ctor::__support::CtorRetType {
+                unsafe {
+                    __ContractGlobalPath__test_contracttrait_trait_AllTypes__4b66c68c88167c0df99dce45fb5157ceb3781fd75f46e2d96e1313a46c234164_ctor();
+                };
+                core::default::Default::default()
+            }
+            f
+        };
+    }
+    {
+        <ContractGlobalPath as soroban_sdk::testutils::ContractFunctionRegister>::register(
+            "test_bool",
+            #[allow(deprecated)]
+            &__ContractGlobalPath__test_bool__invoke_raw_slice,
+        );
+    }
+}
+#[doc(hidden)]
+#[allow(non_snake_case)]
+#[allow(unused)]
+fn __ContractGlobalPath__test_contracttrait_trait_AllTypes__d78659c68ad1cfce2ad440653013d25977b451539dd6f219c8e1e8b875d23c14_ctor(
+) {
+    #[allow(unsafe_code)]
+    {
+        #[link_section = ".init_array"]
+        #[used]
+        #[allow(non_upper_case_globals, non_snake_case)]
+        #[doc(hidden)]
+        static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
+            #[link_section = ".text.startup"]
+            #[allow(non_snake_case)]
+            extern "C" fn f() -> ::ctor::__support::CtorRetType {
+                unsafe {
+                    __ContractGlobalPath__test_contracttrait_trait_AllTypes__d78659c68ad1cfce2ad440653013d25977b451539dd6f219c8e1e8b875d23c14_ctor();
+                };
+                core::default::Default::default()
+            }
+            f
+        };
+    }
+    {
+        <ContractGlobalPath as soroban_sdk::testutils::ContractFunctionRegister>::register(
+            "test_address",
+            #[allow(deprecated)]
+            &__ContractGlobalPath__test_address__invoke_raw_slice,
+        );
+    }
+}
+#[doc(hidden)]
+#[allow(non_snake_case)]
+#[allow(unused)]
+fn __ContractGlobalPath__test_contracttrait_trait_AllTypes__d8369e1d7eccf342204ebd3114d6abb3261652c93b0722901964ebc9a2b869ac_ctor(
+) {
+    #[allow(unsafe_code)]
+    {
+        #[link_section = ".init_array"]
+        #[used]
+        #[allow(non_upper_case_globals, non_snake_case)]
+        #[doc(hidden)]
+        static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
+            #[link_section = ".text.startup"]
+            #[allow(non_snake_case)]
+            extern "C" fn f() -> ::ctor::__support::CtorRetType {
+                unsafe {
+                    __ContractGlobalPath__test_contracttrait_trait_AllTypes__d8369e1d7eccf342204ebd3114d6abb3261652c93b0722901964ebc9a2b869ac_ctor();
+                };
+                core::default::Default::default()
+            }
+            f
+        };
+    }
+    {
+        <ContractGlobalPath as soroban_sdk::testutils::ContractFunctionRegister>::register(
+            "test_bytes",
+            #[allow(deprecated)]
+            &__ContractGlobalPath__test_bytes__invoke_raw_slice,
+        );
+    }
+}
+#[doc(hidden)]
+#[allow(non_snake_case)]
+#[allow(unused)]
+fn __ContractGlobalPath__test_contracttrait_trait_AllTypes__4263283d1487792fb25a9666db2bcf4b7cb85d1596eddd530b28e3dea11ca98e_ctor(
+) {
+    #[allow(unsafe_code)]
+    {
+        #[link_section = ".init_array"]
+        #[used]
+        #[allow(non_upper_case_globals, non_snake_case)]
+        #[doc(hidden)]
+        static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
+            #[link_section = ".text.startup"]
+            #[allow(non_snake_case)]
+            extern "C" fn f() -> ::ctor::__support::CtorRetType {
+                unsafe {
+                    __ContractGlobalPath__test_contracttrait_trait_AllTypes__4263283d1487792fb25a9666db2bcf4b7cb85d1596eddd530b28e3dea11ca98e_ctor();
+                };
+                core::default::Default::default()
+            }
+            f
+        };
+    }
+    {
+        <ContractGlobalPath as soroban_sdk::testutils::ContractFunctionRegister>::register(
+            "test_bytes_n",
+            #[allow(deprecated)]
+            &__ContractGlobalPath__test_bytes_n__invoke_raw_slice,
+        );
+    }
+}
+#[doc(hidden)]
+#[allow(non_snake_case)]
+#[allow(unused)]
+fn __ContractGlobalPath__test_contracttrait_trait_AllTypes__a1a211ad36b73f745fe11cbbe5a3b7111710436824119d305f34af1842e457c4_ctor(
+) {
+    #[allow(unsafe_code)]
+    {
+        #[link_section = ".init_array"]
+        #[used]
+        #[allow(non_upper_case_globals, non_snake_case)]
+        #[doc(hidden)]
+        static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
+            #[link_section = ".text.startup"]
+            #[allow(non_snake_case)]
+            extern "C" fn f() -> ::ctor::__support::CtorRetType {
+                unsafe {
+                    __ContractGlobalPath__test_contracttrait_trait_AllTypes__a1a211ad36b73f745fe11cbbe5a3b7111710436824119d305f34af1842e457c4_ctor();
+                };
+                core::default::Default::default()
+            }
+            f
+        };
+    }
+    {
+        <ContractGlobalPath as soroban_sdk::testutils::ContractFunctionRegister>::register(
+            "test_string",
+            #[allow(deprecated)]
+            &__ContractGlobalPath__test_string__invoke_raw_slice,
+        );
+    }
+}
+#[doc(hidden)]
+#[allow(non_snake_case)]
+#[allow(unused)]
+fn __ContractGlobalPath__test_contracttrait_trait_AllTypes__d218b946ac71446987caada5b1ddd9a88071593dc7947a9b5e0c9684f58016d1_ctor(
+) {
+    #[allow(unsafe_code)]
+    {
+        #[link_section = ".init_array"]
+        #[used]
+        #[allow(non_upper_case_globals, non_snake_case)]
+        #[doc(hidden)]
+        static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
+            #[link_section = ".text.startup"]
+            #[allow(non_snake_case)]
+            extern "C" fn f() -> ::ctor::__support::CtorRetType {
+                unsafe {
+                    __ContractGlobalPath__test_contracttrait_trait_AllTypes__d218b946ac71446987caada5b1ddd9a88071593dc7947a9b5e0c9684f58016d1_ctor();
+                };
+                core::default::Default::default()
+            }
+            f
+        };
+    }
+    {
+        <ContractGlobalPath as soroban_sdk::testutils::ContractFunctionRegister>::register(
+            "test_symbol",
+            #[allow(deprecated)]
+            &__ContractGlobalPath__test_symbol__invoke_raw_slice,
+        );
+    }
+}
+#[doc(hidden)]
+#[allow(non_snake_case)]
+#[allow(unused)]
+fn __ContractGlobalPath__test_contracttrait_trait_AllTypes__3dab3b2e67a5258edc6046d3b3cb677c43a508a69de5786d8a34361ad5c12e80_ctor(
+) {
+    #[allow(unsafe_code)]
+    {
+        #[link_section = ".init_array"]
+        #[used]
+        #[allow(non_upper_case_globals, non_snake_case)]
+        #[doc(hidden)]
+        static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
+            #[link_section = ".text.startup"]
+            #[allow(non_snake_case)]
+            extern "C" fn f() -> ::ctor::__support::CtorRetType {
+                unsafe {
+                    __ContractGlobalPath__test_contracttrait_trait_AllTypes__3dab3b2e67a5258edc6046d3b3cb677c43a508a69de5786d8a34361ad5c12e80_ctor();
+                };
+                core::default::Default::default()
+            }
+            f
+        };
+    }
+    {
+        <ContractGlobalPath as soroban_sdk::testutils::ContractFunctionRegister>::register(
+            "test_vec",
+            #[allow(deprecated)]
+            &__ContractGlobalPath__test_vec__invoke_raw_slice,
+        );
+    }
+}
+#[doc(hidden)]
+#[allow(non_snake_case)]
+#[allow(unused)]
+fn __ContractGlobalPath__test_contracttrait_trait_AllTypes__26529164027f0c953c7b3a907b09c5e144a82b6430185ad98603b636b4b3b349_ctor(
+) {
+    #[allow(unsafe_code)]
+    {
+        #[link_section = ".init_array"]
+        #[used]
+        #[allow(non_upper_case_globals, non_snake_case)]
+        #[doc(hidden)]
+        static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
+            #[link_section = ".text.startup"]
+            #[allow(non_snake_case)]
+            extern "C" fn f() -> ::ctor::__support::CtorRetType {
+                unsafe {
+                    __ContractGlobalPath__test_contracttrait_trait_AllTypes__26529164027f0c953c7b3a907b09c5e144a82b6430185ad98603b636b4b3b349_ctor();
+                };
+                core::default::Default::default()
+            }
+            f
+        };
+    }
+    {
+        <ContractGlobalPath as soroban_sdk::testutils::ContractFunctionRegister>::register(
+            "test_map",
+            #[allow(deprecated)]
+            &__ContractGlobalPath__test_map__invoke_raw_slice,
+        );
+    }
+}
+#[doc(hidden)]
+#[allow(non_snake_case)]
+#[allow(unused)]
+fn __ContractGlobalPath__test_contracttrait_trait_AllTypes__152e048563476cac8dd28938f3c41518456072e651f690c6b1ea6814466aea27_ctor(
+) {
+    #[allow(unsafe_code)]
+    {
+        #[link_section = ".init_array"]
+        #[used]
+        #[allow(non_upper_case_globals, non_snake_case)]
+        #[doc(hidden)]
+        static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
+            #[link_section = ".text.startup"]
+            #[allow(non_snake_case)]
+            extern "C" fn f() -> ::ctor::__support::CtorRetType {
+                unsafe {
+                    __ContractGlobalPath__test_contracttrait_trait_AllTypes__152e048563476cac8dd28938f3c41518456072e651f690c6b1ea6814466aea27_ctor();
+                };
+                core::default::Default::default()
+            }
+            f
+        };
+    }
+    {
+        <ContractGlobalPath as soroban_sdk::testutils::ContractFunctionRegister>::register(
+            "test_duration",
+            #[allow(deprecated)]
+            &__ContractGlobalPath__test_duration__invoke_raw_slice,
+        );
+    }
+}
+#[doc(hidden)]
+#[allow(non_snake_case)]
+#[allow(unused)]
+fn __ContractGlobalPath__test_contracttrait_trait_AllTypes__6ab993c9945db4a3067443e6b98939664c9b314387f62bdaaccf83a79f172330_ctor(
+) {
+    #[allow(unsafe_code)]
+    {
+        #[link_section = ".init_array"]
+        #[used]
+        #[allow(non_upper_case_globals, non_snake_case)]
+        #[doc(hidden)]
+        static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
+            #[link_section = ".text.startup"]
+            #[allow(non_snake_case)]
+            extern "C" fn f() -> ::ctor::__support::CtorRetType {
+                unsafe {
+                    __ContractGlobalPath__test_contracttrait_trait_AllTypes__6ab993c9945db4a3067443e6b98939664c9b314387f62bdaaccf83a79f172330_ctor();
+                };
+                core::default::Default::default()
+            }
+            f
+        };
+    }
+    {
+        <ContractGlobalPath as soroban_sdk::testutils::ContractFunctionRegister>::register(
+            "test_timepoint",
+            #[allow(deprecated)]
+            &__ContractGlobalPath__test_timepoint__invoke_raw_slice,
+        );
+    }
+}
+#[doc(hidden)]
+#[allow(non_snake_case)]
+#[allow(unused)]
+fn __ContractGlobalPath__test_contracttrait_trait_AllTypes__720f8551818518259a0743a812712dcfb905b3c817117e017891bbf6229633f2_ctor(
+) {
+    #[allow(unsafe_code)]
+    {
+        #[link_section = ".init_array"]
+        #[used]
+        #[allow(non_upper_case_globals, non_snake_case)]
+        #[doc(hidden)]
+        static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
+            #[link_section = ".text.startup"]
+            #[allow(non_snake_case)]
+            extern "C" fn f() -> ::ctor::__support::CtorRetType {
+                unsafe {
+                    __ContractGlobalPath__test_contracttrait_trait_AllTypes__720f8551818518259a0743a812712dcfb905b3c817117e017891bbf6229633f2_ctor();
+                };
+                core::default::Default::default()
+            }
+            f
+        };
+    }
+    {
+        <ContractGlobalPath as soroban_sdk::testutils::ContractFunctionRegister>::register(
+            "test_i256",
+            #[allow(deprecated)]
+            &__ContractGlobalPath__test_i256__invoke_raw_slice,
+        );
+    }
+}
+#[doc(hidden)]
+#[allow(non_snake_case)]
+#[allow(unused)]
+fn __ContractGlobalPath__test_contracttrait_trait_AllTypes__c11a38375965f06d3e70c95d14652a94d7d10c85964c69ff29449fd1fdd684df_ctor(
+) {
+    #[allow(unsafe_code)]
+    {
+        #[link_section = ".init_array"]
+        #[used]
+        #[allow(non_upper_case_globals, non_snake_case)]
+        #[doc(hidden)]
+        static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
+            #[link_section = ".text.startup"]
+            #[allow(non_snake_case)]
+            extern "C" fn f() -> ::ctor::__support::CtorRetType {
+                unsafe {
+                    __ContractGlobalPath__test_contracttrait_trait_AllTypes__c11a38375965f06d3e70c95d14652a94d7d10c85964c69ff29449fd1fdd684df_ctor();
+                };
+                core::default::Default::default()
+            }
+            f
+        };
+    }
+    {
+        <ContractGlobalPath as soroban_sdk::testutils::ContractFunctionRegister>::register(
+            "test_u256",
+            #[allow(deprecated)]
+            &__ContractGlobalPath__test_u256__invoke_raw_slice,
+        );
+    }
+}
+#[doc(hidden)]
+#[allow(non_snake_case)]
+#[allow(unused)]
+fn __ContractGlobalPath__test_contracttrait_trait_AllTypes__d66789a1d5c62b2e13ce77eb51642b42a21d817718902956ded0ca9720c4f2c2_ctor(
+) {
+    #[allow(unsafe_code)]
+    {
+        #[link_section = ".init_array"]
+        #[used]
+        #[allow(non_upper_case_globals, non_snake_case)]
+        #[doc(hidden)]
+        static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
+            #[link_section = ".text.startup"]
+            #[allow(non_snake_case)]
+            extern "C" fn f() -> ::ctor::__support::CtorRetType {
+                unsafe {
+                    __ContractGlobalPath__test_contracttrait_trait_AllTypes__d66789a1d5c62b2e13ce77eb51642b42a21d817718902956ded0ca9720c4f2c2_ctor();
+                };
+                core::default::Default::default()
+            }
+            f
+        };
+    }
+    {
+        <ContractGlobalPath as soroban_sdk::testutils::ContractFunctionRegister>::register(
+            "test_env_param",
+            #[allow(deprecated)]
+            &__ContractGlobalPath__test_env_param__invoke_raw_slice,
+        );
+    }
+}
+#[doc(hidden)]
+#[allow(non_snake_case)]
+#[allow(unused)]
+fn __ContractGlobalPath__test_contracttrait_trait_AllTypes__8eddde8d361a1a64147292e9556cb28d1efeec7df66b8064c5cc8af95e9b9bad_ctor(
+) {
+    #[allow(unsafe_code)]
+    {
+        #[link_section = ".init_array"]
+        #[used]
+        #[allow(non_upper_case_globals, non_snake_case)]
+        #[doc(hidden)]
+        static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
+            #[link_section = ".text.startup"]
+            #[allow(non_snake_case)]
+            extern "C" fn f() -> ::ctor::__support::CtorRetType {
+                unsafe {
+                    __ContractGlobalPath__test_contracttrait_trait_AllTypes__8eddde8d361a1a64147292e9556cb28d1efeec7df66b8064c5cc8af95e9b9bad_ctor();
+                };
+                core::default::Default::default()
+            }
+            f
+        };
+    }
+    {
+        <ContractGlobalPath as soroban_sdk::testutils::ContractFunctionRegister>::register(
+            "test_struct",
+            #[allow(deprecated)]
+            &__ContractGlobalPath__test_struct__invoke_raw_slice,
+        );
+    }
+}
+#[doc(hidden)]
+#[allow(non_snake_case)]
+#[allow(unused)]
+fn __ContractGlobalPath__test_contracttrait_trait_AllTypes__4a069ddc7591bc91505072ab63fbb531eadd377db8acb22014e849a66a1e26e0_ctor(
+) {
+    #[allow(unsafe_code)]
+    {
+        #[link_section = ".init_array"]
+        #[used]
+        #[allow(non_upper_case_globals, non_snake_case)]
+        #[doc(hidden)]
+        static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
+            #[link_section = ".text.startup"]
+            #[allow(non_snake_case)]
+            extern "C" fn f() -> ::ctor::__support::CtorRetType {
+                unsafe {
+                    __ContractGlobalPath__test_contracttrait_trait_AllTypes__4a069ddc7591bc91505072ab63fbb531eadd377db8acb22014e849a66a1e26e0_ctor();
+                };
+                core::default::Default::default()
+            }
+            f
+        };
+    }
+    {
+        <ContractGlobalPath as soroban_sdk::testutils::ContractFunctionRegister>::register(
+            "test_enum_unit",
+            #[allow(deprecated)]
+            &__ContractGlobalPath__test_enum_unit__invoke_raw_slice,
+        );
+    }
+}
+#[doc(hidden)]
+#[allow(non_snake_case)]
+#[allow(unused)]
+fn __ContractGlobalPath__test_contracttrait_trait_AllTypes__d2b0ba6d429ff899ab7fa1f5126ecddb66bdaec3f51d9aabaa916af14c3079a8_ctor(
+) {
+    #[allow(unsafe_code)]
+    {
+        #[link_section = ".init_array"]
+        #[used]
+        #[allow(non_upper_case_globals, non_snake_case)]
+        #[doc(hidden)]
+        static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
+            #[link_section = ".text.startup"]
+            #[allow(non_snake_case)]
+            extern "C" fn f() -> ::ctor::__support::CtorRetType {
+                unsafe {
+                    __ContractGlobalPath__test_contracttrait_trait_AllTypes__d2b0ba6d429ff899ab7fa1f5126ecddb66bdaec3f51d9aabaa916af14c3079a8_ctor();
+                };
+                core::default::Default::default()
+            }
+            f
+        };
+    }
+    {
+        <ContractGlobalPath as soroban_sdk::testutils::ContractFunctionRegister>::register(
+            "test_enum_variants",
+            #[allow(deprecated)]
+            &__ContractGlobalPath__test_enum_variants__invoke_raw_slice,
+        );
+    }
 }
 mod test {
     use super::*;

--- a/tests-expanded/test_contracttrait_path_global_wasm32v1-none.rs
+++ b/tests-expanded/test_contracttrait_path_global_wasm32v1-none.rs
@@ -1748,11 +1748,14 @@ impl<'a> ContractGlobalPathClient<'a> {
     }
 }
 impl ContractGlobalPathArgs {
+    /// Test u32 values.
+    /// Returns the input unchanged.
     #[inline(always)]
     #[allow(clippy::unused_unit)]
     pub fn test_u32<'i>(v: &'i u32) -> (&'i u32,) {
         (v,)
     }
+    /// Test i32 values.
     #[inline(always)]
     #[allow(clippy::unused_unit)]
     pub fn test_i32<'i>(v: &'i i32) -> (&'i i32,) {

--- a/tests-expanded/test_contracttrait_path_relative_tests.rs
+++ b/tests-expanded/test_contracttrait_path_relative_tests.rs
@@ -478,7 +478,7 @@ impl ContractRelativePathArgs {
 #[doc(hidden)]
 #[allow(non_snake_case)]
 #[allow(unused)]
-fn __ContractRelativePath__traits_RelativePathTrait__4ac15b461ebbdd4a76eab36b99dba87aec581768e17fd8b229f6bd4a5800d478_ctor(
+fn __ContractRelativePath__traits_RelativePathTrait__fcb4031a6cb55f06cb6f3c867344eb9d83a0bcfacb20de3f7d24390d36908673_ctor(
 ) {
     #[allow(unsafe_code)]
     {
@@ -491,7 +491,7 @@ fn __ContractRelativePath__traits_RelativePathTrait__4ac15b461ebbdd4a76eab36b99d
             #[allow(non_snake_case)]
             extern "C" fn f() -> ::ctor::__support::CtorRetType {
                 unsafe {
-                    __ContractRelativePath__traits_RelativePathTrait__4ac15b461ebbdd4a76eab36b99dba87aec581768e17fd8b229f6bd4a5800d478_ctor();
+                    __ContractRelativePath__traits_RelativePathTrait__fcb4031a6cb55f06cb6f3c867344eb9d83a0bcfacb20de3f7d24390d36908673_ctor();
                 };
                 core::default::Default::default()
             }
@@ -505,31 +505,6 @@ fn __ContractRelativePath__traits_RelativePathTrait__4ac15b461ebbdd4a76eab36b99d
             &__ContractRelativePath__relative_path_method__invoke_raw_slice,
         );
     }
-}
-#[doc(hidden)]
-#[allow(non_snake_case)]
-#[allow(unused)]
-fn __ContractRelativePath__traits_RelativePathTrait__e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855_ctor(
-) {
-    #[allow(unsafe_code)]
-    {
-        #[link_section = ".init_array"]
-        #[used]
-        #[allow(non_upper_case_globals, non_snake_case)]
-        #[doc(hidden)]
-        static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
-            #[link_section = ".text.startup"]
-            #[allow(non_snake_case)]
-            extern "C" fn f() -> ::ctor::__support::CtorRetType {
-                unsafe {
-                    __ContractRelativePath__traits_RelativePathTrait__e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855_ctor();
-                };
-                core::default::Default::default()
-            }
-            f
-        };
-    }
-    {}
 }
 mod test {
     use super::*;

--- a/tests-expanded/test_contracttrait_path_self_tests.rs
+++ b/tests-expanded/test_contracttrait_path_self_tests.rs
@@ -469,7 +469,7 @@ impl ContractSelfPathArgs {
 #[doc(hidden)]
 #[allow(non_snake_case)]
 #[allow(unused)]
-fn __ContractSelfPath__self_SelfPathTrait__dc5f37562c93d76ec88b95b8afc4265e99af33ca688eed9a0b515ee0a60c5b8d_ctor(
+fn __ContractSelfPath__self_SelfPathTrait__43099aea02c82fab4ba8f114379a580a4e002e6dca61c881d9dd8daaaccac1a6_ctor(
 ) {
     #[allow(unsafe_code)]
     {
@@ -482,7 +482,7 @@ fn __ContractSelfPath__self_SelfPathTrait__dc5f37562c93d76ec88b95b8afc4265e99af3
             #[allow(non_snake_case)]
             extern "C" fn f() -> ::ctor::__support::CtorRetType {
                 unsafe {
-                    __ContractSelfPath__self_SelfPathTrait__dc5f37562c93d76ec88b95b8afc4265e99af33ca688eed9a0b515ee0a60c5b8d_ctor();
+                    __ContractSelfPath__self_SelfPathTrait__43099aea02c82fab4ba8f114379a580a4e002e6dca61c881d9dd8daaaccac1a6_ctor();
                 };
                 core::default::Default::default()
             }
@@ -496,31 +496,6 @@ fn __ContractSelfPath__self_SelfPathTrait__dc5f37562c93d76ec88b95b8afc4265e99af3
             &__ContractSelfPath__self_path_method__invoke_raw_slice,
         );
     }
-}
-#[doc(hidden)]
-#[allow(non_snake_case)]
-#[allow(unused)]
-fn __ContractSelfPath__self_SelfPathTrait__e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855_ctor(
-) {
-    #[allow(unsafe_code)]
-    {
-        #[link_section = ".init_array"]
-        #[used]
-        #[allow(non_upper_case_globals, non_snake_case)]
-        #[doc(hidden)]
-        static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
-            #[link_section = ".text.startup"]
-            #[allow(non_snake_case)]
-            extern "C" fn f() -> ::ctor::__support::CtorRetType {
-                unsafe {
-                    __ContractSelfPath__self_SelfPathTrait__e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855_ctor();
-                };
-                core::default::Default::default()
-            }
-            f
-        };
-    }
-    {}
 }
 mod test {
     use super::*;

--- a/tests-expanded/test_contracttrait_path_super_tests.rs
+++ b/tests-expanded/test_contracttrait_path_super_tests.rs
@@ -477,7 +477,7 @@ pub mod submodule {
     #[doc(hidden)]
     #[allow(non_snake_case)]
     #[allow(unused)]
-    fn __ContractSuperPath__super_SuperPathTrait__027cbc237c9f13b03e39d11891fd87f1aacbf08c9bcea0bcd8a3a5a7226d3ade_ctor(
+    fn __ContractSuperPath__super_SuperPathTrait__a7ea99188db0ce23ed33cf6b3a90f45b4a9d59de6133f0c5b6c8b55fb24f89f0_ctor(
     ) {
         #[allow(unsafe_code)]
         {
@@ -490,7 +490,7 @@ pub mod submodule {
                 #[allow(non_snake_case)]
                 extern "C" fn f() -> ::ctor::__support::CtorRetType {
                     unsafe {
-                        __ContractSuperPath__super_SuperPathTrait__027cbc237c9f13b03e39d11891fd87f1aacbf08c9bcea0bcd8a3a5a7226d3ade_ctor();
+                        __ContractSuperPath__super_SuperPathTrait__a7ea99188db0ce23ed33cf6b3a90f45b4a9d59de6133f0c5b6c8b55fb24f89f0_ctor();
                     };
                     core::default::Default::default()
                 }
@@ -504,31 +504,6 @@ pub mod submodule {
                 &__ContractSuperPath__super_path_method__invoke_raw_slice,
             );
         }
-    }
-    #[doc(hidden)]
-    #[allow(non_snake_case)]
-    #[allow(unused)]
-    fn __ContractSuperPath__super_SuperPathTrait__e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855_ctor(
-    ) {
-        #[allow(unsafe_code)]
-        {
-            #[link_section = ".init_array"]
-            #[used]
-            #[allow(non_upper_case_globals, non_snake_case)]
-            #[doc(hidden)]
-            static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
-                #[link_section = ".text.startup"]
-                #[allow(non_snake_case)]
-                extern "C" fn f() -> ::ctor::__support::CtorRetType {
-                    unsafe {
-                        __ContractSuperPath__super_SuperPathTrait__e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855_ctor();
-                    };
-                    core::default::Default::default()
-                }
-                f
-            };
-        }
-        {}
     }
 }
 mod test {

--- a/tests-expanded/test_contracttrait_trait_tests.rs
+++ b/tests-expanded/test_contracttrait_trait_tests.rs
@@ -3218,11 +3218,14 @@ impl<'a> AllTypesClient<'a> {
 ///AllTypesArgs is a type for building arg lists for functions defined in "AllTypes".
 pub struct AllTypesArgs;
 impl AllTypesArgs {
+    /// Test u32 values.
+    /// Returns the input unchanged.
     #[inline(always)]
     #[allow(clippy::unused_unit)]
     pub fn test_u32<'i>(v: &'i u32) -> (&'i u32,) {
         (v,)
     }
+    /// Test i32 values.
     #[inline(always)]
     #[allow(clippy::unused_unit)]
     pub fn test_i32<'i>(v: &'i i32) -> (&'i i32,) {
@@ -3462,6 +3465,291 @@ impl AllTypesSpec {
     #[allow(non_snake_case)]
     pub const fn spec_xdr_test_enum_variants() -> [u8; 100usize] {
         *b"\0\0\0\0\0\0\0\0\0\0\0\x12test_enum_variants\0\0\0\0\0\x01\0\0\0\0\0\0\0\x01v\0\0\0\0\0\x07\xd0\0\0\0\x0eMyEnumVariants\0\0\0\0\0\x01\0\0\x07\xd0\0\0\0\x0eMyEnumVariants\0\0"
+    }
+}
+pub struct CfgGatedSpec;
+/// Macro for `contractimpl`ing the default functions of the trait that are not overridden.
+pub use __contractimpl_for_cfg_gated as CfgGated;
+pub trait CfgGated {
+    fn shown(env: Env) -> u32 {
+        let _ = env;
+        8
+    }
+    fn feature_enabled(env: Env) -> u32 {
+        let _ = env;
+        9
+    }
+}
+///CfgGatedClient is a client for calling the contract defined in "CfgGated".
+pub struct CfgGatedClient<'a> {
+    pub env: soroban_sdk::Env,
+    pub address: soroban_sdk::Address,
+    #[doc(hidden)]
+    set_auths: Option<&'a [soroban_sdk::xdr::SorobanAuthorizationEntry]>,
+    #[doc(hidden)]
+    mock_auths: Option<&'a [soroban_sdk::testutils::MockAuth<'a>]>,
+    #[doc(hidden)]
+    mock_all_auths: bool,
+    #[doc(hidden)]
+    allow_non_root_auth: bool,
+}
+impl<'a> CfgGatedClient<'a> {
+    pub fn new(env: &soroban_sdk::Env, address: &soroban_sdk::Address) -> Self {
+        Self {
+            env: env.clone(),
+            address: address.clone(),
+            set_auths: None,
+            mock_auths: None,
+            mock_all_auths: false,
+            allow_non_root_auth: false,
+        }
+    }
+    /// Set authorizations in the environment which will be consumed by
+    /// contracts when they invoke `Address::require_auth` or
+    /// `Address::require_auth_for_args` functions.
+    ///
+    /// Requires valid signatures for the authorization to be successful.
+    /// To mock auth without requiring valid signatures, use `mock_auths`.
+    ///
+    /// See `soroban_sdk::Env::set_auths` for more details and examples.
+    pub fn set_auths(&self, auths: &'a [soroban_sdk::xdr::SorobanAuthorizationEntry]) -> Self {
+        Self {
+            env: self.env.clone(),
+            address: self.address.clone(),
+            set_auths: Some(auths),
+            mock_auths: self.mock_auths.clone(),
+            mock_all_auths: false,
+            allow_non_root_auth: false,
+        }
+    }
+    /// Mock authorizations in the environment which will cause matching invokes
+    /// of `Address::require_auth` and `Address::require_auth_for_args` to
+    /// pass.
+    ///
+    /// See `soroban_sdk::Env::set_auths` for more details and examples.
+    pub fn mock_auths(&self, mock_auths: &'a [soroban_sdk::testutils::MockAuth<'a>]) -> Self {
+        Self {
+            env: self.env.clone(),
+            address: self.address.clone(),
+            set_auths: self.set_auths.clone(),
+            mock_auths: Some(mock_auths),
+            mock_all_auths: false,
+            allow_non_root_auth: false,
+        }
+    }
+    /// Mock all calls to the `Address::require_auth` and
+    /// `Address::require_auth_for_args` functions in invoked contracts,
+    /// having them succeed as if authorization was provided.
+    ///
+    /// See `soroban_sdk::Env::mock_all_auths` for more details and
+    /// examples.
+    pub fn mock_all_auths(&self) -> Self {
+        Self {
+            env: self.env.clone(),
+            address: self.address.clone(),
+            set_auths: None,
+            mock_auths: None,
+            mock_all_auths: true,
+            allow_non_root_auth: false,
+        }
+    }
+    /// A version of `mock_all_auths` that allows authorizations that
+    /// are not present in the root invocation.
+    ///
+    /// Refer to `mock_all_auths` documentation for details and
+    /// prefer using `mock_all_auths` unless non-root authorization is
+    /// required.
+    ///
+    /// See `soroban_sdk::Env::mock_all_auths_allowing_non_root_auth`
+    /// for more details and examples.
+    pub fn mock_all_auths_allowing_non_root_auth(&self) -> Self {
+        Self {
+            env: self.env.clone(),
+            address: self.address.clone(),
+            set_auths: None,
+            mock_auths: None,
+            mock_all_auths: true,
+            allow_non_root_auth: true,
+        }
+    }
+}
+impl<'a> CfgGatedClient<'a> {
+    pub fn shown(&self) -> u32 {
+        use core::ops::Not;
+        let old_auth_manager = self
+            .env
+            .in_contract()
+            .not()
+            .then(|| self.env.host().snapshot_auth_manager().unwrap());
+        {
+            if let Some(set_auths) = self.set_auths {
+                self.env.set_auths(set_auths);
+            }
+            if let Some(mock_auths) = self.mock_auths {
+                self.env.mock_auths(mock_auths);
+            }
+            if self.mock_all_auths {
+                if self.allow_non_root_auth {
+                    self.env.mock_all_auths_allowing_non_root_auth();
+                } else {
+                    self.env.mock_all_auths();
+                }
+            }
+        }
+        use soroban_sdk::{FromVal, IntoVal};
+        let res = self.env.invoke_contract(
+            &self.address,
+            &{
+                #[allow(deprecated)]
+                const SYMBOL: soroban_sdk::Symbol = soroban_sdk::Symbol::short("shown");
+                SYMBOL
+            },
+            ::soroban_sdk::Vec::new(&self.env),
+        );
+        if let Some(old_auth_manager) = old_auth_manager {
+            self.env.host().set_auth_manager(old_auth_manager).unwrap();
+        }
+        res
+    }
+    pub fn try_shown(
+        &self,
+    ) -> Result<
+        Result<u32, <u32 as soroban_sdk::TryFromVal<soroban_sdk::Env, soroban_sdk::Val>>::Error>,
+        Result<soroban_sdk::Error, soroban_sdk::InvokeError>,
+    > {
+        use core::ops::Not;
+        let old_auth_manager = self
+            .env
+            .in_contract()
+            .not()
+            .then(|| self.env.host().snapshot_auth_manager().unwrap());
+        {
+            if let Some(set_auths) = self.set_auths {
+                self.env.set_auths(set_auths);
+            }
+            if let Some(mock_auths) = self.mock_auths {
+                self.env.mock_auths(mock_auths);
+            }
+            if self.mock_all_auths {
+                if self.allow_non_root_auth {
+                    self.env.mock_all_auths_allowing_non_root_auth();
+                } else {
+                    self.env.mock_all_auths();
+                }
+            }
+        }
+        use soroban_sdk::{FromVal, IntoVal};
+        let res = self.env.try_invoke_contract(
+            &self.address,
+            &{
+                #[allow(deprecated)]
+                const SYMBOL: soroban_sdk::Symbol = soroban_sdk::Symbol::short("shown");
+                SYMBOL
+            },
+            ::soroban_sdk::Vec::new(&self.env),
+        );
+        if let Some(old_auth_manager) = old_auth_manager {
+            self.env.host().set_auth_manager(old_auth_manager).unwrap();
+        }
+        res
+    }
+    pub fn feature_enabled(&self) -> u32 {
+        use core::ops::Not;
+        let old_auth_manager = self
+            .env
+            .in_contract()
+            .not()
+            .then(|| self.env.host().snapshot_auth_manager().unwrap());
+        {
+            if let Some(set_auths) = self.set_auths {
+                self.env.set_auths(set_auths);
+            }
+            if let Some(mock_auths) = self.mock_auths {
+                self.env.mock_auths(mock_auths);
+            }
+            if self.mock_all_auths {
+                if self.allow_non_root_auth {
+                    self.env.mock_all_auths_allowing_non_root_auth();
+                } else {
+                    self.env.mock_all_auths();
+                }
+            }
+        }
+        use soroban_sdk::{FromVal, IntoVal};
+        let res = self.env.invoke_contract(
+            &self.address,
+            &{ soroban_sdk::Symbol::new(&self.env, "feature_enabled") },
+            ::soroban_sdk::Vec::new(&self.env),
+        );
+        if let Some(old_auth_manager) = old_auth_manager {
+            self.env.host().set_auth_manager(old_auth_manager).unwrap();
+        }
+        res
+    }
+    pub fn try_feature_enabled(
+        &self,
+    ) -> Result<
+        Result<u32, <u32 as soroban_sdk::TryFromVal<soroban_sdk::Env, soroban_sdk::Val>>::Error>,
+        Result<soroban_sdk::Error, soroban_sdk::InvokeError>,
+    > {
+        use core::ops::Not;
+        let old_auth_manager = self
+            .env
+            .in_contract()
+            .not()
+            .then(|| self.env.host().snapshot_auth_manager().unwrap());
+        {
+            if let Some(set_auths) = self.set_auths {
+                self.env.set_auths(set_auths);
+            }
+            if let Some(mock_auths) = self.mock_auths {
+                self.env.mock_auths(mock_auths);
+            }
+            if self.mock_all_auths {
+                if self.allow_non_root_auth {
+                    self.env.mock_all_auths_allowing_non_root_auth();
+                } else {
+                    self.env.mock_all_auths();
+                }
+            }
+        }
+        use soroban_sdk::{FromVal, IntoVal};
+        let res = self.env.try_invoke_contract(
+            &self.address,
+            &{ soroban_sdk::Symbol::new(&self.env, "feature_enabled") },
+            ::soroban_sdk::Vec::new(&self.env),
+        );
+        if let Some(old_auth_manager) = old_auth_manager {
+            self.env.host().set_auth_manager(old_auth_manager).unwrap();
+        }
+        res
+    }
+}
+///CfgGatedArgs is a type for building arg lists for functions defined in "CfgGated".
+pub struct CfgGatedArgs;
+impl CfgGatedArgs {
+    #[inline(always)]
+    #[allow(clippy::unused_unit)]
+    pub fn shown<'i>() -> () {
+        ()
+    }
+    #[inline(always)]
+    #[allow(clippy::unused_unit)]
+    pub fn feature_enabled<'i>() -> () {
+        ()
+    }
+}
+impl CfgGatedSpec {}
+impl CfgGatedSpec {
+    #[allow(non_snake_case)]
+    pub const fn spec_xdr_shown() -> [u8; 32usize] {
+        *b"\0\0\0\0\0\0\0\0\0\0\0\x05shown\0\0\0\0\0\0\0\0\0\0\x01\0\0\0\x04"
+    }
+}
+impl CfgGatedSpec {
+    #[allow(non_snake_case)]
+    pub const fn spec_xdr_feature_enabled() -> [u8; 40usize] {
+        *b"\0\0\0\0\0\0\0\0\0\0\0\x0ffeature_enabled\0\0\0\0\0\0\0\0\x01\0\0\0\x04"
     }
 }
 mod test {
@@ -6735,11 +7023,14 @@ mod test {
         }
     }
     impl ContractArgs {
+        /// Test u32 values.
+        /// Returns the input unchanged.
         #[inline(always)]
         #[allow(clippy::unused_unit)]
         pub fn test_u32<'i>(v: &'i u32) -> (&'i u32,) {
             (v,)
         }
+        /// Test i32 values.
         #[inline(always)]
         #[allow(clippy::unused_unit)]
         pub fn test_i32<'i>(v: &'i i32) -> (&'i i32,) {
@@ -6849,7 +7140,7 @@ mod test {
     #[doc(hidden)]
     #[allow(non_snake_case)]
     #[allow(unused)]
-    fn __Contract__AllTypes__959aee9d42336ade92416504111dfbb4e37b0472bbb1e487310c05a170c39d28_ctor()
+    fn __Contract__AllTypes__53d758cb364e30212244bac7f86701cb2cd52ec2d1e81aa422edf52088793ca1_ctor()
     {
         #[allow(unsafe_code)]
         {
@@ -6862,7 +7153,7 @@ mod test {
                 #[allow(non_snake_case)]
                 extern "C" fn f() -> ::ctor::__support::CtorRetType {
                     unsafe {
-                        __Contract__AllTypes__959aee9d42336ade92416504111dfbb4e37b0472bbb1e487310c05a170c39d28_ctor();
+                        __Contract__AllTypes__53d758cb364e30212244bac7f86701cb2cd52ec2d1e81aa422edf52088793ca1_ctor();
                     };
                     core::default::Default::default()
                 }
@@ -6875,117 +7166,12 @@ mod test {
                 #[allow(deprecated)]
                 &__Contract__test_u32__invoke_raw_slice,
             );
-            <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
-                "test_i32",
-                #[allow(deprecated)]
-                &__Contract__test_i32__invoke_raw_slice,
-            );
-            <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
-                "test_u64",
-                #[allow(deprecated)]
-                &__Contract__test_u64__invoke_raw_slice,
-            );
-            <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
-                "test_i64",
-                #[allow(deprecated)]
-                &__Contract__test_i64__invoke_raw_slice,
-            );
-            <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
-                "test_u128",
-                #[allow(deprecated)]
-                &__Contract__test_u128__invoke_raw_slice,
-            );
-            <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
-                "test_i128",
-                #[allow(deprecated)]
-                &__Contract__test_i128__invoke_raw_slice,
-            );
-            <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
-                "test_bool",
-                #[allow(deprecated)]
-                &__Contract__test_bool__invoke_raw_slice,
-            );
-            <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
-                "test_address",
-                #[allow(deprecated)]
-                &__Contract__test_address__invoke_raw_slice,
-            );
-            <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
-                "test_bytes",
-                #[allow(deprecated)]
-                &__Contract__test_bytes__invoke_raw_slice,
-            );
-            <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
-                "test_bytes_n",
-                #[allow(deprecated)]
-                &__Contract__test_bytes_n__invoke_raw_slice,
-            );
-            <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
-                "test_string",
-                #[allow(deprecated)]
-                &__Contract__test_string__invoke_raw_slice,
-            );
-            <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
-                "test_symbol",
-                #[allow(deprecated)]
-                &__Contract__test_symbol__invoke_raw_slice,
-            );
-            <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
-                "test_vec",
-                #[allow(deprecated)]
-                &__Contract__test_vec__invoke_raw_slice,
-            );
-            <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
-                "test_map",
-                #[allow(deprecated)]
-                &__Contract__test_map__invoke_raw_slice,
-            );
-            <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
-                "test_duration",
-                #[allow(deprecated)]
-                &__Contract__test_duration__invoke_raw_slice,
-            );
-            <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
-                "test_timepoint",
-                #[allow(deprecated)]
-                &__Contract__test_timepoint__invoke_raw_slice,
-            );
-            <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
-                "test_i256",
-                #[allow(deprecated)]
-                &__Contract__test_i256__invoke_raw_slice,
-            );
-            <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
-                "test_u256",
-                #[allow(deprecated)]
-                &__Contract__test_u256__invoke_raw_slice,
-            );
-            <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
-                "test_env_param",
-                #[allow(deprecated)]
-                &__Contract__test_env_param__invoke_raw_slice,
-            );
-            <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
-                "test_struct",
-                #[allow(deprecated)]
-                &__Contract__test_struct__invoke_raw_slice,
-            );
-            <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
-                "test_enum_unit",
-                #[allow(deprecated)]
-                &__Contract__test_enum_unit__invoke_raw_slice,
-            );
-            <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
-                "test_enum_variants",
-                #[allow(deprecated)]
-                &__Contract__test_enum_variants__invoke_raw_slice,
-            );
         }
     }
     #[doc(hidden)]
     #[allow(non_snake_case)]
     #[allow(unused)]
-    fn __Contract__AllTypes__e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855_ctor()
+    fn __Contract__AllTypes__fc0e53ecfa4163838da8f2017151f32594d5d3960028ec820f6052edb4a84059_ctor()
     {
         #[allow(unsafe_code)]
         {
@@ -6998,14 +7184,2598 @@ mod test {
                 #[allow(non_snake_case)]
                 extern "C" fn f() -> ::ctor::__support::CtorRetType {
                     unsafe {
-                        __Contract__AllTypes__e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855_ctor();
+                        __Contract__AllTypes__fc0e53ecfa4163838da8f2017151f32594d5d3960028ec820f6052edb4a84059_ctor();
                     };
                     core::default::Default::default()
                 }
                 f
             };
         }
-        {}
+        {
+            <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
+                "test_i32",
+                #[allow(deprecated)]
+                &__Contract__test_i32__invoke_raw_slice,
+            );
+        }
+    }
+    #[doc(hidden)]
+    #[allow(non_snake_case)]
+    #[allow(unused)]
+    fn __Contract__AllTypes__b770dfe9b2adeb806c45d6b5ef3d31c7b9c987740d9a583ed8e1683b5debdb75_ctor()
+    {
+        #[allow(unsafe_code)]
+        {
+            #[link_section = ".init_array"]
+            #[used]
+            #[allow(non_upper_case_globals, non_snake_case)]
+            #[doc(hidden)]
+            static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
+                #[link_section = ".text.startup"]
+                #[allow(non_snake_case)]
+                extern "C" fn f() -> ::ctor::__support::CtorRetType {
+                    unsafe {
+                        __Contract__AllTypes__b770dfe9b2adeb806c45d6b5ef3d31c7b9c987740d9a583ed8e1683b5debdb75_ctor();
+                    };
+                    core::default::Default::default()
+                }
+                f
+            };
+        }
+        {
+            <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
+                "test_u64",
+                #[allow(deprecated)]
+                &__Contract__test_u64__invoke_raw_slice,
+            );
+        }
+    }
+    #[doc(hidden)]
+    #[allow(non_snake_case)]
+    #[allow(unused)]
+    fn __Contract__AllTypes__c7e2f7ef9f571dc3460d8b374883a38011169cfe419aa02ad69ddbff73b746d7_ctor()
+    {
+        #[allow(unsafe_code)]
+        {
+            #[link_section = ".init_array"]
+            #[used]
+            #[allow(non_upper_case_globals, non_snake_case)]
+            #[doc(hidden)]
+            static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
+                #[link_section = ".text.startup"]
+                #[allow(non_snake_case)]
+                extern "C" fn f() -> ::ctor::__support::CtorRetType {
+                    unsafe {
+                        __Contract__AllTypes__c7e2f7ef9f571dc3460d8b374883a38011169cfe419aa02ad69ddbff73b746d7_ctor();
+                    };
+                    core::default::Default::default()
+                }
+                f
+            };
+        }
+        {
+            <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
+                "test_i64",
+                #[allow(deprecated)]
+                &__Contract__test_i64__invoke_raw_slice,
+            );
+        }
+    }
+    #[doc(hidden)]
+    #[allow(non_snake_case)]
+    #[allow(unused)]
+    fn __Contract__AllTypes__1f04aa8787240d34edecbbf647ed2ed836655df078df79a8b7d5840e300aae9d_ctor()
+    {
+        #[allow(unsafe_code)]
+        {
+            #[link_section = ".init_array"]
+            #[used]
+            #[allow(non_upper_case_globals, non_snake_case)]
+            #[doc(hidden)]
+            static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
+                #[link_section = ".text.startup"]
+                #[allow(non_snake_case)]
+                extern "C" fn f() -> ::ctor::__support::CtorRetType {
+                    unsafe {
+                        __Contract__AllTypes__1f04aa8787240d34edecbbf647ed2ed836655df078df79a8b7d5840e300aae9d_ctor();
+                    };
+                    core::default::Default::default()
+                }
+                f
+            };
+        }
+        {
+            <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
+                "test_u128",
+                #[allow(deprecated)]
+                &__Contract__test_u128__invoke_raw_slice,
+            );
+        }
+    }
+    #[doc(hidden)]
+    #[allow(non_snake_case)]
+    #[allow(unused)]
+    fn __Contract__AllTypes__21c197ddff91b560d684eefa2ec923ac1edb7ba246d887790999555f1f1082b4_ctor()
+    {
+        #[allow(unsafe_code)]
+        {
+            #[link_section = ".init_array"]
+            #[used]
+            #[allow(non_upper_case_globals, non_snake_case)]
+            #[doc(hidden)]
+            static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
+                #[link_section = ".text.startup"]
+                #[allow(non_snake_case)]
+                extern "C" fn f() -> ::ctor::__support::CtorRetType {
+                    unsafe {
+                        __Contract__AllTypes__21c197ddff91b560d684eefa2ec923ac1edb7ba246d887790999555f1f1082b4_ctor();
+                    };
+                    core::default::Default::default()
+                }
+                f
+            };
+        }
+        {
+            <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
+                "test_i128",
+                #[allow(deprecated)]
+                &__Contract__test_i128__invoke_raw_slice,
+            );
+        }
+    }
+    #[doc(hidden)]
+    #[allow(non_snake_case)]
+    #[allow(unused)]
+    fn __Contract__AllTypes__4b66c68c88167c0df99dce45fb5157ceb3781fd75f46e2d96e1313a46c234164_ctor()
+    {
+        #[allow(unsafe_code)]
+        {
+            #[link_section = ".init_array"]
+            #[used]
+            #[allow(non_upper_case_globals, non_snake_case)]
+            #[doc(hidden)]
+            static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
+                #[link_section = ".text.startup"]
+                #[allow(non_snake_case)]
+                extern "C" fn f() -> ::ctor::__support::CtorRetType {
+                    unsafe {
+                        __Contract__AllTypes__4b66c68c88167c0df99dce45fb5157ceb3781fd75f46e2d96e1313a46c234164_ctor();
+                    };
+                    core::default::Default::default()
+                }
+                f
+            };
+        }
+        {
+            <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
+                "test_bool",
+                #[allow(deprecated)]
+                &__Contract__test_bool__invoke_raw_slice,
+            );
+        }
+    }
+    #[doc(hidden)]
+    #[allow(non_snake_case)]
+    #[allow(unused)]
+    fn __Contract__AllTypes__d78659c68ad1cfce2ad440653013d25977b451539dd6f219c8e1e8b875d23c14_ctor()
+    {
+        #[allow(unsafe_code)]
+        {
+            #[link_section = ".init_array"]
+            #[used]
+            #[allow(non_upper_case_globals, non_snake_case)]
+            #[doc(hidden)]
+            static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
+                #[link_section = ".text.startup"]
+                #[allow(non_snake_case)]
+                extern "C" fn f() -> ::ctor::__support::CtorRetType {
+                    unsafe {
+                        __Contract__AllTypes__d78659c68ad1cfce2ad440653013d25977b451539dd6f219c8e1e8b875d23c14_ctor();
+                    };
+                    core::default::Default::default()
+                }
+                f
+            };
+        }
+        {
+            <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
+                "test_address",
+                #[allow(deprecated)]
+                &__Contract__test_address__invoke_raw_slice,
+            );
+        }
+    }
+    #[doc(hidden)]
+    #[allow(non_snake_case)]
+    #[allow(unused)]
+    fn __Contract__AllTypes__d8369e1d7eccf342204ebd3114d6abb3261652c93b0722901964ebc9a2b869ac_ctor()
+    {
+        #[allow(unsafe_code)]
+        {
+            #[link_section = ".init_array"]
+            #[used]
+            #[allow(non_upper_case_globals, non_snake_case)]
+            #[doc(hidden)]
+            static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
+                #[link_section = ".text.startup"]
+                #[allow(non_snake_case)]
+                extern "C" fn f() -> ::ctor::__support::CtorRetType {
+                    unsafe {
+                        __Contract__AllTypes__d8369e1d7eccf342204ebd3114d6abb3261652c93b0722901964ebc9a2b869ac_ctor();
+                    };
+                    core::default::Default::default()
+                }
+                f
+            };
+        }
+        {
+            <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
+                "test_bytes",
+                #[allow(deprecated)]
+                &__Contract__test_bytes__invoke_raw_slice,
+            );
+        }
+    }
+    #[doc(hidden)]
+    #[allow(non_snake_case)]
+    #[allow(unused)]
+    fn __Contract__AllTypes__4263283d1487792fb25a9666db2bcf4b7cb85d1596eddd530b28e3dea11ca98e_ctor()
+    {
+        #[allow(unsafe_code)]
+        {
+            #[link_section = ".init_array"]
+            #[used]
+            #[allow(non_upper_case_globals, non_snake_case)]
+            #[doc(hidden)]
+            static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
+                #[link_section = ".text.startup"]
+                #[allow(non_snake_case)]
+                extern "C" fn f() -> ::ctor::__support::CtorRetType {
+                    unsafe {
+                        __Contract__AllTypes__4263283d1487792fb25a9666db2bcf4b7cb85d1596eddd530b28e3dea11ca98e_ctor();
+                    };
+                    core::default::Default::default()
+                }
+                f
+            };
+        }
+        {
+            <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
+                "test_bytes_n",
+                #[allow(deprecated)]
+                &__Contract__test_bytes_n__invoke_raw_slice,
+            );
+        }
+    }
+    #[doc(hidden)]
+    #[allow(non_snake_case)]
+    #[allow(unused)]
+    fn __Contract__AllTypes__a1a211ad36b73f745fe11cbbe5a3b7111710436824119d305f34af1842e457c4_ctor()
+    {
+        #[allow(unsafe_code)]
+        {
+            #[link_section = ".init_array"]
+            #[used]
+            #[allow(non_upper_case_globals, non_snake_case)]
+            #[doc(hidden)]
+            static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
+                #[link_section = ".text.startup"]
+                #[allow(non_snake_case)]
+                extern "C" fn f() -> ::ctor::__support::CtorRetType {
+                    unsafe {
+                        __Contract__AllTypes__a1a211ad36b73f745fe11cbbe5a3b7111710436824119d305f34af1842e457c4_ctor();
+                    };
+                    core::default::Default::default()
+                }
+                f
+            };
+        }
+        {
+            <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
+                "test_string",
+                #[allow(deprecated)]
+                &__Contract__test_string__invoke_raw_slice,
+            );
+        }
+    }
+    #[doc(hidden)]
+    #[allow(non_snake_case)]
+    #[allow(unused)]
+    fn __Contract__AllTypes__d218b946ac71446987caada5b1ddd9a88071593dc7947a9b5e0c9684f58016d1_ctor()
+    {
+        #[allow(unsafe_code)]
+        {
+            #[link_section = ".init_array"]
+            #[used]
+            #[allow(non_upper_case_globals, non_snake_case)]
+            #[doc(hidden)]
+            static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
+                #[link_section = ".text.startup"]
+                #[allow(non_snake_case)]
+                extern "C" fn f() -> ::ctor::__support::CtorRetType {
+                    unsafe {
+                        __Contract__AllTypes__d218b946ac71446987caada5b1ddd9a88071593dc7947a9b5e0c9684f58016d1_ctor();
+                    };
+                    core::default::Default::default()
+                }
+                f
+            };
+        }
+        {
+            <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
+                "test_symbol",
+                #[allow(deprecated)]
+                &__Contract__test_symbol__invoke_raw_slice,
+            );
+        }
+    }
+    #[doc(hidden)]
+    #[allow(non_snake_case)]
+    #[allow(unused)]
+    fn __Contract__AllTypes__3dab3b2e67a5258edc6046d3b3cb677c43a508a69de5786d8a34361ad5c12e80_ctor()
+    {
+        #[allow(unsafe_code)]
+        {
+            #[link_section = ".init_array"]
+            #[used]
+            #[allow(non_upper_case_globals, non_snake_case)]
+            #[doc(hidden)]
+            static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
+                #[link_section = ".text.startup"]
+                #[allow(non_snake_case)]
+                extern "C" fn f() -> ::ctor::__support::CtorRetType {
+                    unsafe {
+                        __Contract__AllTypes__3dab3b2e67a5258edc6046d3b3cb677c43a508a69de5786d8a34361ad5c12e80_ctor();
+                    };
+                    core::default::Default::default()
+                }
+                f
+            };
+        }
+        {
+            <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
+                "test_vec",
+                #[allow(deprecated)]
+                &__Contract__test_vec__invoke_raw_slice,
+            );
+        }
+    }
+    #[doc(hidden)]
+    #[allow(non_snake_case)]
+    #[allow(unused)]
+    fn __Contract__AllTypes__26529164027f0c953c7b3a907b09c5e144a82b6430185ad98603b636b4b3b349_ctor()
+    {
+        #[allow(unsafe_code)]
+        {
+            #[link_section = ".init_array"]
+            #[used]
+            #[allow(non_upper_case_globals, non_snake_case)]
+            #[doc(hidden)]
+            static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
+                #[link_section = ".text.startup"]
+                #[allow(non_snake_case)]
+                extern "C" fn f() -> ::ctor::__support::CtorRetType {
+                    unsafe {
+                        __Contract__AllTypes__26529164027f0c953c7b3a907b09c5e144a82b6430185ad98603b636b4b3b349_ctor();
+                    };
+                    core::default::Default::default()
+                }
+                f
+            };
+        }
+        {
+            <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
+                "test_map",
+                #[allow(deprecated)]
+                &__Contract__test_map__invoke_raw_slice,
+            );
+        }
+    }
+    #[doc(hidden)]
+    #[allow(non_snake_case)]
+    #[allow(unused)]
+    fn __Contract__AllTypes__152e048563476cac8dd28938f3c41518456072e651f690c6b1ea6814466aea27_ctor()
+    {
+        #[allow(unsafe_code)]
+        {
+            #[link_section = ".init_array"]
+            #[used]
+            #[allow(non_upper_case_globals, non_snake_case)]
+            #[doc(hidden)]
+            static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
+                #[link_section = ".text.startup"]
+                #[allow(non_snake_case)]
+                extern "C" fn f() -> ::ctor::__support::CtorRetType {
+                    unsafe {
+                        __Contract__AllTypes__152e048563476cac8dd28938f3c41518456072e651f690c6b1ea6814466aea27_ctor();
+                    };
+                    core::default::Default::default()
+                }
+                f
+            };
+        }
+        {
+            <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
+                "test_duration",
+                #[allow(deprecated)]
+                &__Contract__test_duration__invoke_raw_slice,
+            );
+        }
+    }
+    #[doc(hidden)]
+    #[allow(non_snake_case)]
+    #[allow(unused)]
+    fn __Contract__AllTypes__6ab993c9945db4a3067443e6b98939664c9b314387f62bdaaccf83a79f172330_ctor()
+    {
+        #[allow(unsafe_code)]
+        {
+            #[link_section = ".init_array"]
+            #[used]
+            #[allow(non_upper_case_globals, non_snake_case)]
+            #[doc(hidden)]
+            static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
+                #[link_section = ".text.startup"]
+                #[allow(non_snake_case)]
+                extern "C" fn f() -> ::ctor::__support::CtorRetType {
+                    unsafe {
+                        __Contract__AllTypes__6ab993c9945db4a3067443e6b98939664c9b314387f62bdaaccf83a79f172330_ctor();
+                    };
+                    core::default::Default::default()
+                }
+                f
+            };
+        }
+        {
+            <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
+                "test_timepoint",
+                #[allow(deprecated)]
+                &__Contract__test_timepoint__invoke_raw_slice,
+            );
+        }
+    }
+    #[doc(hidden)]
+    #[allow(non_snake_case)]
+    #[allow(unused)]
+    fn __Contract__AllTypes__720f8551818518259a0743a812712dcfb905b3c817117e017891bbf6229633f2_ctor()
+    {
+        #[allow(unsafe_code)]
+        {
+            #[link_section = ".init_array"]
+            #[used]
+            #[allow(non_upper_case_globals, non_snake_case)]
+            #[doc(hidden)]
+            static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
+                #[link_section = ".text.startup"]
+                #[allow(non_snake_case)]
+                extern "C" fn f() -> ::ctor::__support::CtorRetType {
+                    unsafe {
+                        __Contract__AllTypes__720f8551818518259a0743a812712dcfb905b3c817117e017891bbf6229633f2_ctor();
+                    };
+                    core::default::Default::default()
+                }
+                f
+            };
+        }
+        {
+            <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
+                "test_i256",
+                #[allow(deprecated)]
+                &__Contract__test_i256__invoke_raw_slice,
+            );
+        }
+    }
+    #[doc(hidden)]
+    #[allow(non_snake_case)]
+    #[allow(unused)]
+    fn __Contract__AllTypes__c11a38375965f06d3e70c95d14652a94d7d10c85964c69ff29449fd1fdd684df_ctor()
+    {
+        #[allow(unsafe_code)]
+        {
+            #[link_section = ".init_array"]
+            #[used]
+            #[allow(non_upper_case_globals, non_snake_case)]
+            #[doc(hidden)]
+            static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
+                #[link_section = ".text.startup"]
+                #[allow(non_snake_case)]
+                extern "C" fn f() -> ::ctor::__support::CtorRetType {
+                    unsafe {
+                        __Contract__AllTypes__c11a38375965f06d3e70c95d14652a94d7d10c85964c69ff29449fd1fdd684df_ctor();
+                    };
+                    core::default::Default::default()
+                }
+                f
+            };
+        }
+        {
+            <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
+                "test_u256",
+                #[allow(deprecated)]
+                &__Contract__test_u256__invoke_raw_slice,
+            );
+        }
+    }
+    #[doc(hidden)]
+    #[allow(non_snake_case)]
+    #[allow(unused)]
+    fn __Contract__AllTypes__d66789a1d5c62b2e13ce77eb51642b42a21d817718902956ded0ca9720c4f2c2_ctor()
+    {
+        #[allow(unsafe_code)]
+        {
+            #[link_section = ".init_array"]
+            #[used]
+            #[allow(non_upper_case_globals, non_snake_case)]
+            #[doc(hidden)]
+            static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
+                #[link_section = ".text.startup"]
+                #[allow(non_snake_case)]
+                extern "C" fn f() -> ::ctor::__support::CtorRetType {
+                    unsafe {
+                        __Contract__AllTypes__d66789a1d5c62b2e13ce77eb51642b42a21d817718902956ded0ca9720c4f2c2_ctor();
+                    };
+                    core::default::Default::default()
+                }
+                f
+            };
+        }
+        {
+            <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
+                "test_env_param",
+                #[allow(deprecated)]
+                &__Contract__test_env_param__invoke_raw_slice,
+            );
+        }
+    }
+    #[doc(hidden)]
+    #[allow(non_snake_case)]
+    #[allow(unused)]
+    fn __Contract__AllTypes__8eddde8d361a1a64147292e9556cb28d1efeec7df66b8064c5cc8af95e9b9bad_ctor()
+    {
+        #[allow(unsafe_code)]
+        {
+            #[link_section = ".init_array"]
+            #[used]
+            #[allow(non_upper_case_globals, non_snake_case)]
+            #[doc(hidden)]
+            static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
+                #[link_section = ".text.startup"]
+                #[allow(non_snake_case)]
+                extern "C" fn f() -> ::ctor::__support::CtorRetType {
+                    unsafe {
+                        __Contract__AllTypes__8eddde8d361a1a64147292e9556cb28d1efeec7df66b8064c5cc8af95e9b9bad_ctor();
+                    };
+                    core::default::Default::default()
+                }
+                f
+            };
+        }
+        {
+            <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
+                "test_struct",
+                #[allow(deprecated)]
+                &__Contract__test_struct__invoke_raw_slice,
+            );
+        }
+    }
+    #[doc(hidden)]
+    #[allow(non_snake_case)]
+    #[allow(unused)]
+    fn __Contract__AllTypes__4a069ddc7591bc91505072ab63fbb531eadd377db8acb22014e849a66a1e26e0_ctor()
+    {
+        #[allow(unsafe_code)]
+        {
+            #[link_section = ".init_array"]
+            #[used]
+            #[allow(non_upper_case_globals, non_snake_case)]
+            #[doc(hidden)]
+            static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
+                #[link_section = ".text.startup"]
+                #[allow(non_snake_case)]
+                extern "C" fn f() -> ::ctor::__support::CtorRetType {
+                    unsafe {
+                        __Contract__AllTypes__4a069ddc7591bc91505072ab63fbb531eadd377db8acb22014e849a66a1e26e0_ctor();
+                    };
+                    core::default::Default::default()
+                }
+                f
+            };
+        }
+        {
+            <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
+                "test_enum_unit",
+                #[allow(deprecated)]
+                &__Contract__test_enum_unit__invoke_raw_slice,
+            );
+        }
+    }
+    #[doc(hidden)]
+    #[allow(non_snake_case)]
+    #[allow(unused)]
+    fn __Contract__AllTypes__d2b0ba6d429ff899ab7fa1f5126ecddb66bdaec3f51d9aabaa916af14c3079a8_ctor()
+    {
+        #[allow(unsafe_code)]
+        {
+            #[link_section = ".init_array"]
+            #[used]
+            #[allow(non_upper_case_globals, non_snake_case)]
+            #[doc(hidden)]
+            static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
+                #[link_section = ".text.startup"]
+                #[allow(non_snake_case)]
+                extern "C" fn f() -> ::ctor::__support::CtorRetType {
+                    unsafe {
+                        __Contract__AllTypes__d2b0ba6d429ff899ab7fa1f5126ecddb66bdaec3f51d9aabaa916af14c3079a8_ctor();
+                    };
+                    core::default::Default::default()
+                }
+                f
+            };
+        }
+        {
+            <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
+                "test_enum_variants",
+                #[allow(deprecated)]
+                &__Contract__test_enum_variants__invoke_raw_slice,
+            );
+        }
+    }
+    pub struct CfgGatedContract;
+    ///CfgGatedContractArgs is a type for building arg lists for functions defined in "CfgGatedContract".
+    pub struct CfgGatedContractArgs;
+    ///CfgGatedContractClient is a client for calling the contract defined in "CfgGatedContract".
+    pub struct CfgGatedContractClient<'a> {
+        pub env: soroban_sdk::Env,
+        pub address: soroban_sdk::Address,
+        #[doc(hidden)]
+        set_auths: Option<&'a [soroban_sdk::xdr::SorobanAuthorizationEntry]>,
+        #[doc(hidden)]
+        mock_auths: Option<&'a [soroban_sdk::testutils::MockAuth<'a>]>,
+        #[doc(hidden)]
+        mock_all_auths: bool,
+        #[doc(hidden)]
+        allow_non_root_auth: bool,
+    }
+    impl<'a> CfgGatedContractClient<'a> {
+        pub fn new(env: &soroban_sdk::Env, address: &soroban_sdk::Address) -> Self {
+            Self {
+                env: env.clone(),
+                address: address.clone(),
+                set_auths: None,
+                mock_auths: None,
+                mock_all_auths: false,
+                allow_non_root_auth: false,
+            }
+        }
+        /// Set authorizations in the environment which will be consumed by
+        /// contracts when they invoke `Address::require_auth` or
+        /// `Address::require_auth_for_args` functions.
+        ///
+        /// Requires valid signatures for the authorization to be successful.
+        /// To mock auth without requiring valid signatures, use `mock_auths`.
+        ///
+        /// See `soroban_sdk::Env::set_auths` for more details and examples.
+        pub fn set_auths(&self, auths: &'a [soroban_sdk::xdr::SorobanAuthorizationEntry]) -> Self {
+            Self {
+                env: self.env.clone(),
+                address: self.address.clone(),
+                set_auths: Some(auths),
+                mock_auths: self.mock_auths.clone(),
+                mock_all_auths: false,
+                allow_non_root_auth: false,
+            }
+        }
+        /// Mock authorizations in the environment which will cause matching invokes
+        /// of `Address::require_auth` and `Address::require_auth_for_args` to
+        /// pass.
+        ///
+        /// See `soroban_sdk::Env::set_auths` for more details and examples.
+        pub fn mock_auths(&self, mock_auths: &'a [soroban_sdk::testutils::MockAuth<'a>]) -> Self {
+            Self {
+                env: self.env.clone(),
+                address: self.address.clone(),
+                set_auths: self.set_auths.clone(),
+                mock_auths: Some(mock_auths),
+                mock_all_auths: false,
+                allow_non_root_auth: false,
+            }
+        }
+        /// Mock all calls to the `Address::require_auth` and
+        /// `Address::require_auth_for_args` functions in invoked contracts,
+        /// having them succeed as if authorization was provided.
+        ///
+        /// See `soroban_sdk::Env::mock_all_auths` for more details and
+        /// examples.
+        pub fn mock_all_auths(&self) -> Self {
+            Self {
+                env: self.env.clone(),
+                address: self.address.clone(),
+                set_auths: None,
+                mock_auths: None,
+                mock_all_auths: true,
+                allow_non_root_auth: false,
+            }
+        }
+        /// A version of `mock_all_auths` that allows authorizations that
+        /// are not present in the root invocation.
+        ///
+        /// Refer to `mock_all_auths` documentation for details and
+        /// prefer using `mock_all_auths` unless non-root authorization is
+        /// required.
+        ///
+        /// See `soroban_sdk::Env::mock_all_auths_allowing_non_root_auth`
+        /// for more details and examples.
+        pub fn mock_all_auths_allowing_non_root_auth(&self) -> Self {
+            Self {
+                env: self.env.clone(),
+                address: self.address.clone(),
+                set_auths: None,
+                mock_auths: None,
+                mock_all_auths: true,
+                allow_non_root_auth: true,
+            }
+        }
+    }
+    mod __cfggatedcontract_fn_set_registry {
+        use super::*;
+        extern crate std;
+        use std::collections::BTreeMap;
+        use std::sync::Mutex;
+        pub type F = soroban_sdk::testutils::ContractFunctionF;
+        static FUNCS: Mutex<BTreeMap<&'static str, &'static F>> = Mutex::new(BTreeMap::new());
+        pub fn register(name: &'static str, func: &'static F) {
+            FUNCS.lock().unwrap().insert(name, func);
+        }
+        pub fn call(
+            name: &str,
+            env: soroban_sdk::Env,
+            args: &[soroban_sdk::Val],
+        ) -> Option<soroban_sdk::Val> {
+            let fopt: Option<&'static F> = FUNCS.lock().unwrap().get(name).map(|f| f.clone());
+            fopt.map(|f| f(env, args))
+        }
+    }
+    impl soroban_sdk::testutils::ContractFunctionRegister for CfgGatedContract {
+        fn register(name: &'static str, func: &'static __cfggatedcontract_fn_set_registry::F) {
+            __cfggatedcontract_fn_set_registry::register(name, func);
+        }
+    }
+    #[doc(hidden)]
+    impl soroban_sdk::testutils::ContractFunctionSet for CfgGatedContract {
+        fn call(
+            &self,
+            func: &str,
+            env: soroban_sdk::Env,
+            args: &[soroban_sdk::Val],
+        ) -> Option<soroban_sdk::Val> {
+            __cfggatedcontract_fn_set_registry::call(func, env, args)
+        }
+    }
+    impl CfgGated for CfgGatedContract {}
+    impl<'a> CfgGatedContractClient<'a> {}
+    impl CfgGatedContractArgs {}
+    #[doc(hidden)]
+    #[allow(non_snake_case)]
+    #[deprecated(note = "use `CfgGatedContractClient::new(&env, &contract_id).shown` instead")]
+    #[allow(deprecated)]
+    pub fn __CfgGatedContract__shown__invoke_raw(env: soroban_sdk::Env) -> soroban_sdk::Val {
+        soroban_sdk::IntoValForContractFn::into_val_for_contract_fn(
+            <CfgGatedContract as CfgGated>::shown(env.clone()),
+            &env,
+        )
+    }
+    #[doc(hidden)]
+    #[allow(non_snake_case)]
+    #[deprecated(note = "use `CfgGatedContractClient::new(&env, &contract_id).shown` instead")]
+    pub fn __CfgGatedContract__shown__invoke_raw_slice(
+        env: soroban_sdk::Env,
+        args: &[soroban_sdk::Val],
+    ) -> soroban_sdk::Val {
+        if args.len() != 0usize {
+            {
+                ::core::panicking::panic_fmt(format_args!(
+                    "invalid number of input arguments: {0} expected, got {1}",
+                    0usize,
+                    args.len(),
+                ));
+            };
+        }
+        #[allow(deprecated)]
+        __CfgGatedContract__shown__invoke_raw(env)
+    }
+    #[doc(hidden)]
+    #[allow(non_snake_case)]
+    #[deprecated(note = "use `CfgGatedContractClient::new(&env, &contract_id).shown` instead")]
+    pub extern "C" fn __CfgGatedContract__shown__invoke_raw_extern() -> soroban_sdk::Val {
+        #[allow(deprecated)]
+        __CfgGatedContract__shown__invoke_raw(soroban_sdk::Env::default())
+    }
+    #[doc(hidden)]
+    #[allow(non_snake_case)]
+    #[deprecated(
+        note = "use `CfgGatedContractClient::new(&env, &contract_id).feature_enabled` instead"
+    )]
+    #[allow(deprecated)]
+    pub fn __CfgGatedContract__feature_enabled__invoke_raw(
+        env: soroban_sdk::Env,
+    ) -> soroban_sdk::Val {
+        soroban_sdk::IntoValForContractFn::into_val_for_contract_fn(
+            <CfgGatedContract as CfgGated>::feature_enabled(env.clone()),
+            &env,
+        )
+    }
+    #[doc(hidden)]
+    #[allow(non_snake_case)]
+    #[deprecated(
+        note = "use `CfgGatedContractClient::new(&env, &contract_id).feature_enabled` instead"
+    )]
+    pub fn __CfgGatedContract__feature_enabled__invoke_raw_slice(
+        env: soroban_sdk::Env,
+        args: &[soroban_sdk::Val],
+    ) -> soroban_sdk::Val {
+        if args.len() != 0usize {
+            {
+                ::core::panicking::panic_fmt(format_args!(
+                    "invalid number of input arguments: {0} expected, got {1}",
+                    0usize,
+                    args.len(),
+                ));
+            };
+        }
+        #[allow(deprecated)]
+        __CfgGatedContract__feature_enabled__invoke_raw(env)
+    }
+    #[doc(hidden)]
+    #[allow(non_snake_case)]
+    #[deprecated(
+        note = "use `CfgGatedContractClient::new(&env, &contract_id).feature_enabled` instead"
+    )]
+    pub extern "C" fn __CfgGatedContract__feature_enabled__invoke_raw_extern() -> soroban_sdk::Val {
+        #[allow(deprecated)]
+        __CfgGatedContract__feature_enabled__invoke_raw(soroban_sdk::Env::default())
+    }
+    impl CfgGatedContract {}
+    #[doc(hidden)]
+    #[allow(non_snake_case)]
+    pub mod __CfgGatedContract__shown__spec {
+        #[doc(hidden)]
+        #[allow(non_snake_case)]
+        #[allow(non_upper_case_globals)]
+        pub static __SPEC_XDR_FN_SHOWN: [u8; 32usize] = super::CfgGatedContract::spec_xdr_shown();
+    }
+    impl CfgGatedContract {
+        #[allow(non_snake_case)]
+        pub const fn spec_xdr_shown() -> [u8; 32usize] {
+            *b"\0\0\0\0\0\0\0\0\0\0\0\x05shown\0\0\0\0\0\0\0\0\0\0\x01\0\0\0\x04"
+        }
+    }
+    #[doc(hidden)]
+    #[allow(non_snake_case)]
+    pub mod __CfgGatedContract__feature_enabled__spec {
+        #[doc(hidden)]
+        #[allow(non_snake_case)]
+        #[allow(non_upper_case_globals)]
+        pub static __SPEC_XDR_FN_FEATURE_ENABLED: [u8; 40usize] =
+            super::CfgGatedContract::spec_xdr_feature_enabled();
+    }
+    impl CfgGatedContract {
+        #[allow(non_snake_case)]
+        pub const fn spec_xdr_feature_enabled() -> [u8; 40usize] {
+            *b"\0\0\0\0\0\0\0\0\0\0\0\x0ffeature_enabled\0\0\0\0\0\0\0\0\x01\0\0\0\x04"
+        }
+    }
+    impl<'a> CfgGatedContractClient<'a> {
+        pub fn shown(&self) -> u32 {
+            use core::ops::Not;
+            let old_auth_manager = self
+                .env
+                .in_contract()
+                .not()
+                .then(|| self.env.host().snapshot_auth_manager().unwrap());
+            {
+                if let Some(set_auths) = self.set_auths {
+                    self.env.set_auths(set_auths);
+                }
+                if let Some(mock_auths) = self.mock_auths {
+                    self.env.mock_auths(mock_auths);
+                }
+                if self.mock_all_auths {
+                    if self.allow_non_root_auth {
+                        self.env.mock_all_auths_allowing_non_root_auth();
+                    } else {
+                        self.env.mock_all_auths();
+                    }
+                }
+            }
+            use soroban_sdk::{FromVal, IntoVal};
+            let res = self.env.invoke_contract(
+                &self.address,
+                &{
+                    #[allow(deprecated)]
+                    const SYMBOL: soroban_sdk::Symbol = soroban_sdk::Symbol::short("shown");
+                    SYMBOL
+                },
+                ::soroban_sdk::Vec::new(&self.env),
+            );
+            if let Some(old_auth_manager) = old_auth_manager {
+                self.env.host().set_auth_manager(old_auth_manager).unwrap();
+            }
+            res
+        }
+        pub fn try_shown(
+            &self,
+        ) -> Result<
+            Result<
+                u32,
+                <u32 as soroban_sdk::TryFromVal<soroban_sdk::Env, soroban_sdk::Val>>::Error,
+            >,
+            Result<soroban_sdk::Error, soroban_sdk::InvokeError>,
+        > {
+            use core::ops::Not;
+            let old_auth_manager = self
+                .env
+                .in_contract()
+                .not()
+                .then(|| self.env.host().snapshot_auth_manager().unwrap());
+            {
+                if let Some(set_auths) = self.set_auths {
+                    self.env.set_auths(set_auths);
+                }
+                if let Some(mock_auths) = self.mock_auths {
+                    self.env.mock_auths(mock_auths);
+                }
+                if self.mock_all_auths {
+                    if self.allow_non_root_auth {
+                        self.env.mock_all_auths_allowing_non_root_auth();
+                    } else {
+                        self.env.mock_all_auths();
+                    }
+                }
+            }
+            use soroban_sdk::{FromVal, IntoVal};
+            let res = self.env.try_invoke_contract(
+                &self.address,
+                &{
+                    #[allow(deprecated)]
+                    const SYMBOL: soroban_sdk::Symbol = soroban_sdk::Symbol::short("shown");
+                    SYMBOL
+                },
+                ::soroban_sdk::Vec::new(&self.env),
+            );
+            if let Some(old_auth_manager) = old_auth_manager {
+                self.env.host().set_auth_manager(old_auth_manager).unwrap();
+            }
+            res
+        }
+        pub fn feature_enabled(&self) -> u32 {
+            use core::ops::Not;
+            let old_auth_manager = self
+                .env
+                .in_contract()
+                .not()
+                .then(|| self.env.host().snapshot_auth_manager().unwrap());
+            {
+                if let Some(set_auths) = self.set_auths {
+                    self.env.set_auths(set_auths);
+                }
+                if let Some(mock_auths) = self.mock_auths {
+                    self.env.mock_auths(mock_auths);
+                }
+                if self.mock_all_auths {
+                    if self.allow_non_root_auth {
+                        self.env.mock_all_auths_allowing_non_root_auth();
+                    } else {
+                        self.env.mock_all_auths();
+                    }
+                }
+            }
+            use soroban_sdk::{FromVal, IntoVal};
+            let res = self.env.invoke_contract(
+                &self.address,
+                &{ soroban_sdk::Symbol::new(&self.env, "feature_enabled") },
+                ::soroban_sdk::Vec::new(&self.env),
+            );
+            if let Some(old_auth_manager) = old_auth_manager {
+                self.env.host().set_auth_manager(old_auth_manager).unwrap();
+            }
+            res
+        }
+        pub fn try_feature_enabled(
+            &self,
+        ) -> Result<
+            Result<
+                u32,
+                <u32 as soroban_sdk::TryFromVal<soroban_sdk::Env, soroban_sdk::Val>>::Error,
+            >,
+            Result<soroban_sdk::Error, soroban_sdk::InvokeError>,
+        > {
+            use core::ops::Not;
+            let old_auth_manager = self
+                .env
+                .in_contract()
+                .not()
+                .then(|| self.env.host().snapshot_auth_manager().unwrap());
+            {
+                if let Some(set_auths) = self.set_auths {
+                    self.env.set_auths(set_auths);
+                }
+                if let Some(mock_auths) = self.mock_auths {
+                    self.env.mock_auths(mock_auths);
+                }
+                if self.mock_all_auths {
+                    if self.allow_non_root_auth {
+                        self.env.mock_all_auths_allowing_non_root_auth();
+                    } else {
+                        self.env.mock_all_auths();
+                    }
+                }
+            }
+            use soroban_sdk::{FromVal, IntoVal};
+            let res = self.env.try_invoke_contract(
+                &self.address,
+                &{ soroban_sdk::Symbol::new(&self.env, "feature_enabled") },
+                ::soroban_sdk::Vec::new(&self.env),
+            );
+            if let Some(old_auth_manager) = old_auth_manager {
+                self.env.host().set_auth_manager(old_auth_manager).unwrap();
+            }
+            res
+        }
+    }
+    impl CfgGatedContractArgs {
+        #[inline(always)]
+        #[allow(clippy::unused_unit)]
+        pub fn shown<'i>() -> () {
+            ()
+        }
+        #[inline(always)]
+        #[allow(clippy::unused_unit)]
+        pub fn feature_enabled<'i>() -> () {
+            ()
+        }
+    }
+    #[doc(hidden)]
+    #[allow(non_snake_case)]
+    #[allow(unused)]
+    fn __CfgGatedContract__CfgGated__f4db9ab03a219f9ef1cecf98c7ccfdc83419274753acb76e2f464116514bd341_ctor(
+    ) {
+        #[allow(unsafe_code)]
+        {
+            #[link_section = ".init_array"]
+            #[used]
+            #[allow(non_upper_case_globals, non_snake_case)]
+            #[doc(hidden)]
+            static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
+                #[link_section = ".text.startup"]
+                #[allow(non_snake_case)]
+                extern "C" fn f() -> ::ctor::__support::CtorRetType {
+                    unsafe {
+                        __CfgGatedContract__CfgGated__f4db9ab03a219f9ef1cecf98c7ccfdc83419274753acb76e2f464116514bd341_ctor();
+                    };
+                    core::default::Default::default()
+                }
+                f
+            };
+        }
+        {
+            <CfgGatedContract as soroban_sdk::testutils::ContractFunctionRegister>::register(
+                "shown",
+                #[allow(deprecated)]
+                &__CfgGatedContract__shown__invoke_raw_slice,
+            );
+        }
+    }
+    #[doc(hidden)]
+    #[allow(non_snake_case)]
+    #[allow(unused)]
+    fn __CfgGatedContract__CfgGated__287ec90a09a11b5554d5353aea2c389d61a11a98fcc5ebb6a58ce90ccf5aba0d_ctor(
+    ) {
+        #[allow(unsafe_code)]
+        {
+            #[link_section = ".init_array"]
+            #[used]
+            #[allow(non_upper_case_globals, non_snake_case)]
+            #[doc(hidden)]
+            static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
+                #[link_section = ".text.startup"]
+                #[allow(non_snake_case)]
+                extern "C" fn f() -> ::ctor::__support::CtorRetType {
+                    unsafe {
+                        __CfgGatedContract__CfgGated__287ec90a09a11b5554d5353aea2c389d61a11a98fcc5ebb6a58ce90ccf5aba0d_ctor();
+                    };
+                    core::default::Default::default()
+                }
+                f
+            };
+        }
+        {
+            <CfgGatedContract as soroban_sdk::testutils::ContractFunctionRegister>::register(
+                "feature_enabled",
+                #[allow(deprecated)]
+                &__CfgGatedContract__feature_enabled__invoke_raw_slice,
+            );
+        }
+    }
+    pub struct CfgGatedOverrideContract;
+    ///CfgGatedOverrideContractArgs is a type for building arg lists for functions defined in "CfgGatedOverrideContract".
+    pub struct CfgGatedOverrideContractArgs;
+    ///CfgGatedOverrideContractClient is a client for calling the contract defined in "CfgGatedOverrideContract".
+    pub struct CfgGatedOverrideContractClient<'a> {
+        pub env: soroban_sdk::Env,
+        pub address: soroban_sdk::Address,
+        #[doc(hidden)]
+        set_auths: Option<&'a [soroban_sdk::xdr::SorobanAuthorizationEntry]>,
+        #[doc(hidden)]
+        mock_auths: Option<&'a [soroban_sdk::testutils::MockAuth<'a>]>,
+        #[doc(hidden)]
+        mock_all_auths: bool,
+        #[doc(hidden)]
+        allow_non_root_auth: bool,
+    }
+    impl<'a> CfgGatedOverrideContractClient<'a> {
+        pub fn new(env: &soroban_sdk::Env, address: &soroban_sdk::Address) -> Self {
+            Self {
+                env: env.clone(),
+                address: address.clone(),
+                set_auths: None,
+                mock_auths: None,
+                mock_all_auths: false,
+                allow_non_root_auth: false,
+            }
+        }
+        /// Set authorizations in the environment which will be consumed by
+        /// contracts when they invoke `Address::require_auth` or
+        /// `Address::require_auth_for_args` functions.
+        ///
+        /// Requires valid signatures for the authorization to be successful.
+        /// To mock auth without requiring valid signatures, use `mock_auths`.
+        ///
+        /// See `soroban_sdk::Env::set_auths` for more details and examples.
+        pub fn set_auths(&self, auths: &'a [soroban_sdk::xdr::SorobanAuthorizationEntry]) -> Self {
+            Self {
+                env: self.env.clone(),
+                address: self.address.clone(),
+                set_auths: Some(auths),
+                mock_auths: self.mock_auths.clone(),
+                mock_all_auths: false,
+                allow_non_root_auth: false,
+            }
+        }
+        /// Mock authorizations in the environment which will cause matching invokes
+        /// of `Address::require_auth` and `Address::require_auth_for_args` to
+        /// pass.
+        ///
+        /// See `soroban_sdk::Env::set_auths` for more details and examples.
+        pub fn mock_auths(&self, mock_auths: &'a [soroban_sdk::testutils::MockAuth<'a>]) -> Self {
+            Self {
+                env: self.env.clone(),
+                address: self.address.clone(),
+                set_auths: self.set_auths.clone(),
+                mock_auths: Some(mock_auths),
+                mock_all_auths: false,
+                allow_non_root_auth: false,
+            }
+        }
+        /// Mock all calls to the `Address::require_auth` and
+        /// `Address::require_auth_for_args` functions in invoked contracts,
+        /// having them succeed as if authorization was provided.
+        ///
+        /// See `soroban_sdk::Env::mock_all_auths` for more details and
+        /// examples.
+        pub fn mock_all_auths(&self) -> Self {
+            Self {
+                env: self.env.clone(),
+                address: self.address.clone(),
+                set_auths: None,
+                mock_auths: None,
+                mock_all_auths: true,
+                allow_non_root_auth: false,
+            }
+        }
+        /// A version of `mock_all_auths` that allows authorizations that
+        /// are not present in the root invocation.
+        ///
+        /// Refer to `mock_all_auths` documentation for details and
+        /// prefer using `mock_all_auths` unless non-root authorization is
+        /// required.
+        ///
+        /// See `soroban_sdk::Env::mock_all_auths_allowing_non_root_auth`
+        /// for more details and examples.
+        pub fn mock_all_auths_allowing_non_root_auth(&self) -> Self {
+            Self {
+                env: self.env.clone(),
+                address: self.address.clone(),
+                set_auths: None,
+                mock_auths: None,
+                mock_all_auths: true,
+                allow_non_root_auth: true,
+            }
+        }
+    }
+    mod __cfggatedoverridecontract_fn_set_registry {
+        use super::*;
+        extern crate std;
+        use std::collections::BTreeMap;
+        use std::sync::Mutex;
+        pub type F = soroban_sdk::testutils::ContractFunctionF;
+        static FUNCS: Mutex<BTreeMap<&'static str, &'static F>> = Mutex::new(BTreeMap::new());
+        pub fn register(name: &'static str, func: &'static F) {
+            FUNCS.lock().unwrap().insert(name, func);
+        }
+        pub fn call(
+            name: &str,
+            env: soroban_sdk::Env,
+            args: &[soroban_sdk::Val],
+        ) -> Option<soroban_sdk::Val> {
+            let fopt: Option<&'static F> = FUNCS.lock().unwrap().get(name).map(|f| f.clone());
+            fopt.map(|f| f(env, args))
+        }
+    }
+    impl soroban_sdk::testutils::ContractFunctionRegister for CfgGatedOverrideContract {
+        fn register(
+            name: &'static str,
+            func: &'static __cfggatedoverridecontract_fn_set_registry::F,
+        ) {
+            __cfggatedoverridecontract_fn_set_registry::register(name, func);
+        }
+    }
+    #[doc(hidden)]
+    impl soroban_sdk::testutils::ContractFunctionSet for CfgGatedOverrideContract {
+        fn call(
+            &self,
+            func: &str,
+            env: soroban_sdk::Env,
+            args: &[soroban_sdk::Val],
+        ) -> Option<soroban_sdk::Val> {
+            __cfggatedoverridecontract_fn_set_registry::call(func, env, args)
+        }
+    }
+    impl CfgGated for CfgGatedOverrideContract {
+        fn feature_enabled(env: Env) -> u32 {
+            let _ = env;
+            99
+        }
+    }
+    impl CfgGatedOverrideContract {}
+    #[doc(hidden)]
+    #[allow(non_snake_case)]
+    pub mod __CfgGatedOverrideContract__feature_enabled__spec {
+        #[doc(hidden)]
+        #[allow(non_snake_case)]
+        #[allow(non_upper_case_globals)]
+        pub static __SPEC_XDR_FN_FEATURE_ENABLED: [u8; 40usize] =
+            super::CfgGatedOverrideContract::spec_xdr_feature_enabled();
+    }
+    impl CfgGatedOverrideContract {
+        #[allow(non_snake_case)]
+        pub const fn spec_xdr_feature_enabled() -> [u8; 40usize] {
+            *b"\0\0\0\0\0\0\0\0\0\0\0\x0ffeature_enabled\0\0\0\0\0\0\0\0\x01\0\0\0\x04"
+        }
+    }
+    impl<'a> CfgGatedOverrideContractClient<'a> {
+        pub fn feature_enabled(&self) -> u32 {
+            use core::ops::Not;
+            let old_auth_manager = self
+                .env
+                .in_contract()
+                .not()
+                .then(|| self.env.host().snapshot_auth_manager().unwrap());
+            {
+                if let Some(set_auths) = self.set_auths {
+                    self.env.set_auths(set_auths);
+                }
+                if let Some(mock_auths) = self.mock_auths {
+                    self.env.mock_auths(mock_auths);
+                }
+                if self.mock_all_auths {
+                    if self.allow_non_root_auth {
+                        self.env.mock_all_auths_allowing_non_root_auth();
+                    } else {
+                        self.env.mock_all_auths();
+                    }
+                }
+            }
+            use soroban_sdk::{FromVal, IntoVal};
+            let res = self.env.invoke_contract(
+                &self.address,
+                &{ soroban_sdk::Symbol::new(&self.env, "feature_enabled") },
+                ::soroban_sdk::Vec::new(&self.env),
+            );
+            if let Some(old_auth_manager) = old_auth_manager {
+                self.env.host().set_auth_manager(old_auth_manager).unwrap();
+            }
+            res
+        }
+        pub fn try_feature_enabled(
+            &self,
+        ) -> Result<
+            Result<
+                u32,
+                <u32 as soroban_sdk::TryFromVal<soroban_sdk::Env, soroban_sdk::Val>>::Error,
+            >,
+            Result<soroban_sdk::Error, soroban_sdk::InvokeError>,
+        > {
+            use core::ops::Not;
+            let old_auth_manager = self
+                .env
+                .in_contract()
+                .not()
+                .then(|| self.env.host().snapshot_auth_manager().unwrap());
+            {
+                if let Some(set_auths) = self.set_auths {
+                    self.env.set_auths(set_auths);
+                }
+                if let Some(mock_auths) = self.mock_auths {
+                    self.env.mock_auths(mock_auths);
+                }
+                if self.mock_all_auths {
+                    if self.allow_non_root_auth {
+                        self.env.mock_all_auths_allowing_non_root_auth();
+                    } else {
+                        self.env.mock_all_auths();
+                    }
+                }
+            }
+            use soroban_sdk::{FromVal, IntoVal};
+            let res = self.env.try_invoke_contract(
+                &self.address,
+                &{ soroban_sdk::Symbol::new(&self.env, "feature_enabled") },
+                ::soroban_sdk::Vec::new(&self.env),
+            );
+            if let Some(old_auth_manager) = old_auth_manager {
+                self.env.host().set_auth_manager(old_auth_manager).unwrap();
+            }
+            res
+        }
+    }
+    impl CfgGatedOverrideContractArgs {
+        #[inline(always)]
+        #[allow(clippy::unused_unit)]
+        pub fn feature_enabled<'i>() -> () {
+            ()
+        }
+    }
+    #[doc(hidden)]
+    #[allow(non_snake_case)]
+    #[deprecated(
+        note = "use `CfgGatedOverrideContractClient::new(&env, &contract_id).feature_enabled` instead"
+    )]
+    #[allow(deprecated)]
+    pub fn __CfgGatedOverrideContract__feature_enabled__invoke_raw(
+        env: soroban_sdk::Env,
+    ) -> soroban_sdk::Val {
+        soroban_sdk::IntoValForContractFn::into_val_for_contract_fn(
+            <CfgGatedOverrideContract as CfgGated>::feature_enabled(env.clone()),
+            &env,
+        )
+    }
+    #[doc(hidden)]
+    #[allow(non_snake_case)]
+    #[deprecated(
+        note = "use `CfgGatedOverrideContractClient::new(&env, &contract_id).feature_enabled` instead"
+    )]
+    pub fn __CfgGatedOverrideContract__feature_enabled__invoke_raw_slice(
+        env: soroban_sdk::Env,
+        args: &[soroban_sdk::Val],
+    ) -> soroban_sdk::Val {
+        if args.len() != 0usize {
+            {
+                ::core::panicking::panic_fmt(format_args!(
+                    "invalid number of input arguments: {0} expected, got {1}",
+                    0usize,
+                    args.len(),
+                ));
+            };
+        }
+        #[allow(deprecated)]
+        __CfgGatedOverrideContract__feature_enabled__invoke_raw(env)
+    }
+    #[doc(hidden)]
+    #[allow(non_snake_case)]
+    #[deprecated(
+        note = "use `CfgGatedOverrideContractClient::new(&env, &contract_id).feature_enabled` instead"
+    )]
+    pub extern "C" fn __CfgGatedOverrideContract__feature_enabled__invoke_raw_extern(
+    ) -> soroban_sdk::Val {
+        #[allow(deprecated)]
+        __CfgGatedOverrideContract__feature_enabled__invoke_raw(soroban_sdk::Env::default())
+    }
+    #[doc(hidden)]
+    #[allow(non_snake_case)]
+    #[deprecated(
+        note = "use `CfgGatedOverrideContractClient::new(&env, &contract_id).shown` instead"
+    )]
+    #[allow(deprecated)]
+    pub fn __CfgGatedOverrideContract__shown__invoke_raw(
+        env: soroban_sdk::Env,
+    ) -> soroban_sdk::Val {
+        soroban_sdk::IntoValForContractFn::into_val_for_contract_fn(
+            <CfgGatedOverrideContract as CfgGated>::shown(env.clone()),
+            &env,
+        )
+    }
+    #[doc(hidden)]
+    #[allow(non_snake_case)]
+    #[deprecated(
+        note = "use `CfgGatedOverrideContractClient::new(&env, &contract_id).shown` instead"
+    )]
+    pub fn __CfgGatedOverrideContract__shown__invoke_raw_slice(
+        env: soroban_sdk::Env,
+        args: &[soroban_sdk::Val],
+    ) -> soroban_sdk::Val {
+        if args.len() != 0usize {
+            {
+                ::core::panicking::panic_fmt(format_args!(
+                    "invalid number of input arguments: {0} expected, got {1}",
+                    0usize,
+                    args.len(),
+                ));
+            };
+        }
+        #[allow(deprecated)]
+        __CfgGatedOverrideContract__shown__invoke_raw(env)
+    }
+    #[doc(hidden)]
+    #[allow(non_snake_case)]
+    #[deprecated(
+        note = "use `CfgGatedOverrideContractClient::new(&env, &contract_id).shown` instead"
+    )]
+    pub extern "C" fn __CfgGatedOverrideContract__shown__invoke_raw_extern() -> soroban_sdk::Val {
+        #[allow(deprecated)]
+        __CfgGatedOverrideContract__shown__invoke_raw(soroban_sdk::Env::default())
+    }
+    impl CfgGatedOverrideContract {}
+    #[doc(hidden)]
+    #[allow(non_snake_case)]
+    pub mod __CfgGatedOverrideContract__shown__spec {
+        #[doc(hidden)]
+        #[allow(non_snake_case)]
+        #[allow(non_upper_case_globals)]
+        pub static __SPEC_XDR_FN_SHOWN: [u8; 32usize] =
+            super::CfgGatedOverrideContract::spec_xdr_shown();
+    }
+    impl CfgGatedOverrideContract {
+        #[allow(non_snake_case)]
+        pub const fn spec_xdr_shown() -> [u8; 32usize] {
+            *b"\0\0\0\0\0\0\0\0\0\0\0\x05shown\0\0\0\0\0\0\0\0\0\0\x01\0\0\0\x04"
+        }
+    }
+    impl CfgGatedOverrideContract {}
+    impl<'a> CfgGatedOverrideContractClient<'a> {
+        pub fn shown(&self) -> u32 {
+            use core::ops::Not;
+            let old_auth_manager = self
+                .env
+                .in_contract()
+                .not()
+                .then(|| self.env.host().snapshot_auth_manager().unwrap());
+            {
+                if let Some(set_auths) = self.set_auths {
+                    self.env.set_auths(set_auths);
+                }
+                if let Some(mock_auths) = self.mock_auths {
+                    self.env.mock_auths(mock_auths);
+                }
+                if self.mock_all_auths {
+                    if self.allow_non_root_auth {
+                        self.env.mock_all_auths_allowing_non_root_auth();
+                    } else {
+                        self.env.mock_all_auths();
+                    }
+                }
+            }
+            use soroban_sdk::{FromVal, IntoVal};
+            let res = self.env.invoke_contract(
+                &self.address,
+                &{
+                    #[allow(deprecated)]
+                    const SYMBOL: soroban_sdk::Symbol = soroban_sdk::Symbol::short("shown");
+                    SYMBOL
+                },
+                ::soroban_sdk::Vec::new(&self.env),
+            );
+            if let Some(old_auth_manager) = old_auth_manager {
+                self.env.host().set_auth_manager(old_auth_manager).unwrap();
+            }
+            res
+        }
+        pub fn try_shown(
+            &self,
+        ) -> Result<
+            Result<
+                u32,
+                <u32 as soroban_sdk::TryFromVal<soroban_sdk::Env, soroban_sdk::Val>>::Error,
+            >,
+            Result<soroban_sdk::Error, soroban_sdk::InvokeError>,
+        > {
+            use core::ops::Not;
+            let old_auth_manager = self
+                .env
+                .in_contract()
+                .not()
+                .then(|| self.env.host().snapshot_auth_manager().unwrap());
+            {
+                if let Some(set_auths) = self.set_auths {
+                    self.env.set_auths(set_auths);
+                }
+                if let Some(mock_auths) = self.mock_auths {
+                    self.env.mock_auths(mock_auths);
+                }
+                if self.mock_all_auths {
+                    if self.allow_non_root_auth {
+                        self.env.mock_all_auths_allowing_non_root_auth();
+                    } else {
+                        self.env.mock_all_auths();
+                    }
+                }
+            }
+            use soroban_sdk::{FromVal, IntoVal};
+            let res = self.env.try_invoke_contract(
+                &self.address,
+                &{
+                    #[allow(deprecated)]
+                    const SYMBOL: soroban_sdk::Symbol = soroban_sdk::Symbol::short("shown");
+                    SYMBOL
+                },
+                ::soroban_sdk::Vec::new(&self.env),
+            );
+            if let Some(old_auth_manager) = old_auth_manager {
+                self.env.host().set_auth_manager(old_auth_manager).unwrap();
+            }
+            res
+        }
+    }
+    impl CfgGatedOverrideContractArgs {
+        #[inline(always)]
+        #[allow(clippy::unused_unit)]
+        pub fn shown<'i>() -> () {
+            ()
+        }
+    }
+    #[doc(hidden)]
+    #[allow(non_snake_case)]
+    #[allow(unused)]
+    fn __CfgGatedOverrideContract__CfgGated__16a729dadded3472fa701b2dfbe26e7bf55fb1e39781642bdda36186881b9f56_ctor(
+    ) {
+        #[allow(unsafe_code)]
+        {
+            #[link_section = ".init_array"]
+            #[used]
+            #[allow(non_upper_case_globals, non_snake_case)]
+            #[doc(hidden)]
+            static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
+                #[link_section = ".text.startup"]
+                #[allow(non_snake_case)]
+                extern "C" fn f() -> ::ctor::__support::CtorRetType {
+                    unsafe {
+                        __CfgGatedOverrideContract__CfgGated__16a729dadded3472fa701b2dfbe26e7bf55fb1e39781642bdda36186881b9f56_ctor();
+                    };
+                    core::default::Default::default()
+                }
+                f
+            };
+        }
+        {
+            <CfgGatedOverrideContract as soroban_sdk::testutils::ContractFunctionRegister>::register(
+                "shown",
+                #[allow(deprecated)]
+                &__CfgGatedOverrideContract__shown__invoke_raw_slice,
+            );
+        }
+    }
+    #[doc(hidden)]
+    #[allow(non_snake_case)]
+    #[allow(unused)]
+    fn __CfgGatedOverrideContract__CfgGated__287ec90a09a11b5554d5353aea2c389d61a11a98fcc5ebb6a58ce90ccf5aba0d_ctor(
+    ) {
+        #[allow(unsafe_code)]
+        {
+            #[link_section = ".init_array"]
+            #[used]
+            #[allow(non_upper_case_globals, non_snake_case)]
+            #[doc(hidden)]
+            static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
+                #[link_section = ".text.startup"]
+                #[allow(non_snake_case)]
+                extern "C" fn f() -> ::ctor::__support::CtorRetType {
+                    unsafe {
+                        __CfgGatedOverrideContract__CfgGated__287ec90a09a11b5554d5353aea2c389d61a11a98fcc5ebb6a58ce90ccf5aba0d_ctor();
+                    };
+                    core::default::Default::default()
+                }
+                f
+            };
+        }
+        {
+            <CfgGatedOverrideContract as soroban_sdk::testutils::ContractFunctionRegister>::register(
+                "feature_enabled",
+                #[allow(deprecated)]
+                &__CfgGatedOverrideContract__feature_enabled__invoke_raw_slice,
+            );
+        }
+    }
+    pub struct CfgGatedUnconditionalOverrideContract;
+    ///CfgGatedUnconditionalOverrideContractArgs is a type for building arg lists for functions defined in "CfgGatedUnconditionalOverrideContract".
+    pub struct CfgGatedUnconditionalOverrideContractArgs;
+    ///CfgGatedUnconditionalOverrideContractClient is a client for calling the contract defined in "CfgGatedUnconditionalOverrideContract".
+    pub struct CfgGatedUnconditionalOverrideContractClient<'a> {
+        pub env: soroban_sdk::Env,
+        pub address: soroban_sdk::Address,
+        #[doc(hidden)]
+        set_auths: Option<&'a [soroban_sdk::xdr::SorobanAuthorizationEntry]>,
+        #[doc(hidden)]
+        mock_auths: Option<&'a [soroban_sdk::testutils::MockAuth<'a>]>,
+        #[doc(hidden)]
+        mock_all_auths: bool,
+        #[doc(hidden)]
+        allow_non_root_auth: bool,
+    }
+    impl<'a> CfgGatedUnconditionalOverrideContractClient<'a> {
+        pub fn new(env: &soroban_sdk::Env, address: &soroban_sdk::Address) -> Self {
+            Self {
+                env: env.clone(),
+                address: address.clone(),
+                set_auths: None,
+                mock_auths: None,
+                mock_all_auths: false,
+                allow_non_root_auth: false,
+            }
+        }
+        /// Set authorizations in the environment which will be consumed by
+        /// contracts when they invoke `Address::require_auth` or
+        /// `Address::require_auth_for_args` functions.
+        ///
+        /// Requires valid signatures for the authorization to be successful.
+        /// To mock auth without requiring valid signatures, use `mock_auths`.
+        ///
+        /// See `soroban_sdk::Env::set_auths` for more details and examples.
+        pub fn set_auths(&self, auths: &'a [soroban_sdk::xdr::SorobanAuthorizationEntry]) -> Self {
+            Self {
+                env: self.env.clone(),
+                address: self.address.clone(),
+                set_auths: Some(auths),
+                mock_auths: self.mock_auths.clone(),
+                mock_all_auths: false,
+                allow_non_root_auth: false,
+            }
+        }
+        /// Mock authorizations in the environment which will cause matching invokes
+        /// of `Address::require_auth` and `Address::require_auth_for_args` to
+        /// pass.
+        ///
+        /// See `soroban_sdk::Env::set_auths` for more details and examples.
+        pub fn mock_auths(&self, mock_auths: &'a [soroban_sdk::testutils::MockAuth<'a>]) -> Self {
+            Self {
+                env: self.env.clone(),
+                address: self.address.clone(),
+                set_auths: self.set_auths.clone(),
+                mock_auths: Some(mock_auths),
+                mock_all_auths: false,
+                allow_non_root_auth: false,
+            }
+        }
+        /// Mock all calls to the `Address::require_auth` and
+        /// `Address::require_auth_for_args` functions in invoked contracts,
+        /// having them succeed as if authorization was provided.
+        ///
+        /// See `soroban_sdk::Env::mock_all_auths` for more details and
+        /// examples.
+        pub fn mock_all_auths(&self) -> Self {
+            Self {
+                env: self.env.clone(),
+                address: self.address.clone(),
+                set_auths: None,
+                mock_auths: None,
+                mock_all_auths: true,
+                allow_non_root_auth: false,
+            }
+        }
+        /// A version of `mock_all_auths` that allows authorizations that
+        /// are not present in the root invocation.
+        ///
+        /// Refer to `mock_all_auths` documentation for details and
+        /// prefer using `mock_all_auths` unless non-root authorization is
+        /// required.
+        ///
+        /// See `soroban_sdk::Env::mock_all_auths_allowing_non_root_auth`
+        /// for more details and examples.
+        pub fn mock_all_auths_allowing_non_root_auth(&self) -> Self {
+            Self {
+                env: self.env.clone(),
+                address: self.address.clone(),
+                set_auths: None,
+                mock_auths: None,
+                mock_all_auths: true,
+                allow_non_root_auth: true,
+            }
+        }
+    }
+    mod __cfggatedunconditionaloverridecontract_fn_set_registry {
+        use super::*;
+        extern crate std;
+        use std::collections::BTreeMap;
+        use std::sync::Mutex;
+        pub type F = soroban_sdk::testutils::ContractFunctionF;
+        static FUNCS: Mutex<BTreeMap<&'static str, &'static F>> = Mutex::new(BTreeMap::new());
+        pub fn register(name: &'static str, func: &'static F) {
+            FUNCS.lock().unwrap().insert(name, func);
+        }
+        pub fn call(
+            name: &str,
+            env: soroban_sdk::Env,
+            args: &[soroban_sdk::Val],
+        ) -> Option<soroban_sdk::Val> {
+            let fopt: Option<&'static F> = FUNCS.lock().unwrap().get(name).map(|f| f.clone());
+            fopt.map(|f| f(env, args))
+        }
+    }
+    impl soroban_sdk::testutils::ContractFunctionRegister for CfgGatedUnconditionalOverrideContract {
+        fn register(
+            name: &'static str,
+            func: &'static __cfggatedunconditionaloverridecontract_fn_set_registry::F,
+        ) {
+            __cfggatedunconditionaloverridecontract_fn_set_registry::register(name, func);
+        }
+    }
+    #[doc(hidden)]
+    impl soroban_sdk::testutils::ContractFunctionSet for CfgGatedUnconditionalOverrideContract {
+        fn call(
+            &self,
+            func: &str,
+            env: soroban_sdk::Env,
+            args: &[soroban_sdk::Val],
+        ) -> Option<soroban_sdk::Val> {
+            __cfggatedunconditionaloverridecontract_fn_set_registry::call(func, env, args)
+        }
+    }
+    impl CfgGated for CfgGatedUnconditionalOverrideContract {
+        fn feature_enabled(env: Env) -> u32 {
+            let _ = env;
+            100
+        }
+    }
+    #[doc(hidden)]
+    #[allow(non_snake_case)]
+    pub mod __CfgGatedUnconditionalOverrideContract__feature_enabled__spec {
+        #[doc(hidden)]
+        #[allow(non_snake_case)]
+        #[allow(non_upper_case_globals)]
+        pub static __SPEC_XDR_FN_FEATURE_ENABLED: [u8; 40usize] =
+            super::CfgGatedUnconditionalOverrideContract::spec_xdr_feature_enabled();
+    }
+    impl CfgGatedUnconditionalOverrideContract {
+        #[allow(non_snake_case)]
+        pub const fn spec_xdr_feature_enabled() -> [u8; 40usize] {
+            *b"\0\0\0\0\0\0\0\0\0\0\0\x0ffeature_enabled\0\0\0\0\0\0\0\0\x01\0\0\0\x04"
+        }
+    }
+    impl<'a> CfgGatedUnconditionalOverrideContractClient<'a> {
+        pub fn feature_enabled(&self) -> u32 {
+            use core::ops::Not;
+            let old_auth_manager = self
+                .env
+                .in_contract()
+                .not()
+                .then(|| self.env.host().snapshot_auth_manager().unwrap());
+            {
+                if let Some(set_auths) = self.set_auths {
+                    self.env.set_auths(set_auths);
+                }
+                if let Some(mock_auths) = self.mock_auths {
+                    self.env.mock_auths(mock_auths);
+                }
+                if self.mock_all_auths {
+                    if self.allow_non_root_auth {
+                        self.env.mock_all_auths_allowing_non_root_auth();
+                    } else {
+                        self.env.mock_all_auths();
+                    }
+                }
+            }
+            use soroban_sdk::{FromVal, IntoVal};
+            let res = self.env.invoke_contract(
+                &self.address,
+                &{ soroban_sdk::Symbol::new(&self.env, "feature_enabled") },
+                ::soroban_sdk::Vec::new(&self.env),
+            );
+            if let Some(old_auth_manager) = old_auth_manager {
+                self.env.host().set_auth_manager(old_auth_manager).unwrap();
+            }
+            res
+        }
+        pub fn try_feature_enabled(
+            &self,
+        ) -> Result<
+            Result<
+                u32,
+                <u32 as soroban_sdk::TryFromVal<soroban_sdk::Env, soroban_sdk::Val>>::Error,
+            >,
+            Result<soroban_sdk::Error, soroban_sdk::InvokeError>,
+        > {
+            use core::ops::Not;
+            let old_auth_manager = self
+                .env
+                .in_contract()
+                .not()
+                .then(|| self.env.host().snapshot_auth_manager().unwrap());
+            {
+                if let Some(set_auths) = self.set_auths {
+                    self.env.set_auths(set_auths);
+                }
+                if let Some(mock_auths) = self.mock_auths {
+                    self.env.mock_auths(mock_auths);
+                }
+                if self.mock_all_auths {
+                    if self.allow_non_root_auth {
+                        self.env.mock_all_auths_allowing_non_root_auth();
+                    } else {
+                        self.env.mock_all_auths();
+                    }
+                }
+            }
+            use soroban_sdk::{FromVal, IntoVal};
+            let res = self.env.try_invoke_contract(
+                &self.address,
+                &{ soroban_sdk::Symbol::new(&self.env, "feature_enabled") },
+                ::soroban_sdk::Vec::new(&self.env),
+            );
+            if let Some(old_auth_manager) = old_auth_manager {
+                self.env.host().set_auth_manager(old_auth_manager).unwrap();
+            }
+            res
+        }
+    }
+    impl CfgGatedUnconditionalOverrideContractArgs {
+        #[inline(always)]
+        #[allow(clippy::unused_unit)]
+        pub fn feature_enabled<'i>() -> () {
+            ()
+        }
+    }
+    #[doc(hidden)]
+    #[allow(non_snake_case)]
+    #[deprecated(
+        note = "use `CfgGatedUnconditionalOverrideContractClient::new(&env, &contract_id).feature_enabled` instead"
+    )]
+    #[allow(deprecated)]
+    pub fn __CfgGatedUnconditionalOverrideContract__feature_enabled__invoke_raw(
+        env: soroban_sdk::Env,
+    ) -> soroban_sdk::Val {
+        soroban_sdk::IntoValForContractFn::into_val_for_contract_fn(
+            <CfgGatedUnconditionalOverrideContract as CfgGated>::feature_enabled(env.clone()),
+            &env,
+        )
+    }
+    #[doc(hidden)]
+    #[allow(non_snake_case)]
+    #[deprecated(
+        note = "use `CfgGatedUnconditionalOverrideContractClient::new(&env, &contract_id).feature_enabled` instead"
+    )]
+    pub fn __CfgGatedUnconditionalOverrideContract__feature_enabled__invoke_raw_slice(
+        env: soroban_sdk::Env,
+        args: &[soroban_sdk::Val],
+    ) -> soroban_sdk::Val {
+        if args.len() != 0usize {
+            {
+                ::core::panicking::panic_fmt(format_args!(
+                    "invalid number of input arguments: {0} expected, got {1}",
+                    0usize,
+                    args.len(),
+                ));
+            };
+        }
+        #[allow(deprecated)]
+        __CfgGatedUnconditionalOverrideContract__feature_enabled__invoke_raw(env)
+    }
+    #[doc(hidden)]
+    #[allow(non_snake_case)]
+    #[deprecated(
+        note = "use `CfgGatedUnconditionalOverrideContractClient::new(&env, &contract_id).feature_enabled` instead"
+    )]
+    pub extern "C" fn __CfgGatedUnconditionalOverrideContract__feature_enabled__invoke_raw_extern(
+    ) -> soroban_sdk::Val {
+        #[allow(deprecated)]
+        __CfgGatedUnconditionalOverrideContract__feature_enabled__invoke_raw(
+            soroban_sdk::Env::default(),
+        )
+    }
+    #[doc(hidden)]
+    #[allow(non_snake_case)]
+    #[deprecated(
+        note = "use `CfgGatedUnconditionalOverrideContractClient::new(&env, &contract_id).shown` instead"
+    )]
+    #[allow(deprecated)]
+    pub fn __CfgGatedUnconditionalOverrideContract__shown__invoke_raw(
+        env: soroban_sdk::Env,
+    ) -> soroban_sdk::Val {
+        soroban_sdk::IntoValForContractFn::into_val_for_contract_fn(
+            <CfgGatedUnconditionalOverrideContract as CfgGated>::shown(env.clone()),
+            &env,
+        )
+    }
+    #[doc(hidden)]
+    #[allow(non_snake_case)]
+    #[deprecated(
+        note = "use `CfgGatedUnconditionalOverrideContractClient::new(&env, &contract_id).shown` instead"
+    )]
+    pub fn __CfgGatedUnconditionalOverrideContract__shown__invoke_raw_slice(
+        env: soroban_sdk::Env,
+        args: &[soroban_sdk::Val],
+    ) -> soroban_sdk::Val {
+        if args.len() != 0usize {
+            {
+                ::core::panicking::panic_fmt(format_args!(
+                    "invalid number of input arguments: {0} expected, got {1}",
+                    0usize,
+                    args.len(),
+                ));
+            };
+        }
+        #[allow(deprecated)]
+        __CfgGatedUnconditionalOverrideContract__shown__invoke_raw(env)
+    }
+    #[doc(hidden)]
+    #[allow(non_snake_case)]
+    #[deprecated(
+        note = "use `CfgGatedUnconditionalOverrideContractClient::new(&env, &contract_id).shown` instead"
+    )]
+    pub extern "C" fn __CfgGatedUnconditionalOverrideContract__shown__invoke_raw_extern(
+    ) -> soroban_sdk::Val {
+        #[allow(deprecated)]
+        __CfgGatedUnconditionalOverrideContract__shown__invoke_raw(soroban_sdk::Env::default())
+    }
+    impl CfgGatedUnconditionalOverrideContract {}
+    #[doc(hidden)]
+    #[allow(non_snake_case)]
+    pub mod __CfgGatedUnconditionalOverrideContract__shown__spec {
+        #[doc(hidden)]
+        #[allow(non_snake_case)]
+        #[allow(non_upper_case_globals)]
+        pub static __SPEC_XDR_FN_SHOWN: [u8; 32usize] =
+            super::CfgGatedUnconditionalOverrideContract::spec_xdr_shown();
+    }
+    impl CfgGatedUnconditionalOverrideContract {
+        #[allow(non_snake_case)]
+        pub const fn spec_xdr_shown() -> [u8; 32usize] {
+            *b"\0\0\0\0\0\0\0\0\0\0\0\x05shown\0\0\0\0\0\0\0\0\0\0\x01\0\0\0\x04"
+        }
+    }
+    impl<'a> CfgGatedUnconditionalOverrideContractClient<'a> {
+        pub fn shown(&self) -> u32 {
+            use core::ops::Not;
+            let old_auth_manager = self
+                .env
+                .in_contract()
+                .not()
+                .then(|| self.env.host().snapshot_auth_manager().unwrap());
+            {
+                if let Some(set_auths) = self.set_auths {
+                    self.env.set_auths(set_auths);
+                }
+                if let Some(mock_auths) = self.mock_auths {
+                    self.env.mock_auths(mock_auths);
+                }
+                if self.mock_all_auths {
+                    if self.allow_non_root_auth {
+                        self.env.mock_all_auths_allowing_non_root_auth();
+                    } else {
+                        self.env.mock_all_auths();
+                    }
+                }
+            }
+            use soroban_sdk::{FromVal, IntoVal};
+            let res = self.env.invoke_contract(
+                &self.address,
+                &{
+                    #[allow(deprecated)]
+                    const SYMBOL: soroban_sdk::Symbol = soroban_sdk::Symbol::short("shown");
+                    SYMBOL
+                },
+                ::soroban_sdk::Vec::new(&self.env),
+            );
+            if let Some(old_auth_manager) = old_auth_manager {
+                self.env.host().set_auth_manager(old_auth_manager).unwrap();
+            }
+            res
+        }
+        pub fn try_shown(
+            &self,
+        ) -> Result<
+            Result<
+                u32,
+                <u32 as soroban_sdk::TryFromVal<soroban_sdk::Env, soroban_sdk::Val>>::Error,
+            >,
+            Result<soroban_sdk::Error, soroban_sdk::InvokeError>,
+        > {
+            use core::ops::Not;
+            let old_auth_manager = self
+                .env
+                .in_contract()
+                .not()
+                .then(|| self.env.host().snapshot_auth_manager().unwrap());
+            {
+                if let Some(set_auths) = self.set_auths {
+                    self.env.set_auths(set_auths);
+                }
+                if let Some(mock_auths) = self.mock_auths {
+                    self.env.mock_auths(mock_auths);
+                }
+                if self.mock_all_auths {
+                    if self.allow_non_root_auth {
+                        self.env.mock_all_auths_allowing_non_root_auth();
+                    } else {
+                        self.env.mock_all_auths();
+                    }
+                }
+            }
+            use soroban_sdk::{FromVal, IntoVal};
+            let res = self.env.try_invoke_contract(
+                &self.address,
+                &{
+                    #[allow(deprecated)]
+                    const SYMBOL: soroban_sdk::Symbol = soroban_sdk::Symbol::short("shown");
+                    SYMBOL
+                },
+                ::soroban_sdk::Vec::new(&self.env),
+            );
+            if let Some(old_auth_manager) = old_auth_manager {
+                self.env.host().set_auth_manager(old_auth_manager).unwrap();
+            }
+            res
+        }
+    }
+    impl CfgGatedUnconditionalOverrideContractArgs {
+        #[inline(always)]
+        #[allow(clippy::unused_unit)]
+        pub fn shown<'i>() -> () {
+            ()
+        }
+    }
+    #[doc(hidden)]
+    #[allow(non_snake_case)]
+    #[allow(unused)]
+    fn __CfgGatedUnconditionalOverrideContract__CfgGated__f4db9ab03a219f9ef1cecf98c7ccfdc83419274753acb76e2f464116514bd341_ctor(
+    ) {
+        #[allow(unsafe_code)]
+        {
+            #[link_section = ".init_array"]
+            #[used]
+            #[allow(non_upper_case_globals, non_snake_case)]
+            #[doc(hidden)]
+            static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
+                #[link_section = ".text.startup"]
+                #[allow(non_snake_case)]
+                extern "C" fn f() -> ::ctor::__support::CtorRetType {
+                    unsafe {
+                        __CfgGatedUnconditionalOverrideContract__CfgGated__f4db9ab03a219f9ef1cecf98c7ccfdc83419274753acb76e2f464116514bd341_ctor();
+                    };
+                    core::default::Default::default()
+                }
+                f
+            };
+        }
+        {
+            <CfgGatedUnconditionalOverrideContract as soroban_sdk::testutils::ContractFunctionRegister>::register(
+                "shown",
+                #[allow(deprecated)]
+                &__CfgGatedUnconditionalOverrideContract__shown__invoke_raw_slice,
+            );
+        }
+    }
+    #[doc(hidden)]
+    #[allow(non_snake_case)]
+    #[allow(unused)]
+    fn __CfgGatedUnconditionalOverrideContract__CfgGated__a18e3f9f4404828114b4e64e5bdf25a21eca2b7b590258def3adafbd4225c9a2_ctor(
+    ) {
+        #[allow(unsafe_code)]
+        {
+            #[link_section = ".init_array"]
+            #[used]
+            #[allow(non_upper_case_globals, non_snake_case)]
+            #[doc(hidden)]
+            static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
+                #[link_section = ".text.startup"]
+                #[allow(non_snake_case)]
+                extern "C" fn f() -> ::ctor::__support::CtorRetType {
+                    unsafe {
+                        __CfgGatedUnconditionalOverrideContract__CfgGated__a18e3f9f4404828114b4e64e5bdf25a21eca2b7b590258def3adafbd4225c9a2_ctor();
+                    };
+                    core::default::Default::default()
+                }
+                f
+            };
+        }
+        {
+            <CfgGatedUnconditionalOverrideContract as soroban_sdk::testutils::ContractFunctionRegister>::register(
+                "feature_enabled",
+                #[allow(deprecated)]
+                &__CfgGatedUnconditionalOverrideContract__feature_enabled__invoke_raw_slice,
+            );
+        }
+    }
+    pub struct CfgGatedImplContract;
+    ///CfgGatedImplContractArgs is a type for building arg lists for functions defined in "CfgGatedImplContract".
+    pub struct CfgGatedImplContractArgs;
+    ///CfgGatedImplContractClient is a client for calling the contract defined in "CfgGatedImplContract".
+    pub struct CfgGatedImplContractClient<'a> {
+        pub env: soroban_sdk::Env,
+        pub address: soroban_sdk::Address,
+        #[doc(hidden)]
+        set_auths: Option<&'a [soroban_sdk::xdr::SorobanAuthorizationEntry]>,
+        #[doc(hidden)]
+        mock_auths: Option<&'a [soroban_sdk::testutils::MockAuth<'a>]>,
+        #[doc(hidden)]
+        mock_all_auths: bool,
+        #[doc(hidden)]
+        allow_non_root_auth: bool,
+    }
+    impl<'a> CfgGatedImplContractClient<'a> {
+        pub fn new(env: &soroban_sdk::Env, address: &soroban_sdk::Address) -> Self {
+            Self {
+                env: env.clone(),
+                address: address.clone(),
+                set_auths: None,
+                mock_auths: None,
+                mock_all_auths: false,
+                allow_non_root_auth: false,
+            }
+        }
+        /// Set authorizations in the environment which will be consumed by
+        /// contracts when they invoke `Address::require_auth` or
+        /// `Address::require_auth_for_args` functions.
+        ///
+        /// Requires valid signatures for the authorization to be successful.
+        /// To mock auth without requiring valid signatures, use `mock_auths`.
+        ///
+        /// See `soroban_sdk::Env::set_auths` for more details and examples.
+        pub fn set_auths(&self, auths: &'a [soroban_sdk::xdr::SorobanAuthorizationEntry]) -> Self {
+            Self {
+                env: self.env.clone(),
+                address: self.address.clone(),
+                set_auths: Some(auths),
+                mock_auths: self.mock_auths.clone(),
+                mock_all_auths: false,
+                allow_non_root_auth: false,
+            }
+        }
+        /// Mock authorizations in the environment which will cause matching invokes
+        /// of `Address::require_auth` and `Address::require_auth_for_args` to
+        /// pass.
+        ///
+        /// See `soroban_sdk::Env::set_auths` for more details and examples.
+        pub fn mock_auths(&self, mock_auths: &'a [soroban_sdk::testutils::MockAuth<'a>]) -> Self {
+            Self {
+                env: self.env.clone(),
+                address: self.address.clone(),
+                set_auths: self.set_auths.clone(),
+                mock_auths: Some(mock_auths),
+                mock_all_auths: false,
+                allow_non_root_auth: false,
+            }
+        }
+        /// Mock all calls to the `Address::require_auth` and
+        /// `Address::require_auth_for_args` functions in invoked contracts,
+        /// having them succeed as if authorization was provided.
+        ///
+        /// See `soroban_sdk::Env::mock_all_auths` for more details and
+        /// examples.
+        pub fn mock_all_auths(&self) -> Self {
+            Self {
+                env: self.env.clone(),
+                address: self.address.clone(),
+                set_auths: None,
+                mock_auths: None,
+                mock_all_auths: true,
+                allow_non_root_auth: false,
+            }
+        }
+        /// A version of `mock_all_auths` that allows authorizations that
+        /// are not present in the root invocation.
+        ///
+        /// Refer to `mock_all_auths` documentation for details and
+        /// prefer using `mock_all_auths` unless non-root authorization is
+        /// required.
+        ///
+        /// See `soroban_sdk::Env::mock_all_auths_allowing_non_root_auth`
+        /// for more details and examples.
+        pub fn mock_all_auths_allowing_non_root_auth(&self) -> Self {
+            Self {
+                env: self.env.clone(),
+                address: self.address.clone(),
+                set_auths: None,
+                mock_auths: None,
+                mock_all_auths: true,
+                allow_non_root_auth: true,
+            }
+        }
+    }
+    mod __cfggatedimplcontract_fn_set_registry {
+        use super::*;
+        extern crate std;
+        use std::collections::BTreeMap;
+        use std::sync::Mutex;
+        pub type F = soroban_sdk::testutils::ContractFunctionF;
+        static FUNCS: Mutex<BTreeMap<&'static str, &'static F>> = Mutex::new(BTreeMap::new());
+        pub fn register(name: &'static str, func: &'static F) {
+            FUNCS.lock().unwrap().insert(name, func);
+        }
+        pub fn call(
+            name: &str,
+            env: soroban_sdk::Env,
+            args: &[soroban_sdk::Val],
+        ) -> Option<soroban_sdk::Val> {
+            let fopt: Option<&'static F> = FUNCS.lock().unwrap().get(name).map(|f| f.clone());
+            fopt.map(|f| f(env, args))
+        }
+    }
+    impl soroban_sdk::testutils::ContractFunctionRegister for CfgGatedImplContract {
+        fn register(name: &'static str, func: &'static __cfggatedimplcontract_fn_set_registry::F) {
+            __cfggatedimplcontract_fn_set_registry::register(name, func);
+        }
+    }
+    #[doc(hidden)]
+    impl soroban_sdk::testutils::ContractFunctionSet for CfgGatedImplContract {
+        fn call(
+            &self,
+            func: &str,
+            env: soroban_sdk::Env,
+            args: &[soroban_sdk::Val],
+        ) -> Option<soroban_sdk::Val> {
+            __cfggatedimplcontract_fn_set_registry::call(func, env, args)
+        }
+    }
+    impl CfgGatedImplContract {
+        pub fn shown(env: Env) -> u32 {
+            let _ = env;
+            8
+        }
+        pub fn feature_enabled(env: Env) -> u32 {
+            let _ = env;
+            9
+        }
+    }
+    impl CfgGatedImplContract {}
+    #[doc(hidden)]
+    #[allow(non_snake_case)]
+    pub mod __CfgGatedImplContract__shown__spec {
+        #[doc(hidden)]
+        #[allow(non_snake_case)]
+        #[allow(non_upper_case_globals)]
+        pub static __SPEC_XDR_FN_SHOWN: [u8; 32usize] =
+            super::CfgGatedImplContract::spec_xdr_shown();
+    }
+    impl CfgGatedImplContract {
+        #[allow(non_snake_case)]
+        pub const fn spec_xdr_shown() -> [u8; 32usize] {
+            *b"\0\0\0\0\0\0\0\0\0\0\0\x05shown\0\0\0\0\0\0\0\0\0\0\x01\0\0\0\x04"
+        }
+    }
+    #[doc(hidden)]
+    #[allow(non_snake_case)]
+    pub mod __CfgGatedImplContract__feature_enabled__spec {
+        #[doc(hidden)]
+        #[allow(non_snake_case)]
+        #[allow(non_upper_case_globals)]
+        pub static __SPEC_XDR_FN_FEATURE_ENABLED: [u8; 40usize] =
+            super::CfgGatedImplContract::spec_xdr_feature_enabled();
+    }
+    impl CfgGatedImplContract {
+        #[allow(non_snake_case)]
+        pub const fn spec_xdr_feature_enabled() -> [u8; 40usize] {
+            *b"\0\0\0\0\0\0\0\0\0\0\0\x0ffeature_enabled\0\0\0\0\0\0\0\0\x01\0\0\0\x04"
+        }
+    }
+    impl<'a> CfgGatedImplContractClient<'a> {
+        pub fn shown(&self) -> u32 {
+            use core::ops::Not;
+            let old_auth_manager = self
+                .env
+                .in_contract()
+                .not()
+                .then(|| self.env.host().snapshot_auth_manager().unwrap());
+            {
+                if let Some(set_auths) = self.set_auths {
+                    self.env.set_auths(set_auths);
+                }
+                if let Some(mock_auths) = self.mock_auths {
+                    self.env.mock_auths(mock_auths);
+                }
+                if self.mock_all_auths {
+                    if self.allow_non_root_auth {
+                        self.env.mock_all_auths_allowing_non_root_auth();
+                    } else {
+                        self.env.mock_all_auths();
+                    }
+                }
+            }
+            use soroban_sdk::{FromVal, IntoVal};
+            let res = self.env.invoke_contract(
+                &self.address,
+                &{
+                    #[allow(deprecated)]
+                    const SYMBOL: soroban_sdk::Symbol = soroban_sdk::Symbol::short("shown");
+                    SYMBOL
+                },
+                ::soroban_sdk::Vec::new(&self.env),
+            );
+            if let Some(old_auth_manager) = old_auth_manager {
+                self.env.host().set_auth_manager(old_auth_manager).unwrap();
+            }
+            res
+        }
+        pub fn try_shown(
+            &self,
+        ) -> Result<
+            Result<
+                u32,
+                <u32 as soroban_sdk::TryFromVal<soroban_sdk::Env, soroban_sdk::Val>>::Error,
+            >,
+            Result<soroban_sdk::Error, soroban_sdk::InvokeError>,
+        > {
+            use core::ops::Not;
+            let old_auth_manager = self
+                .env
+                .in_contract()
+                .not()
+                .then(|| self.env.host().snapshot_auth_manager().unwrap());
+            {
+                if let Some(set_auths) = self.set_auths {
+                    self.env.set_auths(set_auths);
+                }
+                if let Some(mock_auths) = self.mock_auths {
+                    self.env.mock_auths(mock_auths);
+                }
+                if self.mock_all_auths {
+                    if self.allow_non_root_auth {
+                        self.env.mock_all_auths_allowing_non_root_auth();
+                    } else {
+                        self.env.mock_all_auths();
+                    }
+                }
+            }
+            use soroban_sdk::{FromVal, IntoVal};
+            let res = self.env.try_invoke_contract(
+                &self.address,
+                &{
+                    #[allow(deprecated)]
+                    const SYMBOL: soroban_sdk::Symbol = soroban_sdk::Symbol::short("shown");
+                    SYMBOL
+                },
+                ::soroban_sdk::Vec::new(&self.env),
+            );
+            if let Some(old_auth_manager) = old_auth_manager {
+                self.env.host().set_auth_manager(old_auth_manager).unwrap();
+            }
+            res
+        }
+        pub fn feature_enabled(&self) -> u32 {
+            use core::ops::Not;
+            let old_auth_manager = self
+                .env
+                .in_contract()
+                .not()
+                .then(|| self.env.host().snapshot_auth_manager().unwrap());
+            {
+                if let Some(set_auths) = self.set_auths {
+                    self.env.set_auths(set_auths);
+                }
+                if let Some(mock_auths) = self.mock_auths {
+                    self.env.mock_auths(mock_auths);
+                }
+                if self.mock_all_auths {
+                    if self.allow_non_root_auth {
+                        self.env.mock_all_auths_allowing_non_root_auth();
+                    } else {
+                        self.env.mock_all_auths();
+                    }
+                }
+            }
+            use soroban_sdk::{FromVal, IntoVal};
+            let res = self.env.invoke_contract(
+                &self.address,
+                &{ soroban_sdk::Symbol::new(&self.env, "feature_enabled") },
+                ::soroban_sdk::Vec::new(&self.env),
+            );
+            if let Some(old_auth_manager) = old_auth_manager {
+                self.env.host().set_auth_manager(old_auth_manager).unwrap();
+            }
+            res
+        }
+        pub fn try_feature_enabled(
+            &self,
+        ) -> Result<
+            Result<
+                u32,
+                <u32 as soroban_sdk::TryFromVal<soroban_sdk::Env, soroban_sdk::Val>>::Error,
+            >,
+            Result<soroban_sdk::Error, soroban_sdk::InvokeError>,
+        > {
+            use core::ops::Not;
+            let old_auth_manager = self
+                .env
+                .in_contract()
+                .not()
+                .then(|| self.env.host().snapshot_auth_manager().unwrap());
+            {
+                if let Some(set_auths) = self.set_auths {
+                    self.env.set_auths(set_auths);
+                }
+                if let Some(mock_auths) = self.mock_auths {
+                    self.env.mock_auths(mock_auths);
+                }
+                if self.mock_all_auths {
+                    if self.allow_non_root_auth {
+                        self.env.mock_all_auths_allowing_non_root_auth();
+                    } else {
+                        self.env.mock_all_auths();
+                    }
+                }
+            }
+            use soroban_sdk::{FromVal, IntoVal};
+            let res = self.env.try_invoke_contract(
+                &self.address,
+                &{ soroban_sdk::Symbol::new(&self.env, "feature_enabled") },
+                ::soroban_sdk::Vec::new(&self.env),
+            );
+            if let Some(old_auth_manager) = old_auth_manager {
+                self.env.host().set_auth_manager(old_auth_manager).unwrap();
+            }
+            res
+        }
+    }
+    impl CfgGatedImplContractArgs {
+        #[inline(always)]
+        #[allow(clippy::unused_unit)]
+        pub fn shown<'i>() -> () {
+            ()
+        }
+        #[inline(always)]
+        #[allow(clippy::unused_unit)]
+        pub fn feature_enabled<'i>() -> () {
+            ()
+        }
+    }
+    #[doc(hidden)]
+    #[allow(non_snake_case)]
+    #[deprecated(note = "use `CfgGatedImplContractClient::new(&env, &contract_id).shown` instead")]
+    #[allow(deprecated)]
+    pub fn __CfgGatedImplContract__shown__invoke_raw(env: soroban_sdk::Env) -> soroban_sdk::Val {
+        soroban_sdk::IntoValForContractFn::into_val_for_contract_fn(
+            <CfgGatedImplContract>::shown(env.clone()),
+            &env,
+        )
+    }
+    #[doc(hidden)]
+    #[allow(non_snake_case)]
+    #[deprecated(note = "use `CfgGatedImplContractClient::new(&env, &contract_id).shown` instead")]
+    pub fn __CfgGatedImplContract__shown__invoke_raw_slice(
+        env: soroban_sdk::Env,
+        args: &[soroban_sdk::Val],
+    ) -> soroban_sdk::Val {
+        if args.len() != 0usize {
+            {
+                ::core::panicking::panic_fmt(format_args!(
+                    "invalid number of input arguments: {0} expected, got {1}",
+                    0usize,
+                    args.len(),
+                ));
+            };
+        }
+        #[allow(deprecated)]
+        __CfgGatedImplContract__shown__invoke_raw(env)
+    }
+    #[doc(hidden)]
+    #[allow(non_snake_case)]
+    #[deprecated(note = "use `CfgGatedImplContractClient::new(&env, &contract_id).shown` instead")]
+    pub extern "C" fn __CfgGatedImplContract__shown__invoke_raw_extern() -> soroban_sdk::Val {
+        #[allow(deprecated)]
+        __CfgGatedImplContract__shown__invoke_raw(soroban_sdk::Env::default())
+    }
+    #[doc(hidden)]
+    #[allow(non_snake_case)]
+    #[deprecated(
+        note = "use `CfgGatedImplContractClient::new(&env, &contract_id).feature_enabled` instead"
+    )]
+    #[allow(deprecated)]
+    pub fn __CfgGatedImplContract__feature_enabled__invoke_raw(
+        env: soroban_sdk::Env,
+    ) -> soroban_sdk::Val {
+        soroban_sdk::IntoValForContractFn::into_val_for_contract_fn(
+            <CfgGatedImplContract>::feature_enabled(env.clone()),
+            &env,
+        )
+    }
+    #[doc(hidden)]
+    #[allow(non_snake_case)]
+    #[deprecated(
+        note = "use `CfgGatedImplContractClient::new(&env, &contract_id).feature_enabled` instead"
+    )]
+    pub fn __CfgGatedImplContract__feature_enabled__invoke_raw_slice(
+        env: soroban_sdk::Env,
+        args: &[soroban_sdk::Val],
+    ) -> soroban_sdk::Val {
+        if args.len() != 0usize {
+            {
+                ::core::panicking::panic_fmt(format_args!(
+                    "invalid number of input arguments: {0} expected, got {1}",
+                    0usize,
+                    args.len(),
+                ));
+            };
+        }
+        #[allow(deprecated)]
+        __CfgGatedImplContract__feature_enabled__invoke_raw(env)
+    }
+    #[doc(hidden)]
+    #[allow(non_snake_case)]
+    #[deprecated(
+        note = "use `CfgGatedImplContractClient::new(&env, &contract_id).feature_enabled` instead"
+    )]
+    pub extern "C" fn __CfgGatedImplContract__feature_enabled__invoke_raw_extern(
+    ) -> soroban_sdk::Val {
+        #[allow(deprecated)]
+        __CfgGatedImplContract__feature_enabled__invoke_raw(soroban_sdk::Env::default())
+    }
+    #[doc(hidden)]
+    #[allow(non_snake_case)]
+    #[allow(unused)]
+    fn __CfgGatedImplContract____f4db9ab03a219f9ef1cecf98c7ccfdc83419274753acb76e2f464116514bd341_ctor(
+    ) {
+        #[allow(unsafe_code)]
+        {
+            #[link_section = ".init_array"]
+            #[used]
+            #[allow(non_upper_case_globals, non_snake_case)]
+            #[doc(hidden)]
+            static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
+                #[link_section = ".text.startup"]
+                #[allow(non_snake_case)]
+                extern "C" fn f() -> ::ctor::__support::CtorRetType {
+                    unsafe {
+                        __CfgGatedImplContract____f4db9ab03a219f9ef1cecf98c7ccfdc83419274753acb76e2f464116514bd341_ctor();
+                    };
+                    core::default::Default::default()
+                }
+                f
+            };
+        }
+        {
+            <CfgGatedImplContract as soroban_sdk::testutils::ContractFunctionRegister>::register(
+                "shown",
+                #[allow(deprecated)]
+                &__CfgGatedImplContract__shown__invoke_raw_slice,
+            );
+        }
+    }
+    #[doc(hidden)]
+    #[allow(non_snake_case)]
+    #[allow(unused)]
+    fn __CfgGatedImplContract____287ec90a09a11b5554d5353aea2c389d61a11a98fcc5ebb6a58ce90ccf5aba0d_ctor(
+    ) {
+        #[allow(unsafe_code)]
+        {
+            #[link_section = ".init_array"]
+            #[used]
+            #[allow(non_upper_case_globals, non_snake_case)]
+            #[doc(hidden)]
+            static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
+                #[link_section = ".text.startup"]
+                #[allow(non_snake_case)]
+                extern "C" fn f() -> ::ctor::__support::CtorRetType {
+                    unsafe {
+                        __CfgGatedImplContract____287ec90a09a11b5554d5353aea2c389d61a11a98fcc5ebb6a58ce90ccf5aba0d_ctor();
+                    };
+                    core::default::Default::default()
+                }
+                f
+            };
+        }
+        {
+            <CfgGatedImplContract as soroban_sdk::testutils::ContractFunctionRegister>::register(
+                "feature_enabled",
+                #[allow(deprecated)]
+                &__CfgGatedImplContract__feature_enabled__invoke_raw_slice,
+            );
+        }
     }
     extern crate test;
     #[rustc_test_marker = "test::test_types"]
@@ -7016,9 +9786,9 @@ mod test {
             ignore: false,
             ignore_message: ::core::option::Option::None,
             source_file: "tests/contracttrait_trait/src/lib.rs",
-            start_line: 126usize,
+            start_line: 206usize,
             start_col: 8usize,
-            end_line: 126usize,
+            end_line: 206usize,
             end_col: 18usize,
             compile_fail: false,
             no_run: false,
@@ -7339,6 +10109,228 @@ mod test {
         };
     }
     extern crate test;
+    #[rustc_test_marker = "test::test_cfg_gated_contracttrait_default_fn"]
+    #[doc(hidden)]
+    pub const test_cfg_gated_contracttrait_default_fn: test::TestDescAndFn = test::TestDescAndFn {
+        desc: test::TestDesc {
+            name: test::StaticTestName("test::test_cfg_gated_contracttrait_default_fn"),
+            ignore: false,
+            ignore_message: ::core::option::Option::None,
+            source_file: "tests/contracttrait_trait/src/lib.rs",
+            start_line: 269usize,
+            start_col: 8usize,
+            end_line: 269usize,
+            end_col: 47usize,
+            compile_fail: false,
+            no_run: false,
+            should_panic: test::ShouldPanic::No,
+            test_type: test::TestType::UnitTest,
+        },
+        testfn: test::StaticTestFn(
+            #[coverage(off)]
+            || test::assert_test_result(test_cfg_gated_contracttrait_default_fn()),
+        ),
+    };
+    fn test_cfg_gated_contracttrait_default_fn() {
+        let e = Env::default();
+        let contract_id = e.register(CfgGatedContract, ());
+        let client = CfgGatedContractClient::new(&e, &contract_id);
+        match (&client.shown(), &8) {
+            (left_val, right_val) => {
+                if !(*left_val == *right_val) {
+                    let kind = ::core::panicking::AssertKind::Eq;
+                    ::core::panicking::assert_failed(
+                        kind,
+                        &*left_val,
+                        &*right_val,
+                        ::core::option::Option::None,
+                    );
+                }
+            }
+        };
+        match (&client.feature_enabled(), &9) {
+            (left_val, right_val) => {
+                if !(*left_val == *right_val) {
+                    let kind = ::core::panicking::AssertKind::Eq;
+                    ::core::panicking::assert_failed(
+                        kind,
+                        &*left_val,
+                        &*right_val,
+                        ::core::option::Option::None,
+                    );
+                }
+            }
+        };
+    }
+    extern crate test;
+    #[rustc_test_marker = "test::test_cfg_gated_disabled_override_uses_default_fn"]
+    #[doc(hidden)]
+    pub const test_cfg_gated_disabled_override_uses_default_fn: test::TestDescAndFn =
+        test::TestDescAndFn {
+            desc: test::TestDesc {
+                name: test::StaticTestName(
+                    "test::test_cfg_gated_disabled_override_uses_default_fn",
+                ),
+                ignore: false,
+                ignore_message: ::core::option::Option::None,
+                source_file: "tests/contracttrait_trait/src/lib.rs",
+                start_line: 280usize,
+                start_col: 8usize,
+                end_line: 280usize,
+                end_col: 56usize,
+                compile_fail: false,
+                no_run: false,
+                should_panic: test::ShouldPanic::No,
+                test_type: test::TestType::UnitTest,
+            },
+            testfn: test::StaticTestFn(
+                #[coverage(off)]
+                || test::assert_test_result(test_cfg_gated_disabled_override_uses_default_fn()),
+            ),
+        };
+    fn test_cfg_gated_disabled_override_uses_default_fn() {
+        let e = Env::default();
+        let contract_id = e.register(CfgGatedOverrideContract, ());
+        let client = CfgGatedOverrideContractClient::new(&e, &contract_id);
+        match (&client.shown(), &8) {
+            (left_val, right_val) => {
+                if !(*left_val == *right_val) {
+                    let kind = ::core::panicking::AssertKind::Eq;
+                    ::core::panicking::assert_failed(
+                        kind,
+                        &*left_val,
+                        &*right_val,
+                        ::core::option::Option::None,
+                    );
+                }
+            }
+        };
+        match (&client.feature_enabled(), &99) {
+            (left_val, right_val) => {
+                if !(*left_val == *right_val) {
+                    let kind = ::core::panicking::AssertKind::Eq;
+                    ::core::panicking::assert_failed(
+                        kind,
+                        &*left_val,
+                        &*right_val,
+                        ::core::option::Option::None,
+                    );
+                }
+            }
+        };
+    }
+    extern crate test;
+    #[rustc_test_marker = "test::test_cfg_gated_default_with_unconditional_override"]
+    #[doc(hidden)]
+    pub const test_cfg_gated_default_with_unconditional_override: test::TestDescAndFn =
+        test::TestDescAndFn {
+            desc: test::TestDesc {
+                name: test::StaticTestName(
+                    "test::test_cfg_gated_default_with_unconditional_override",
+                ),
+                ignore: false,
+                ignore_message: ::core::option::Option::None,
+                source_file: "tests/contracttrait_trait/src/lib.rs",
+                start_line: 292usize,
+                start_col: 8usize,
+                end_line: 292usize,
+                end_col: 58usize,
+                compile_fail: false,
+                no_run: false,
+                should_panic: test::ShouldPanic::No,
+                test_type: test::TestType::UnitTest,
+            },
+            testfn: test::StaticTestFn(
+                #[coverage(off)]
+                || test::assert_test_result(test_cfg_gated_default_with_unconditional_override()),
+            ),
+        };
+    fn test_cfg_gated_default_with_unconditional_override() {
+        let e = Env::default();
+        let contract_id = e.register(CfgGatedUnconditionalOverrideContract, ());
+        let client = CfgGatedUnconditionalOverrideContractClient::new(&e, &contract_id);
+        match (&client.shown(), &8) {
+            (left_val, right_val) => {
+                if !(*left_val == *right_val) {
+                    let kind = ::core::panicking::AssertKind::Eq;
+                    ::core::panicking::assert_failed(
+                        kind,
+                        &*left_val,
+                        &*right_val,
+                        ::core::option::Option::None,
+                    );
+                }
+            }
+        };
+        match (&client.feature_enabled(), &100) {
+            (left_val, right_val) => {
+                if !(*left_val == *right_val) {
+                    let kind = ::core::panicking::AssertKind::Eq;
+                    ::core::panicking::assert_failed(
+                        kind,
+                        &*left_val,
+                        &*right_val,
+                        ::core::option::Option::None,
+                    );
+                }
+            }
+        };
+    }
+    extern crate test;
+    #[rustc_test_marker = "test::test_cfg_gated_contractimpl_fn"]
+    #[doc(hidden)]
+    pub const test_cfg_gated_contractimpl_fn: test::TestDescAndFn = test::TestDescAndFn {
+        desc: test::TestDesc {
+            name: test::StaticTestName("test::test_cfg_gated_contractimpl_fn"),
+            ignore: false,
+            ignore_message: ::core::option::Option::None,
+            source_file: "tests/contracttrait_trait/src/lib.rs",
+            start_line: 302usize,
+            start_col: 8usize,
+            end_line: 302usize,
+            end_col: 38usize,
+            compile_fail: false,
+            no_run: false,
+            should_panic: test::ShouldPanic::No,
+            test_type: test::TestType::UnitTest,
+        },
+        testfn: test::StaticTestFn(
+            #[coverage(off)]
+            || test::assert_test_result(test_cfg_gated_contractimpl_fn()),
+        ),
+    };
+    fn test_cfg_gated_contractimpl_fn() {
+        let e = Env::default();
+        let contract_id = e.register(CfgGatedImplContract, ());
+        let client = CfgGatedImplContractClient::new(&e, &contract_id);
+        match (&client.shown(), &8) {
+            (left_val, right_val) => {
+                if !(*left_val == *right_val) {
+                    let kind = ::core::panicking::AssertKind::Eq;
+                    ::core::panicking::assert_failed(
+                        kind,
+                        &*left_val,
+                        &*right_val,
+                        ::core::option::Option::None,
+                    );
+                }
+            }
+        };
+        match (&client.feature_enabled(), &9) {
+            (left_val, right_val) => {
+                if !(*left_val == *right_val) {
+                    let kind = ::core::panicking::AssertKind::Eq;
+                    ::core::panicking::assert_failed(
+                        kind,
+                        &*left_val,
+                        &*right_val,
+                        ::core::option::Option::None,
+                    );
+                }
+            }
+        };
+    }
+    extern crate test;
     #[rustc_test_marker = "test::test_spec_docs"]
     #[doc(hidden)]
     pub const test_spec_docs: test::TestDescAndFn = test::TestDescAndFn {
@@ -7347,9 +10339,9 @@ mod test {
             ignore: false,
             ignore_message: ::core::option::Option::None,
             source_file: "tests/contracttrait_trait/src/lib.rs",
-            start_line: 189usize,
+            start_line: 313usize,
             start_col: 8usize,
-            end_line: 189usize,
+            end_line: 313usize,
             end_col: 22usize,
             compile_fail: false,
             no_run: false,
@@ -7412,5 +10404,12 @@ mod test {
 #[doc(hidden)]
 pub fn main() -> () {
     extern crate test;
-    test::test_main_static(&[&test_spec_docs, &test_types])
+    test::test_main_static(&[
+        &test_cfg_gated_contractimpl_fn,
+        &test_cfg_gated_contracttrait_default_fn,
+        &test_cfg_gated_default_with_unconditional_override,
+        &test_cfg_gated_disabled_override_uses_default_fn,
+        &test_spec_docs,
+        &test_types,
+    ])
 }

--- a/tests-expanded/test_contracttrait_trait_wasm32v1-none.rs
+++ b/tests-expanded/test_contracttrait_trait_wasm32v1-none.rs
@@ -1168,11 +1168,14 @@ impl<'a> AllTypesClient<'a> {
 ///AllTypesArgs is a type for building arg lists for functions defined in "AllTypes".
 pub struct AllTypesArgs;
 impl AllTypesArgs {
+    /// Test u32 values.
+    /// Returns the input unchanged.
     #[inline(always)]
     #[allow(clippy::unused_unit)]
     pub fn test_u32<'i>(v: &'i u32) -> (&'i u32,) {
         (v,)
     }
+    /// Test i32 values.
     #[inline(always)]
     #[allow(clippy::unused_unit)]
     pub fn test_i32<'i>(v: &'i i32) -> (&'i i32,) {
@@ -1412,5 +1415,119 @@ impl AllTypesSpec {
     #[allow(non_snake_case)]
     pub const fn spec_xdr_test_enum_variants() -> [u8; 100usize] {
         *b"\0\0\0\0\0\0\0\0\0\0\0\x12test_enum_variants\0\0\0\0\0\x01\0\0\0\0\0\0\0\x01v\0\0\0\0\0\x07\xd0\0\0\0\x0eMyEnumVariants\0\0\0\0\0\x01\0\0\x07\xd0\0\0\0\x0eMyEnumVariants\0\0"
+    }
+}
+pub struct CfgGatedSpec;
+/// Macro for `contractimpl`ing the default functions of the trait that are not overridden.
+pub use __contractimpl_for_cfg_gated as CfgGated;
+pub trait CfgGated {
+    fn shown(env: Env) -> u32 {
+        let _ = env;
+        8
+    }
+    fn feature_enabled(env: Env) -> u32 {
+        let _ = env;
+        9
+    }
+}
+///CfgGatedClient is a client for calling the contract defined in "CfgGated".
+pub struct CfgGatedClient<'a> {
+    pub env: soroban_sdk::Env,
+    pub address: soroban_sdk::Address,
+    #[doc(hidden)]
+    _phantom: core::marker::PhantomData<&'a ()>,
+}
+impl<'a> CfgGatedClient<'a> {
+    pub fn new(env: &soroban_sdk::Env, address: &soroban_sdk::Address) -> Self {
+        Self {
+            env: env.clone(),
+            address: address.clone(),
+            _phantom: core::marker::PhantomData,
+        }
+    }
+}
+impl<'a> CfgGatedClient<'a> {
+    pub fn shown(&self) -> u32 {
+        use core::ops::Not;
+        use soroban_sdk::{FromVal, IntoVal};
+        let res = self.env.invoke_contract(
+            &self.address,
+            &{
+                #[allow(deprecated)]
+                const SYMBOL: soroban_sdk::Symbol = soroban_sdk::Symbol::short("shown");
+                SYMBOL
+            },
+            ::soroban_sdk::Vec::new(&self.env),
+        );
+        res
+    }
+    pub fn try_shown(
+        &self,
+    ) -> Result<
+        Result<u32, <u32 as soroban_sdk::TryFromVal<soroban_sdk::Env, soroban_sdk::Val>>::Error>,
+        Result<soroban_sdk::Error, soroban_sdk::InvokeError>,
+    > {
+        use soroban_sdk::{FromVal, IntoVal};
+        let res = self.env.try_invoke_contract(
+            &self.address,
+            &{
+                #[allow(deprecated)]
+                const SYMBOL: soroban_sdk::Symbol = soroban_sdk::Symbol::short("shown");
+                SYMBOL
+            },
+            ::soroban_sdk::Vec::new(&self.env),
+        );
+        res
+    }
+    pub fn feature_enabled(&self) -> u32 {
+        use core::ops::Not;
+        use soroban_sdk::{FromVal, IntoVal};
+        let res = self.env.invoke_contract(
+            &self.address,
+            &{ soroban_sdk::Symbol::new(&self.env, "feature_enabled") },
+            ::soroban_sdk::Vec::new(&self.env),
+        );
+        res
+    }
+    pub fn try_feature_enabled(
+        &self,
+    ) -> Result<
+        Result<u32, <u32 as soroban_sdk::TryFromVal<soroban_sdk::Env, soroban_sdk::Val>>::Error>,
+        Result<soroban_sdk::Error, soroban_sdk::InvokeError>,
+    > {
+        use soroban_sdk::{FromVal, IntoVal};
+        let res = self.env.try_invoke_contract(
+            &self.address,
+            &{ soroban_sdk::Symbol::new(&self.env, "feature_enabled") },
+            ::soroban_sdk::Vec::new(&self.env),
+        );
+        res
+    }
+}
+///CfgGatedArgs is a type for building arg lists for functions defined in "CfgGated".
+pub struct CfgGatedArgs;
+impl CfgGatedArgs {
+    #[inline(always)]
+    #[allow(clippy::unused_unit)]
+    pub fn shown<'i>() -> () {
+        ()
+    }
+    #[inline(always)]
+    #[allow(clippy::unused_unit)]
+    pub fn feature_enabled<'i>() -> () {
+        ()
+    }
+}
+impl CfgGatedSpec {}
+impl CfgGatedSpec {
+    #[allow(non_snake_case)]
+    pub const fn spec_xdr_shown() -> [u8; 32usize] {
+        *b"\0\0\0\0\0\0\0\0\0\0\0\x05shown\0\0\0\0\0\0\0\0\0\0\x01\0\0\0\x04"
+    }
+}
+impl CfgGatedSpec {
+    #[allow(non_snake_case)]
+    pub const fn spec_xdr_feature_enabled() -> [u8; 40usize] {
+        *b"\0\0\0\0\0\0\0\0\0\0\0\x0ffeature_enabled\0\0\0\0\0\0\0\0\x01\0\0\0\x04"
     }
 }

--- a/tests-expanded/test_empty2_tests.rs
+++ b/tests-expanded/test_empty2_tests.rs
@@ -139,30 +139,6 @@ impl soroban_sdk::testutils::ContractFunctionSet for Contract {
 impl Contract {}
 impl<'a> ContractClient<'a> {}
 impl ContractArgs {}
-#[doc(hidden)]
-#[allow(non_snake_case)]
-#[allow(unused)]
-fn __Contract____e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855_ctor() {
-    #[allow(unsafe_code)]
-    {
-        #[link_section = ".init_array"]
-        #[used]
-        #[allow(non_upper_case_globals, non_snake_case)]
-        #[doc(hidden)]
-        static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
-            #[link_section = ".text.startup"]
-            #[allow(non_snake_case)]
-            extern "C" fn f() -> ::ctor::__support::CtorRetType {
-                unsafe {
-                    __Contract____e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855_ctor();
-                };
-                core::default::Default::default()
-            }
-            f
-        };
-    }
-    {}
-}
 mod test {
     use crate::{Contract, ContractClient};
     use soroban_sdk::Env;

--- a/tests-expanded/test_empty_tests.rs
+++ b/tests-expanded/test_empty_tests.rs
@@ -277,7 +277,7 @@ pub extern "C" fn __Contract__empty__invoke_raw_extern() -> soroban_sdk::Val {
 #[doc(hidden)]
 #[allow(non_snake_case)]
 #[allow(unused)]
-fn __Contract____2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d_ctor() {
+fn __Contract____e6845188b1d2aebdf19d13c1613d7a49b5806a7fe336ec775fa182b36719bbc1_ctor() {
     #[allow(unsafe_code)]
     {
         #[link_section = ".init_array"]
@@ -289,7 +289,7 @@ fn __Contract____2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10
             #[allow(non_snake_case)]
             extern "C" fn f() -> ::ctor::__support::CtorRetType {
                 unsafe {
-                    __Contract____2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d_ctor();
+                    __Contract____e6845188b1d2aebdf19d13c1613d7a49b5806a7fe336ec775fa182b36719bbc1_ctor();
                 };
                 core::default::Default::default()
             }

--- a/tests-expanded/test_errors_tests.rs
+++ b/tests-expanded/test_errors_tests.rs
@@ -955,7 +955,7 @@ pub extern "C" fn __Contract__persisted__invoke_raw_extern() -> soroban_sdk::Val
 #[doc(hidden)]
 #[allow(non_snake_case)]
 #[allow(unused)]
-fn __Contract____dc66cfa30fdb08b17ba29ed3da0a0be599deef8db57bfb9cd9b3dcbf8c3be498_ctor() {
+fn __Contract____5aa762ae383fbb727af3c7a36d4940a5b8c40a989452d2304fc958ff3f354e7a_ctor() {
     #[allow(unsafe_code)]
     {
         #[link_section = ".init_array"]
@@ -967,7 +967,7 @@ fn __Contract____dc66cfa30fdb08b17ba29ed3da0a0be599deef8db57bfb9cd9b3dcbf8c3be49
             #[allow(non_snake_case)]
             extern "C" fn f() -> ::ctor::__support::CtorRetType {
                 unsafe {
-                    __Contract____dc66cfa30fdb08b17ba29ed3da0a0be599deef8db57bfb9cd9b3dcbf8c3be498_ctor();
+                    __Contract____5aa762ae383fbb727af3c7a36d4940a5b8c40a989452d2304fc958ff3f354e7a_ctor();
                 };
                 core::default::Default::default()
             }
@@ -980,6 +980,31 @@ fn __Contract____dc66cfa30fdb08b17ba29ed3da0a0be599deef8db57bfb9cd9b3dcbf8c3be49
             #[allow(deprecated)]
             &__Contract__hello__invoke_raw_slice,
         );
+    }
+}
+#[doc(hidden)]
+#[allow(non_snake_case)]
+#[allow(unused)]
+fn __Contract____0c532c591830f77adb3d009e7dd886994c502c98e15a136eb5c2b42ef24dd4d8_ctor() {
+    #[allow(unsafe_code)]
+    {
+        #[link_section = ".init_array"]
+        #[used]
+        #[allow(non_upper_case_globals, non_snake_case)]
+        #[doc(hidden)]
+        static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
+            #[link_section = ".text.startup"]
+            #[allow(non_snake_case)]
+            extern "C" fn f() -> ::ctor::__support::CtorRetType {
+                unsafe {
+                    __Contract____0c532c591830f77adb3d009e7dd886994c502c98e15a136eb5c2b42ef24dd4d8_ctor();
+                };
+                core::default::Default::default()
+            }
+            f
+        };
+    }
+    {
         <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
             "persisted",
             #[allow(deprecated)]

--- a/tests-expanded/test_errors_wasm32v1-none.rs
+++ b/tests-expanded/test_errors_wasm32v1-none.rs
@@ -348,11 +348,6 @@ impl ContractArgs {
     pub fn hello<'i>(flag: &'i Flag) -> (&'i Flag,) {
         (flag,)
     }
-    #[inline(always)]
-    #[allow(clippy::unused_unit)]
-    pub fn persisted<'i>() -> () {
-        ()
-    }
 }
 #[doc(hidden)]
 #[allow(non_snake_case)]

--- a/tests-expanded/test_events_ref_tests.rs
+++ b/tests-expanded/test_events_ref_tests.rs
@@ -585,7 +585,7 @@ pub extern "C" fn __Contract__failed_transfer__invoke_raw_extern(
 #[doc(hidden)]
 #[allow(non_snake_case)]
 #[allow(unused)]
-fn __Contract____a60968eb9ff75bf813738a9007ab5bbea9f174011ab4092819ed57e87eb6b301_ctor() {
+fn __Contract____7708079517f101c8daa66f7e425488fc59e1ffde88e2f5a8d081e90ef7983664_ctor() {
     #[allow(unsafe_code)]
     {
         #[link_section = ".init_array"]
@@ -597,7 +597,7 @@ fn __Contract____a60968eb9ff75bf813738a9007ab5bbea9f174011ab4092819ed57e87eb6b30
             #[allow(non_snake_case)]
             extern "C" fn f() -> ::ctor::__support::CtorRetType {
                 unsafe {
-                    __Contract____a60968eb9ff75bf813738a9007ab5bbea9f174011ab4092819ed57e87eb6b301_ctor();
+                    __Contract____7708079517f101c8daa66f7e425488fc59e1ffde88e2f5a8d081e90ef7983664_ctor();
                 };
                 core::default::Default::default()
             }
@@ -610,6 +610,31 @@ fn __Contract____a60968eb9ff75bf813738a9007ab5bbea9f174011ab4092819ed57e87eb6b30
             #[allow(deprecated)]
             &__Contract__transfer__invoke_raw_slice,
         );
+    }
+}
+#[doc(hidden)]
+#[allow(non_snake_case)]
+#[allow(unused)]
+fn __Contract____160dea745e1d3ebda006b1e49d8d6962b3bbe3424b0642c794f94574753fac58_ctor() {
+    #[allow(unsafe_code)]
+    {
+        #[link_section = ".init_array"]
+        #[used]
+        #[allow(non_upper_case_globals, non_snake_case)]
+        #[doc(hidden)]
+        static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
+            #[link_section = ".text.startup"]
+            #[allow(non_snake_case)]
+            extern "C" fn f() -> ::ctor::__support::CtorRetType {
+                unsafe {
+                    __Contract____160dea745e1d3ebda006b1e49d8d6962b3bbe3424b0642c794f94574753fac58_ctor();
+                };
+                core::default::Default::default()
+            }
+            f
+        };
+    }
+    {
         <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
             "failed_transfer",
             #[allow(deprecated)]

--- a/tests-expanded/test_events_tests.rs
+++ b/tests-expanded/test_events_tests.rs
@@ -585,7 +585,7 @@ pub extern "C" fn __Contract__failed_transfer__invoke_raw_extern(
 #[doc(hidden)]
 #[allow(non_snake_case)]
 #[allow(unused)]
-fn __Contract____a60968eb9ff75bf813738a9007ab5bbea9f174011ab4092819ed57e87eb6b301_ctor() {
+fn __Contract____7708079517f101c8daa66f7e425488fc59e1ffde88e2f5a8d081e90ef7983664_ctor() {
     #[allow(unsafe_code)]
     {
         #[link_section = ".init_array"]
@@ -597,7 +597,7 @@ fn __Contract____a60968eb9ff75bf813738a9007ab5bbea9f174011ab4092819ed57e87eb6b30
             #[allow(non_snake_case)]
             extern "C" fn f() -> ::ctor::__support::CtorRetType {
                 unsafe {
-                    __Contract____a60968eb9ff75bf813738a9007ab5bbea9f174011ab4092819ed57e87eb6b301_ctor();
+                    __Contract____7708079517f101c8daa66f7e425488fc59e1ffde88e2f5a8d081e90ef7983664_ctor();
                 };
                 core::default::Default::default()
             }
@@ -610,6 +610,31 @@ fn __Contract____a60968eb9ff75bf813738a9007ab5bbea9f174011ab4092819ed57e87eb6b30
             #[allow(deprecated)]
             &__Contract__transfer__invoke_raw_slice,
         );
+    }
+}
+#[doc(hidden)]
+#[allow(non_snake_case)]
+#[allow(unused)]
+fn __Contract____160dea745e1d3ebda006b1e49d8d6962b3bbe3424b0642c794f94574753fac58_ctor() {
+    #[allow(unsafe_code)]
+    {
+        #[link_section = ".init_array"]
+        #[used]
+        #[allow(non_upper_case_globals, non_snake_case)]
+        #[doc(hidden)]
+        static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
+            #[link_section = ".text.startup"]
+            #[allow(non_snake_case)]
+            extern "C" fn f() -> ::ctor::__support::CtorRetType {
+                unsafe {
+                    __Contract____160dea745e1d3ebda006b1e49d8d6962b3bbe3424b0642c794f94574753fac58_ctor();
+                };
+                core::default::Default::default()
+            }
+            f
+        };
+    }
+    {
         <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
             "failed_transfer",
             #[allow(deprecated)]

--- a/tests-expanded/test_fuzz_tests.rs
+++ b/tests-expanded/test_fuzz_tests.rs
@@ -314,7 +314,7 @@ pub extern "C" fn __Contract__run__invoke_raw_extern(
 #[doc(hidden)]
 #[allow(non_snake_case)]
 #[allow(unused)]
-fn __Contract____acba25512100f80b56fc3ccd14c65be55d94800cda77585c5f41a887e398f9be_ctor() {
+fn __Contract____5e87f618bd8837e87070ae7f83753c6a23ff095f43de6ededcd38ae535031c29_ctor() {
     #[allow(unsafe_code)]
     {
         #[link_section = ".init_array"]
@@ -326,7 +326,7 @@ fn __Contract____acba25512100f80b56fc3ccd14c65be55d94800cda77585c5f41a887e398f9b
             #[allow(non_snake_case)]
             extern "C" fn f() -> ::ctor::__support::CtorRetType {
                 unsafe {
-                    __Contract____acba25512100f80b56fc3ccd14c65be55d94800cda77585c5f41a887e398f9be_ctor();
+                    __Contract____5e87f618bd8837e87070ae7f83753c6a23ff095f43de6ededcd38ae535031c29_ctor();
                 };
                 core::default::Default::default()
             }

--- a/tests-expanded/test_generics_tests.rs
+++ b/tests-expanded/test_generics_tests.rs
@@ -330,7 +330,7 @@ pub extern "C" fn __Contract__exec__invoke_raw_extern(
 #[doc(hidden)]
 #[allow(non_snake_case)]
 #[allow(unused)]
-fn __Contract____2706c619fe73f0cf112473c6ee02e66c04e1c01c110b0c37b88d8eb509630c9f_ctor() {
+fn __Contract____37c9a5bba64484ff1971b80862a96916501e4624e59e717e16e7686f6f41be73_ctor() {
     #[allow(unsafe_code)]
     {
         #[link_section = ".init_array"]
@@ -342,7 +342,7 @@ fn __Contract____2706c619fe73f0cf112473c6ee02e66c04e1c01c110b0c37b88d8eb509630c9
             #[allow(non_snake_case)]
             extern "C" fn f() -> ::ctor::__support::CtorRetType {
                 unsafe {
-                    __Contract____2706c619fe73f0cf112473c6ee02e66c04e1c01c110b0c37b88d8eb509630c9f_ctor();
+                    __Contract____37c9a5bba64484ff1971b80862a96916501e4624e59e717e16e7686f6f41be73_ctor();
                 };
                 core::default::Default::default()
             }

--- a/tests-expanded/test_import_contract_tests.rs
+++ b/tests-expanded/test_import_contract_tests.rs
@@ -1556,7 +1556,7 @@ pub extern "C" fn __Contract__safe_add_with_two__invoke_raw_extern(
 #[doc(hidden)]
 #[allow(non_snake_case)]
 #[allow(unused)]
-fn __Contract____7f4ee4d361d09b9f0b349441853c9c2507e71fb15e4ddfe088d43fd41f0e1d27_ctor() {
+fn __Contract____a65401bbc7b9c746c39c9a9e22087a96ad048be784b0c2c6eb05243a85b227bb_ctor() {
     #[allow(unsafe_code)]
     {
         #[link_section = ".init_array"]
@@ -1568,7 +1568,7 @@ fn __Contract____7f4ee4d361d09b9f0b349441853c9c2507e71fb15e4ddfe088d43fd41f0e1d2
             #[allow(non_snake_case)]
             extern "C" fn f() -> ::ctor::__support::CtorRetType {
                 unsafe {
-                    __Contract____7f4ee4d361d09b9f0b349441853c9c2507e71fb15e4ddfe088d43fd41f0e1d27_ctor();
+                    __Contract____a65401bbc7b9c746c39c9a9e22087a96ad048be784b0c2c6eb05243a85b227bb_ctor();
                 };
                 core::default::Default::default()
             }
@@ -1581,11 +1581,61 @@ fn __Contract____7f4ee4d361d09b9f0b349441853c9c2507e71fb15e4ddfe088d43fd41f0e1d2
             #[allow(deprecated)]
             &__Contract__add_with__invoke_raw_slice,
         );
+    }
+}
+#[doc(hidden)]
+#[allow(non_snake_case)]
+#[allow(unused)]
+fn __Contract____ef00c9e592aaad2132e9664718d0f5a7d157016f0b6e2bfabf7cc7ee9a9343ac_ctor() {
+    #[allow(unsafe_code)]
+    {
+        #[link_section = ".init_array"]
+        #[used]
+        #[allow(non_upper_case_globals, non_snake_case)]
+        #[doc(hidden)]
+        static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
+            #[link_section = ".text.startup"]
+            #[allow(non_snake_case)]
+            extern "C" fn f() -> ::ctor::__support::CtorRetType {
+                unsafe {
+                    __Contract____ef00c9e592aaad2132e9664718d0f5a7d157016f0b6e2bfabf7cc7ee9a9343ac_ctor();
+                };
+                core::default::Default::default()
+            }
+            f
+        };
+    }
+    {
         <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
             "safe_add_with",
             #[allow(deprecated)]
             &__Contract__safe_add_with__invoke_raw_slice,
         );
+    }
+}
+#[doc(hidden)]
+#[allow(non_snake_case)]
+#[allow(unused)]
+fn __Contract____cf95a266dc51de2574c4c58e7aa871cea0e723db7bf26d912a6c802c6148e966_ctor() {
+    #[allow(unsafe_code)]
+    {
+        #[link_section = ".init_array"]
+        #[used]
+        #[allow(non_upper_case_globals, non_snake_case)]
+        #[doc(hidden)]
+        static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
+            #[link_section = ".text.startup"]
+            #[allow(non_snake_case)]
+            extern "C" fn f() -> ::ctor::__support::CtorRetType {
+                unsafe {
+                    __Contract____cf95a266dc51de2574c4c58e7aa871cea0e723db7bf26d912a6c802c6148e966_ctor();
+                };
+                core::default::Default::default()
+            }
+            f
+        };
+    }
+    {
         <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
             "safe_add_with_two",
             #[allow(deprecated)]

--- a/tests-expanded/test_invoke_contract_tests.rs
+++ b/tests-expanded/test_invoke_contract_tests.rs
@@ -340,7 +340,7 @@ pub extern "C" fn __Contract__add_with__invoke_raw_extern(
 #[doc(hidden)]
 #[allow(non_snake_case)]
 #[allow(unused)]
-fn __Contract____70a46203e4054de1ddff57b7a47699d47775f2dc3cd806328562e85117ee9756_ctor() {
+fn __Contract____a65401bbc7b9c746c39c9a9e22087a96ad048be784b0c2c6eb05243a85b227bb_ctor() {
     #[allow(unsafe_code)]
     {
         #[link_section = ".init_array"]
@@ -352,7 +352,7 @@ fn __Contract____70a46203e4054de1ddff57b7a47699d47775f2dc3cd806328562e85117ee975
             #[allow(non_snake_case)]
             extern "C" fn f() -> ::ctor::__support::CtorRetType {
                 unsafe {
-                    __Contract____70a46203e4054de1ddff57b7a47699d47775f2dc3cd806328562e85117ee9756_ctor();
+                    __Contract____a65401bbc7b9c746c39c9a9e22087a96ad048be784b0c2c6eb05243a85b227bb_ctor();
                 };
                 core::default::Default::default()
             }
@@ -673,7 +673,7 @@ pub extern "C" fn __AddContract__add__invoke_raw_extern(
 #[doc(hidden)]
 #[allow(non_snake_case)]
 #[allow(unused)]
-fn __AddContract____7e9e5ac30f2216fd0fd6f5faed316f2d5983361a4203c3330cfa46ef65bb4767_ctor() {
+fn __AddContract____7b8a6f33b43ca26a3f2aa73e408748f9ceb391ac21dfe746c94563016ab72f85_ctor() {
     #[allow(unsafe_code)]
     {
         #[link_section = ".init_array"]
@@ -685,7 +685,7 @@ fn __AddContract____7e9e5ac30f2216fd0fd6f5faed316f2d5983361a4203c3330cfa46ef65bb
             #[allow(non_snake_case)]
             extern "C" fn f() -> ::ctor::__support::CtorRetType {
                 unsafe {
-                    __AddContract____7e9e5ac30f2216fd0fd6f5faed316f2d5983361a4203c3330cfa46ef65bb4767_ctor();
+                    __AddContract____7b8a6f33b43ca26a3f2aa73e408748f9ceb391ac21dfe746c94563016ab72f85_ctor();
                 };
                 core::default::Default::default()
             }

--- a/tests-expanded/test_logging_tests.rs
+++ b/tests-expanded/test_logging_tests.rs
@@ -363,7 +363,7 @@ pub extern "C" fn __Contract__hello__invoke_raw_extern() -> soroban_sdk::Val {
 #[doc(hidden)]
 #[allow(non_snake_case)]
 #[allow(unused)]
-fn __Contract____2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824_ctor() {
+fn __Contract____5aa762ae383fbb727af3c7a36d4940a5b8c40a989452d2304fc958ff3f354e7a_ctor() {
     #[allow(unsafe_code)]
     {
         #[link_section = ".init_array"]
@@ -375,7 +375,7 @@ fn __Contract____2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b982
             #[allow(non_snake_case)]
             extern "C" fn f() -> ::ctor::__support::CtorRetType {
                 unsafe {
-                    __Contract____2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824_ctor();
+                    __Contract____5aa762ae383fbb727af3c7a36d4940a5b8c40a989452d2304fc958ff3f354e7a_ctor();
                 };
                 core::default::Default::default()
             }

--- a/tests-expanded/test_macros_tests.rs
+++ b/tests-expanded/test_macros_tests.rs
@@ -412,7 +412,7 @@ pub extern "C" fn __Contract__empty2__invoke_raw_extern() -> soroban_sdk::Val {
 #[doc(hidden)]
 #[allow(non_snake_case)]
 #[allow(unused)]
-fn __Contract____3d3f4e42d091a0f5587b8b2342b95a9ce7a0f5074262f199c972d2b2f43f23c1_ctor() {
+fn __Contract____e6845188b1d2aebdf19d13c1613d7a49b5806a7fe336ec775fa182b36719bbc1_ctor() {
     #[allow(unsafe_code)]
     {
         #[link_section = ".init_array"]
@@ -424,7 +424,7 @@ fn __Contract____3d3f4e42d091a0f5587b8b2342b95a9ce7a0f5074262f199c972d2b2f43f23c
             #[allow(non_snake_case)]
             extern "C" fn f() -> ::ctor::__support::CtorRetType {
                 unsafe {
-                    __Contract____3d3f4e42d091a0f5587b8b2342b95a9ce7a0f5074262f199c972d2b2f43f23c1_ctor();
+                    __Contract____e6845188b1d2aebdf19d13c1613d7a49b5806a7fe336ec775fa182b36719bbc1_ctor();
                 };
                 core::default::Default::default()
             }
@@ -437,6 +437,31 @@ fn __Contract____3d3f4e42d091a0f5587b8b2342b95a9ce7a0f5074262f199c972d2b2f43f23c
             #[allow(deprecated)]
             &__Contract__empty__invoke_raw_slice,
         );
+    }
+}
+#[doc(hidden)]
+#[allow(non_snake_case)]
+#[allow(unused)]
+fn __Contract____fbc93c891fb42ed6490478fb2d34720c5af09a9af4372d682454f701d5125956_ctor() {
+    #[allow(unsafe_code)]
+    {
+        #[link_section = ".init_array"]
+        #[used]
+        #[allow(non_upper_case_globals, non_snake_case)]
+        #[doc(hidden)]
+        static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
+            #[link_section = ".text.startup"]
+            #[allow(non_snake_case)]
+            extern "C" fn f() -> ::ctor::__support::CtorRetType {
+                unsafe {
+                    __Contract____fbc93c891fb42ed6490478fb2d34720c5af09a9af4372d682454f701d5125956_ctor();
+                };
+                core::default::Default::default()
+            }
+            f
+        };
+    }
+    {
         <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
             "empty2",
             #[allow(deprecated)]

--- a/tests-expanded/test_modular_tests.rs
+++ b/tests-expanded/test_modular_tests.rs
@@ -156,7 +156,7 @@ mod feat1 {
     #[doc(hidden)]
     #[allow(non_snake_case)]
     #[allow(unused)]
-    fn __Contract____7692c3ad3540bb803c020b3aee66cd8887123234ea0c6e7143c0add73ff431ed_ctor() {
+    fn __Contract____49e9fcfb5617aad332d56d58ffd0c7020d29ec1d0d0a03b7d7c47f268820acf3_ctor() {
         #[allow(unsafe_code)]
         {
             #[link_section = ".init_array"]
@@ -168,7 +168,7 @@ mod feat1 {
                 #[allow(non_snake_case)]
                 extern "C" fn f() -> ::ctor::__support::CtorRetType {
                     unsafe {
-                        __Contract____7692c3ad3540bb803c020b3aee66cd8887123234ea0c6e7143c0add73ff431ed_ctor();
+                        __Contract____49e9fcfb5617aad332d56d58ffd0c7020d29ec1d0d0a03b7d7c47f268820acf3_ctor();
                     };
                     core::default::Default::default()
                 }
@@ -334,7 +334,7 @@ mod feat2 {
     #[doc(hidden)]
     #[allow(non_snake_case)]
     #[allow(unused)]
-    fn __super__Contract____3fc4ccfe745870e2c0d99f71f30ff0656c8dedd41cc1d7d3d376b0dbe685e2f3_ctor()
+    fn __super__Contract____b85d38dc71a8027700bebd3c30d39424852cf532883d88f0a0d992d3bf0eba9b_ctor()
     {
         #[allow(unsafe_code)]
         {
@@ -347,7 +347,7 @@ mod feat2 {
                 #[allow(non_snake_case)]
                 extern "C" fn f() -> ::ctor::__support::CtorRetType {
                     unsafe {
-                        __super__Contract____3fc4ccfe745870e2c0d99f71f30ff0656c8dedd41cc1d7d3d376b0dbe685e2f3_ctor();
+                        __super__Contract____b85d38dc71a8027700bebd3c30d39424852cf532883d88f0a0d992d3bf0eba9b_ctor();
                     };
                     core::default::Default::default()
                 }
@@ -708,7 +708,7 @@ pub extern "C" fn __Contract__zero__invoke_raw_extern() -> soroban_sdk::Val {
 #[doc(hidden)]
 #[allow(non_snake_case)]
 #[allow(unused)]
-fn __Contract____f9194e73f9e9459e3450ea10a179cdf77aafa695beecd3b9344a98d111622243_ctor() {
+fn __Contract____b7ce3f814d0e14e74eb1dc742ad4a2c7a798413fb9771560f107cad87ef46402_ctor() {
     #[allow(unsafe_code)]
     {
         #[link_section = ".init_array"]
@@ -720,7 +720,7 @@ fn __Contract____f9194e73f9e9459e3450ea10a179cdf77aafa695beecd3b9344a98d11162224
             #[allow(non_snake_case)]
             extern "C" fn f() -> ::ctor::__support::CtorRetType {
                 unsafe {
-                    __Contract____f9194e73f9e9459e3450ea10a179cdf77aafa695beecd3b9344a98d111622243_ctor();
+                    __Contract____b7ce3f814d0e14e74eb1dc742ad4a2c7a798413fb9771560f107cad87ef46402_ctor();
                 };
                 core::default::Default::default()
             }

--- a/tests-expanded/test_multiimpl_tests.rs
+++ b/tests-expanded/test_multiimpl_tests.rs
@@ -277,7 +277,7 @@ pub extern "C" fn __Contract__empty__invoke_raw_extern() -> soroban_sdk::Val {
 #[doc(hidden)]
 #[allow(non_snake_case)]
 #[allow(unused)]
-fn __Contract____2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d_ctor() {
+fn __Contract____e6845188b1d2aebdf19d13c1613d7a49b5806a7fe336ec775fa182b36719bbc1_ctor() {
     #[allow(unsafe_code)]
     {
         #[link_section = ".init_array"]
@@ -289,7 +289,7 @@ fn __Contract____2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10
             #[allow(non_snake_case)]
             extern "C" fn f() -> ::ctor::__support::CtorRetType {
                 unsafe {
-                    __Contract____2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d_ctor();
+                    __Contract____e6845188b1d2aebdf19d13c1613d7a49b5806a7fe336ec775fa182b36719bbc1_ctor();
                 };
                 core::default::Default::default()
             }
@@ -445,7 +445,7 @@ pub extern "C" fn __Contract__empty2__invoke_raw_extern() -> soroban_sdk::Val {
 #[doc(hidden)]
 #[allow(non_snake_case)]
 #[allow(unused)]
-fn __Contract____a081c9c13231c3c184333e4fde14f4f10e045d30869e1b800f4338ab8a726ca4_ctor() {
+fn __Contract____fbc93c891fb42ed6490478fb2d34720c5af09a9af4372d682454f701d5125956_ctor() {
     #[allow(unsafe_code)]
     {
         #[link_section = ".init_array"]
@@ -457,7 +457,7 @@ fn __Contract____a081c9c13231c3c184333e4fde14f4f10e045d30869e1b800f4338ab8a726ca
             #[allow(non_snake_case)]
             extern "C" fn f() -> ::ctor::__support::CtorRetType {
                 unsafe {
-                    __Contract____a081c9c13231c3c184333e4fde14f4f10e045d30869e1b800f4338ab8a726ca4_ctor();
+                    __Contract____fbc93c891fb42ed6490478fb2d34720c5af09a9af4372d682454f701d5125956_ctor();
                 };
                 core::default::Default::default()
             }
@@ -616,7 +616,7 @@ pub extern "C" fn __Contract__empty3__invoke_raw_extern() -> soroban_sdk::Val {
 #[doc(hidden)]
 #[allow(non_snake_case)]
 #[allow(unused)]
-fn __Contract__Trait__2be3aa1100044a64e8135c570a7b382cebaca742493cf17b77052a7ae50fa889_ctor() {
+fn __Contract__Trait__fc52446fa09f8b548e373d26f4eba7f7c2b579a6a402dd683f3c060ac15fd845_ctor() {
     #[allow(unsafe_code)]
     {
         #[link_section = ".init_array"]
@@ -628,7 +628,7 @@ fn __Contract__Trait__2be3aa1100044a64e8135c570a7b382cebaca742493cf17b77052a7ae5
             #[allow(non_snake_case)]
             extern "C" fn f() -> ::ctor::__support::CtorRetType {
                 unsafe {
-                    __Contract__Trait__2be3aa1100044a64e8135c570a7b382cebaca742493cf17b77052a7ae50fa889_ctor();
+                    __Contract__Trait__fc52446fa09f8b548e373d26f4eba7f7c2b579a6a402dd683f3c060ac15fd845_ctor();
                 };
                 core::default::Default::default()
             }

--- a/tests-expanded/test_mutability_tests.rs
+++ b/tests-expanded/test_mutability_tests.rs
@@ -311,7 +311,7 @@ pub extern "C" fn __Contract__calc__invoke_raw_extern(
 #[doc(hidden)]
 #[allow(non_snake_case)]
 #[allow(unused)]
-fn __Contract____311f38b7836c4228463d6464f854761b7cc8c6071b5f9731b6377df5d7d0ea89_ctor() {
+fn __Contract____942a6de810594bfeb49a6124156cdd64169bcb51c92a194ad710b40b3ad319b2_ctor() {
     #[allow(unsafe_code)]
     {
         #[link_section = ".init_array"]
@@ -323,7 +323,7 @@ fn __Contract____311f38b7836c4228463d6464f854761b7cc8c6071b5f9731b6377df5d7d0ea8
             #[allow(non_snake_case)]
             extern "C" fn f() -> ::ctor::__support::CtorRetType {
                 unsafe {
-                    __Contract____311f38b7836c4228463d6464f854761b7cc8c6071b5f9731b6377df5d7d0ea89_ctor();
+                    __Contract____942a6de810594bfeb49a6124156cdd64169bcb51c92a194ad710b40b3ad319b2_ctor();
                 };
                 core::default::Default::default()
             }

--- a/tests-expanded/test_spec_shaking_v1_tests.rs
+++ b/tests-expanded/test_spec_shaking_v1_tests.rs
@@ -24372,7 +24372,7 @@ pub extern "C" fn __Contract__publish_ref_event__invoke_raw_extern() -> soroban_
 #[doc(hidden)]
 #[allow(non_snake_case)]
 #[allow(unused)]
-fn __Contract____e2d4dfe024732e4cdeeeac2f5bc8fbebcb3aed9b64a15d5cdfc055258ca216d0_ctor() {
+fn __Contract____de8989879016d56690c155b7479a22620438b27232776bc56be831421881950f_ctor() {
     #[allow(unsafe_code)]
     {
         #[link_section = ".init_array"]
@@ -24384,7 +24384,7 @@ fn __Contract____e2d4dfe024732e4cdeeeac2f5bc8fbebcb3aed9b64a15d5cdfc055258ca216d
             #[allow(non_snake_case)]
             extern "C" fn f() -> ::ctor::__support::CtorRetType {
                 unsafe {
-                    __Contract____e2d4dfe024732e4cdeeeac2f5bc8fbebcb3aed9b64a15d5cdfc055258ca216d0_ctor();
+                    __Contract____de8989879016d56690c155b7479a22620438b27232776bc56be831421881950f_ctor();
                 };
                 core::default::Default::default()
             }
@@ -24397,116 +24397,691 @@ fn __Contract____e2d4dfe024732e4cdeeeac2f5bc8fbebcb3aed9b64a15d5cdfc055258ca216d
             #[allow(deprecated)]
             &__Contract__with_param__invoke_raw_slice,
         );
+    }
+}
+#[doc(hidden)]
+#[allow(non_snake_case)]
+#[allow(unused)]
+fn __Contract____c7dd68c3a57bf327a27ed297d1e0d05b54ae6cd9f09ca6bd29e43daccbc211d0_ctor() {
+    #[allow(unsafe_code)]
+    {
+        #[link_section = ".init_array"]
+        #[used]
+        #[allow(non_upper_case_globals, non_snake_case)]
+        #[doc(hidden)]
+        static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
+            #[link_section = ".text.startup"]
+            #[allow(non_snake_case)]
+            extern "C" fn f() -> ::ctor::__support::CtorRetType {
+                unsafe {
+                    __Contract____c7dd68c3a57bf327a27ed297d1e0d05b54ae6cd9f09ca6bd29e43daccbc211d0_ctor();
+                };
+                core::default::Default::default()
+            }
+            f
+        };
+    }
+    {
         <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
             "with_return",
             #[allow(deprecated)]
             &__Contract__with_return__invoke_raw_slice,
         );
+    }
+}
+#[doc(hidden)]
+#[allow(non_snake_case)]
+#[allow(unused)]
+fn __Contract____5967bd1deddc569c93a0432530a1bf4751effbb12e7c40ed0f5d1d5951d39383_ctor() {
+    #[allow(unsafe_code)]
+    {
+        #[link_section = ".init_array"]
+        #[used]
+        #[allow(non_upper_case_globals, non_snake_case)]
+        #[doc(hidden)]
+        static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
+            #[link_section = ".text.startup"]
+            #[allow(non_snake_case)]
+            extern "C" fn f() -> ::ctor::__support::CtorRetType {
+                unsafe {
+                    __Contract____5967bd1deddc569c93a0432530a1bf4751effbb12e7c40ed0f5d1d5951d39383_ctor();
+                };
+                core::default::Default::default()
+            }
+            f
+        };
+    }
+    {
         <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
             "with_error",
             #[allow(deprecated)]
             &__Contract__with_error__invoke_raw_slice,
         );
+    }
+}
+#[doc(hidden)]
+#[allow(non_snake_case)]
+#[allow(unused)]
+fn __Contract____c7521f238f15ebbbada3af0d1165466d11ffdeaef8452d647e066d64d8d149b2_ctor() {
+    #[allow(unsafe_code)]
+    {
+        #[link_section = ".init_array"]
+        #[used]
+        #[allow(non_upper_case_globals, non_snake_case)]
+        #[doc(hidden)]
+        static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
+            #[link_section = ".text.startup"]
+            #[allow(non_snake_case)]
+            extern "C" fn f() -> ::ctor::__support::CtorRetType {
+                unsafe {
+                    __Contract____c7521f238f15ebbbada3af0d1165466d11ffdeaef8452d647e066d64d8d149b2_ctor();
+                };
+                core::default::Default::default()
+            }
+            f
+        };
+    }
+    {
         <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
             "with_panic_error",
             #[allow(deprecated)]
             &__Contract__with_panic_error__invoke_raw_slice,
         );
+    }
+}
+#[doc(hidden)]
+#[allow(non_snake_case)]
+#[allow(unused)]
+fn __Contract____6f608f5f9d3a869f205210ccc844b88e045ee26186ebe225f57d422a8ce1a38b_ctor() {
+    #[allow(unsafe_code)]
+    {
+        #[link_section = ".init_array"]
+        #[used]
+        #[allow(non_upper_case_globals, non_snake_case)]
+        #[doc(hidden)]
+        static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
+            #[link_section = ".text.startup"]
+            #[allow(non_snake_case)]
+            extern "C" fn f() -> ::ctor::__support::CtorRetType {
+                unsafe {
+                    __Contract____6f608f5f9d3a869f205210ccc844b88e045ee26186ebe225f57d422a8ce1a38b_ctor();
+                };
+                core::default::Default::default()
+            }
+            f
+        };
+    }
+    {
         <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
             "with_assert_error",
             #[allow(deprecated)]
             &__Contract__with_assert_error__invoke_raw_slice,
         );
+    }
+}
+#[doc(hidden)]
+#[allow(non_snake_case)]
+#[allow(unused)]
+fn __Contract____67f8bdda2ac5b04b7ca85a95592cdafaed7646e85495e9973e5adfe694809f66_ctor() {
+    #[allow(unsafe_code)]
+    {
+        #[link_section = ".init_array"]
+        #[used]
+        #[allow(non_upper_case_globals, non_snake_case)]
+        #[doc(hidden)]
+        static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
+            #[link_section = ".text.startup"]
+            #[allow(non_snake_case)]
+            extern "C" fn f() -> ::ctor::__support::CtorRetType {
+                unsafe {
+                    __Contract____67f8bdda2ac5b04b7ca85a95592cdafaed7646e85495e9973e5adfe694809f66_ctor();
+                };
+                core::default::Default::default()
+            }
+            f
+        };
+    }
+    {
         <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
             "with_panic_raw_error",
             #[allow(deprecated)]
             &__Contract__with_panic_raw_error__invoke_raw_slice,
         );
+    }
+}
+#[doc(hidden)]
+#[allow(non_snake_case)]
+#[allow(unused)]
+fn __Contract____cdda7bde10f3b7f002382ffedf91a9032478ae8451cd714812e10f4918827683_ctor() {
+    #[allow(unsafe_code)]
+    {
+        #[link_section = ".init_array"]
+        #[used]
+        #[allow(non_upper_case_globals, non_snake_case)]
+        #[doc(hidden)]
+        static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
+            #[link_section = ".text.startup"]
+            #[allow(non_snake_case)]
+            extern "C" fn f() -> ::ctor::__support::CtorRetType {
+                unsafe {
+                    __Contract____cdda7bde10f3b7f002382ffedf91a9032478ae8451cd714812e10f4918827683_ctor();
+                };
+                core::default::Default::default()
+            }
+            f
+        };
+    }
+    {
         <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
             "with_vec",
             #[allow(deprecated)]
             &__Contract__with_vec__invoke_raw_slice,
         );
+    }
+}
+#[doc(hidden)]
+#[allow(non_snake_case)]
+#[allow(unused)]
+fn __Contract____dbcf823c947e550751e15b090cf93ae24c16e81387dcb964f67aeea374845c1c_ctor() {
+    #[allow(unsafe_code)]
+    {
+        #[link_section = ".init_array"]
+        #[used]
+        #[allow(non_upper_case_globals, non_snake_case)]
+        #[doc(hidden)]
+        static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
+            #[link_section = ".text.startup"]
+            #[allow(non_snake_case)]
+            extern "C" fn f() -> ::ctor::__support::CtorRetType {
+                unsafe {
+                    __Contract____dbcf823c947e550751e15b090cf93ae24c16e81387dcb964f67aeea374845c1c_ctor();
+                };
+                core::default::Default::default()
+            }
+            f
+        };
+    }
+    {
         <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
             "with_vec_nested",
             #[allow(deprecated)]
             &__Contract__with_vec_nested__invoke_raw_slice,
         );
+    }
+}
+#[doc(hidden)]
+#[allow(non_snake_case)]
+#[allow(unused)]
+fn __Contract____63049c72e8ee7605c3f34c433efaaba02f35544f9c7b0ca691ccb2c0da04e4b5_ctor() {
+    #[allow(unsafe_code)]
+    {
+        #[link_section = ".init_array"]
+        #[used]
+        #[allow(non_upper_case_globals, non_snake_case)]
+        #[doc(hidden)]
+        static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
+            #[link_section = ".text.startup"]
+            #[allow(non_snake_case)]
+            extern "C" fn f() -> ::ctor::__support::CtorRetType {
+                unsafe {
+                    __Contract____63049c72e8ee7605c3f34c433efaaba02f35544f9c7b0ca691ccb2c0da04e4b5_ctor();
+                };
+                core::default::Default::default()
+            }
+            f
+        };
+    }
+    {
         <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
             "with_map",
             #[allow(deprecated)]
             &__Contract__with_map__invoke_raw_slice,
         );
+    }
+}
+#[doc(hidden)]
+#[allow(non_snake_case)]
+#[allow(unused)]
+fn __Contract____c6ca285f51a793e55b1a5168570d940b29bf2c67f734c64900c8f2b15a42f82f_ctor() {
+    #[allow(unsafe_code)]
+    {
+        #[link_section = ".init_array"]
+        #[used]
+        #[allow(non_upper_case_globals, non_snake_case)]
+        #[doc(hidden)]
+        static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
+            #[link_section = ".text.startup"]
+            #[allow(non_snake_case)]
+            extern "C" fn f() -> ::ctor::__support::CtorRetType {
+                unsafe {
+                    __Contract____c6ca285f51a793e55b1a5168570d940b29bf2c67f734c64900c8f2b15a42f82f_ctor();
+                };
+                core::default::Default::default()
+            }
+            f
+        };
+    }
+    {
         <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
             "with_option",
             #[allow(deprecated)]
             &__Contract__with_option__invoke_raw_slice,
         );
+    }
+}
+#[doc(hidden)]
+#[allow(non_snake_case)]
+#[allow(unused)]
+fn __Contract____3e2a70e06a6069703e2f332f22edb37d3cda00746ea9ad20342c77ba84467c1f_ctor() {
+    #[allow(unsafe_code)]
+    {
+        #[link_section = ".init_array"]
+        #[used]
+        #[allow(non_upper_case_globals, non_snake_case)]
+        #[doc(hidden)]
+        static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
+            #[link_section = ".text.startup"]
+            #[allow(non_snake_case)]
+            extern "C" fn f() -> ::ctor::__support::CtorRetType {
+                unsafe {
+                    __Contract____3e2a70e06a6069703e2f332f22edb37d3cda00746ea9ad20342c77ba84467c1f_ctor();
+                };
+                core::default::Default::default()
+            }
+            f
+        };
+    }
+    {
         <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
             "with_result",
             #[allow(deprecated)]
             &__Contract__with_result__invoke_raw_slice,
         );
+    }
+}
+#[doc(hidden)]
+#[allow(non_snake_case)]
+#[allow(unused)]
+fn __Contract____55e45c9e8e39386c520b338c542cda417942334415e9c4ebb760c9e0dff5a38a_ctor() {
+    #[allow(unsafe_code)]
+    {
+        #[link_section = ".init_array"]
+        #[used]
+        #[allow(non_upper_case_globals, non_snake_case)]
+        #[doc(hidden)]
+        static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
+            #[link_section = ".text.startup"]
+            #[allow(non_snake_case)]
+            extern "C" fn f() -> ::ctor::__support::CtorRetType {
+                unsafe {
+                    __Contract____55e45c9e8e39386c520b338c542cda417942334415e9c4ebb760c9e0dff5a38a_ctor();
+                };
+                core::default::Default::default()
+            }
+            f
+        };
+    }
+    {
         <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
             "with_recursion",
             #[allow(deprecated)]
             &__Contract__with_recursion__invoke_raw_slice,
         );
+    }
+}
+#[doc(hidden)]
+#[allow(non_snake_case)]
+#[allow(unused)]
+fn __Contract____d15131812703285c4071662fb2a0d1193c4424e1dcccc310cc5acf8d96716ab4_ctor() {
+    #[allow(unsafe_code)]
+    {
+        #[link_section = ".init_array"]
+        #[used]
+        #[allow(non_upper_case_globals, non_snake_case)]
+        #[doc(hidden)]
+        static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
+            #[link_section = ".text.startup"]
+            #[allow(non_snake_case)]
+            extern "C" fn f() -> ::ctor::__support::CtorRetType {
+                unsafe {
+                    __Contract____d15131812703285c4071662fb2a0d1193c4424e1dcccc310cc5acf8d96716ab4_ctor();
+                };
+                core::default::Default::default()
+            }
+            f
+        };
+    }
+    {
         <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
             "publish_simple",
             #[allow(deprecated)]
             &__Contract__publish_simple__invoke_raw_slice,
         );
+    }
+}
+#[doc(hidden)]
+#[allow(non_snake_case)]
+#[allow(unused)]
+fn __Contract____abca73fd8780fb72dcda96ebf932b8e323c4b948f45e7002e9200e16d286f454_ctor() {
+    #[allow(unsafe_code)]
+    {
+        #[link_section = ".init_array"]
+        #[used]
+        #[allow(non_upper_case_globals, non_snake_case)]
+        #[doc(hidden)]
+        static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
+            #[link_section = ".text.startup"]
+            #[allow(non_snake_case)]
+            extern "C" fn f() -> ::ctor::__support::CtorRetType {
+                unsafe {
+                    __Contract____abca73fd8780fb72dcda96ebf932b8e323c4b948f45e7002e9200e16d286f454_ctor();
+                };
+                core::default::Default::default()
+            }
+            f
+        };
+    }
+    {
         <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
             "publish_topic_type",
             #[allow(deprecated)]
             &__Contract__publish_topic_type__invoke_raw_slice,
         );
+    }
+}
+#[doc(hidden)]
+#[allow(non_snake_case)]
+#[allow(unused)]
+fn __Contract____1ad012612a35ff4b9e906df408f1e426bc429e6764d30f4bf12bc8f093543bb7_ctor() {
+    #[allow(unsafe_code)]
+    {
+        #[link_section = ".init_array"]
+        #[used]
+        #[allow(non_upper_case_globals, non_snake_case)]
+        #[doc(hidden)]
+        static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
+            #[link_section = ".text.startup"]
+            #[allow(non_snake_case)]
+            extern "C" fn f() -> ::ctor::__support::CtorRetType {
+                unsafe {
+                    __Contract____1ad012612a35ff4b9e906df408f1e426bc429e6764d30f4bf12bc8f093543bb7_ctor();
+                };
+                core::default::Default::default()
+            }
+            f
+        };
+    }
+    {
         <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
             "publish_data_type",
             #[allow(deprecated)]
             &__Contract__publish_data_type__invoke_raw_slice,
         );
+    }
+}
+#[doc(hidden)]
+#[allow(non_snake_case)]
+#[allow(unused)]
+fn __Contract____2b36164b5a5c2c978250f53a572f8fdd55e0fdbb9b550a9b36eaac2247bbd697_ctor() {
+    #[allow(unsafe_code)]
+    {
+        #[link_section = ".init_array"]
+        #[used]
+        #[allow(non_upper_case_globals, non_snake_case)]
+        #[doc(hidden)]
+        static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
+            #[link_section = ".text.startup"]
+            #[allow(non_snake_case)]
+            extern "C" fn f() -> ::ctor::__support::CtorRetType {
+                unsafe {
+                    __Contract____2b36164b5a5c2c978250f53a572f8fdd55e0fdbb9b550a9b36eaac2247bbd697_ctor();
+                };
+                core::default::Default::default()
+            }
+            f
+        };
+    }
+    {
         <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
             "publish_nested_topic",
             #[allow(deprecated)]
             &__Contract__publish_nested_topic__invoke_raw_slice,
         );
+    }
+}
+#[doc(hidden)]
+#[allow(non_snake_case)]
+#[allow(unused)]
+fn __Contract____40162a45c8dac77d5ffe897c19b97b6fb8c5929469c22fd85f2bce4fcb29963c_ctor() {
+    #[allow(unsafe_code)]
+    {
+        #[link_section = ".init_array"]
+        #[used]
+        #[allow(non_upper_case_globals, non_snake_case)]
+        #[doc(hidden)]
+        static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
+            #[link_section = ".text.startup"]
+            #[allow(non_snake_case)]
+            extern "C" fn f() -> ::ctor::__support::CtorRetType {
+                unsafe {
+                    __Contract____40162a45c8dac77d5ffe897c19b97b6fb8c5929469c22fd85f2bce4fcb29963c_ctor();
+                };
+                core::default::Default::default()
+            }
+            f
+        };
+    }
+    {
         <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
             "publish_nested_data",
             #[allow(deprecated)]
             &__Contract__publish_nested_data__invoke_raw_slice,
         );
+    }
+}
+#[doc(hidden)]
+#[allow(non_snake_case)]
+#[allow(unused)]
+fn __Contract____fd5649547c848160d900b76e45a2900f2ee9935e7c848f1010da8714a7a2fabb_ctor() {
+    #[allow(unsafe_code)]
+    {
+        #[link_section = ".init_array"]
+        #[used]
+        #[allow(non_upper_case_globals, non_snake_case)]
+        #[doc(hidden)]
+        static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
+            #[link_section = ".text.startup"]
+            #[allow(non_snake_case)]
+            extern "C" fn f() -> ::ctor::__support::CtorRetType {
+                unsafe {
+                    __Contract____fd5649547c848160d900b76e45a2900f2ee9935e7c848f1010da8714a7a2fabb_ctor();
+                };
+                core::default::Default::default()
+            }
+            f
+        };
+    }
+    {
         <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
             "with_lib_struct",
             #[allow(deprecated)]
             &__Contract__with_lib_struct__invoke_raw_slice,
         );
+    }
+}
+#[doc(hidden)]
+#[allow(non_snake_case)]
+#[allow(unused)]
+fn __Contract____2d85f9de24970d9ae995df9f67529cf227ff20cbf07a8bf2cbf944267f275244_ctor() {
+    #[allow(unsafe_code)]
+    {
+        #[link_section = ".init_array"]
+        #[used]
+        #[allow(non_upper_case_globals, non_snake_case)]
+        #[doc(hidden)]
+        static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
+            #[link_section = ".text.startup"]
+            #[allow(non_snake_case)]
+            extern "C" fn f() -> ::ctor::__support::CtorRetType {
+                unsafe {
+                    __Contract____2d85f9de24970d9ae995df9f67529cf227ff20cbf07a8bf2cbf944267f275244_ctor();
+                };
+                core::default::Default::default()
+            }
+            f
+        };
+    }
+    {
         <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
             "with_wasm_imported",
             #[allow(deprecated)]
             &__Contract__with_wasm_imported__invoke_raw_slice,
         );
+    }
+}
+#[doc(hidden)]
+#[allow(non_snake_case)]
+#[allow(unused)]
+fn __Contract____d23dd58a9cec71653a0ff9716ef1db735249a385b811f711bed6dfc0aade1cd4_ctor() {
+    #[allow(unsafe_code)]
+    {
+        #[link_section = ".init_array"]
+        #[used]
+        #[allow(non_upper_case_globals, non_snake_case)]
+        #[doc(hidden)]
+        static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
+            #[link_section = ".text.startup"]
+            #[allow(non_snake_case)]
+            extern "C" fn f() -> ::ctor::__support::CtorRetType {
+                unsafe {
+                    __Contract____d23dd58a9cec71653a0ff9716ef1db735249a385b811f711bed6dfc0aade1cd4_ctor();
+                };
+                core::default::Default::default()
+            }
+            f
+        };
+    }
+    {
         <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
             "with_non_pub",
             #[allow(deprecated)]
             &__Contract__with_non_pub__invoke_raw_slice,
         );
+    }
+}
+#[doc(hidden)]
+#[allow(non_snake_case)]
+#[allow(unused)]
+fn __Contract____e58fcb6e541518f705e0572d8325326c8fc7bd7ee35c5eda37d1bcb4a4852f42_ctor() {
+    #[allow(unsafe_code)]
+    {
+        #[link_section = ".init_array"]
+        #[used]
+        #[allow(non_upper_case_globals, non_snake_case)]
+        #[doc(hidden)]
+        static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
+            #[link_section = ".text.startup"]
+            #[allow(non_snake_case)]
+            extern "C" fn f() -> ::ctor::__support::CtorRetType {
+                unsafe {
+                    __Contract____e58fcb6e541518f705e0572d8325326c8fc7bd7ee35c5eda37d1bcb4a4852f42_ctor();
+                };
+                core::default::Default::default()
+            }
+            f
+        };
+    }
+    {
         <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
             "with_non_pub_error",
             #[allow(deprecated)]
             &__Contract__with_non_pub_error__invoke_raw_slice,
         );
+    }
+}
+#[doc(hidden)]
+#[allow(non_snake_case)]
+#[allow(unused)]
+fn __Contract____63edccf4439b8d0e403b6aa66d2d711914474e2271d7e5bb9a92767ba8a2e4c2_ctor() {
+    #[allow(unsafe_code)]
+    {
+        #[link_section = ".init_array"]
+        #[used]
+        #[allow(non_upper_case_globals, non_snake_case)]
+        #[doc(hidden)]
+        static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
+            #[link_section = ".text.startup"]
+            #[allow(non_snake_case)]
+            extern "C" fn f() -> ::ctor::__support::CtorRetType {
+                unsafe {
+                    __Contract____63edccf4439b8d0e403b6aa66d2d711914474e2271d7e5bb9a92767ba8a2e4c2_ctor();
+                };
+                core::default::Default::default()
+            }
+            f
+        };
+    }
+    {
         <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
             "with_tuple",
             #[allow(deprecated)]
             &__Contract__with_tuple__invoke_raw_slice,
         );
+    }
+}
+#[doc(hidden)]
+#[allow(non_snake_case)]
+#[allow(unused)]
+fn __Contract____ee2e16de256ae8ba478066467e6ce7fafb81c62ba9225d821055c038eb12644a_ctor() {
+    #[allow(unsafe_code)]
+    {
+        #[link_section = ".init_array"]
+        #[used]
+        #[allow(non_upper_case_globals, non_snake_case)]
+        #[doc(hidden)]
+        static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
+            #[link_section = ".text.startup"]
+            #[allow(non_snake_case)]
+            extern "C" fn f() -> ::ctor::__support::CtorRetType {
+                unsafe {
+                    __Contract____ee2e16de256ae8ba478066467e6ce7fafb81c62ba9225d821055c038eb12644a_ctor();
+                };
+                core::default::Default::default()
+            }
+            f
+        };
+    }
+    {
         <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
             "with_tuple_return",
             #[allow(deprecated)]
             &__Contract__with_tuple_return__invoke_raw_slice,
         );
+    }
+}
+#[doc(hidden)]
+#[allow(non_snake_case)]
+#[allow(unused)]
+fn __Contract____e6557f25d7784a468b8898a88389307adf23c93322db235c82bfcfe63177a7ba_ctor() {
+    #[allow(unsafe_code)]
+    {
+        #[link_section = ".init_array"]
+        #[used]
+        #[allow(non_upper_case_globals, non_snake_case)]
+        #[doc(hidden)]
+        static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
+            #[link_section = ".text.startup"]
+            #[allow(non_snake_case)]
+            extern "C" fn f() -> ::ctor::__support::CtorRetType {
+                unsafe {
+                    __Contract____e6557f25d7784a468b8898a88389307adf23c93322db235c82bfcfe63177a7ba_ctor();
+                };
+                core::default::Default::default()
+            }
+            f
+        };
+    }
+    {
         <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
             "publish_ref_event",
             #[allow(deprecated)]

--- a/tests-expanded/test_spec_shaking_v2_tests.rs
+++ b/tests-expanded/test_spec_shaking_v2_tests.rs
@@ -24940,7 +24940,7 @@ pub extern "C" fn __Contract__publish_ref_event__invoke_raw_extern() -> soroban_
 #[doc(hidden)]
 #[allow(non_snake_case)]
 #[allow(unused)]
-fn __Contract____e2d4dfe024732e4cdeeeac2f5bc8fbebcb3aed9b64a15d5cdfc055258ca216d0_ctor() {
+fn __Contract____de8989879016d56690c155b7479a22620438b27232776bc56be831421881950f_ctor() {
     #[allow(unsafe_code)]
     {
         #[link_section = ".init_array"]
@@ -24952,7 +24952,7 @@ fn __Contract____e2d4dfe024732e4cdeeeac2f5bc8fbebcb3aed9b64a15d5cdfc055258ca216d
             #[allow(non_snake_case)]
             extern "C" fn f() -> ::ctor::__support::CtorRetType {
                 unsafe {
-                    __Contract____e2d4dfe024732e4cdeeeac2f5bc8fbebcb3aed9b64a15d5cdfc055258ca216d0_ctor();
+                    __Contract____de8989879016d56690c155b7479a22620438b27232776bc56be831421881950f_ctor();
                 };
                 core::default::Default::default()
             }
@@ -24965,116 +24965,691 @@ fn __Contract____e2d4dfe024732e4cdeeeac2f5bc8fbebcb3aed9b64a15d5cdfc055258ca216d
             #[allow(deprecated)]
             &__Contract__with_param__invoke_raw_slice,
         );
+    }
+}
+#[doc(hidden)]
+#[allow(non_snake_case)]
+#[allow(unused)]
+fn __Contract____c7dd68c3a57bf327a27ed297d1e0d05b54ae6cd9f09ca6bd29e43daccbc211d0_ctor() {
+    #[allow(unsafe_code)]
+    {
+        #[link_section = ".init_array"]
+        #[used]
+        #[allow(non_upper_case_globals, non_snake_case)]
+        #[doc(hidden)]
+        static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
+            #[link_section = ".text.startup"]
+            #[allow(non_snake_case)]
+            extern "C" fn f() -> ::ctor::__support::CtorRetType {
+                unsafe {
+                    __Contract____c7dd68c3a57bf327a27ed297d1e0d05b54ae6cd9f09ca6bd29e43daccbc211d0_ctor();
+                };
+                core::default::Default::default()
+            }
+            f
+        };
+    }
+    {
         <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
             "with_return",
             #[allow(deprecated)]
             &__Contract__with_return__invoke_raw_slice,
         );
+    }
+}
+#[doc(hidden)]
+#[allow(non_snake_case)]
+#[allow(unused)]
+fn __Contract____5967bd1deddc569c93a0432530a1bf4751effbb12e7c40ed0f5d1d5951d39383_ctor() {
+    #[allow(unsafe_code)]
+    {
+        #[link_section = ".init_array"]
+        #[used]
+        #[allow(non_upper_case_globals, non_snake_case)]
+        #[doc(hidden)]
+        static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
+            #[link_section = ".text.startup"]
+            #[allow(non_snake_case)]
+            extern "C" fn f() -> ::ctor::__support::CtorRetType {
+                unsafe {
+                    __Contract____5967bd1deddc569c93a0432530a1bf4751effbb12e7c40ed0f5d1d5951d39383_ctor();
+                };
+                core::default::Default::default()
+            }
+            f
+        };
+    }
+    {
         <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
             "with_error",
             #[allow(deprecated)]
             &__Contract__with_error__invoke_raw_slice,
         );
+    }
+}
+#[doc(hidden)]
+#[allow(non_snake_case)]
+#[allow(unused)]
+fn __Contract____c7521f238f15ebbbada3af0d1165466d11ffdeaef8452d647e066d64d8d149b2_ctor() {
+    #[allow(unsafe_code)]
+    {
+        #[link_section = ".init_array"]
+        #[used]
+        #[allow(non_upper_case_globals, non_snake_case)]
+        #[doc(hidden)]
+        static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
+            #[link_section = ".text.startup"]
+            #[allow(non_snake_case)]
+            extern "C" fn f() -> ::ctor::__support::CtorRetType {
+                unsafe {
+                    __Contract____c7521f238f15ebbbada3af0d1165466d11ffdeaef8452d647e066d64d8d149b2_ctor();
+                };
+                core::default::Default::default()
+            }
+            f
+        };
+    }
+    {
         <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
             "with_panic_error",
             #[allow(deprecated)]
             &__Contract__with_panic_error__invoke_raw_slice,
         );
+    }
+}
+#[doc(hidden)]
+#[allow(non_snake_case)]
+#[allow(unused)]
+fn __Contract____6f608f5f9d3a869f205210ccc844b88e045ee26186ebe225f57d422a8ce1a38b_ctor() {
+    #[allow(unsafe_code)]
+    {
+        #[link_section = ".init_array"]
+        #[used]
+        #[allow(non_upper_case_globals, non_snake_case)]
+        #[doc(hidden)]
+        static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
+            #[link_section = ".text.startup"]
+            #[allow(non_snake_case)]
+            extern "C" fn f() -> ::ctor::__support::CtorRetType {
+                unsafe {
+                    __Contract____6f608f5f9d3a869f205210ccc844b88e045ee26186ebe225f57d422a8ce1a38b_ctor();
+                };
+                core::default::Default::default()
+            }
+            f
+        };
+    }
+    {
         <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
             "with_assert_error",
             #[allow(deprecated)]
             &__Contract__with_assert_error__invoke_raw_slice,
         );
+    }
+}
+#[doc(hidden)]
+#[allow(non_snake_case)]
+#[allow(unused)]
+fn __Contract____67f8bdda2ac5b04b7ca85a95592cdafaed7646e85495e9973e5adfe694809f66_ctor() {
+    #[allow(unsafe_code)]
+    {
+        #[link_section = ".init_array"]
+        #[used]
+        #[allow(non_upper_case_globals, non_snake_case)]
+        #[doc(hidden)]
+        static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
+            #[link_section = ".text.startup"]
+            #[allow(non_snake_case)]
+            extern "C" fn f() -> ::ctor::__support::CtorRetType {
+                unsafe {
+                    __Contract____67f8bdda2ac5b04b7ca85a95592cdafaed7646e85495e9973e5adfe694809f66_ctor();
+                };
+                core::default::Default::default()
+            }
+            f
+        };
+    }
+    {
         <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
             "with_panic_raw_error",
             #[allow(deprecated)]
             &__Contract__with_panic_raw_error__invoke_raw_slice,
         );
+    }
+}
+#[doc(hidden)]
+#[allow(non_snake_case)]
+#[allow(unused)]
+fn __Contract____cdda7bde10f3b7f002382ffedf91a9032478ae8451cd714812e10f4918827683_ctor() {
+    #[allow(unsafe_code)]
+    {
+        #[link_section = ".init_array"]
+        #[used]
+        #[allow(non_upper_case_globals, non_snake_case)]
+        #[doc(hidden)]
+        static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
+            #[link_section = ".text.startup"]
+            #[allow(non_snake_case)]
+            extern "C" fn f() -> ::ctor::__support::CtorRetType {
+                unsafe {
+                    __Contract____cdda7bde10f3b7f002382ffedf91a9032478ae8451cd714812e10f4918827683_ctor();
+                };
+                core::default::Default::default()
+            }
+            f
+        };
+    }
+    {
         <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
             "with_vec",
             #[allow(deprecated)]
             &__Contract__with_vec__invoke_raw_slice,
         );
+    }
+}
+#[doc(hidden)]
+#[allow(non_snake_case)]
+#[allow(unused)]
+fn __Contract____dbcf823c947e550751e15b090cf93ae24c16e81387dcb964f67aeea374845c1c_ctor() {
+    #[allow(unsafe_code)]
+    {
+        #[link_section = ".init_array"]
+        #[used]
+        #[allow(non_upper_case_globals, non_snake_case)]
+        #[doc(hidden)]
+        static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
+            #[link_section = ".text.startup"]
+            #[allow(non_snake_case)]
+            extern "C" fn f() -> ::ctor::__support::CtorRetType {
+                unsafe {
+                    __Contract____dbcf823c947e550751e15b090cf93ae24c16e81387dcb964f67aeea374845c1c_ctor();
+                };
+                core::default::Default::default()
+            }
+            f
+        };
+    }
+    {
         <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
             "with_vec_nested",
             #[allow(deprecated)]
             &__Contract__with_vec_nested__invoke_raw_slice,
         );
+    }
+}
+#[doc(hidden)]
+#[allow(non_snake_case)]
+#[allow(unused)]
+fn __Contract____63049c72e8ee7605c3f34c433efaaba02f35544f9c7b0ca691ccb2c0da04e4b5_ctor() {
+    #[allow(unsafe_code)]
+    {
+        #[link_section = ".init_array"]
+        #[used]
+        #[allow(non_upper_case_globals, non_snake_case)]
+        #[doc(hidden)]
+        static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
+            #[link_section = ".text.startup"]
+            #[allow(non_snake_case)]
+            extern "C" fn f() -> ::ctor::__support::CtorRetType {
+                unsafe {
+                    __Contract____63049c72e8ee7605c3f34c433efaaba02f35544f9c7b0ca691ccb2c0da04e4b5_ctor();
+                };
+                core::default::Default::default()
+            }
+            f
+        };
+    }
+    {
         <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
             "with_map",
             #[allow(deprecated)]
             &__Contract__with_map__invoke_raw_slice,
         );
+    }
+}
+#[doc(hidden)]
+#[allow(non_snake_case)]
+#[allow(unused)]
+fn __Contract____c6ca285f51a793e55b1a5168570d940b29bf2c67f734c64900c8f2b15a42f82f_ctor() {
+    #[allow(unsafe_code)]
+    {
+        #[link_section = ".init_array"]
+        #[used]
+        #[allow(non_upper_case_globals, non_snake_case)]
+        #[doc(hidden)]
+        static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
+            #[link_section = ".text.startup"]
+            #[allow(non_snake_case)]
+            extern "C" fn f() -> ::ctor::__support::CtorRetType {
+                unsafe {
+                    __Contract____c6ca285f51a793e55b1a5168570d940b29bf2c67f734c64900c8f2b15a42f82f_ctor();
+                };
+                core::default::Default::default()
+            }
+            f
+        };
+    }
+    {
         <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
             "with_option",
             #[allow(deprecated)]
             &__Contract__with_option__invoke_raw_slice,
         );
+    }
+}
+#[doc(hidden)]
+#[allow(non_snake_case)]
+#[allow(unused)]
+fn __Contract____3e2a70e06a6069703e2f332f22edb37d3cda00746ea9ad20342c77ba84467c1f_ctor() {
+    #[allow(unsafe_code)]
+    {
+        #[link_section = ".init_array"]
+        #[used]
+        #[allow(non_upper_case_globals, non_snake_case)]
+        #[doc(hidden)]
+        static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
+            #[link_section = ".text.startup"]
+            #[allow(non_snake_case)]
+            extern "C" fn f() -> ::ctor::__support::CtorRetType {
+                unsafe {
+                    __Contract____3e2a70e06a6069703e2f332f22edb37d3cda00746ea9ad20342c77ba84467c1f_ctor();
+                };
+                core::default::Default::default()
+            }
+            f
+        };
+    }
+    {
         <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
             "with_result",
             #[allow(deprecated)]
             &__Contract__with_result__invoke_raw_slice,
         );
+    }
+}
+#[doc(hidden)]
+#[allow(non_snake_case)]
+#[allow(unused)]
+fn __Contract____55e45c9e8e39386c520b338c542cda417942334415e9c4ebb760c9e0dff5a38a_ctor() {
+    #[allow(unsafe_code)]
+    {
+        #[link_section = ".init_array"]
+        #[used]
+        #[allow(non_upper_case_globals, non_snake_case)]
+        #[doc(hidden)]
+        static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
+            #[link_section = ".text.startup"]
+            #[allow(non_snake_case)]
+            extern "C" fn f() -> ::ctor::__support::CtorRetType {
+                unsafe {
+                    __Contract____55e45c9e8e39386c520b338c542cda417942334415e9c4ebb760c9e0dff5a38a_ctor();
+                };
+                core::default::Default::default()
+            }
+            f
+        };
+    }
+    {
         <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
             "with_recursion",
             #[allow(deprecated)]
             &__Contract__with_recursion__invoke_raw_slice,
         );
+    }
+}
+#[doc(hidden)]
+#[allow(non_snake_case)]
+#[allow(unused)]
+fn __Contract____d15131812703285c4071662fb2a0d1193c4424e1dcccc310cc5acf8d96716ab4_ctor() {
+    #[allow(unsafe_code)]
+    {
+        #[link_section = ".init_array"]
+        #[used]
+        #[allow(non_upper_case_globals, non_snake_case)]
+        #[doc(hidden)]
+        static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
+            #[link_section = ".text.startup"]
+            #[allow(non_snake_case)]
+            extern "C" fn f() -> ::ctor::__support::CtorRetType {
+                unsafe {
+                    __Contract____d15131812703285c4071662fb2a0d1193c4424e1dcccc310cc5acf8d96716ab4_ctor();
+                };
+                core::default::Default::default()
+            }
+            f
+        };
+    }
+    {
         <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
             "publish_simple",
             #[allow(deprecated)]
             &__Contract__publish_simple__invoke_raw_slice,
         );
+    }
+}
+#[doc(hidden)]
+#[allow(non_snake_case)]
+#[allow(unused)]
+fn __Contract____abca73fd8780fb72dcda96ebf932b8e323c4b948f45e7002e9200e16d286f454_ctor() {
+    #[allow(unsafe_code)]
+    {
+        #[link_section = ".init_array"]
+        #[used]
+        #[allow(non_upper_case_globals, non_snake_case)]
+        #[doc(hidden)]
+        static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
+            #[link_section = ".text.startup"]
+            #[allow(non_snake_case)]
+            extern "C" fn f() -> ::ctor::__support::CtorRetType {
+                unsafe {
+                    __Contract____abca73fd8780fb72dcda96ebf932b8e323c4b948f45e7002e9200e16d286f454_ctor();
+                };
+                core::default::Default::default()
+            }
+            f
+        };
+    }
+    {
         <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
             "publish_topic_type",
             #[allow(deprecated)]
             &__Contract__publish_topic_type__invoke_raw_slice,
         );
+    }
+}
+#[doc(hidden)]
+#[allow(non_snake_case)]
+#[allow(unused)]
+fn __Contract____1ad012612a35ff4b9e906df408f1e426bc429e6764d30f4bf12bc8f093543bb7_ctor() {
+    #[allow(unsafe_code)]
+    {
+        #[link_section = ".init_array"]
+        #[used]
+        #[allow(non_upper_case_globals, non_snake_case)]
+        #[doc(hidden)]
+        static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
+            #[link_section = ".text.startup"]
+            #[allow(non_snake_case)]
+            extern "C" fn f() -> ::ctor::__support::CtorRetType {
+                unsafe {
+                    __Contract____1ad012612a35ff4b9e906df408f1e426bc429e6764d30f4bf12bc8f093543bb7_ctor();
+                };
+                core::default::Default::default()
+            }
+            f
+        };
+    }
+    {
         <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
             "publish_data_type",
             #[allow(deprecated)]
             &__Contract__publish_data_type__invoke_raw_slice,
         );
+    }
+}
+#[doc(hidden)]
+#[allow(non_snake_case)]
+#[allow(unused)]
+fn __Contract____2b36164b5a5c2c978250f53a572f8fdd55e0fdbb9b550a9b36eaac2247bbd697_ctor() {
+    #[allow(unsafe_code)]
+    {
+        #[link_section = ".init_array"]
+        #[used]
+        #[allow(non_upper_case_globals, non_snake_case)]
+        #[doc(hidden)]
+        static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
+            #[link_section = ".text.startup"]
+            #[allow(non_snake_case)]
+            extern "C" fn f() -> ::ctor::__support::CtorRetType {
+                unsafe {
+                    __Contract____2b36164b5a5c2c978250f53a572f8fdd55e0fdbb9b550a9b36eaac2247bbd697_ctor();
+                };
+                core::default::Default::default()
+            }
+            f
+        };
+    }
+    {
         <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
             "publish_nested_topic",
             #[allow(deprecated)]
             &__Contract__publish_nested_topic__invoke_raw_slice,
         );
+    }
+}
+#[doc(hidden)]
+#[allow(non_snake_case)]
+#[allow(unused)]
+fn __Contract____40162a45c8dac77d5ffe897c19b97b6fb8c5929469c22fd85f2bce4fcb29963c_ctor() {
+    #[allow(unsafe_code)]
+    {
+        #[link_section = ".init_array"]
+        #[used]
+        #[allow(non_upper_case_globals, non_snake_case)]
+        #[doc(hidden)]
+        static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
+            #[link_section = ".text.startup"]
+            #[allow(non_snake_case)]
+            extern "C" fn f() -> ::ctor::__support::CtorRetType {
+                unsafe {
+                    __Contract____40162a45c8dac77d5ffe897c19b97b6fb8c5929469c22fd85f2bce4fcb29963c_ctor();
+                };
+                core::default::Default::default()
+            }
+            f
+        };
+    }
+    {
         <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
             "publish_nested_data",
             #[allow(deprecated)]
             &__Contract__publish_nested_data__invoke_raw_slice,
         );
+    }
+}
+#[doc(hidden)]
+#[allow(non_snake_case)]
+#[allow(unused)]
+fn __Contract____fd5649547c848160d900b76e45a2900f2ee9935e7c848f1010da8714a7a2fabb_ctor() {
+    #[allow(unsafe_code)]
+    {
+        #[link_section = ".init_array"]
+        #[used]
+        #[allow(non_upper_case_globals, non_snake_case)]
+        #[doc(hidden)]
+        static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
+            #[link_section = ".text.startup"]
+            #[allow(non_snake_case)]
+            extern "C" fn f() -> ::ctor::__support::CtorRetType {
+                unsafe {
+                    __Contract____fd5649547c848160d900b76e45a2900f2ee9935e7c848f1010da8714a7a2fabb_ctor();
+                };
+                core::default::Default::default()
+            }
+            f
+        };
+    }
+    {
         <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
             "with_lib_struct",
             #[allow(deprecated)]
             &__Contract__with_lib_struct__invoke_raw_slice,
         );
+    }
+}
+#[doc(hidden)]
+#[allow(non_snake_case)]
+#[allow(unused)]
+fn __Contract____2d85f9de24970d9ae995df9f67529cf227ff20cbf07a8bf2cbf944267f275244_ctor() {
+    #[allow(unsafe_code)]
+    {
+        #[link_section = ".init_array"]
+        #[used]
+        #[allow(non_upper_case_globals, non_snake_case)]
+        #[doc(hidden)]
+        static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
+            #[link_section = ".text.startup"]
+            #[allow(non_snake_case)]
+            extern "C" fn f() -> ::ctor::__support::CtorRetType {
+                unsafe {
+                    __Contract____2d85f9de24970d9ae995df9f67529cf227ff20cbf07a8bf2cbf944267f275244_ctor();
+                };
+                core::default::Default::default()
+            }
+            f
+        };
+    }
+    {
         <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
             "with_wasm_imported",
             #[allow(deprecated)]
             &__Contract__with_wasm_imported__invoke_raw_slice,
         );
+    }
+}
+#[doc(hidden)]
+#[allow(non_snake_case)]
+#[allow(unused)]
+fn __Contract____d23dd58a9cec71653a0ff9716ef1db735249a385b811f711bed6dfc0aade1cd4_ctor() {
+    #[allow(unsafe_code)]
+    {
+        #[link_section = ".init_array"]
+        #[used]
+        #[allow(non_upper_case_globals, non_snake_case)]
+        #[doc(hidden)]
+        static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
+            #[link_section = ".text.startup"]
+            #[allow(non_snake_case)]
+            extern "C" fn f() -> ::ctor::__support::CtorRetType {
+                unsafe {
+                    __Contract____d23dd58a9cec71653a0ff9716ef1db735249a385b811f711bed6dfc0aade1cd4_ctor();
+                };
+                core::default::Default::default()
+            }
+            f
+        };
+    }
+    {
         <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
             "with_non_pub",
             #[allow(deprecated)]
             &__Contract__with_non_pub__invoke_raw_slice,
         );
+    }
+}
+#[doc(hidden)]
+#[allow(non_snake_case)]
+#[allow(unused)]
+fn __Contract____e58fcb6e541518f705e0572d8325326c8fc7bd7ee35c5eda37d1bcb4a4852f42_ctor() {
+    #[allow(unsafe_code)]
+    {
+        #[link_section = ".init_array"]
+        #[used]
+        #[allow(non_upper_case_globals, non_snake_case)]
+        #[doc(hidden)]
+        static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
+            #[link_section = ".text.startup"]
+            #[allow(non_snake_case)]
+            extern "C" fn f() -> ::ctor::__support::CtorRetType {
+                unsafe {
+                    __Contract____e58fcb6e541518f705e0572d8325326c8fc7bd7ee35c5eda37d1bcb4a4852f42_ctor();
+                };
+                core::default::Default::default()
+            }
+            f
+        };
+    }
+    {
         <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
             "with_non_pub_error",
             #[allow(deprecated)]
             &__Contract__with_non_pub_error__invoke_raw_slice,
         );
+    }
+}
+#[doc(hidden)]
+#[allow(non_snake_case)]
+#[allow(unused)]
+fn __Contract____63edccf4439b8d0e403b6aa66d2d711914474e2271d7e5bb9a92767ba8a2e4c2_ctor() {
+    #[allow(unsafe_code)]
+    {
+        #[link_section = ".init_array"]
+        #[used]
+        #[allow(non_upper_case_globals, non_snake_case)]
+        #[doc(hidden)]
+        static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
+            #[link_section = ".text.startup"]
+            #[allow(non_snake_case)]
+            extern "C" fn f() -> ::ctor::__support::CtorRetType {
+                unsafe {
+                    __Contract____63edccf4439b8d0e403b6aa66d2d711914474e2271d7e5bb9a92767ba8a2e4c2_ctor();
+                };
+                core::default::Default::default()
+            }
+            f
+        };
+    }
+    {
         <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
             "with_tuple",
             #[allow(deprecated)]
             &__Contract__with_tuple__invoke_raw_slice,
         );
+    }
+}
+#[doc(hidden)]
+#[allow(non_snake_case)]
+#[allow(unused)]
+fn __Contract____ee2e16de256ae8ba478066467e6ce7fafb81c62ba9225d821055c038eb12644a_ctor() {
+    #[allow(unsafe_code)]
+    {
+        #[link_section = ".init_array"]
+        #[used]
+        #[allow(non_upper_case_globals, non_snake_case)]
+        #[doc(hidden)]
+        static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
+            #[link_section = ".text.startup"]
+            #[allow(non_snake_case)]
+            extern "C" fn f() -> ::ctor::__support::CtorRetType {
+                unsafe {
+                    __Contract____ee2e16de256ae8ba478066467e6ce7fafb81c62ba9225d821055c038eb12644a_ctor();
+                };
+                core::default::Default::default()
+            }
+            f
+        };
+    }
+    {
         <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
             "with_tuple_return",
             #[allow(deprecated)]
             &__Contract__with_tuple_return__invoke_raw_slice,
         );
+    }
+}
+#[doc(hidden)]
+#[allow(non_snake_case)]
+#[allow(unused)]
+fn __Contract____e6557f25d7784a468b8898a88389307adf23c93322db235c82bfcfe63177a7ba_ctor() {
+    #[allow(unsafe_code)]
+    {
+        #[link_section = ".init_array"]
+        #[used]
+        #[allow(non_upper_case_globals, non_snake_case)]
+        #[doc(hidden)]
+        static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
+            #[link_section = ".text.startup"]
+            #[allow(non_snake_case)]
+            extern "C" fn f() -> ::ctor::__support::CtorRetType {
+                unsafe {
+                    __Contract____e6557f25d7784a468b8898a88389307adf23c93322db235c82bfcfe63177a7ba_ctor();
+                };
+                core::default::Default::default()
+            }
+            f
+        };
+    }
+    {
         <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
             "publish_ref_event",
             #[allow(deprecated)]

--- a/tests-expanded/test_tuples_tests.rs
+++ b/tests-expanded/test_tuples_tests.rs
@@ -599,7 +599,7 @@ pub extern "C" fn __Contract__tuple2__invoke_raw_extern(
 #[doc(hidden)]
 #[allow(non_snake_case)]
 #[allow(unused)]
-fn __Contract____69e94e814d1599c21b8ac3d759295183311eaabe224b3ad8865aaa5d01729db0_ctor() {
+fn __Contract____ef46ee4f8d2fe96c590a333b6587464cb38e0652abffbebd301ab9327a62d81a_ctor() {
     #[allow(unsafe_code)]
     {
         #[link_section = ".init_array"]
@@ -611,7 +611,7 @@ fn __Contract____69e94e814d1599c21b8ac3d759295183311eaabe224b3ad8865aaa5d01729db
             #[allow(non_snake_case)]
             extern "C" fn f() -> ::ctor::__support::CtorRetType {
                 unsafe {
-                    __Contract____69e94e814d1599c21b8ac3d759295183311eaabe224b3ad8865aaa5d01729db0_ctor();
+                    __Contract____ef46ee4f8d2fe96c590a333b6587464cb38e0652abffbebd301ab9327a62d81a_ctor();
                 };
                 core::default::Default::default()
             }
@@ -624,11 +624,61 @@ fn __Contract____69e94e814d1599c21b8ac3d759295183311eaabe224b3ad8865aaa5d01729db
             #[allow(deprecated)]
             &__Contract__void_fn__invoke_raw_slice,
         );
+    }
+}
+#[doc(hidden)]
+#[allow(non_snake_case)]
+#[allow(unused)]
+fn __Contract____abfa02e5c60cce0656ad2397b649d719872a5371e992241a47fe28f18a856721_ctor() {
+    #[allow(unsafe_code)]
+    {
+        #[link_section = ".init_array"]
+        #[used]
+        #[allow(non_upper_case_globals, non_snake_case)]
+        #[doc(hidden)]
+        static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
+            #[link_section = ".text.startup"]
+            #[allow(non_snake_case)]
+            extern "C" fn f() -> ::ctor::__support::CtorRetType {
+                unsafe {
+                    __Contract____abfa02e5c60cce0656ad2397b649d719872a5371e992241a47fe28f18a856721_ctor();
+                };
+                core::default::Default::default()
+            }
+            f
+        };
+    }
+    {
         <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
             "tuple1",
             #[allow(deprecated)]
             &__Contract__tuple1__invoke_raw_slice,
         );
+    }
+}
+#[doc(hidden)]
+#[allow(non_snake_case)]
+#[allow(unused)]
+fn __Contract____a846798eea815411e646d8e2bf31b970483168093587b8f2f616d9f608dd350e_ctor() {
+    #[allow(unsafe_code)]
+    {
+        #[link_section = ".init_array"]
+        #[used]
+        #[allow(non_upper_case_globals, non_snake_case)]
+        #[doc(hidden)]
+        static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
+            #[link_section = ".text.startup"]
+            #[allow(non_snake_case)]
+            extern "C" fn f() -> ::ctor::__support::CtorRetType {
+                unsafe {
+                    __Contract____a846798eea815411e646d8e2bf31b970483168093587b8f2f616d9f608dd350e_ctor();
+                };
+                core::default::Default::default()
+            }
+            f
+        };
+    }
+    {
         <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
             "tuple2",
             #[allow(deprecated)]

--- a/tests-expanded/test_udt_tests.rs
+++ b/tests-expanded/test_udt_tests.rs
@@ -3826,7 +3826,7 @@ pub extern "C" fn __Contract__recursive_enum__invoke_raw_extern(
 #[doc(hidden)]
 #[allow(non_snake_case)]
 #[allow(unused)]
-fn __Contract____ca538446cb58e8272191ab7091913766c05361045f91847da7c92c7de8846af4_ctor() {
+fn __Contract____7b8a6f33b43ca26a3f2aa73e408748f9ceb391ac21dfe746c94563016ab72f85_ctor() {
     #[allow(unsafe_code)]
     {
         #[link_section = ".init_array"]
@@ -3838,7 +3838,7 @@ fn __Contract____ca538446cb58e8272191ab7091913766c05361045f91847da7c92c7de8846af
             #[allow(non_snake_case)]
             extern "C" fn f() -> ::ctor::__support::CtorRetType {
                 unsafe {
-                    __Contract____ca538446cb58e8272191ab7091913766c05361045f91847da7c92c7de8846af4_ctor();
+                    __Contract____7b8a6f33b43ca26a3f2aa73e408748f9ceb391ac21dfe746c94563016ab72f85_ctor();
                 };
                 core::default::Default::default()
             }
@@ -3851,11 +3851,61 @@ fn __Contract____ca538446cb58e8272191ab7091913766c05361045f91847da7c92c7de8846af
             #[allow(deprecated)]
             &__Contract__add__invoke_raw_slice,
         );
+    }
+}
+#[doc(hidden)]
+#[allow(non_snake_case)]
+#[allow(unused)]
+fn __Contract____3b6dd7419a2a779da57ff13e20217e378a2501df160cd17e6982604b8707a37d_ctor() {
+    #[allow(unsafe_code)]
+    {
+        #[link_section = ".init_array"]
+        #[used]
+        #[allow(non_upper_case_globals, non_snake_case)]
+        #[doc(hidden)]
+        static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
+            #[link_section = ".text.startup"]
+            #[allow(non_snake_case)]
+            extern "C" fn f() -> ::ctor::__support::CtorRetType {
+                unsafe {
+                    __Contract____3b6dd7419a2a779da57ff13e20217e378a2501df160cd17e6982604b8707a37d_ctor();
+                };
+                core::default::Default::default()
+            }
+            f
+        };
+    }
+    {
         <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
             "recursive",
             #[allow(deprecated)]
             &__Contract__recursive__invoke_raw_slice,
         );
+    }
+}
+#[doc(hidden)]
+#[allow(non_snake_case)]
+#[allow(unused)]
+fn __Contract____26f892f950609ba9f96abbf8e2a939b7f5154579798718ea18f2febdf9c659bb_ctor() {
+    #[allow(unsafe_code)]
+    {
+        #[link_section = ".init_array"]
+        #[used]
+        #[allow(non_upper_case_globals, non_snake_case)]
+        #[doc(hidden)]
+        static f: extern "C" fn() -> ::ctor::__support::CtorRetType = {
+            #[link_section = ".text.startup"]
+            #[allow(non_snake_case)]
+            extern "C" fn f() -> ::ctor::__support::CtorRetType {
+                unsafe {
+                    __Contract____26f892f950609ba9f96abbf8e2a939b7f5154579798718ea18f2febdf9c659bb_ctor();
+                };
+                core::default::Default::default()
+            }
+            f
+        };
+    }
+    {
         <Contract as soroban_sdk::testutils::ContractFunctionRegister>::register(
             "recursive_enum",
             #[allow(deprecated)]

--- a/tests-expanded/test_workspace_contract_tests.rs
+++ b/tests-expanded/test_workspace_contract_tests.rs
@@ -283,7 +283,7 @@ pub extern "C" fn __Contract__value__invoke_raw_extern() -> soroban_sdk::Val {
 #[doc(hidden)]
 #[allow(non_snake_case)]
 #[allow(unused)]
-fn __Contract____cd42404d52ad55ccfa9aca4adc828aa5800ad9d385a0671fbcbf724118320619_ctor() {
+fn __Contract____a0b7821a11db531982044ca5ca2e788e2d749d6b696cd3aa4172342f584f2ee1_ctor() {
     #[allow(unsafe_code)]
     {
         #[link_section = ".init_array"]
@@ -295,7 +295,7 @@ fn __Contract____cd42404d52ad55ccfa9aca4adc828aa5800ad9d385a0671fbcbf72411832061
             #[allow(non_snake_case)]
             extern "C" fn f() -> ::ctor::__support::CtorRetType {
                 unsafe {
-                    __Contract____cd42404d52ad55ccfa9aca4adc828aa5800ad9d385a0671fbcbf724118320619_ctor();
+                    __Contract____a0b7821a11db531982044ca5ca2e788e2d749d6b696cd3aa4172342f584f2ee1_ctor();
                 };
                 core::default::Default::default()
             }

--- a/tests/contracttrait_impl_full/Cargo.toml
+++ b/tests/contracttrait_impl_full/Cargo.toml
@@ -11,6 +11,9 @@ rust-version.workspace = true
 crate-type = ["cdylib"]
 doctest = false
 
+[features]
+cfg-gated-fn = []
+
 [dependencies]
 soroban-sdk = {path = "../../soroban-sdk", features = ["experimental_spec_shaking_v2"]}
 test_contracttrait_trait = {path = "../contracttrait_trait"}

--- a/tests/contracttrait_impl_full/src/lib.rs
+++ b/tests/contracttrait_impl_full/src/lib.rs
@@ -3,13 +3,19 @@ use soroban_sdk::{
     contract, contractimpl, Address, Bytes, BytesN, Duration, Map, String, Symbol, Timepoint, Vec,
     I256, U256,
 };
-use test_contracttrait_trait::{AllTypes, MyEnumUnit, MyEnumVariants, MyStruct};
+use test_contracttrait_trait::{AllTypes, CfgGated, MyEnumUnit, MyEnumVariants, MyStruct};
 
 #[contract]
 pub struct Contract;
 
 #[contractimpl(contracttrait)]
 impl AllTypes for Contract {}
+
+#[contract]
+pub struct CfgGatedContract;
+
+#[contractimpl(contracttrait)]
+impl CfgGated for CfgGatedContract {}
 
 #[cfg(test)]
 mod test {
@@ -77,5 +83,14 @@ mod test {
 
         let my_enum = MyEnumVariants::VarB(MyStruct { a: 1, b: 2 });
         assert_eq!(client.test_enum_variants(&my_enum), my_enum);
+    }
+
+    #[test]
+    fn test_cross_crate_cfg_gated_default_fn() {
+        let e = Env::default();
+        let contract_id = e.register(CfgGatedContract, ());
+        let client = CfgGatedContractClient::new(&e, &contract_id);
+
+        assert_eq!(client.shown(), 8);
     }
 }

--- a/tests/contracttrait_impl_full/test_snapshots/test/test_cross_crate_cfg_gated_default_fn.1.json
+++ b/tests/contracttrait_impl_full/test_snapshots/test/test_cross_crate_cfg_gated_default_fn.1.json
@@ -1,0 +1,61 @@
+{
+  "generators": {
+    "address": 1,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 26,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": "ledger_key_contract_instance",
+              "durability": "persistent",
+              "val": {
+                "contract_instance": {
+                  "executable": {
+                    "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  },
+                  "storage": null
+                }
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_code": {
+              "ext": "v0",
+              "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+              "code": ""
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      }
+    ]
+  },
+  "events": []
+}

--- a/tests/contracttrait_trait/Cargo.toml
+++ b/tests/contracttrait_trait/Cargo.toml
@@ -11,6 +11,10 @@ rust-version.workspace = true
 crate-type = ["lib"]
 doctest = false
 
+[features]
+default = ["cfg-gated-fn"]
+cfg-gated-fn = []
+
 [dependencies]
 soroban-sdk = {path = "../../soroban-sdk", features = ["experimental_spec_shaking_v2"]}
 

--- a/tests/contracttrait_trait/src/lib.rs
+++ b/tests/contracttrait_trait/src/lib.rs
@@ -109,6 +109,26 @@ pub trait AllTypes {
     }
 }
 
+#[contracttrait]
+pub trait CfgGated {
+    #[cfg(any())]
+    fn hidden(env: Env) -> u32 {
+        let _ = env;
+        7
+    }
+
+    fn shown(env: Env) -> u32 {
+        let _ = env;
+        8
+    }
+
+    #[cfg(feature = "cfg-gated-fn")]
+    fn feature_enabled(env: Env) -> u32 {
+        let _ = env;
+        9
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;
@@ -121,6 +141,66 @@ mod test {
 
     #[contractimpl(contracttrait)]
     impl AllTypes for Contract {}
+
+    #[contract]
+    pub struct CfgGatedContract;
+
+    #[contractimpl(contracttrait)]
+    impl CfgGated for CfgGatedContract {}
+
+    #[contract]
+    pub struct CfgGatedOverrideContract;
+
+    #[contractimpl(contracttrait)]
+    impl CfgGated for CfgGatedOverrideContract {
+        #[cfg(any())]
+        fn shown(env: Env) -> u32 {
+            let _ = env;
+            99
+        }
+
+        #[cfg(feature = "cfg-gated-fn")]
+        fn feature_enabled(env: Env) -> u32 {
+            let _ = env;
+            99
+        }
+    }
+
+    #[cfg(feature = "cfg-gated-fn")]
+    #[contract]
+    pub struct CfgGatedUnconditionalOverrideContract;
+
+    #[cfg(feature = "cfg-gated-fn")]
+    #[contractimpl(contracttrait)]
+    impl CfgGated for CfgGatedUnconditionalOverrideContract {
+        fn feature_enabled(env: Env) -> u32 {
+            let _ = env;
+            100
+        }
+    }
+
+    #[contract]
+    pub struct CfgGatedImplContract;
+
+    #[contractimpl]
+    impl CfgGatedImplContract {
+        #[cfg(any())]
+        pub fn hidden(env: Env) -> u32 {
+            let _ = env;
+            7
+        }
+
+        pub fn shown(env: Env) -> u32 {
+            let _ = env;
+            8
+        }
+
+        #[cfg(feature = "cfg-gated-fn")]
+        pub fn feature_enabled(env: Env) -> u32 {
+            let _ = env;
+            9
+        }
+    }
 
     #[test]
     fn test_types() {
@@ -183,6 +263,50 @@ mod test {
 
         let my_enum = MyEnumVariants::VarB(MyStruct { a: 1, b: 2 });
         assert_eq!(client.test_enum_variants(&my_enum), my_enum);
+    }
+
+    #[test]
+    fn test_cfg_gated_contracttrait_default_fn() {
+        let e = Env::default();
+        let contract_id = e.register(CfgGatedContract, ());
+        let client = CfgGatedContractClient::new(&e, &contract_id);
+
+        assert_eq!(client.shown(), 8);
+        #[cfg(feature = "cfg-gated-fn")]
+        assert_eq!(client.feature_enabled(), 9);
+    }
+
+    #[test]
+    fn test_cfg_gated_disabled_override_uses_default_fn() {
+        let e = Env::default();
+        let contract_id = e.register(CfgGatedOverrideContract, ());
+        let client = CfgGatedOverrideContractClient::new(&e, &contract_id);
+
+        assert_eq!(client.shown(), 8);
+        #[cfg(feature = "cfg-gated-fn")]
+        assert_eq!(client.feature_enabled(), 99);
+    }
+
+    #[cfg(feature = "cfg-gated-fn")]
+    #[test]
+    fn test_cfg_gated_default_with_unconditional_override() {
+        let e = Env::default();
+        let contract_id = e.register(CfgGatedUnconditionalOverrideContract, ());
+        let client = CfgGatedUnconditionalOverrideContractClient::new(&e, &contract_id);
+
+        assert_eq!(client.shown(), 8);
+        assert_eq!(client.feature_enabled(), 100);
+    }
+
+    #[test]
+    fn test_cfg_gated_contractimpl_fn() {
+        let e = Env::default();
+        let contract_id = e.register(CfgGatedImplContract, ());
+        let client = CfgGatedImplContractClient::new(&e, &contract_id);
+
+        assert_eq!(client.shown(), 8);
+        #[cfg(feature = "cfg-gated-fn")]
+        assert_eq!(client.feature_enabled(), 9);
     }
 
     #[test]

--- a/tests/contracttrait_trait/test_snapshots/test/test_cfg_gated_contractimpl_fn.1.json
+++ b/tests/contracttrait_trait/test_snapshots/test/test_cfg_gated_contractimpl_fn.1.json
@@ -1,0 +1,62 @@
+{
+  "generators": {
+    "address": 1,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 26,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": "ledger_key_contract_instance",
+              "durability": "persistent",
+              "val": {
+                "contract_instance": {
+                  "executable": {
+                    "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  },
+                  "storage": null
+                }
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_code": {
+              "ext": "v0",
+              "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+              "code": ""
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      }
+    ]
+  },
+  "events": []
+}

--- a/tests/contracttrait_trait/test_snapshots/test/test_cfg_gated_contracttrait_default_fn.1.json
+++ b/tests/contracttrait_trait/test_snapshots/test/test_cfg_gated_contracttrait_default_fn.1.json
@@ -1,0 +1,62 @@
+{
+  "generators": {
+    "address": 1,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 26,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": "ledger_key_contract_instance",
+              "durability": "persistent",
+              "val": {
+                "contract_instance": {
+                  "executable": {
+                    "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  },
+                  "storage": null
+                }
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_code": {
+              "ext": "v0",
+              "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+              "code": ""
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      }
+    ]
+  },
+  "events": []
+}

--- a/tests/contracttrait_trait/test_snapshots/test/test_cfg_gated_default_with_unconditional_override.1.json
+++ b/tests/contracttrait_trait/test_snapshots/test/test_cfg_gated_default_with_unconditional_override.1.json
@@ -1,0 +1,62 @@
+{
+  "generators": {
+    "address": 1,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 26,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": "ledger_key_contract_instance",
+              "durability": "persistent",
+              "val": {
+                "contract_instance": {
+                  "executable": {
+                    "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  },
+                  "storage": null
+                }
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_code": {
+              "ext": "v0",
+              "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+              "code": ""
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      }
+    ]
+  },
+  "events": []
+}

--- a/tests/contracttrait_trait/test_snapshots/test/test_cfg_gated_disabled_override_uses_default_fn.1.json
+++ b/tests/contracttrait_trait/test_snapshots/test/test_cfg_gated_disabled_override_uses_default_fn.1.json
@@ -1,0 +1,62 @@
+{
+  "generators": {
+    "address": 1,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 26,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": "ledger_key_contract_instance",
+              "durability": "persistent",
+              "val": {
+                "contract_instance": {
+                  "executable": {
+                    "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  },
+                  "storage": null
+                }
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_code": {
+              "ext": "v0",
+              "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+              "code": ""
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      }
+    ]
+  },
+  "events": []
+}


### PR DESCRIPTION
### What

Preserve pass-through function attributes, including `#[cfg(...)]`, when `#[contracttrait]` records default trait functions for later `#[contractimpl(contracttrait)]` code generation.

This also makes generated args and native test registration code cfg-aware, and adds regression coverage for cfg-disabled defaults, cfg-enabled defaults, cfg-gated overrides, and regular `#[contractimpl]` cfg-gated functions.

### Why

`#[contracttrait]` previously serialized only doc attributes for default trait methods. If a default method was cfg-gated, the generated trait helper lost that cfg and later generated wrappers for a method that Rust had compiled out of the trait.

Cfg-gated overrides also need special handling: an override should suppress the trait default only when the override's cfg is active. Otherwise, the default implementation should remain available.

Native test registration needed the same treatment because registration ctors referenced generated raw wrapper functions. If a wrapper was cfg-disabled but its registration was not, the generated test code could reference a missing symbol.

Fixes #1868 

### Known limitations

`cfg_attr` is not interpreted for function gating. Use direct `#[cfg(...)]` on `#[contracttrait]` default functions and `#[contractimpl]` functions.

For cross-crate `#[contracttrait]` default functions, function-level cfgs are evaluated in the implementing contract crate's configuration context when generating wrappers. Shared trait crates should prefer cfg-gating the whole trait item, or require implementing contracts to define matching features for function-level cfgs.