### PR TITLE
Warn on wasm builds without spec shaking v2

### DIFF
--- a/soroban-sdk/build.rs
+++ b/soroban-sdk/build.rs
@@ -20,15 +20,19 @@ pub fn main() {
         println!("cargo:rustc-env=RUSTC_VERSION={rustc_version}");
     }
 
-    // When the experimental_spec_shaking_v2 feature is enabled on a wasm target, check for an
-    // env var from the build system (Stellar CLI) that indicates it supports spec optimization
-    // using markers.
+    // The env var set by the build system (Stellar CLI) that indicates it supports spec
+    // optimization using markers.
+    let build_system_env_name = "SOROBAN_SDK_BUILD_SYSTEM_SUPPORTS_SPEC_SHAKING_V2";
+    println!("cargo::rerun-if-env-changed={build_system_env_name}");
+    let build_system_supports_spec_shaking_v2 = std::env::var(build_system_env_name).is_ok();
+    let target_family_is_wasm =
+        std::env::var("CARGO_CFG_TARGET_FAMILY").unwrap_or_default() == "wasm";
+
     if std::env::var("CARGO_FEATURE_EXPERIMENTAL_SPEC_SHAKING_V2").is_ok() {
-        let env_name = "SOROBAN_SDK_BUILD_SYSTEM_SUPPORTS_SPEC_SHAKING_V2";
-        println!("cargo::rerun-if-env-changed={env_name}");
-        if std::env::var(env_name).is_err()
-            && std::env::var("CARGO_CFG_TARGET_FAMILY").unwrap_or_default() == "wasm"
-        {
+        // When the experimental_spec_shaking_v2 feature is enabled on a wasm target, the build
+        // system must support spec optimization using markers, otherwise the build cannot produce
+        // a correct spec.
+        if !build_system_supports_spec_shaking_v2 && target_family_is_wasm {
             eprintln!(
                 "\
 \nerror: soroban-sdk feature 'experimental_spec_shaking_v2' requires stellar-cli v25.2.0+\
@@ -44,6 +48,18 @@ pub fn main() {
             );
             std::process::exit(1);
         }
+    } else if !build_system_supports_spec_shaking_v2 && target_family_is_wasm {
+        // When the experimental_spec_shaking_v2 feature is not enabled, building a wasm without a
+        // build system that supports spec optimization using markers still works today, but a
+        // future SDK version will enable spec shaking v2 by default which requires a supported
+        // build tool. Warn so users can migrate ahead of time.
+        println!(
+            "cargo::warning=\
+soroban-sdk: building for wasm without a build tool that supports spec shaking v2. \
+A future SDK version will enable spec shaking v2 by default, which requires building with a \
+supported build tool. Migrate to `stellar contract build` from stellar-cli v25.2.0 or newer to \
+ensure your contracts keep building."
+        );
     }
 
     crate_git_revision::init();

--- a/soroban-sdk/src/_features.rs
+++ b/soroban-sdk/src/_features.rs
@@ -139,6 +139,14 @@
 //! set. The check only fires for wasm targets; native builds (e.g. unit tests)
 //! are unaffected.
 //!
+//! Even when this feature is *not* enabled, building for wasm without a
+//! supported build tool (i.e. without the
+//! `SOROBAN_SDK_BUILD_SYSTEM_SUPPORTS_SPEC_SHAKING_V2` environment variable
+//! set) emits a build warning. A future SDK version will enable spec shaking v2
+//! by default, which will require a supported build tool, so the warning
+//! advises migrating to `stellar contract build`. As above, the warning only
+//! fires for wasm targets and not native builds.
+//!
 //! [`contracttype`]: crate::contracttype
 //! [`contracterror`]: crate::contracterror
 //! [`contractevent`]: crate::contractevent


### PR DESCRIPTION
### What

Building a contract for a wasm target without a build tool that supports spec shaking v2 now emits a build warning advising migration to `stellar contract build` from stellar-cli v25.2.0 or newer, even when the `experimental_spec_shaking_v2` feature is not enabled. The warning only fires for wasm targets and never for native builds, and is suppressed when the build system signals support via the `SOROBAN_SDK_BUILD_SYSTEM_SUPPORTS_SPEC_SHAKING_V2` environment variable.

### Why

This is the remaining Protocol 26 deliverable from the phased spec shaking v2 rollout in #1844. Protocol 26 keeps spec shaking v2 opt-in and already errors when the feature is enabled without a supporting build tool, but a future SDK version (Protocol 27) will enable spec shaking v2 by default, which requires building with a supported tool. Warning now, while spec shaking v2 is still off by default, gives developers building wasm without the Stellar CLI advance notice to migrate before the default flips and their builds would otherwise break.

### Known limitations

The warning is not exercised by CI because CI always sets `SOROBAN_SDK_BUILD_SYSTEM_SUPPORTS_SPEC_SHAKING_V2`, so the new path was verified manually with `cargo build --target wasm32v1-none`. This change only covers the Protocol 26 scope; making the feature default (Protocol 27) and removing it (Protocol 28) remain future work tracked in #1844.

Part of #1844

---
_Generated by [Claude Code](https://claude.ai/code/session_01KDf43nJgSct3Z3hpWAwNCj)_