### PR TITLE
SPIKE: CAP-71 SDK support — expose delegate_account_auth

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1378,9 +1378,8 @@ checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "soroban-builtin-sdk-macros"
-version = "26.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35a3a2b57b132b800e132d2c81e1818359bb2cf787ca39c61c151d6bd0798403"
+version = "26.1.2"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=7fb0a840812fe8921bb48bebf7b4aa7160467ec8#7fb0a840812fe8921bb48bebf7b4aa7160467ec8"
 dependencies = [
  "itertools",
  "proc-macro2",
@@ -1390,9 +1389,8 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-common"
-version = "26.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c76fad735f9622d8aa0fa0c75838d2023a659a0c57638a783b8b2eb967f7822"
+version = "26.1.2"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=7fb0a840812fe8921bb48bebf7b4aa7160467ec8#7fb0a840812fe8921bb48bebf7b4aa7160467ec8"
 dependencies = [
  "arbitrary",
  "crate-git-revision",
@@ -1409,9 +1407,8 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-guest"
-version = "26.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15aeed6d7a4dc4d3bba65e2ac92f7eeaa664900bbc82e1055e024bf637d74ed3"
+version = "26.1.2"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=7fb0a840812fe8921bb48bebf7b4aa7160467ec8#7fb0a840812fe8921bb48bebf7b4aa7160467ec8"
 dependencies = [
  "soroban-env-common",
  "static_assertions",
@@ -1419,9 +1416,8 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-host"
-version = "26.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fb523456b4efe9cdf869233cff5a2a1a5ebfae8c0acc405e57479c83781a20c"
+version = "26.1.2"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=7fb0a840812fe8921bb48bebf7b4aa7160467ec8#7fb0a840812fe8921bb48bebf7b4aa7160467ec8"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -1456,9 +1452,8 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-macros"
-version = "26.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ada3449bb23c964a88a1bf633ac66ca3ebac2061693f53148b199ce816791d0"
+version = "26.1.2"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=7fb0a840812fe8921bb48bebf7b4aa7160467ec8#7fb0a840812fe8921bb48bebf7b4aa7160467ec8"
 dependencies = [
  "itertools",
  "proc-macro2",
@@ -1588,8 +1583,7 @@ dependencies = [
 [[package]]
 name = "soroban-wasmi"
 version = "0.31.1-soroban.20.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "710403de32d0e0c35375518cb995d4fc056d0d48966f2e56ea471b8cb8fc9719"
+source = "git+https://github.com/stellar/wasmi?rev=0ed3f3dee30dc41ebe21972399e0a73a41944aa0#0ed3f3dee30dc41ebe21972399e0a73a41944aa0"
 dependencies = [
  "smallvec",
  "spin",
@@ -1658,9 +1652,8 @@ dependencies = [
 
 [[package]]
 name = "stellar-xdr"
-version = "26.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea6e29c7e1f071c2767916460d006668197843d5d93f0ec8893a26f72a14f595"
+version = "26.0.0"
+source = "git+https://github.com/stellar/rs-stellar-xdr?rev=a749b69b3471aec0c20ec431b0297f3414d66421#a749b69b3471aec0c20ec431b0297f3414d66421"
 dependencies = [
  "arbitrary",
  "base64",
@@ -2189,15 +2182,13 @@ checksum = "c62a0a307cb4a311d3a07867860911ca130c3494e8c2719593806c08bc5d0484"
 
 [[package]]
 name = "wasmi_arena"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "104a7f73be44570cac297b3035d76b169d6599637631cf37a1703326a0727073"
+version = "0.4.0"
+source = "git+https://github.com/stellar/wasmi?rev=0ed3f3dee30dc41ebe21972399e0a73a41944aa0#0ed3f3dee30dc41ebe21972399e0a73a41944aa0"
 
 [[package]]
 name = "wasmi_core"
 version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcf1a7db34bff95b85c261002720c00c3a6168256dcb93041d3fa2054d19856a"
+source = "git+https://github.com/stellar/wasmi?rev=0ed3f3dee30dc41ebe21972399e0a73a41944aa0#0ed3f3dee30dc41ebe21972399e0a73a41944aa0"
 dependencies = [
  "downcast-rs",
  "libm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,29 +30,30 @@ soroban-token-spec = { version = "26.0.1", path = "soroban-token-spec" }
 stellar-asset-spec = { version = "26.0.1", path = "stellar-asset-spec" }
 
 [workspace.dependencies.soroban-env-common]
-version = "=26.1.3"
-# git = "https://github.com/stellar/rs-soroban-env"
-# rev = "c0e58f94ff2983a09440cef6a54253349fd3c4db"
+version = "=26.1.2"
+git = "https://github.com/stellar/rs-soroban-env"
+rev = "7fb0a840812fe8921bb48bebf7b4aa7160467ec8"
 
 [workspace.dependencies.soroban-env-guest]
-version = "=26.1.3"
-# git = "https://github.com/stellar/rs-soroban-env"
-# rev = "c0e58f94ff2983a09440cef6a54253349fd3c4db"
+version = "=26.1.2"
+git = "https://github.com/stellar/rs-soroban-env"
+rev = "7fb0a840812fe8921bb48bebf7b4aa7160467ec8"
 
 [workspace.dependencies.soroban-env-host]
-version = "=26.1.3"
-# git = "https://github.com/stellar/rs-soroban-env"
-# rev = "c0e58f94ff2983a09440cef6a54253349fd3c4db"
+version = "=26.1.2"
+git = "https://github.com/stellar/rs-soroban-env"
+rev = "7fb0a840812fe8921bb48bebf7b4aa7160467ec8"
 
 [workspace.dependencies.stellar-strkey]
 version = "=0.0.16"
 
+# CAP-71 pre-release pin: per-cap-feature layout; "curr" feature no longer exists.
 [workspace.dependencies.stellar-xdr]
-version = "=26.0.1"
-# git = "https://github.com/stellar/rs-stellar-xdr"
-# rev = "dd7a165a193126fd37a751d867bee1cb8f3b55a6"
+version = "=26.0.0"
+git = "https://github.com/stellar/rs-stellar-xdr"
+rev = "a749b69b3471aec0c20ec431b0297f3414d66421"
 default-features = false
-features = ["curr"]
+features = ["cap_0071"]
 
 #[patch.crates-io]
 #soroban-env-common = { path = "../rs-soroban-env/soroban-env-common" }

--- a/soroban-meta/Cargo.toml
+++ b/soroban-meta/Cargo.toml
@@ -11,6 +11,6 @@ edition = "2021"
 rust-version.workspace = true
 
 [dependencies]
-stellar-xdr = { workspace = true, features = ["curr", "std"] }
+stellar-xdr = { workspace = true, features = ["std"] }
 thiserror = "1.0.32"
 wasmparser = "0.116.1"

--- a/soroban-meta/src/read.rs
+++ b/soroban-meta/src/read.rs
@@ -1,6 +1,5 @@
 use std::io::Cursor;
 
-use stellar_xdr::curr as stellar_xdr;
 use stellar_xdr::{Limited, Limits, ReadXdr, ScMetaEntry};
 use wasmparser::{BinaryReaderError, Parser, Payload};
 

--- a/soroban-meta/src/tests.rs
+++ b/soroban-meta/src/tests.rs
@@ -1,6 +1,6 @@
 use crate::read;
 use std::fs;
-use stellar_xdr::curr::{Limits, ScMetaEntry, ScMetaV0, StringM, WriteXdr};
+use stellar_xdr::{Limits, ScMetaEntry, ScMetaV0, StringM, WriteXdr};
 
 #[test]
 fn test_from_wasm() {

--- a/soroban-sdk-macros/Cargo.toml
+++ b/soroban-sdk-macros/Cargo.toml
@@ -18,7 +18,7 @@ doctest = false
 soroban-spec = { workspace = true }
 soroban-spec-rust = { workspace = true }
 soroban-env-common = { workspace = true }
-stellar-xdr = { workspace = true, features = ["curr", "std"] }
+stellar-xdr = { workspace = true, features = ["std"] }
 syn = {version="2.0.77",features=["full"]}
 quote = "1.0"
 proc-macro2 = "1.0"

--- a/soroban-sdk-macros/src/derive_enum.rs
+++ b/soroban-sdk-macros/src/derive_enum.rs
@@ -6,7 +6,6 @@ use syn::{
     Visibility,
 };
 
-use stellar_xdr::curr as stellar_xdr;
 use stellar_xdr::{
     Error as XdrError, ScSpecEntry, ScSpecTypeDef, ScSpecUdtUnionCaseTupleV0, ScSpecUdtUnionCaseV0,
     ScSpecUdtUnionCaseVoidV0, ScSpecUdtUnionV0, StringM, VecM, WriteXdr, SCSYMBOL_LIMIT,

--- a/soroban-sdk-macros/src/derive_enum_int.rs
+++ b/soroban-sdk-macros/src/derive_enum_int.rs
@@ -1,7 +1,6 @@
 use itertools::MultiUnzip;
 use proc_macro2::TokenStream as TokenStream2;
 use quote::{format_ident, quote};
-use stellar_xdr::curr as stellar_xdr;
 use stellar_xdr::{ScSpecUdtEnumV0, StringM};
 use syn::{
     ext::IdentExt as _, spanned::Spanned, Attribute, DataEnum, Error, ExprLit, Ident, Lit, Path,

--- a/soroban-sdk-macros/src/derive_error_enum_int.rs
+++ b/soroban-sdk-macros/src/derive_error_enum_int.rs
@@ -1,7 +1,6 @@
 use itertools::MultiUnzip;
 use proc_macro2::TokenStream as TokenStream2;
 use quote::{format_ident, quote};
-use stellar_xdr::curr as stellar_xdr;
 use stellar_xdr::{ScSpecEntry, ScSpecUdtErrorEnumCaseV0, ScSpecUdtErrorEnumV0, StringM, WriteXdr};
 use syn::{
     ext::IdentExt as _, spanned::Spanned, Attribute, DataEnum, Error, ExprLit, Ident, Lit, Path,

--- a/soroban-sdk-macros/src/derive_event.rs
+++ b/soroban-sdk-macros/src/derive_event.rs
@@ -7,7 +7,7 @@ use heck::ToSnakeCase;
 use proc_macro2::Span;
 use proc_macro2::TokenStream as TokenStream2;
 use quote::{format_ident, quote};
-use stellar_xdr::curr::{
+use stellar_xdr::{
     ScSpecEntry, ScSpecEventDataFormat, ScSpecEventParamLocationV0, ScSpecEventParamV0,
     ScSpecEventV0, ScSymbol, StringM, WriteXdr,
 };

--- a/soroban-sdk-macros/src/derive_spec_fn.rs
+++ b/soroban-sdk-macros/src/derive_spec_fn.rs
@@ -1,6 +1,5 @@
 use proc_macro2::TokenStream as TokenStream2;
 use quote::{format_ident, quote};
-use stellar_xdr::curr as stellar_xdr;
 use stellar_xdr::{
     ScSpecEntry, ScSpecFunctionInputV0, ScSpecFunctionV0, ScSpecTypeDef, ScSymbol, StringM,
     WriteXdr, SCSYMBOL_LIMIT,

--- a/soroban-sdk-macros/src/derive_struct.rs
+++ b/soroban-sdk-macros/src/derive_struct.rs
@@ -3,7 +3,6 @@ use proc_macro2::{Literal, TokenStream as TokenStream2};
 use quote::{format_ident, quote};
 use syn::{ext::IdentExt as _, Attribute, DataStruct, Error, Ident, Path, Visibility};
 
-use stellar_xdr::curr as stellar_xdr;
 use stellar_xdr::{
     ScSpecEntry, ScSpecTypeDef, ScSpecUdtStructFieldV0, ScSpecUdtStructV0, StringM, WriteXdr,
 };

--- a/soroban-sdk-macros/src/derive_struct_tuple.rs
+++ b/soroban-sdk-macros/src/derive_struct_tuple.rs
@@ -3,7 +3,6 @@ use proc_macro2::{Literal, TokenStream as TokenStream2};
 use quote::{format_ident, quote};
 use syn::{ext::IdentExt as _, Attribute, DataStruct, Error, Ident, Path, Visibility};
 
-use stellar_xdr::curr as stellar_xdr;
 use stellar_xdr::{
     ScSpecEntry, ScSpecTypeDef, ScSpecUdtStructFieldV0, ScSpecUdtStructV0, StringM, WriteXdr,
 };

--- a/soroban-sdk-macros/src/doc.rs
+++ b/soroban-sdk-macros/src/doc.rs
@@ -1,5 +1,4 @@
 use itertools::Itertools;
-use stellar_xdr::curr as stellar_xdr;
 use stellar_xdr::StringM;
 use syn::{Attribute, Expr, ExprLit, Lit, Meta, MetaNameValue};
 

--- a/soroban-sdk-macros/src/lib.rs
+++ b/soroban-sdk-macros/src/lib.rs
@@ -1,3 +1,4 @@
+use stellar_xdr;
 extern crate proc_macro;
 
 mod arbitrary;
@@ -54,7 +55,6 @@ use syn_ext::HasFnsItem;
 
 use soroban_spec_rust::{generate_from_wasm_with_options, GenerateFromFileError, GenerateOptions};
 
-use stellar_xdr::curr as stellar_xdr;
 use stellar_xdr::{Limits, ScMetaEntry, ScMetaV0, StringM, WriteXdr};
 
 pub(crate) const DEFAULT_XDR_RW_LIMITS: Limits = Limits {

--- a/soroban-sdk-macros/src/map_type.rs
+++ b/soroban-sdk-macros/src/map_type.rs
@@ -1,5 +1,4 @@
 use quote::ToTokens;
-use stellar_xdr::curr as stellar_xdr;
 use stellar_xdr::{
     ScSpecTypeBytesN, ScSpecTypeDef, ScSpecTypeMap, ScSpecTypeOption, ScSpecTypeResult,
     ScSpecTypeTuple, ScSpecTypeUdt, ScSpecTypeVec,

--- a/soroban-sdk/Cargo.toml
+++ b/soroban-sdk/Cargo.toml
@@ -46,7 +46,7 @@ ctor = { version = "0.5.0", optional = true }
 soroban-sdk-macros = { workspace = true, features = ["testutils"] }
 soroban-env-host = { workspace = true, features = ["testutils"] }
 soroban-ledger-snapshot = { workspace = true, features = ["testutils"] }
-stellar-xdr = { workspace = true, features = ["curr", "std"] }
+stellar-xdr = { workspace = true, features = ["std"] }
 soroban-spec = { workspace = true }
 ed25519-dalek = "2.0.0"
 rand = "0.8.5"

--- a/soroban-sdk/src/address.rs
+++ b/soroban-sdk/src/address.rs
@@ -262,6 +262,20 @@ impl Address {
         self.env.require_auth(self);
     }
 
+    /// Delegates the current `__check_auth` authorization to the provided
+    /// `address`. CAP-71-01: must be called from inside a custom account's
+    /// `__check_auth`. The host requires `address` to have authorized the same
+    /// call tree (same signature payload + context) via the auth entry's
+    /// delegate signatures.
+    ///
+    /// ### Panics
+    ///
+    /// If called outside of `__check_auth`, or if `address` has not
+    /// authorized this invocation.
+    pub fn delegate_account_auth(&self) {
+        self.env.delegate_account_auth(self);
+    }
+
     /// Creates an `Address` corresponding to the provided Stellar strkey.
     ///
     /// The only supported strkey types are account keys (`G...`) and contract keys (`C...`). Any

--- a/soroban-sdk/src/env.rs
+++ b/soroban-sdk/src/env.rs
@@ -392,6 +392,11 @@ impl Env {
         internal::Env::require_auth(self, address.to_object()).unwrap_infallible();
     }
 
+    #[doc(hidden)]
+    pub(crate) fn delegate_account_auth(&self, address: &Address) {
+        internal::Env::delegate_account_auth(self, address.to_object()).unwrap_infallible();
+    }
+
     /// Invokes a function of a contract that is registered in the [Env].
     ///
     /// # Panics

--- a/soroban-sdk/src/tests/contract_add_i32.rs
+++ b/soroban-sdk/src/tests/contract_add_i32.rs
@@ -1,6 +1,5 @@
 use crate as soroban_sdk;
 use soroban_sdk::{contract, contractimpl, Env};
-use stellar_xdr::curr as stellar_xdr;
 use stellar_xdr::{
     Limits, ReadXdr, ScSpecEntry, ScSpecFunctionInputV0, ScSpecFunctionV0, ScSpecTypeDef,
 };

--- a/soroban-sdk/src/tests/contract_docs.rs
+++ b/soroban-sdk/src/tests/contract_docs.rs
@@ -1,8 +1,7 @@
 mod fn_ {
     use crate as soroban_sdk;
     use soroban_sdk::{contract, contractimpl, Env};
-    use stellar_xdr::curr as stellar_xdr;
-    use stellar_xdr::{Limits, ReadXdr, ScSpecEntry, ScSpecFunctionV0};
+        use stellar_xdr::{Limits, ReadXdr, ScSpecEntry, ScSpecFunctionV0};
 
     #[contract]
     pub struct Contract;
@@ -39,8 +38,7 @@ mod fn_ {
 mod struct_ {
     use crate as soroban_sdk;
     use soroban_sdk::contracttype;
-    use stellar_xdr::curr as stellar_xdr;
-    use stellar_xdr::{Limits, ReadXdr, ScSpecEntry, ScSpecUdtStructFieldV0, ScSpecUdtStructV0};
+        use stellar_xdr::{Limits, ReadXdr, ScSpecEntry, ScSpecUdtStructFieldV0, ScSpecUdtStructV0};
 
     /// S holds a and
     // TODO: Implement.
@@ -83,8 +81,7 @@ mod struct_ {
 mod struct_tuple {
     use crate as soroban_sdk;
     use soroban_sdk::contracttype;
-    use stellar_xdr::curr as stellar_xdr;
-    use stellar_xdr::{Limits, ReadXdr, ScSpecEntry, ScSpecUdtStructFieldV0, ScSpecUdtStructV0};
+        use stellar_xdr::{Limits, ReadXdr, ScSpecEntry, ScSpecUdtStructFieldV0, ScSpecUdtStructV0};
 
     /// S holds two u64s.
     #[contracttype]
@@ -125,8 +122,7 @@ mod struct_tuple {
 mod enum_ {
     use crate as soroban_sdk;
     use soroban_sdk::contracttype;
-    use stellar_xdr::curr as stellar_xdr;
-    use stellar_xdr::{
+        use stellar_xdr::{
         Limits, ReadXdr, ScSpecEntry, ScSpecUdtUnionCaseTupleV0, ScSpecUdtUnionCaseV0,
         ScSpecUdtUnionCaseVoidV0, ScSpecUdtUnionV0,
     };
@@ -177,8 +173,7 @@ mod enum_ {
 mod enum_int {
     use crate as soroban_sdk;
     use soroban_sdk::contracttype;
-    use stellar_xdr::curr as stellar_xdr;
-    use stellar_xdr::{Limits, ReadXdr, ScSpecEntry, ScSpecUdtEnumCaseV0, ScSpecUdtEnumV0};
+        use stellar_xdr::{Limits, ReadXdr, ScSpecEntry, ScSpecUdtEnumCaseV0, ScSpecUdtEnumV0};
 
     /// E has variants A and B.
     #[contracttype]
@@ -220,8 +215,7 @@ mod enum_int {
 mod enum_error_int {
     use crate as soroban_sdk;
     use soroban_sdk::contracterror;
-    use stellar_xdr::curr as stellar_xdr;
-    use stellar_xdr::{
+        use stellar_xdr::{
         Limits, ReadXdr, ScSpecEntry, ScSpecUdtErrorEnumCaseV0, ScSpecUdtErrorEnumV0,
     };
 

--- a/soroban-sdk/src/tests/contract_fn.rs
+++ b/soroban-sdk/src/tests/contract_fn.rs
@@ -1,6 +1,5 @@
 use crate as soroban_sdk;
 use soroban_sdk::{contract, contractimpl, Env};
-use stellar_xdr::curr as stellar_xdr;
 use stellar_xdr::{
     Limits, ReadXdr, ScSpecEntry, ScSpecFunctionInputV0, ScSpecFunctionV0, ScSpecTypeDef,
     ScSpecTypeTuple,

--- a/soroban-sdk/src/tests/contract_meta.rs
+++ b/soroban-sdk/src/tests/contract_meta.rs
@@ -1,6 +1,5 @@
 use crate as soroban_sdk;
 use soroban_sdk::contractmeta;
-use stellar_xdr::curr as stellar_xdr;
 use stellar_xdr::{Limits, ReadXdr, ScMetaEntry, ScMetaV0};
 
 #[test]

--- a/soroban-sdk/src/tests/contract_udt_raw_identifier.rs
+++ b/soroban-sdk/src/tests/contract_udt_raw_identifier.rs
@@ -3,7 +3,6 @@ use soroban_sdk::{
     contract, contracterror, contractevent, contractimpl, contracttrait, contracttype,
     testutils::Events as _, Env,
 };
-use stellar_xdr::curr as stellar_xdr;
 use stellar_xdr::{
     Limits, ReadXdr, ScSpecEntry, ScSpecEventDataFormat, ScSpecEventParamLocationV0,
     ScSpecEventParamV0, ScSpecEventV0, ScSpecFunctionInputV0, ScSpecFunctionV0, ScSpecTypeDef,

--- a/soroban-sdk/src/tests/contract_udt_struct.rs
+++ b/soroban-sdk/src/tests/contract_udt_struct.rs
@@ -3,7 +3,6 @@ use soroban_sdk::{
     contract, contractimpl, contracttype, map, symbol_short, ConversionError, Env, IntoVal,
     TryFromVal, Val,
 };
-use stellar_xdr::curr as stellar_xdr;
 use stellar_xdr::{
     Limits, ReadXdr, ScSpecEntry, ScSpecFunctionInputV0, ScSpecFunctionV0, ScSpecTypeDef,
     ScSpecTypeTuple, ScSpecTypeUdt,

--- a/soroban-sdk/src/tests/contract_udt_struct_tuple.rs
+++ b/soroban-sdk/src/tests/contract_udt_struct_tuple.rs
@@ -3,7 +3,6 @@ use soroban_sdk::{
     contract, contractimpl, contracttype, vec, ConversionError, Env, IntoVal, TryFromVal,
     TryIntoVal, Val, Vec,
 };
-use stellar_xdr::curr as stellar_xdr;
 use stellar_xdr::{
     Limits, ReadXdr, ScSpecEntry, ScSpecFunctionInputV0, ScSpecFunctionV0, ScSpecTypeDef,
     ScSpecTypeTuple, ScSpecTypeUdt,

--- a/soroban-sdk/src/tests/contractimport.rs
+++ b/soroban-sdk/src/tests/contractimport.rs
@@ -1,6 +1,5 @@
 use crate as soroban_sdk;
 use soroban_sdk::{contract, contractimpl, Address, Env};
-use stellar_xdr::curr as stellar_xdr;
 use stellar_xdr::{ScSpecEntry, ScSpecFunctionInputV0, ScSpecFunctionV0, ScSpecTypeDef};
 
 mod addcontract {

--- a/soroban-spec-rust/Cargo.toml
+++ b/soroban-spec-rust/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2021"
 rust-version.workspace = true
 
 [dependencies]
-stellar-xdr = { workspace = true, features = ["curr", "std", "serde"] }
+stellar-xdr = { workspace = true, features = ["std", "serde"] }
 soroban-spec = { workspace = true }
 thiserror = "1.0.32"
 syn = {version="2.0",features=["full"]}

--- a/soroban-spec-rust/src/lib.rs
+++ b/soroban-spec-rust/src/lib.rs
@@ -8,7 +8,6 @@ use std::{fs, io};
 use proc_macro2::TokenStream;
 use quote::quote;
 use sha2::{Digest, Sha256};
-use stellar_xdr::curr as stellar_xdr;
 use stellar_xdr::{ScSpecEntry, ScSpecTypeDef, ScSpecTypeUdt, ScSpecUdtUnionCaseV0};
 use syn::Error;
 
@@ -399,7 +398,7 @@ pub enum MyError {
     #[test]
     fn test_add_u64_spec_entries() {
         use super::ScSpecEntry;
-        use stellar_xdr::curr::ScSpecTypeDef;
+        use stellar_xdr::ScSpecTypeDef;
 
         let entries = from_wasm(ADD_U64_WASM).unwrap();
 
@@ -473,7 +472,7 @@ pub enum MyError {
     #[test]
     fn test_missing_error_udt_falls_back_to_sdk_error() {
         use super::ScSpecEntry;
-        use stellar_xdr::curr::{ScSpecFunctionV0, ScSpecTypeDef, ScSpecTypeResult};
+        use stellar_xdr::{ScSpecFunctionV0, ScSpecTypeDef, ScSpecTypeResult};
 
         let func = ScSpecFunctionV0 {
             doc: "".try_into().unwrap(),
@@ -509,7 +508,7 @@ pub trait Contract {
     #[test]
     fn test_error_udt_overrides_sdk_error() {
         use super::ScSpecEntry;
-        use stellar_xdr::curr::{
+        use stellar_xdr::{
             ScSpecFunctionV0, ScSpecTypeDef, ScSpecTypeResult, ScSpecUdtErrorEnumCaseV0,
             ScSpecUdtErrorEnumV0,
         };
@@ -567,7 +566,7 @@ pub enum Error {
     #[test]
     fn test_error_udt_override_rewrites_nested_vec() {
         use super::ScSpecEntry;
-        use stellar_xdr::curr::{
+        use stellar_xdr::{
             ScSpecFunctionV0, ScSpecTypeDef, ScSpecTypeVec, ScSpecUdtErrorEnumCaseV0,
             ScSpecUdtErrorEnumV0,
         };

--- a/soroban-spec-rust/src/syn_ext.rs
+++ b/soroban-spec-rust/src/syn_ext.rs
@@ -1,5 +1,5 @@
 use proc_macro2::Ident;
-use stellar_xdr::curr::{ScSymbol, StringM};
+use stellar_xdr::{ScSymbol, StringM};
 
 use crate::types::GenerateError;
 

--- a/soroban-spec-rust/src/trait.rs
+++ b/soroban-spec-rust/src/trait.rs
@@ -1,6 +1,5 @@
 use proc_macro2::TokenStream;
 use quote::quote;
-use stellar_xdr::curr as stellar_xdr;
 use stellar_xdr::ScSpecFunctionV0;
 
 use super::syn_ext::str_to_ident;

--- a/soroban-spec-rust/src/types.rs
+++ b/soroban-spec-rust/src/types.rs
@@ -1,6 +1,5 @@
 use proc_macro2::{Literal, TokenStream};
 use quote::quote;
-use stellar_xdr::curr as stellar_xdr;
 use stellar_xdr::{
     ScSpecEventParamLocationV0, ScSpecEventV0, ScSpecTypeDef, ScSpecUdtEnumV0,
     ScSpecUdtErrorEnumV0, ScSpecUdtStructV0, ScSpecUdtUnionV0,
@@ -348,8 +347,7 @@ mod test {
 
     use super::{generate_event, generate_struct, GenerateError};
     use quote::quote;
-    use stellar_xdr::curr as stellar_xdr;
-    use stellar_xdr::{
+        use stellar_xdr::{
         ScSpecEventDataFormat, ScSpecEventParamLocationV0, ScSpecEventParamV0, ScSpecEventV0,
         ScSpecTypeDef, ScSpecUdtStructFieldV0, ScSpecUdtStructV0, ScSymbol, VecM,
     };

--- a/soroban-spec/Cargo.toml
+++ b/soroban-spec/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2021"
 rust-version.workspace = true
 
 [dependencies]
-stellar-xdr = { workspace = true, features = ["curr", "std", "serde"] }
+stellar-xdr = { workspace = true, features = ["std", "serde"] }
 base64 = "0.22.1"
 thiserror = "1.0.32"
 wasmparser = "0.116.1"

--- a/soroban-spec/src/read.rs
+++ b/soroban-spec/src/read.rs
@@ -1,7 +1,6 @@
 use std::io::Cursor;
 
 use base64::Engine;
-use stellar_xdr::curr as stellar_xdr;
 use stellar_xdr::{Limited, Limits, ReadXdr, ScSpecEntry};
 use wasmparser::{BinaryReaderError, Parser, Payload};
 

--- a/soroban-spec/src/shaking.rs
+++ b/soroban-spec/src/shaking.rs
@@ -36,7 +36,7 @@
 use std::collections::HashSet;
 
 use sha2::{Digest, Sha256};
-use stellar_xdr::curr::{Limits, ScMetaEntry, ScSpecEntry, WriteXdr};
+use stellar_xdr::{Limits, ScMetaEntry, ScSpecEntry, WriteXdr};
 
 /// The contract meta key that indicates the spec shaking version.
 ///
@@ -179,7 +179,7 @@ pub fn filter<'a, I: IntoIterator<Item = ScSpecEntry> + 'a>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use stellar_xdr::curr::{
+    use stellar_xdr::{
         ScMetaV0, ScSpecEntry, ScSpecEventDataFormat, ScSpecEventV0, ScSpecFunctionInputV0,
         ScSpecFunctionV0, ScSpecTypeDef, ScSpecUdtEnumCaseV0, ScSpecUdtEnumV0,
         ScSpecUdtStructFieldV0, ScSpecUdtStructV0, StringM, VecM,

--- a/tests-expanded/test_contracttrait_trait_tests.rs
+++ b/tests-expanded/test_contracttrait_trait_tests.rs
@@ -7362,8 +7362,7 @@ mod test {
         ),
     };
     fn test_spec_docs() {
-        use stellar_xdr::curr as stellar_xdr;
-        use stellar_xdr::{Limits, ReadXdr, ScSpecEntry};
+                use stellar_xdr::{Limits, ReadXdr, ScSpecEntry};
         let entry = ScSpecEntry::from_xdr(Contract::spec_xdr_test_u32(), Limits::none()).unwrap();
         let ScSpecEntry::FunctionV0(func) = entry else {
             {

--- a/tests/contracttrait_trait/src/lib.rs
+++ b/tests/contracttrait_trait/src/lib.rs
@@ -187,8 +187,7 @@ mod test {
 
     #[test]
     fn test_spec_docs() {
-        use stellar_xdr::curr as stellar_xdr;
-        use stellar_xdr::{Limits, ReadXdr, ScSpecEntry};
+                use stellar_xdr::{Limits, ReadXdr, ScSpecEntry};
 
         // Verify that doc strings from trait default functions appear in the spec
         let entry = ScSpecEntry::from_xdr(Contract::spec_xdr_test_u32(), Limits::none()).unwrap();


### PR DESCRIPTION
SPIKE used to e2e-test **CAP-71 (Auth delegation)** end-to-end against a Quickstart Protocol 27 build (with stellar-core PR #5209 = CAP-83 + CAP-71 enabled via \`--enable-next-protocol-version-unsafe-for-production\`).

## What this changes

- Pins \`soroban-env-{common,guest,host}\` and \`stellar-xdr\` to the CAP-71 commit:
  - \`rs-soroban-env\` @ \`7fb0a840…\` (PR #1607, merged) — adds the new \`address.delegate_account_auth\` / \`get_delegated_signers_for_current_auth_check\` host fns.
  - \`rs-stellar-xdr\` @ \`a749b69b…\`, \`features=[\"cap_0071\"]\` — adds \`SOROBAN_CREDENTIALS_ADDRESS_V2\`, \`…_WITH_DELEGATES\`, \`HashIdPreimageSorobanAuthorizationWithAddress\`, \`SorobanDelegateSignature\`.
- Drops the \`curr\` feature on \`stellar-xdr\` (the new per-CAP-feature layout has no \`curr\` module; everything is at the crate root).
- Replaces \`use stellar_xdr::curr as stellar_xdr;\` aliases with crate-root imports.
- Adds \`Address::delegate_account_auth(&self)\` — wraps \`env.delegate_account_auth(AddressObject)\` so a custom-account contract's \`__check_auth\` can call \`delegate.delegate_account_auth()\` to hand off auth (CAP-71-01).

## How it was used

A 13-line custom-account contract was built against this SDK and deployed to a Quickstart p27 node; a \`SOROBAN_CREDENTIALS_ADDRESS_WITH_DELEGATES\` auth entry (with a single \`SorobanDelegateSignature\`) was submitted; the tx returned \`SUCCESS\` from RPC and was ingested by Horizon without error. (Companion testing on \`go-stellar-sdk\`, \`stellar-rpc\`, and \`stellar-horizon\` is tracked in those repos' SPIKE PRs.)

## Notes for a real PR

- Skipping the \`get_delegated_signers_for_current_auth_check\` wrapper for now (returns \`VecObject\` → \`Vec<Address>\` needs a real conversion path).
- The \`stellar-xdr\` version constraint had to drop from \`=26.0.1\` to \`=26.0.0\` to match the rev's self-reported version.
- Many \`use stellar_xdr::curr as stellar_xdr;\` aliases were removed mechanically. A real PR should consolidate to a single re-export.