### PR TITLE
Require stellar-cli for wasm contract builds

### DIFF
--- a/soroban-sdk/build.rs
+++ b/soroban-sdk/build.rs
@@ -60,7 +60,7 @@ pub fn main() {
 \nBuild with `stellar contract build` from stellar-cli v25.2.0 or newer.\
 \n\
 \nTo temporarily allow building without stellar-cli, set the env var:\
-\n  {allow_env}=1\
+\n  SOROBAN_SDK_ALLOW_BUILD_WITHOUT_STELLAR_CLI=1\
 \nThis escape hatch will be removed in a near future version of soroban-sdk.\
 "
             );

--- a/soroban-sdk/build.rs
+++ b/soroban-sdk/build.rs
@@ -20,15 +20,18 @@ pub fn main() {
         println!("cargo:rustc-env=RUSTC_VERSION={rustc_version}");
     }
 
-    // When the experimental_spec_shaking_v2 feature is enabled on a wasm target, check for an
-    // env var from the build system (Stellar CLI) that indicates it supports spec optimization
-    // using markers.
-    if std::env::var("CARGO_FEATURE_EXPERIMENTAL_SPEC_SHAKING_V2").is_ok() {
-        let env_name = "SOROBAN_SDK_BUILD_SYSTEM_SUPPORTS_SPEC_SHAKING_V2";
-        println!("cargo::rerun-if-env-changed={env_name}");
-        if std::env::var(env_name).is_err()
-            && std::env::var("CARGO_CFG_TARGET_FAMILY").unwrap_or_default() == "wasm"
-        {
+    println!("cargo::rerun-if-env-changed=SOROBAN_SDK_BUILD_SYSTEM_SUPPORTS_SPEC_SHAKING_V2");
+    println!("cargo::rerun-if-env-changed=SOROBAN_SDK_ALLOW_BUILD_WITHOUT_STELLAR_CLI");
+
+    // When building for wasm and the build system (e.g. stellar-cli) does not support spec shaking
+    // v2, we check some situations which will compile error to prevent developers from building
+    // contracts that are broken.
+    if std::env::var("CARGO_CFG_TARGET_FAMILY").unwrap_or_default() == "wasm"
+        && std::env::var("SOROBAN_SDK_BUILD_SYSTEM_SUPPORTS_SPEC_SHAKING_V2").is_err()
+    {
+        // Check if spec shaking v2 is enabled, if it is, the build needs to be run with a version
+        // of stellar-cli that supports it.
+        if std::env::var("CARGO_FEATURE_EXPERIMENTAL_SPEC_SHAKING_V2").is_ok() {
             eprintln!(
                 "\
 \nerror: soroban-sdk feature 'experimental_spec_shaking_v2' requires stellar-cli v25.2.0+\
@@ -40,6 +43,25 @@ pub fn main() {
 \n  - Build with `stellar contract build` using stellar-cli v25.2.0+\
 \n  - Disable the feature by removing 'experimental_spec_shaking_v2' from\
 \n    the soroban-sdk import features list in Cargo.toml.\
+"
+            );
+            std::process::exit(1);
+        }
+
+        // Building contracts that use the soroban-sdk will soon require the stellar-cli and a
+        // version that supports spec shaking v2. An env var
+        // escape hatch is provided to temporarily disable the error, and will be removed in a future
+        // version of soroban-sdk.
+        if std::env::var("SOROBAN_SDK_ALLOW_BUILD_WITHOUT_STELLAR_CLI").is_err() {
+            eprintln!(
+                "\
+\nerror: building contracts that use the soroban-sdk will soon require a recent version of the stellar-cli\
+\n\
+\nBuild with `stellar contract build` from stellar-cli v25.2.0 or newer.\
+\n\
+\nTo temporarily allow building without stellar-cli, set the env var:\
+\n  {allow_env}=1\
+\nThis escape hatch will be removed in a near future version of soroban-sdk.\
 "
             );
             std::process::exit(1);

--- a/soroban-sdk/src/_migrating.rs
+++ b/soroban-sdk/src/_migrating.rs
@@ -1,3 +1,13 @@
+//! # Migrating from v26 to v27
+//!
+//! 1. [Building contracts for wasm targets now requires the stellar-cli][v27_stellar_cli].
+//!    Builds that do not use `stellar contract build` from stellar-cli v25.2.0 or newer
+//!    will fail with a compile error. A temporary escape hatch env var
+//!    `SOROBAN_SDK_ALLOW_BUILD_WITHOUT_STELLAR_CLI=1` is provided for the transition
+//!    and will be removed in a near future version of soroban-sdk.
+//!
+//! [v27_stellar_cli]: v27_stellar_cli
+//!
 //! # Migrating from v25 to v26
 //!
 //! 1. Add support for [CAP-78: Host functions for performing limited TTL extensions](https://github.com/stellar/stellar-protocol/blob/master/core/cap-0078.md).
@@ -322,3 +332,4 @@ pub mod v25_contracttrait;
 pub mod v25_event_testing;
 pub mod v25_poseidon;
 pub mod v25_resource_limits;
+pub mod v27_stellar_cli;

--- a/soroban-sdk/src/_migrating/v27_stellar_cli.rs
+++ b/soroban-sdk/src/_migrating/v27_stellar_cli.rs
@@ -16,10 +16,7 @@
 //! stellar contract build
 //! ```
 //!
-//! `stellar contract build` sets the
-//! `SOROBAN_SDK_BUILD_SYSTEM_SUPPORTS_SPEC_SHAKING_V2` environment variable
-//! that the soroban-sdk's build script checks for. No further changes to the
-//! contract crate or its `Cargo.toml` are required.
+//! No further changes to the contract crate or its `Cargo.toml` are required.
 //!
 //! [stellar-cli]: https://github.com/stellar/stellar-cli
 //!
@@ -33,8 +30,9 @@
 //! ```
 //!
 //! This escape hatch is provided for the transition and will be removed in a
-//! near future version of soroban-sdk. Contracts built with the escape hatch
-//! may be missing post-build steps and should not be deployed to mainnet.
+//! near future version of soroban-sdk once support for building without the
+//! stellar-cli is completely removed. Contracts built with the escape hatch may
+//! be missing post-build steps and should not be deployed to mainnet.
 //!
 //! ## Non-Wasm Builds
 //!

--- a/soroban-sdk/src/_migrating/v27_stellar_cli.rs
+++ b/soroban-sdk/src/_migrating/v27_stellar_cli.rs
@@ -1,0 +1,42 @@
+//! Building contracts requires the stellar-cli.
+//!
+//! ## Breaking Change: Wasm Builds Fail Without stellar-cli
+//!
+//! Building a contract for a wasm target without using the stellar-cli now
+//! results in a compile error. The soroban-sdk relies on the stellar-cli's
+//! `stellar contract build` to perform post-build steps such as spec
+//! optimization. Builds that bypass the stellar-cli produce incomplete or
+//! incorrect contract artifacts.
+//!
+//! ## Upgrade
+//!
+//! Install [stellar-cli] v25.2.0 or newer, and build contracts with:
+//!
+//! ```sh
+//! stellar contract build
+//! ```
+//!
+//! `stellar contract build` sets the
+//! `SOROBAN_SDK_BUILD_SYSTEM_SUPPORTS_SPEC_SHAKING_V2` environment variable
+//! that the soroban-sdk's build script checks for. No further changes to the
+//! contract crate or its `Cargo.toml` are required.
+//!
+//! [stellar-cli]: https://github.com/stellar/stellar-cli
+//!
+//! ## Temporary Escape Hatch
+//!
+//! For environments that cannot yet use the stellar-cli, the error can be
+//! suppressed by setting:
+//!
+//! ```sh
+//! SOROBAN_SDK_ALLOW_BUILD_WITHOUT_STELLAR_CLI=1
+//! ```
+//!
+//! This escape hatch is provided for the transition and will be removed in a
+//! near future version of soroban-sdk. Contracts built with the escape hatch
+//! may be missing post-build steps and should not be deployed to mainnet.
+//!
+//! ## Non-Wasm Builds
+//!
+//! The check only applies when building for a wasm target. Host builds (for
+//! example, running tests with `cargo test`) are unaffected.


### PR DESCRIPTION
### What

Fail builds of the soroban-sdk that are not performed with `stellar contract build`, and provide an escape hatch when the `SOROBAN_SDK_ALLOW_BUILD_WITHOUT_STELLAR_CLI` env var is present to temporarily allow developers to get past the error during a period of transition.

### Why

The soroban-sdk will soon rely on `stellar contract build` to run post-build steps such as spec shaking v2, and builds that bypass the stellar-cli produce incomplete or incorrect contract artifacts.

We wanted to surface earlier that this requirement is coming so that developers not using the stellar-cli wouldn't get completely blocked at a new release. (Thanks @mootz12 for the idea.)

It would be ideal if this was a warning and not a hard error but unfortunately cargo doesn't provide good ways to display a warning in this case because warnings in dependencies are hidden during builds. There was an attempt to do that in https://github.com/stellar/rs-soroban-sdk/pull/1879.

### Known limitations

The escape hatch suppresses the error unconditionally and does not verify that the resulting wasm has been post-processed; contracts built with `SOROBAN_SDK_ALLOW_BUILD_WITHOUT_STELLAR_CLI=1` may be missing spec shaking and other future post-build steps, and should not be deployed to mainnet.