### PR TITLE
Vec::extend_from_slice: append in bulk instead of per-element push_back

### DIFF
--- a/soroban-sdk/src/vec.rs
+++ b/soroban-sdk/src/vec.rs
@@ -766,8 +766,23 @@ where
     where
         T: Clone,
     {
-        for item in items {
-            self.push_back(item.clone());
+        // Build the new items in bulk using `vec_new_from_slice` host calls
+        // over fixed-size chunks and append each chunk, rather than making one
+        // `vec_push_back` host call per element (which also allocates a new
+        // intermediate vec object on the host every time). See the benches in
+        // `tests/bench_extend_from_slice` for the cost difference.
+        const CHUNK: usize = 32;
+        let env = self.env().clone();
+        let mut buf = [Val::VOID.to_val(); CHUNK];
+        for chunk in items.chunks(CHUNK) {
+            for (dst, src) in buf.iter_mut().zip(chunk) {
+                *dst = src.into_val(&env);
+            }
+            let obj = env
+                .vec_new_from_slice(&buf[..chunk.len()])
+                .unwrap_infallible();
+            let sub = unsafe { Self::unchecked_new(env.clone(), obj) };
+            self.append(&sub);
         }
     }
 }
@@ -1099,6 +1114,22 @@ mod test {
             v.push_back(1);
             v
         });
+    }
+
+    #[test]
+    fn test_vec_extend_from_slice_chunking() {
+        let env = Env::default();
+        // Cover empty, sub-chunk, exact-chunk-multiple, and cross-chunk lengths
+        // to exercise the chunked bulk append in `extend_from_slice`.
+        for n in [0usize, 1, 31, 32, 33, 64, 65, 100] {
+            let items: std::vec::Vec<u32> = (0..n as u32).collect();
+            let mut v = Vec::<u32>::from_array(&env, [1000u32]);
+            v.extend_from_slice(&items);
+            let mut expected = std::vec![1000u32];
+            expected.extend_from_slice(&items);
+            let got: std::vec::Vec<u32> = v.iter().collect();
+            assert_eq!(got, expected);
+        }
     }
 
     #[test]

--- a/soroban-sdk/src/vec.rs
+++ b/soroban-sdk/src/vec.rs
@@ -762,15 +762,11 @@ where
 
     /// Extend with the items in the slice.
     #[inline(always)]
-    pub fn extend_from_slice(&mut self, items: &[T])
-    where
-        T: Clone,
-    {
+    pub fn extend_from_slice(&mut self, items: &[T]) {
         // Build the new items in bulk using `vec_new_from_slice` host calls
         // over fixed-size chunks and append each chunk, rather than making one
         // `vec_push_back` host call per element (which also allocates a new
-        // intermediate vec object on the host every time). See the benches in
-        // `tests/bench_extend_from_slice` for the cost difference.
+        // intermediate vec object on the host every time).
         const CHUNK: usize = 32;
         let env = self.env().clone();
         let mut buf = [Val::VOID.to_val(); CHUNK];


### PR DESCRIPTION
### What

`Vec::extend_from_slice` appended items by calling `vec_push_back` once per
element. Each call is a host call that also allocates a new intermediate vec
object on the host. This change builds the new items with bulk
`vec_new_from_slice` host calls over fixed-size chunks and appends each chunk,
matching the existing bulk behaviour of `extend_from_array`.

### Why

Same class of inefficiency that was fixed for `BytesN::from` in #1888
(per-element host calls where a bulk host op exists).

Net cost (baseline subtracted), measured on the guest budget with a WASM
compute-budget bench built the same way as the #1888 bench (`baseline_*` twin
subtracted; `extend_from_array` shown as the already-bulk reference):

| Bench | Before CPU | After CPU | Δ% | Before Mem | After Mem | Δ% |
|---------------------------|-----------:|----------:|------:|-----------:|----------:|------:|
| `vec_extend_slice_192`    |    466,698 |    70,134 | −85%  |    172,928 |     8,528 | −95%  |

For reference the already-bulk `vec_extend_array_192` net cost is ~228,894 CPU,
so after this change `extend_from_slice` is on par with (here below) the bulk
path.


Bench contract and harness

Contract (one `test_*` cdylib crate):

```rust
#[no_std]
use soroban_sdk::{contract, contractimpl, Env, Vec};

#[contract]
pub struct Contract;

fn fingerprint(v: &Vec) -> u32 {
    let len = v.len();
    if len == 0 { 0 } else { v.get_unchecked(0).wrapping_add(v.get_unchecked(len - 1)) }
}

#[contractimpl]
impl Contract {
    pub fn baseline_192(_env: Env) -> u32 { let d = [7u32; 192]; d[0].wrapping_add(d[191]) }

    pub fn vec_extend_slice_192(env: Env) -> u32 {
        let mut v: Vec = Vec::from_array(&env, [1u32]);
        v.extend_from_slice(&[7u32; 192]);
        fingerprint(&v)
    }
    pub fn vec_extend_array_192(env: Env) -> u32 {
        let mut v: Vec = Vec::from_array(&env, [1u32]);
        v.extend_from_array([7u32; 192]);
        fingerprint(&v)
    }
}
```

Harness (in `soroban-sdk/src/tests`, `#[ignore]`d):

```rust
mod bench {
    use crate as soroban_sdk;
    soroban_sdk::contractimport!(file = "../target/wasm32v1-none/release/test_bench_extend_from_slice.wasm");
}
fn report(label: &str, env: &Env) {
    let cpu = env.cost_estimate().budget().cpu_instruction_cost();
    let mem = env.cost_estimate().budget().memory_bytes_cost();
    println!("BENCH {label} cpu={cpu} mem={mem}");
}
// register the wasm, reset_unlimited(), call client.(), then report().
```

Run with `make build-test-wasms` then
`cargo test --release -p soroban-sdk --lib --features testutils --  --ignored --nocapture`.


### Notes

The chunked approach uses a fixed-size stack buffer of `Val`s, so it works in
`no_std` without `alloc` (the common contract case). Following the precedent of
#1888, only the fix + a correctness unit test are committed here; the bench
lives in this description rather than in the tree.

One of three related findings from sweeping the SDK for per-element host-call
patterns (see also: `Vec::from_slice`, `Vec::from_iter`).