### PR TITLE
Vec: add to_array/try_to_array for single-host-call bulk reads

### DIFF
--- a/soroban-sdk/src/vec.rs
+++ b/soroban-sdk/src/vec.rs
@@ -770,6 +770,61 @@ where
             self.push_back(item.clone());
         }
     }
+
+    /// Copy the items into an array of fixed length `N`.
+    ///
+    /// All `N` items are read from the environment with a single host call,
+    /// rather than one host call per item as with [`Vec::get`] or iteration.
+    ///
+    /// ### Panics
+    ///
+    /// If the length of the vec is not exactly `N`.
+    ///
+    /// If any item cannot be converted to type `T`.
+    #[inline(always)]
+    pub fn to_array<const N: usize>(&self) -> [T; N] {
+        self.try_to_array().unwrap_optimized()
+    }
+
+    /// Copy the items into an array of fixed length `N`.
+    ///
+    /// All `N` items are read from the environment with a single host call,
+    /// rather than one host call per item as with [`Vec::get`] or iteration.
+    ///
+    /// ### Errors
+    ///
+    /// If any item cannot be converted to type `T`.
+    ///
+    /// ### Panics
+    ///
+    /// If the length of the vec is not exactly `N`.
+    #[inline(always)]
+    pub fn try_to_array<const N: usize>(&self) -> Result<[T; N], T::Error> {
+        let env = self.env();
+        let mut vals: [Val; N] = [Val::VOID.to_val(); N];
+        env.vec_unpack_to_slice(self.obj, &mut vals)
+            .unwrap_infallible();
+        // Convert each Val into T, short-circuiting on the first error.
+        let mut err: Option<T::Error> = None;
+        let arr = core::array::from_fn(|i| {
+            if err.is_some() {
+                // A previous conversion already failed; avoid further work and
+                // return a placeholder that will be discarded below.
+                return None;
+            }
+            match T::try_from_val(env, &vals[i]) {
+                Ok(v) => Some(v),
+                Err(e) => {
+                    err = Some(e);
+                    None
+                }
+            }
+        });
+        match err {
+            Some(e) => Err(e),
+            None => Ok(arr.map(|o| o.unwrap_optimized())),
+        }
+    }
 }
 
 impl<T> Vec<T> {
@@ -1420,6 +1475,35 @@ mod test {
         assert_eq!(iter.next(), Some(Ok(0)));
         assert_eq!(iter.next(), Some(Ok(1)));
         assert_eq!(iter.into_vec(), vec![&env, 2, 3, 4]);
+    }
+
+    #[test]
+    fn test_vec_to_array() {
+        let env = Env::default();
+        let vec = vec![&env, 0u32, 1, 2, 3, 4];
+        let arr: [u32; 5] = vec.to_array();
+        assert_eq!(arr, [0, 1, 2, 3, 4]);
+
+        let empty: Vec<u32> = vec![&env];
+        let arr: [u32; 0] = empty.to_array();
+        assert_eq!(arr, [0u32; 0]);
+    }
+
+    #[test]
+    #[should_panic(expected = "Error(Object, UnexpectedSize)")]
+    fn test_vec_to_array_wrong_length() {
+        let env = Env::default();
+        let vec = vec![&env, 0u32, 1, 2];
+        let _: [u32; 5] = vec.to_array();
+    }
+
+    #[test]
+    fn test_vec_try_to_array_conversion_error() {
+        let env = Env::default();
+        let vec: Val = (1i64, 2i32).try_into_val(&env).unwrap();
+        let vec: Vec<i64> = vec.try_into_val(&env).unwrap();
+        let r: Result<[i64; 2], _> = vec.try_to_array();
+        assert_eq!(r, Err(ConversionError.into()));
     }
 
     #[test]


### PR DESCRIPTION
### What

Adds `Vec::<T>::to_array::<N>()` and `try_to_array::<N>()`, which read all `N`
items of a `Vec` in a **single** `vec_unpack_to_slice` host call into a stack
`[Val; N]` and then convert each to `T` — instead of one `vec_get` host call
per element as with `Vec::get` or iteration.

### Why

This is the read-side analogue of the bulk write improvements
(#1888 `BytesN::from`, #1891 `Vec::from_slice`, #1892 `Vec::extend_from_slice`,
#1893 `Vec::extend`/`from_iter`), and mirrors the existing
`BytesN::<N>::to_array`. The SDK already wrapped the bulk `vec_unpack_to_slice`
host op (`soroban-sdk/src/env.rs`) but nothing used it; whole-vec reads went
element-by-element.

Net read cost (baseline subtracted), measured on the guest budget with a WASM
compute-budget bench (sum all elements via `.iter()` vs `to_array`):

| N | iter (per-elem) CPU | to_array CPU | Δ% |
|----|--------------------:|-------------:|------:|
| 32 |              86,192 |       55,908 | −35%  |
| 96 |             254,832 |      159,444 | −37%  |
| 192 |            507,792 |      314,388 | −38%  |

Savings scale with N (N host calls → 1); memory is unchanged (both read into a
stack array, no allocation).

### Notes

- The host's `vec_unpack_to_slice` requires the output length to **exactly
  equal** the vec length, so `to_array::<N>()` panics with
  `Error(Object, UnexpectedSize)` if `len() != N` — it is a whole-vec / fixed-N
  read, not a prefix/chunk read. Documented in the panic section.
- `try_to_array` short-circuits on the first conversion error, matching
  iterator semantics.
- `no_std`-safe with no `alloc` (just `core::array::from_fn` + stack arrays).
- Unit tests cover the happy path, the exact-length requirement, and conversion
  errors.

<details>
<summary>Bench contract sketch</summary>

```rust
pub fn baseline_192(_e: Env, v: Vec<u32>) -> u32 { 0 }
pub fn iter_sum_192(_e: Env, v: Vec<u32>) -> u32 { v.iter().fold(0u32, |a, x| a.wrapping_add(x)) }
pub fn to_array_sum_192(_e: Env, v: Vec<u32>) -> u32 {
    let a: [u32; 192] = v.to_array();
    a.iter().fold(0u32, |acc, x| acc.wrapping_add(*x))
}
```
Register the wasm, `reset_unlimited()`, call the client fn, then read
`cpu_instruction_cost()` / `memory_bytes_cost()`. Bench kept out of the tree
per the #1888 precedent.
</details>

Found by an agent sweep for per-element host-call patterns across SDK types.

---
_Generated by [Claude Code](https://claude.ai/code/session_0168wkXopix1LPcuzi6AS4WF)_