### PR TITLE
Warn when building contracts without stellar-cli

### DIFF
--- a/soroban-sdk/build.rs
+++ b/soroban-sdk/build.rs
@@ -43,13 +43,7 @@ pub fn main() {
             );
             std::process::exit(1);
         } else {
-            println!("cargo::warning=stellar-cli will be required in a future version of soroban-sdk to build contracts");
-            println!("cargo::warning=");
-            println!("cargo::warning=Building contracts with `cargo build` directly will not be supported in a");
-            println!("cargo::warning=future version of soroban-sdk.");
-            println!("cargo::warning=");
-            println!("cargo::warning=To prepare, build with `stellar contract build` from stellar-cli now in");
-            println!("cargo::warning=preparation for when it becomes required.");
+            println!("cargo::warning=stellar-cli will be required in a future version of soroban-sdk to build contracts, build with `stellar contract build` from stellar-cli now in preparation for when it becomes required");
         }
     }
 

--- a/soroban-sdk/build.rs
+++ b/soroban-sdk/build.rs
@@ -43,17 +43,13 @@ pub fn main() {
             );
             std::process::exit(1);
         } else {
-            eprintln!(
-                "\
-\nwarning: stellar-cli will be required in a future version of soroban-sdk to build contracts\
-\n\
-\nBuilding contracts with `cargo build` directly will not be supported in a\
-\nfuture version of soroban-sdk.\
-\n\
-\nTo prepare, build with `stellar contract build` from stellar-cli now in\
-\npreparation for when it becomes required.\
-"
-            );
+            println!("cargo::warning=stellar-cli will be required in a future version of soroban-sdk to build contracts");
+            println!("cargo::warning=");
+            println!("cargo::warning=Building contracts with `cargo build` directly will not be supported in a");
+            println!("cargo::warning=future version of soroban-sdk.");
+            println!("cargo::warning=");
+            println!("cargo::warning=To prepare, build with `stellar contract build` from stellar-cli now in");
+            println!("cargo::warning=preparation for when it becomes required.");
         }
     }
 

--- a/soroban-sdk/build.rs
+++ b/soroban-sdk/build.rs
@@ -28,22 +28,9 @@ pub fn main() {
         && std::env::var("CARGO_CFG_TARGET_FAMILY").unwrap_or_default() == "wasm"
     {
         if std::env::var("CARGO_FEATURE_EXPERIMENTAL_SPEC_SHAKING_V2").is_ok() {
-            eprintln!(
-                "\
-\nerror: soroban-sdk feature 'experimental_spec_shaking_v2' requires stellar-cli v25.2.0+\
-\n\
-\nThe soroban-sdk 'experimental_spec_shaking_v2' feature requires building\
-\nwith `stellar contract build` from stellar-cli v25.2.0 or newer.\
-\n\
-\nTo fix, either:\
-\n  - Build with `stellar contract build` using stellar-cli v25.2.0+\
-\n  - Disable the feature by removing 'experimental_spec_shaking_v2' from\
-\n    the soroban-sdk import features list in Cargo.toml.\
-"
-            );
-            std::process::exit(1);
+            println!("cargo::error=The soroban-sdk feature 'experimental_spec_shaking_v2' requires building with `stellar contract build` from stellar-cli v25.2.0 or newer. Either build with stellar-cli v25.2.0+, or remove 'experimental_spec_shaking_v2' from the soroban-sdk features in Cargo.toml");
         } else {
-            println!("cargo::warning=stellar-cli will be required in a future version of soroban-sdk to build contracts, build with `stellar contract build` from stellar-cli now in preparation for when it becomes required");
+            println!("cargo::warning=Building contracts that use the soroban-sdk will require the stellar-cli in a future version of soroban-sdk. Build with `stellar contract build` from stellar-cli now in preparation for when it becomes required");
         }
     }
 

--- a/soroban-sdk/build.rs
+++ b/soroban-sdk/build.rs
@@ -43,7 +43,7 @@ pub fn main() {
             );
             std::process::exit(1);
         } else {
-            println!("cargo::warning=Building contracts that use the soroban-sdk will require the stellar-cli in a future version of soroban-sdk. Build with `stellar contract build` from stellar-cli now in preparation for when it becomes required");
+            println!("cargo::warning=Building contracts that use the soroban-sdk will require the stellar-cli in a future version of soroban-sdk. Build with `stellar contract build` soon in preparation for when it becomes required.");
         }
     }
 

--- a/soroban-sdk/build.rs
+++ b/soroban-sdk/build.rs
@@ -28,9 +28,22 @@ pub fn main() {
         && std::env::var("CARGO_CFG_TARGET_FAMILY").unwrap_or_default() == "wasm"
     {
         if std::env::var("CARGO_FEATURE_EXPERIMENTAL_SPEC_SHAKING_V2").is_ok() {
-            println!("cargo::error=The soroban-sdk feature 'experimental_spec_shaking_v2' requires building with `stellar contract build` from stellar-cli v25.2.0 or newer. Either build with stellar-cli v25.2.0+, or remove 'experimental_spec_shaking_v2' from the soroban-sdk features in Cargo.toml");
+            eprintln!(
+                "\
+\nerror: soroban-sdk feature 'experimental_spec_shaking_v2' requires stellar-cli v25.2.0+\
+\n\
+\nThe soroban-sdk 'experimental_spec_shaking_v2' feature requires building\
+\nwith `stellar contract build` from stellar-cli v25.2.0 or newer.\
+\n\
+\nTo fix, either:\
+\n  - Build with `stellar contract build` using stellar-cli v25.2.0+\
+\n  - Disable the feature by removing 'experimental_spec_shaking_v2' from\
+\n    the soroban-sdk import features list in Cargo.toml.\
+"
+            );
+            std::process::exit(1);
         } else {
-            println!("cargo::warning=Building contracts that use the soroban-sdk will require the stellar-cli in a future version of soroban-sdk. Build with `stellar contract build` from stellar-cli now in preparation for when it becomes required");
+            println!("cargo::warning=stellar-cli will be required in a future version of soroban-sdk to build contracts, build with `stellar contract build` from stellar-cli now in preparation for when it becomes required");
         }
     }
 

--- a/soroban-sdk/build.rs
+++ b/soroban-sdk/build.rs
@@ -43,7 +43,7 @@ pub fn main() {
             );
             std::process::exit(1);
         } else {
-            println!("cargo::warning=stellar-cli will be required in a future version of soroban-sdk to build contracts, build with `stellar contract build` from stellar-cli now in preparation for when it becomes required");
+            println!("cargo::warning=Building contracts that use the soroban-sdk will require the stellar-cli in a future version of soroban-sdk. Build with `stellar contract build` from stellar-cli now in preparation for when it becomes required");
         }
     }
 

--- a/soroban-sdk/build.rs
+++ b/soroban-sdk/build.rs
@@ -20,15 +20,14 @@ pub fn main() {
         println!("cargo:rustc-env=RUSTC_VERSION={rustc_version}");
     }
 
-    // When the experimental_spec_shaking_v2 feature is enabled on a wasm target, check for an
-    // env var from the build system (Stellar CLI) that indicates it supports spec optimization
-    // using markers.
-    if std::env::var("CARGO_FEATURE_EXPERIMENTAL_SPEC_SHAKING_V2").is_ok() {
-        let env_name = "SOROBAN_SDK_BUILD_SYSTEM_SUPPORTS_SPEC_SHAKING_V2";
-        println!("cargo::rerun-if-env-changed={env_name}");
-        if std::env::var(env_name).is_err()
-            && std::env::var("CARGO_CFG_TARGET_FAMILY").unwrap_or_default() == "wasm"
-        {
+    // Check for an env var from the build system (Stellar CLI) that indicates the contract is
+    // being built with the Stellar CLI, which supports spec optimization using markers.
+    let env_name = "SOROBAN_SDK_BUILD_SYSTEM_SUPPORTS_SPEC_SHAKING_V2";
+    println!("cargo::rerun-if-env-changed={env_name}");
+    if std::env::var(env_name).is_err()
+        && std::env::var("CARGO_CFG_TARGET_FAMILY").unwrap_or_default() == "wasm"
+    {
+        if std::env::var("CARGO_FEATURE_EXPERIMENTAL_SPEC_SHAKING_V2").is_ok() {
             eprintln!(
                 "\
 \nerror: soroban-sdk feature 'experimental_spec_shaking_v2' requires stellar-cli v25.2.0+\
@@ -43,6 +42,18 @@ pub fn main() {
 "
             );
             std::process::exit(1);
+        } else {
+            eprintln!(
+                "\
+\nwarning: stellar-cli will be required in a future version of soroban-sdk to build contracts\
+\n\
+\nBuilding contracts with `cargo build` directly will not be supported in a\
+\nfuture version of soroban-sdk.\
+\n\
+\nTo prepare, build with `stellar contract build` from stellar-cli now in\
+\npreparation for when it becomes required.\
+"
+            );
         }
     }
 


### PR DESCRIPTION
### What

The build script now emits a warning when building wasm contracts without the Stellar CLI environment signal, indicating that the CLI will be required in future versions. The check is always performed on wasm targets, but the warning only triggers when neither the experimental_spec_shaking_v2 feature nor the CLI signal is present.

### Why

This prepares contract developers for an upcoming change where the Stellar CLI will be mandatory for building contracts with soroban-sdk. By warning users now, they have time to adopt `stellar contract build` in their workflows before it becomes a requirement.

### Known limitations

N/A