### PR TITLE
Vec::extend/from_iter: accumulate in bulk instead of per-element push_back

### DIFF
--- a/soroban-sdk/src/vec.rs
+++ b/soroban-sdk/src/vec.rs
@@ -380,9 +380,9 @@ where
     ///
     /// This provides FromIterator-like functionality but requires an Env parameter.
     ///
-    /// Note: This function iteratively adds each item one at a time, making a call to the Soroban
-    /// environment for each item making it inefficient for joining two [`Vec`]s. Use
-    /// [`Vec::append`] to join two [`Vec`]s.
+    /// Note: This function adds the items in bulk in fixed-size chunks. To join
+    /// two existing [`Vec`]s, prefer [`Vec::append`], which is a single host
+    /// call.
     ///
     /// ### Examples
     ///
@@ -951,8 +951,28 @@ where
     T: IntoVal<Env, Val> + TryFromVal<Env, Val>,
 {
     fn extend<I: IntoIterator<Item = T>>(&mut self, iter: I) {
+        // Accumulate items into a fixed-size stack buffer and flush each full
+        // buffer with a single bulk `vec_new_from_slice` + append, rather than
+        // making one `vec_push_back` host call per element (which also
+        // allocates a new intermediate vec object on the host every time).
+        const CHUNK: usize = 32;
+        let env = self.env().clone();
+        let mut buf = [Val::VOID.to_val(); CHUNK];
+        let mut n = 0;
         for item in iter {
-            self.push_back(item);
+            buf[n] = item.into_val(&env);
+            n += 1;
+            if n == CHUNK {
+                let obj = env.vec_new_from_slice(&buf).unwrap_infallible();
+                let sub = unsafe { Self::unchecked_new(env.clone(), obj) };
+                self.append(&sub);
+                n = 0;
+            }
+        }
+        if n > 0 {
+            let obj = env.vec_new_from_slice(&buf[..n]).unwrap_infallible();
+            let sub = unsafe { Self::unchecked_new(env.clone(), obj) };
+            self.append(&sub);
         }
     }
 }
@@ -1099,6 +1119,28 @@ mod test {
             v.push_back(1);
             v
         });
+    }
+
+    #[test]
+    fn test_vec_from_iter_chunking() {
+        let env = Env::default();
+        // Cover empty, sub-chunk, exact-chunk-multiple, and cross-chunk lengths
+        // to exercise the chunked bulk accumulation in `Extend`/`from_iter`.
+        for n in [0usize, 1, 31, 32, 33, 64, 65, 100] {
+            let items: std::vec::Vec<u32> = (0..n as u32).collect();
+            let v = Vec::<u32>::from_iter(&env, items.iter().copied());
+            assert_eq!(v.len() as usize, n);
+            let got: std::vec::Vec<u32> = v.iter().collect();
+            assert_eq!(got, items);
+
+            // extend onto a non-empty vec should preserve order.
+            let mut e = Vec::<u32>::from_array(&env, [1000u32]);
+            e.extend(items.iter().copied());
+            let mut expected = std::vec![1000u32];
+            expected.extend(items.iter().copied());
+            let got_e: std::vec::Vec<u32> = e.iter().collect();
+            assert_eq!(got_e, expected);
+        }
     }
 
     #[test]


### PR DESCRIPTION
### What

The `Extend` impl for `Vec` (used by `Vec::from_iter` and `.extend(..)`)
appended items by calling `vec_push_back` once per element. Each call is a host
call that also allocates a new intermediate vec object on the host. This change
accumulates items into a fixed-size stack buffer and flushes each full buffer
with a single bulk `vec_new_from_slice` + append.

### Why

Same class of inefficiency that was fixed for `BytesN::from` in #1888
(per-element host calls where a bulk host op exists).

Net cost (baseline subtracted), measured on the guest budget with a WASM
compute-budget bench built the same way as the #1888 bench (`baseline_*` twin
subtracted; `from_array` shown as the already-bulk reference):

| Bench | Before CPU | After CPU | Δ% | Before Mem | After Mem | Δ% |
|-----------------------|-----------:|----------:|------:|-----------:|----------:|------:|
| `vec_from_iter_192`   |    466,056 |   230,932 | −50%  |    171,368 |     8,456 | −95%  |


Bench contract and harness

Contract (one `test_*` cdylib crate):

```rust
#[no_std]
use soroban_sdk::{contract, contractimpl, Env, Vec};

#[contract]
pub struct Contract;

fn fp(v: &Vec) -> u32 {
    let l = v.len();
    if l == 0 { 0 } else { v.get_unchecked(0).wrapping_add(v.get_unchecked(l - 1)) }
}

#[contractimpl]
impl Contract {
    pub fn baseline_192(_e: Env) -> u32 { let d = [7u32; 192]; d[0].wrapping_add(d[191]) }
    pub fn vec_from_iter_192(e: Env) -> u32 { fp(&Vec::from_iter(&e, 0..192u32)) }
    pub fn vec_from_array_192(e: Env) -> u32 { fp(&Vec::from_array(&e, [7u32; 192])) }
}
```

Harness (in `soroban-sdk/src/tests`, `#[ignore]`d): register the wasm,
`reset_unlimited()`, call `client.()`, then print
`cpu_instruction_cost()` / `memory_bytes_cost()`.

Run with `make build-test-wasms` then
`cargo test --release -p soroban-sdk --lib --features testutils --  --ignored --nocapture`.


### Notes

The chunked approach works for any iterator and uses a fixed-size stack buffer
of `Val`s, so it works in `no_std` without `alloc` (the common contract case).
The `from_iter` doc note that claimed per-element host calls is updated. A unit
test (`test_vec_from_iter_chunking`) covers empty, sub-chunk,
exact-chunk-multiple and cross-chunk lengths.

Following the precedent of #1888, only the fix + correctness unit test are
committed here; the bench lives in this description rather than in the tree.

One of three related findings from sweeping the SDK for per-element host-call
patterns (see also: `Vec::from_slice` #1891, `Vec::extend_from_slice` #1892).