### PR TITLE
Add opt-in escape hatch for wasm32-unknown-unknown

### DIFF
--- a/soroban-sdk/build.rs
+++ b/soroban-sdk/build.rs
@@ -6,14 +6,14 @@ pub fn main() {
     println!("cargo::rustc-check-cfg=cfg(soroban_sdk_internal_no_rssdkver_meta)");
 
     // Check if we're building for wasm32-unknown-unknown target (cross-compilation safe)
-    println!("cargo::rerun-if-env-changed=SOROBAN_SDK_ALLOW_WASM32_UNKNOWN_UNKNOWN");
     if std::env::var("CARGO_CFG_TARGET_FAMILY").as_deref() == Ok("wasm")
         && std::env::var("CARGO_CFG_TARGET_OS").as_deref() == Ok("unknown")
     {
         if let Ok(version) = rustc_version::version() {
             if version.major == 1 && version.minor >= 82 {
+                println!("cargo::rerun-if-env-changed=SOROBAN_SDK_ALLOW_WASM32_UNKNOWN_UNKNOWN");
                 if std::env::var("SOROBAN_SDK_ALLOW_WASM32_UNKNOWN_UNKNOWN").is_ok() {
-                    println!("cargo:warning=Building for 'wasm32-unknown-unknown' with Rust 1.82+ via SOROBAN_SDK_ALLOW_WASM32_UNKNOWN_UNKNOWN. The produced wasm uses features (reference-types, multi-value) that are not supported by the Soroban Environment and MUST NOT be deployed on-chain. This is only suitable for purposes such as static analysis. To produce deployable contracts, use the 'wasm32v1-none' target available with Rust 1.84+.");
+                    println!("cargo::warning=Building for 'wasm32-unknown-unknown' with Rust 1.82+ via SOROBAN_SDK_ALLOW_WASM32_UNKNOWN_UNKNOWN. The produced wasm uses features (reference-types, multi-value) that are not supported by the Soroban Environment and MUST NOT be deployed on-chain. This is only suitable for purposes such as static analysis. To produce deployable contracts, use the 'wasm32v1-none' target available with Rust 1.84+.");
                 } else {
                     panic!("Rust compiler 1.82+ with target 'wasm32-unknown-unknown' is unsupported by the Soroban Environment, use 'wasm32v1-none' available with Rust 1.84+. The 'wasm32-unknown-unknown' target in Rust 1.82+ has features enabled that are not yet supported and not easily disabled: reference-types, multi-value. If you must build for the 'wasm32-unknown-unknown' use Rust 1.81 or earlier. If you only need to compile (not deploy) the contract, e.g. for static analysis, set the SOROBAN_SDK_ALLOW_WASM32_UNKNOWN_UNKNOWN environment variable to bypass this check.");
                 }

--- a/soroban-sdk/build.rs
+++ b/soroban-sdk/build.rs
@@ -6,12 +6,17 @@ pub fn main() {
     println!("cargo::rustc-check-cfg=cfg(soroban_sdk_internal_no_rssdkver_meta)");
 
     // Check if we're building for wasm32-unknown-unknown target (cross-compilation safe)
+    println!("cargo::rerun-if-env-changed=SOROBAN_SDK_ALLOW_WASM32_UNKNOWN_UNKNOWN");
     if std::env::var("CARGO_CFG_TARGET_FAMILY").as_deref() == Ok("wasm")
         && std::env::var("CARGO_CFG_TARGET_OS").as_deref() == Ok("unknown")
     {
         if let Ok(version) = rustc_version::version() {
             if version.major == 1 && version.minor >= 82 {
-                panic!("Rust compiler 1.82+ with target 'wasm32-unknown-unknown' is unsupported by the Soroban Environment, use 'wasm32v1-none' available with Rust 1.84+. The 'wasm32-unknown-unknown' target in Rust 1.82+ has features enabled that are not yet supported and not easily disabled: reference-types, multi-value. If you must build for the 'wasm32-unknown-unknown' use Rust 1.81 or earlier.");
+                if std::env::var("SOROBAN_SDK_ALLOW_WASM32_UNKNOWN_UNKNOWN").is_ok() {
+                    println!("cargo:warning=Building for 'wasm32-unknown-unknown' with Rust 1.82+ via SOROBAN_SDK_ALLOW_WASM32_UNKNOWN_UNKNOWN. The produced wasm uses features (reference-types, multi-value) that are not supported by the Soroban Environment and MUST NOT be deployed on-chain. This is only suitable for purposes such as static analysis. To produce deployable contracts, use the 'wasm32v1-none' target available with Rust 1.84+.");
+                } else {
+                    panic!("Rust compiler 1.82+ with target 'wasm32-unknown-unknown' is unsupported by the Soroban Environment, use 'wasm32v1-none' available with Rust 1.84+. The 'wasm32-unknown-unknown' target in Rust 1.82+ has features enabled that are not yet supported and not easily disabled: reference-types, multi-value. If you must build for the 'wasm32-unknown-unknown' use Rust 1.81 or earlier. If you only need to compile (not deploy) the contract, e.g. for static analysis, set the SOROBAN_SDK_ALLOW_WASM32_UNKNOWN_UNKNOWN environment variable to bypass this check.");
+                }
             }
         }
     }

--- a/soroban-sdk/src/_features.rs
+++ b/soroban-sdk/src/_features.rs
@@ -139,6 +139,25 @@
 //! set. The check only fires for wasm targets; native builds (e.g. unit tests)
 //! are unaffected.
 //!
+//! # Build Environment Variables
+//!
+//! ## `SOROBAN_SDK_ALLOW_WASM32_UNKNOWN_UNKNOWN`
+//!
+//! The SDK supports the `wasm32v1-none` target (available with Rust 1.84+),
+//! the only Wasm target supported by the Soroban Environment on Stellar.
+//! Building for the `wasm32-unknown-unknown` target with Rust 1.82+ is rejected
+//! at build time with an error, because that target enables Wasm features
+//! (`reference-types`, `multi-value`) that the Soroban Environment does not
+//! support, producing Wasm that cannot be deployed on-chain.
+//!
+//! Setting the `SOROBAN_SDK_ALLOW_WASM32_UNKNOWN_UNKNOWN` environment variable
+//! (to any value) bypasses this check, replacing the error with a build
+//! warning. This is intended only for tooling that needs to *compile* a
+//! contract but never *deploys* the resulting Wasm — for example static
+//! analysis tools that are coupled to a specific newer Rust toolchain. The
+//! Wasm produced this way must not be deployed on-chain. To produce deployable
+//! contracts, use the `wasm32v1-none` target instead.
+//!
 //! [`contracttype`]: crate::contracttype
 //! [`contracterror`]: crate::contracterror
 //! [`contractevent`]: crate::contractevent


### PR DESCRIPTION
### What

Add an opt-in build escape hatch, the `SOROBAN_SDK_ALLOW_WASM32_UNKNOWN_UNKNOWN` environment variable, that lets the soroban-sdk build script downgrade its hard error when building for the `wasm32-unknown-unknown` target with Rust 1.82+ to a build warning, so the contract can be compiled while the build still loudly states that the resulting Wasm must not be deployed on-chain.

### Why

The build script rejects `wasm32-unknown-unknown` on Rust 1.82+ because that target enables Wasm features (reference-types, multi-value) that the Soroban Environment does not support, so the produced Wasm cannot run on Stellar. That default is correct for contract authors, but it fully blocks tooling that only needs to compile a contract and never deploys it. As reported in #1843, the Scout static-analysis tool is coupled to specific newer Rust toolchains and cannot practically downgrade to a pre-1.82 compiler, leaving it unable to build contracts at all. The escape hatch unblocks that compile-only use case without weakening the default protection for anyone producing deployable contracts, and every build that uses it emits a loud warning so it cannot silently produce a deployable-looking artifact.

### Known limitations

Wasm produced with the variable set is not deployable on-chain; the variable is intended only for compile-only workflows such as static analysis. The build-script branch is not covered by an automated test, consistent with the existing target check which is also untested and not readily unit-testable.

Close #1843

---
_Generated by [Claude Code](https://claude.ai/code/session_018bHWCi5Eu327naUs7CPb7T)_