### PR TITLE
Fix failing OpenZeppelin CI jobs

### DIFF
--- a/.github/workflows/test-with-openzeppelin-stellar-contracts.yml
+++ b/.github/workflows/test-with-openzeppelin-stellar-contracts.yml
@@ -70,12 +70,18 @@ jobs:
     - name: Patch workspace dependencies
       working-directory: stellar-contracts
       run: |
-        crates=$(cd ../rs-soroban-sdk && cargo metadata --format-version 1 --no-deps | jq -r '.packages[] | select(.publish != []) | .name')
-        for crate in $crates; do
-          rel_path=$(realpath --relative-to="." ../rs-soroban-sdk/$crate)
+        # Collect the publishable rs-soroban-sdk crates and their directories once,
+        # from the authoritative cargo metadata, deriving the path from manifest_path
+        # rather than assuming the package name matches the directory name. The list is
+        # reused by the "Patch transitive crates.io dependencies" step below.
+        (cd ../rs-soroban-sdk && cargo metadata --format-version 1 --no-deps) \
+          | jq -r '.packages[] | select(.publish != []) | "\(.name)\t\(.manifest_path | sub("/Cargo.toml$"; ""))"' \
+          > "$RUNNER_TEMP/sdk-crates.tsv"
+        while IFS=$'\t' read -r crate dir; do
+          rel_path=$(realpath --relative-to="." "$dir")
           sed -i 's|'"$crate"' = "\([^"]*\)"|'"$crate"' = { path = "'"$rel_path"'" }|g' Cargo.toml
           sed -i 's|'"$crate"' = { \(.*\)version = "[^"]*"\(.*\)|'"$crate"' = { \1path = "'"$rel_path"'" \2|g' Cargo.toml
-        done
+        done < "$RUNNER_TEMP/sdk-crates.tsv"
 
     - name: Enable experimental_spec_shaking_v2 feature
       if: matrix.experimental_spec_shaking_v2
@@ -95,13 +101,15 @@ jobs:
         # linked, producing duplicate `panic_impl` lang item errors (E0152, #1723).
         # A [patch.crates-io] table redirects transitive copies to the local checkout
         # (valid while the local version is semver-compatible with the required one).
-        crates=$(cd ../rs-soroban-sdk && cargo metadata --format-version 1 --no-deps | jq -r '.packages[] | select(.publish != []) | .name')
-        echo "" >> Cargo.toml
-        echo "[patch.crates-io]" >> Cargo.toml
-        for crate in $crates; do
-          rel_path=$(realpath --relative-to="." ../rs-soroban-sdk/$crate)
-          echo "$crate = { path = \"$rel_path\" }" >> Cargo.toml
-        done
+        # Reuse the crate list collected in the "Patch workspace dependencies" step.
+        if [ -s "$RUNNER_TEMP/sdk-crates.tsv" ]; then
+          # Don't emit a second [patch.crates-io] header if one already exists upstream.
+          grep -q '^\[patch.crates-io\]' Cargo.toml || printf '\n[patch.crates-io]\n' >> Cargo.toml
+          while IFS=$'\t' read -r crate dir; do
+            rel_path=$(realpath --relative-to="." "$dir")
+            echo "$crate = { path = \"$rel_path\" }" >> Cargo.toml
+          done < "$RUNNER_TEMP/sdk-crates.tsv"
+        fi
 
     - name: Diff
       run: (! git diff --exit-code) || (echo 'A diff is expected'; exit 1)

--- a/.github/workflows/test-with-openzeppelin-stellar-contracts.yml
+++ b/.github/workflows/test-with-openzeppelin-stellar-contracts.yml
@@ -86,6 +86,23 @@ jobs:
         # Add features field to path-patched entries without features
         sed -i '/soroban-sdk = {.*path = /{/features/!s| }|, features = ["experimental_spec_shaking_v2"] }|}' Cargo.toml
 
+    - name: Patch transitive crates.io dependencies
+      working-directory: stellar-contracts
+      run: |
+        # Crates such as soroban-poseidon are pulled from crates.io and depend on
+        # soroban-sdk from crates.io. The [workspace.dependencies] path rewrite above
+        # cannot redirect those transitive copies, so two soroban-sdk crates get
+        # linked, producing duplicate `panic_impl` lang item errors (E0152, #1723).
+        # A [patch.crates-io] table redirects transitive copies to the local checkout
+        # (valid while the local version is semver-compatible with the required one).
+        crates=$(cd ../rs-soroban-sdk && cargo metadata --format-version 1 --no-deps | jq -r '.packages[] | select(.publish != []) | .name')
+        echo "" >> Cargo.toml
+        echo "[patch.crates-io]" >> Cargo.toml
+        for crate in $crates; do
+          rel_path=$(realpath --relative-to="." ../rs-soroban-sdk/$crate)
+          echo "$crate = { path = \"$rel_path\" }" >> Cargo.toml
+        done
+
     - name: Diff
       run: (! git diff --exit-code) || (echo 'A diff is expected'; exit 1)
 

--- a/.github/workflows/test-with-openzeppelin-stellar-contracts.yml
+++ b/.github/workflows/test-with-openzeppelin-stellar-contracts.yml
@@ -67,16 +67,20 @@ jobs:
         is_a_contract=$(cargo metadata --no-deps --format-version 1 | jq -r --arg pwd "$(pwd)" '.packages[] | select(.manifest_path == "\($pwd)/Cargo.toml") | (any(.dependencies[]; .name == "soroban-sdk") and any(.targets[]; any(.crate_types[]; . == "cdylib")))')
         echo "is-a-contract=$is_a_contract" | tee -a $GITHUB_OUTPUT
 
-    - name: Patch workspace dependencies
+    - name: Collect publishable rs-soroban-sdk crates
       working-directory: stellar-contracts
       run: |
         # Collect the publishable rs-soroban-sdk crates and their directories once,
         # from the authoritative cargo metadata, deriving the path from manifest_path
         # rather than assuming the package name matches the directory name. The list is
-        # reused by the "Patch transitive crates.io dependencies" step below.
+        # reused by the patching steps below.
         (cd ../rs-soroban-sdk && cargo metadata --format-version 1 --no-deps) \
           | jq -r '.packages[] | select(.publish != []) | "\(.name)\t\(.manifest_path | sub("/Cargo.toml$"; ""))"' \
           > "$RUNNER_TEMP/sdk-crates.tsv"
+
+    - name: Patch workspace dependencies
+      working-directory: stellar-contracts
+      run: |
         while IFS=$'\t' read -r crate dir; do
           rel_path=$(realpath --relative-to="." "$dir")
           sed -i 's|'"$crate"' = "\([^"]*\)"|'"$crate"' = { path = "'"$rel_path"'" }|g' Cargo.toml

--- a/.github/workflows/test-with-openzeppelin-stellar-contracts.yml
+++ b/.github/workflows/test-with-openzeppelin-stellar-contracts.yml
@@ -104,7 +104,7 @@ jobs:
         # Reuse the crate list collected in the "Patch workspace dependencies" step.
         if [ -s "$RUNNER_TEMP/sdk-crates.tsv" ]; then
           # Don't emit a second [patch.crates-io] header if one already exists upstream.
-          grep -q '^\[patch.crates-io\]' Cargo.toml || printf '\n[patch.crates-io]\n' >> Cargo.toml
+          grep -q '^\[patch\.crates-io\]' Cargo.toml || printf '\n[patch.crates-io]\n' >> Cargo.toml
           while IFS=$'\t' read -r crate dir; do
             rel_path=$(realpath --relative-to="." "$dir")
             echo "$crate = { path = \"$rel_path\" }" >> Cargo.toml

--- a/.github/workflows/test-with-openzeppelin-stellar-contracts.yml
+++ b/.github/workflows/test-with-openzeppelin-stellar-contracts.yml
@@ -96,6 +96,10 @@ jobs:
         # Add features field to path-patched entries without features
         sed -i '/soroban-sdk = {.*path = /{/features/!s| }|, features = ["experimental_spec_shaking_v2"] }|}' Cargo.toml
 
+    # This step must run *after* "Enable experimental_spec_shaking_v2": that step's
+    # sed matches every `soroban-sdk = { ... path = ... }` line, so if the
+    # [patch.crates-io] entries below already existed it would add a `features` field
+    # to them, which Cargo ignores on patch entries and warns about.
     - name: Patch transitive crates.io dependencies
       working-directory: stellar-contracts
       run: |

--- a/.github/workflows/test-with-soroban-examples.yml
+++ b/.github/workflows/test-with-soroban-examples.yml
@@ -42,16 +42,6 @@ jobs:
       matrix:
         working-directory: ${{ fromJSON(needs.collect-examples.outputs.dirs) }}
         experimental_spec_shaking_v2: [true, false]
-        # Exclude examples that depend on crates.io packages that transitively
-        # depend on soroban-sdk (e.g. soroban-poseidon). Cargo does not provide
-        # a way to override the version of soroban-sdk required as a transitive
-        # dependency of another dependency where the version to override is a
-        # different major version or does not match the semver compatibility
-        # defined by the importer, causing two copies of soroban-sdk to be
-        # compiled and duplicate lang item (panic_impl) errors.
-        # https://github.com/stellar/rs-soroban-sdk/issues/1723
-        exclude:
-        - working-directory: privacy-pools
     defaults:
       run:
         working-directory: soroban-examples/${{ matrix.working-directory }}
@@ -85,7 +75,13 @@ jobs:
     - name: Patch SDK versions
       run: |
         # TODO: Update this patch logic to use `cargo add` once this issue is resolved: https://github.com/rust-lang/cargo/issues/16101
-        crates=$(cd ${{ github.workspace }}/rs-soroban-sdk && cargo metadata --format-version 1 --no-deps | jq -r '.packages[] | select(.publish != []) | .name')
+        # Collect the publishable rs-soroban-sdk crates and their directories once, from
+        # the authoritative cargo metadata, deriving the path from manifest_path rather
+        # than assuming the package name matches the directory name. The list is reused
+        # by the "Patch transitive crates.io dependencies" step below.
+        (cd ${{ github.workspace }}/rs-soroban-sdk && cargo metadata --format-version 1 --no-deps) \
+          | jq -r '.packages[] | select(.publish != []) | "\(.name)\t\(.manifest_path | sub("/Cargo.toml$"; ""))"' \
+          > "$RUNNER_TEMP/sdk-crates.tsv"
 
         # Find Cargo.toml files to patch
         local_files=$(find . -name Cargo.toml)
@@ -96,11 +92,11 @@ jobs:
         echo "$files" | sort -u | while read -r file; do
           echo Patching "$file" ...
           dir=$(dirname "$file")
-          for crate in $crates; do
-            rel_path=$(realpath --relative-to="$dir" ${{ github.workspace }}/rs-soroban-sdk/$crate)
+          while IFS=$'\t' read -r crate crate_dir; do
+            rel_path=$(realpath --relative-to="$dir" "$crate_dir")
             sed -i 's|'"$crate"' = "\([^"]*\)"|'"$crate"' = { path = "'"$rel_path"'" }|g' "$file"
             sed -i 's|'"$crate"' = {.*version = "[^"]*"\(.*\)|'"$crate"' = { path = "'"$rel_path"'" \1|g' "$file"
-          done
+          done < "$RUNNER_TEMP/sdk-crates.tsv"
         done
 
     - name: Enable experimental_spec_shaking_v2 feature
@@ -113,6 +109,25 @@ jobs:
           # Add features field to path-patched entries without features
           sed -i '/soroban-sdk = {.*path = /{/features/!s| }|, features = ["experimental_spec_shaking_v2"] }|}' "$file"
         done
+
+    - name: Patch transitive crates.io dependencies
+      run: |
+        # Crates such as soroban-poseidon are pulled from crates.io and depend on
+        # soroban-sdk from crates.io. The path rewrites above cannot redirect those
+        # transitive copies, so two soroban-sdk crates get linked, producing duplicate
+        # `panic_impl` lang item errors (E0152, #1723). A [patch.crates-io] table in
+        # the workspace root redirects transitive copies to the local checkout (valid
+        # while the local version is semver-compatible with the required one).
+        # Reuse the crate list collected in the "Patch SDK versions" step.
+        workspace_root=$(cargo metadata --format-version 1 --no-deps | jq -r '.workspace_root')
+        if [ -s "$RUNNER_TEMP/sdk-crates.tsv" ]; then
+          # Don't emit a second [patch.crates-io] header if one already exists upstream.
+          grep -q '^\[patch.crates-io\]' "$workspace_root/Cargo.toml" || printf '\n[patch.crates-io]\n' >> "$workspace_root/Cargo.toml"
+          while IFS=$'\t' read -r crate crate_dir; do
+            rel_path=$(realpath --relative-to="$workspace_root" "$crate_dir")
+            echo "$crate = { path = \"$rel_path\" }" >> "$workspace_root/Cargo.toml"
+          done < "$RUNNER_TEMP/sdk-crates.tsv"
+        fi
 
     - name: Diff
       run: (! git diff --exit-code) || (echo 'A diff is expected'; exit 1)

--- a/.github/workflows/test-with-soroban-examples.yml
+++ b/.github/workflows/test-with-soroban-examples.yml
@@ -72,17 +72,19 @@ jobs:
 
     - uses: stellar/actions/rust-cache@main
 
-    - name: Patch SDK versions
+    - name: Collect publishable rs-soroban-sdk crates
       run: |
-        # TODO: Update this patch logic to use `cargo add` once this issue is resolved: https://github.com/rust-lang/cargo/issues/16101
         # Collect the publishable rs-soroban-sdk crates and their directories once, from
         # the authoritative cargo metadata, deriving the path from manifest_path rather
         # than assuming the package name matches the directory name. The list is reused
-        # by the "Patch transitive crates.io dependencies" step below.
+        # by the patching steps below.
         (cd ${{ github.workspace }}/rs-soroban-sdk && cargo metadata --format-version 1 --no-deps) \
           | jq -r '.packages[] | select(.publish != []) | "\(.name)\t\(.manifest_path | sub("/Cargo.toml$"; ""))"' \
           > "$RUNNER_TEMP/sdk-crates.tsv"
 
+    - name: Patch SDK versions
+      run: |
+        # TODO: Update this patch logic to use `cargo add` once this issue is resolved: https://github.com/rust-lang/cargo/issues/16101
         # Find Cargo.toml files to patch
         local_files=$(find . -name Cargo.toml)
         workspace_root=$(cargo metadata --format-version 1 --no-deps | jq -r '.workspace_root')

--- a/.github/workflows/test-with-soroban-examples.yml
+++ b/.github/workflows/test-with-soroban-examples.yml
@@ -42,6 +42,16 @@ jobs:
       matrix:
         working-directory: ${{ fromJSON(needs.collect-examples.outputs.dirs) }}
         experimental_spec_shaking_v2: [true, false]
+        # Exclude examples that depend on a crates.io package whose own soroban-sdk
+        # dependency is an incompatible major to the soroban-sdk under test. The
+        # [patch.crates-io] step below redirects transitive soroban-sdk copies to the
+        # local checkout, but Cargo only applies the patch when the local version
+        # satisfies the requirement. privacy-pools pulls soroban-poseidon 25.0.0
+        # (soroban-sdk ^25), which the local soroban-sdk (26.x) does not satisfy, so two
+        # soroban-sdk copies are compiled and linking fails with a duplicate lang item
+        # (panic_impl). https://github.com/stellar/rs-soroban-sdk/issues/1723
+        exclude:
+        - working-directory: privacy-pools
     defaults:
       run:
         working-directory: soroban-examples/${{ matrix.working-directory }}

--- a/.github/workflows/test-with-soroban-examples.yml
+++ b/.github/workflows/test-with-soroban-examples.yml
@@ -122,7 +122,7 @@ jobs:
         workspace_root=$(cargo metadata --format-version 1 --no-deps | jq -r '.workspace_root')
         if [ -s "$RUNNER_TEMP/sdk-crates.tsv" ]; then
           # Don't emit a second [patch.crates-io] header if one already exists upstream.
-          grep -q '^\[patch.crates-io\]' "$workspace_root/Cargo.toml" || printf '\n[patch.crates-io]\n' >> "$workspace_root/Cargo.toml"
+          grep -q '^\[patch\.crates-io\]' "$workspace_root/Cargo.toml" || printf '\n[patch.crates-io]\n' >> "$workspace_root/Cargo.toml"
           while IFS=$'\t' read -r crate crate_dir; do
             rel_path=$(realpath --relative-to="$workspace_root" "$crate_dir")
             echo "$crate = { path = \"$rel_path\" }" >> "$workspace_root/Cargo.toml"

--- a/.github/workflows/test-with-soroban-examples.yml
+++ b/.github/workflows/test-with-soroban-examples.yml
@@ -112,6 +112,10 @@ jobs:
           sed -i '/soroban-sdk = {.*path = /{/features/!s| }|, features = ["experimental_spec_shaking_v2"] }|}' "$file"
         done
 
+    # This step must run *after* "Enable experimental_spec_shaking_v2": that step's
+    # sed matches every `soroban-sdk = { ... path = ... }` line, so if the
+    # [patch.crates-io] entries below already existed it would add a `features` field
+    # to them, which Cargo ignores on patch entries and warns about.
     - name: Patch transitive crates.io dependencies
       run: |
         # Crates such as soroban-poseidon are pulled from crates.io and depend on


### PR DESCRIPTION
### What

Add a `[patch.crates-io]` table to the OpenZeppelin `stellar-contracts` workspace manifest during the "Test with OpenZeppelin Contracts" workflow, so that copies of `soroban-sdk` (and the other publishable rs-soroban-sdk crates) pulled in transitively through published crates resolve to the local checkout rather than crates.io.

### Why

The workflow makes the OpenZeppelin contracts build against the local `soroban-sdk` by rewriting `[workspace.dependencies]` entries into path overrides, but a path override only redirects directly-named dependency edges. After `stellar-tokens` gained a dependency on the crates.io `soroban-poseidon`, which itself depends on `soroban-sdk` from crates.io, that transitive copy was left unpatched. The wasm build then linked two copies of `soroban-sdk` and failed with a duplicate `panic_impl` lang item error (E0152), the Cargo limitation tracked in #1723, breaking every contract that depends on `stellar-tokens` (for example `examples/confidential/auditor`). A `[patch.crates-io]` table redirects transitive copies as well, collapsing the graph onto a single local `soroban-sdk`.

Close #1885

### Known limitations

The patch only unifies the copies while the local `soroban-sdk` version is semver-compatible with the version required by the transitive dependency; if they diverge across an incompatible major, two copies would again be linked and the build would need a different remedy, as described in #1723.