### PR TITLE
Make spec shaking v2 the default

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -303,7 +303,7 @@ jobs:
         sys:
         - os: ubuntu-latest
           target: wasm32v1-none
-          cargo-hack-feature-options: --manifest-path Cargo.toml --exclude soroban-meta --exclude soroban-spec --exclude soroban-spec-rust --exclude soroban-ledger-snapshot --exclude-features testutils,docs,default,std,experimental_spec_shaking_v2 --feature-powerset
+          cargo-hack-feature-options: --manifest-path Cargo.toml --exclude soroban-meta --exclude soroban-spec --exclude soroban-spec-rust --exclude soroban-ledger-snapshot --exclude-features testutils,docs,default,std,disable_spec_shaking_v2 --feature-powerset
         - os: ubuntu-latest
           target: x86_64-unknown-linux-gnu
           cargo-hack-feature-options: '--feature-powerset --exclude-features docs'

--- a/.github/workflows/test-with-openzeppelin-stellar-contracts.yml
+++ b/.github/workflows/test-with-openzeppelin-stellar-contracts.yml
@@ -36,7 +36,7 @@ jobs:
       fail-fast: false
       matrix:
         working-directory: ${{ fromJSON(needs.collect-crates.outputs.dirs) }}
-        experimental_spec_shaking_v2: [true, false]
+        disable_spec_shaking_v2: [true, false]
     defaults:
       run:
         working-directory: stellar-contracts/${{ matrix.working-directory }}
@@ -88,16 +88,16 @@ jobs:
           sed -i 's|'"$crate"' = { \(.*\)version = "[^"]*"\(.*\)|'"$crate"' = { \1path = "'"$rel_path"'" \2|g' Cargo.toml
         done < "$RUNNER_TEMP/sdk-crates.tsv"
 
-    - name: Enable experimental_spec_shaking_v2 feature
-      if: matrix.experimental_spec_shaking_v2
+    - name: Enable disable_spec_shaking_v2 feature (opt out of v2 default)
+      if: matrix.disable_spec_shaking_v2
       working-directory: stellar-contracts
       run: |
         # Add feature to path-patched entries with existing features
-        sed -i '/soroban-sdk = {.*path = /s|features = \[|features = ["experimental_spec_shaking_v2", |' Cargo.toml
+        sed -i '/soroban-sdk = {.*path = /s|features = \[|features = ["disable_spec_shaking_v2", |' Cargo.toml
         # Add features field to path-patched entries without features
-        sed -i '/soroban-sdk = {.*path = /{/features/!s| }|, features = ["experimental_spec_shaking_v2"] }|}' Cargo.toml
+        sed -i '/soroban-sdk = {.*path = /{/features/!s| }|, features = ["disable_spec_shaking_v2"] }|}' Cargo.toml
 
-    # This step must run *after* "Enable experimental_spec_shaking_v2": that step's
+    # This step must run *after* "Enable disable_spec_shaking_v2": that step's
     # sed matches every `soroban-sdk = { ... path = ... }` line, so if the
     # [patch.crates-io] entries below already existed it would add a `features` field
     # to them, which Cargo ignores on patch entries and warns about.
@@ -156,7 +156,7 @@ jobs:
     - name: Set artifact name
       if: steps.check-if-contract.outputs.is-a-contract == 'true'
       id: artifact-name
-      run: echo "name=wasm-$(echo ${{ matrix.working-directory }} | sed 's/\//-/g')${{ matrix.experimental_spec_shaking_v2 && '-spec-shaking-v2' || '' }}" | tee -a $GITHUB_OUTPUT
+      run: echo "name=wasm-$(echo ${{ matrix.working-directory }} | sed 's/\//-/g')${{ matrix.disable_spec_shaking_v2 && '-spec-shaking-v1' || '' }}" | tee -a $GITHUB_OUTPUT
 
     - name: Upload WASM artifacts
       if: steps.check-if-contract.outputs.is-a-contract == 'true'

--- a/.github/workflows/test-with-soroban-examples.yml
+++ b/.github/workflows/test-with-soroban-examples.yml
@@ -41,7 +41,7 @@ jobs:
       fail-fast: false
       matrix:
         working-directory: ${{ fromJSON(needs.collect-examples.outputs.dirs) }}
-        experimental_spec_shaking_v2: [true, false]
+        disable_spec_shaking_v2: [true, false]
         # Exclude examples that depend on a crates.io package whose own soroban-sdk
         # dependency is an incompatible major to the soroban-sdk under test. The
         # [patch.crates-io] step below redirects transitive soroban-sdk copies to the
@@ -112,18 +112,18 @@ jobs:
           done < "$RUNNER_TEMP/sdk-crates.tsv"
         done
 
-    - name: Enable experimental_spec_shaking_v2 feature
-      if: matrix.experimental_spec_shaking_v2
+    - name: Enable disable_spec_shaking_v2 feature (opt out of v2 default)
+      if: matrix.disable_spec_shaking_v2
       working-directory: soroban-examples
       run: |
         find . -name Cargo.toml | while read -r file; do
           # Add feature to path-patched entries with existing features
-          sed -i '/soroban-sdk = {.*path = /s|features = \[|features = ["experimental_spec_shaking_v2", |' "$file"
+          sed -i '/soroban-sdk = {.*path = /s|features = \[|features = ["disable_spec_shaking_v2", |' "$file"
           # Add features field to path-patched entries without features
-          sed -i '/soroban-sdk = {.*path = /{/features/!s| }|, features = ["experimental_spec_shaking_v2"] }|}' "$file"
+          sed -i '/soroban-sdk = {.*path = /{/features/!s| }|, features = ["disable_spec_shaking_v2"] }|}' "$file"
         done
 
-    # This step must run *after* "Enable experimental_spec_shaking_v2": that step's
+    # This step must run *after* "Enable disable_spec_shaking_v2": that step's
     # sed matches every `soroban-sdk = { ... path = ... }` line, so if the
     # [patch.crates-io] entries below already existed it would add a `features` field
     # to them, which Cargo ignores on patch entries and warns about.
@@ -181,7 +181,7 @@ jobs:
 
     - name: Set artifact name
       id: artifact-name
-      run: echo "name=wasm-$(echo ${{ matrix.working-directory }} | sed 's/\//-/g')${{ matrix.experimental_spec_shaking_v2 && '-spec-shaking-v2' || '' }}" | tee -a $GITHUB_OUTPUT
+      run: echo "name=wasm-$(echo ${{ matrix.working-directory }} | sed 's/\//-/g')${{ matrix.disable_spec_shaking_v2 && '-spec-shaking-v1' || '' }}" | tee -a $GITHUB_OUTPUT
 
     - name: Upload WASM artifacts
       uses: actions/upload-artifact@v4

--- a/soroban-sdk-macros/Cargo.toml
+++ b/soroban-sdk-macros/Cargo.toml
@@ -30,4 +30,4 @@ heck = "0.5.0"
 
 [features]
 testutils = []
-experimental_spec_shaking_v2 = []
+disable_spec_shaking_v2 = []

--- a/soroban-sdk-macros/src/derive_enum.rs
+++ b/soroban-sdk-macros/src/derive_enum.rs
@@ -181,9 +181,9 @@ pub fn derive_type_enum(
         None
     };
 
-    // SpecShakingMarker impl - only generated when spec is true and the
-    // experimental_spec_shaking_v2 feature is enabled.
-    let spec_shaking_impl = if cfg!(feature = "experimental_spec_shaking_v2") {
+    // SpecShakingMarker impl - only generated when spec is true and spec
+    // shaking v2 is enabled (the default).
+    let spec_shaking_impl = if !cfg!(feature = "disable_spec_shaking_v2") {
         spec_xdr.as_ref().map(|spec_xdr| {
             // Flatten all variant field types for shaking calls, deduplicating
             // to avoid redundant calls for types that appear in multiple variants.

--- a/soroban-sdk-macros/src/derive_enum_int.rs
+++ b/soroban-sdk-macros/src/derive_enum_int.rs
@@ -103,9 +103,9 @@ pub fn derive_type_enum_int(
         None
     };
 
-    // SpecShakingMarker impl - only generated when spec is true and the
-    // experimental_spec_shaking_v2 feature is enabled.
-    let spec_shaking_impl = if cfg!(feature = "experimental_spec_shaking_v2") {
+    // SpecShakingMarker impl - only generated when spec is true and spec
+    // shaking v2 is enabled (the default).
+    let spec_shaking_impl = if !cfg!(feature = "disable_spec_shaking_v2") {
         spec_xdr.as_ref().map(|spec_xdr| {
             shaking::generate_marker_impl(
                 path,

--- a/soroban-sdk-macros/src/derive_error_enum_int.rs
+++ b/soroban-sdk-macros/src/derive_error_enum_int.rs
@@ -100,9 +100,9 @@ pub fn derive_type_error_enum_int(
         None
     };
 
-    // SpecShakingMarker impl - only generated when spec is true and the
-    // experimental_spec_shaking_v2 feature is enabled.
-    let spec_shaking_impl = if cfg!(feature = "experimental_spec_shaking_v2") {
+    // SpecShakingMarker impl - only generated when spec is true and spec
+    // shaking v2 is enabled (the default).
+    let spec_shaking_impl = if !cfg!(feature = "disable_spec_shaking_v2") {
         spec_xdr.as_ref().map(|spec_xdr| {
             shaking::generate_marker_impl(
                 path,

--- a/soroban-sdk-macros/src/derive_event.rs
+++ b/soroban-sdk-macros/src/derive_event.rs
@@ -172,11 +172,11 @@ fn derive_impls(args: &ContractEventArgs, input: &DeriveInput) -> Result<TokenSt
     // If errors have occurred, return them.
     let mut errors = errors.checkpoint()?;
 
-    // Generated code spec. Under `experimental_spec_shaking_v2` the spec is
+    // Generated code spec. Under spec shaking v2 (the default) the spec is
     // always emitted and reachability determines what is retained, so an
     // explicit `export = false` is ignored (a deprecation warning is emitted
     // separately).
-    let export = cfg!(feature = "experimental_spec_shaking_v2") || args.export.unwrap_or(true);
+    let export = !cfg!(feature = "disable_spec_shaking_v2") || args.export.unwrap_or(true);
     let export_gen = if export {
         Some(quote! { #[cfg_attr(target_family = "wasm", link_section = "contractspecv0")] })
     } else {
@@ -207,7 +207,7 @@ fn derive_impls(args: &ContractEventArgs, input: &DeriveInput) -> Result<TokenSt
         "__SPEC_XDR_EVENT_{}",
         input.ident.unraw().to_string().to_uppercase()
     );
-    let spec_shaking_call = if export && cfg!(feature = "experimental_spec_shaking_v2") {
+    let spec_shaking_call = if export && !cfg!(feature = "disable_spec_shaking_v2") {
         Some(quote! { <Self as #path::SpecShakingMarker>::spec_shaking_marker(); })
     } else {
         None
@@ -225,9 +225,9 @@ fn derive_impls(args: &ContractEventArgs, input: &DeriveInput) -> Result<TokenSt
         }
     };
 
-    // SpecShakingMarker impl - only generated when export is true and the
-    // experimental_spec_shaking_v2 feature is enabled.
-    let spec_shaking_impl = if export && cfg!(feature = "experimental_spec_shaking_v2") {
+    // SpecShakingMarker impl - only generated when export is true and spec
+    // shaking v2 is enabled (the default).
+    let spec_shaking_impl = if export && !cfg!(feature = "disable_spec_shaking_v2") {
         Some(shaking::generate_marker_impl(
             path,
             quote!(#ident),

--- a/soroban-sdk-macros/src/derive_struct.rs
+++ b/soroban-sdk-macros/src/derive_struct.rs
@@ -110,9 +110,9 @@ pub fn derive_type_struct(
         None
     };
 
-    // SpecShakingMarker impl - only generated when spec is true and the
-    // experimental_spec_shaking_v2 feature is enabled.
-    let spec_shaking_impl = if cfg!(feature = "experimental_spec_shaking_v2") {
+    // SpecShakingMarker impl - only generated when spec is true and spec
+    // shaking v2 is enabled (the default).
+    let spec_shaking_impl = if !cfg!(feature = "disable_spec_shaking_v2") {
         spec_xdr.as_ref().map(|spec_xdr| {
             shaking::generate_marker_impl(
                 path,

--- a/soroban-sdk-macros/src/derive_struct_tuple.rs
+++ b/soroban-sdk-macros/src/derive_struct_tuple.rs
@@ -99,9 +99,9 @@ pub fn derive_type_struct_tuple(
         None
     };
 
-    // SpecShakingMarker impl - only generated when spec is true and the
-    // experimental_spec_shaking_v2 feature is enabled.
-    let spec_shaking_impl = if cfg!(feature = "experimental_spec_shaking_v2") {
+    // SpecShakingMarker impl - only generated when spec is true and spec
+    // shaking v2 is enabled (the default).
+    let spec_shaking_impl = if !cfg!(feature = "disable_spec_shaking_v2") {
         spec_xdr.as_ref().map(|spec_xdr| {
             shaking::generate_marker_impl(
                 path,

--- a/soroban-sdk-macros/src/lib.rs
+++ b/soroban-sdk-macros/src/lib.rs
@@ -62,17 +62,16 @@ pub(crate) const DEFAULT_XDR_RW_LIMITS: Limits = Limits {
     len: 0x1000000,
 };
 
-/// Emit a deprecation warning when `export` is set with the
-/// `experimental_spec_shaking_v2` feature enabled. Under v2 the spec is
-/// determined by reachability, so the argument has no effect and will be
-/// removed in a future release.
+/// Emit a deprecation warning when `export` is set with spec shaking v2
+/// enabled (the default). Under v2 the spec is determined by reachability, so
+/// the argument has no effect and will be removed in a future release.
 pub(crate) fn export_arg_v2_deprecation(export: &Option<bool>, ident: &syn::Ident) -> TokenStream2 {
-    if cfg!(feature = "experimental_spec_shaking_v2") && export.is_some() {
+    if !cfg!(feature = "disable_spec_shaking_v2") && export.is_some() {
         let marker = format_ident!("__SOROBAN_EXPORT_ARG_DEPRECATED_FOR_{}", ident);
         quote! {
             #[doc(hidden)]
             #[allow(non_upper_case_globals)]
-            #[deprecated = "`export` is a no-op under `experimental_spec_shaking_v2` (specs are determined by reachability) and will be removed in a future release"]
+            #[deprecated = "`export` is a no-op under spec shaking v2 (the default; specs are determined by reachability) and will be removed in a future release"]
             const #marker: () = ();
             const _: () = #marker;
         }
@@ -456,11 +455,11 @@ pub fn contracttype(metadata: TokenStream, input: TokenStream) -> TokenStream {
         Err(e) => return e.to_compile_error().into(),
     }
     let export_deprecation = export_arg_v2_deprecation(&args.export, ident);
-    // Under `experimental_spec_shaking_v2` the spec is always emitted and
+    // Under spec shaking v2 (the default) the spec is always emitted and
     // reachability determines what is retained, so the `export` argument is
     // ignored (a deprecation warning is emitted above). Otherwise, honor an
     // explicit `export` value, falling back to exporting only `pub` types.
-    let gen_spec = if cfg!(feature = "experimental_spec_shaking_v2") {
+    let gen_spec = if !cfg!(feature = "disable_spec_shaking_v2") {
         true
     } else if let Some(export) = args.export {
         export
@@ -533,11 +532,11 @@ pub fn contracterror(metadata: TokenStream, input: TokenStream) -> TokenStream {
     let ident = &input.ident;
     let attrs = &input.attrs;
     let export_deprecation = export_arg_v2_deprecation(&args.export, ident);
-    // Under `experimental_spec_shaking_v2` the spec is always emitted and
+    // Under spec shaking v2 (the default) the spec is always emitted and
     // reachability determines what is retained, so the `export` argument is
     // ignored (a deprecation warning is emitted above). Otherwise, honor an
     // explicit `export` value, falling back to exporting only `pub` types.
-    let gen_spec = if cfg!(feature = "experimental_spec_shaking_v2") {
+    let gen_spec = if !cfg!(feature = "disable_spec_shaking_v2") {
         true
     } else if let Some(export) = args.export {
         export
@@ -726,10 +725,10 @@ pub fn contractimport(metadata: TokenStream) -> TokenStream {
         }
     };
 
-    // Generate with options based on whether the experimental_spec_shaking_v2
-    // feature is enabled.
+    // Generate with options based on whether spec shaking v2 is enabled (the
+    // default; disabled only with `disable_spec_shaking_v2`).
     let opts = GenerateOptions {
-        export: cfg!(feature = "experimental_spec_shaking_v2"),
+        export: !cfg!(feature = "disable_spec_shaking_v2"),
     };
     match generate_from_wasm_with_options(&wasm, &args.file, args.sha256.as_deref(), &opts) {
         Ok(code) => quote! { #code },

--- a/soroban-sdk/Cargo.toml
+++ b/soroban-sdk/Cargo.toml
@@ -67,7 +67,7 @@ trybuild = "1.0.115"
 [features]
 alloc = []
 testutils = ["soroban-sdk-macros/testutils", "soroban-env-host/testutils", "soroban-ledger-snapshot/testutils", "dep:ed25519-dalek", "dep:arbitrary", "dep:derive_arbitrary", "dep:ctor", "dep:soroban-ledger-snapshot"]
-experimental_spec_shaking_v2 = ["soroban-sdk-macros/experimental_spec_shaking_v2"]
+disable_spec_shaking_v2 = ["soroban-sdk-macros/disable_spec_shaking_v2"]
 docs = []
 
 # Umbrella feature that enables all hazmat sub-features (backwards compatible)

--- a/soroban-sdk/build.rs
+++ b/soroban-sdk/build.rs
@@ -20,10 +20,11 @@ pub fn main() {
         println!("cargo:rustc-env=RUSTC_VERSION={rustc_version}");
     }
 
-    // When the experimental_spec_shaking_v2 feature is enabled on a wasm target, check for an
-    // env var from the build system (Stellar CLI) that indicates it supports spec optimization
-    // using markers.
-    if std::env::var("CARGO_FEATURE_EXPERIMENTAL_SPEC_SHAKING_V2").is_ok() {
+    // Spec shaking v2 is the default behavior (active unless the
+    // `disable_spec_shaking_v2` feature is set). When active on a wasm target,
+    // check for an env var from the build system (Stellar CLI) that indicates
+    // it supports spec optimization using markers.
+    if std::env::var("CARGO_FEATURE_DISABLE_SPEC_SHAKING_V2").is_err() {
         let env_name = "SOROBAN_SDK_BUILD_SYSTEM_SUPPORTS_SPEC_SHAKING_V2";
         println!("cargo::rerun-if-env-changed={env_name}");
         if std::env::var(env_name).is_err()
@@ -31,15 +32,17 @@ pub fn main() {
         {
             eprintln!(
                 "\
-\nerror: soroban-sdk feature 'experimental_spec_shaking_v2' requires stellar-cli v25.2.0+\
+\nerror: soroban-sdk spec shaking v2 (the default) requires stellar-cli v25.2.0+\
 \n\
-\nThe soroban-sdk 'experimental_spec_shaking_v2' feature requires building\
-\nwith `stellar contract build` from stellar-cli v25.2.0 or newer.\
+\nspec shaking v2 is now the default behavior of soroban-sdk and requires\
+\nbuilding with `stellar contract build` from stellar-cli v25.2.0 or newer.\
 \n\
 \nTo fix, either:\
 \n  - Build with `stellar contract build` using stellar-cli v25.2.0+\
-\n  - Disable the feature by removing 'experimental_spec_shaking_v2' from\
-\n    the soroban-sdk import features list in Cargo.toml.\
+\n  - Set the SOROBAN_SDK_BUILD_SYSTEM_SUPPORTS_SPEC_SHAKING_V2 env var if\
+\n    your build system supports spec optimization using markers\
+\n  - Opt out of spec shaking v2 by adding 'disable_spec_shaking_v2' to the\
+\n    soroban-sdk import features list in Cargo.toml.\
 "
             );
             std::process::exit(1);

--- a/soroban-sdk/src/_features.rs
+++ b/soroban-sdk/src/_features.rs
@@ -26,12 +26,16 @@
 //! [`Address::from_payload`][crate::Address::from_payload]) that are easy to
 //! misuse. Use with care.
 //!
-//! ## `experimental_spec_shaking_v2`
+//! ## `disable_spec_shaking_v2`
 //!
-//! Enables v2 spec shaking, an improved mechanism for controlling which type,
-//! event, and function definitions appear in a contract's spec.
+//! Spec shaking v2 is an improved mechanism for controlling which type, event,
+//! and function definitions appear in a contract's spec. **It is the default
+//! behavior of the SDK.** The `disable_spec_shaking_v2` feature opts out of v2
+//! and falls back to the legacy v1 behavior. It is provided as a transitional
+//! escape hatch for the v26 release period in case the new default causes
+//! issues, and is expected to be removed in a future release.
 //!
-//! ### Spec Shaking v1 (default, no feature flag)
+//! ### Spec Shaking v1 (opt-out, `disable_spec_shaking_v2` feature)
 //!
 //! - Lib imports (via `contractimport!`): exported
 //! - Wasm imports (via `contractimport!`): not exported
@@ -40,7 +44,7 @@
 //! - All events: exported
 //! - All functions: exported
 //!
-//! ### Spec Shaking v2 (this feature)
+//! ### Spec Shaking v2 (default)
 //!
 //! - Everything exported (types, events, functions, imports)
 //! - Unused entries shaken out using dead code / spec elimination
@@ -53,7 +57,7 @@
 //!
 //! ### How It Works
 //!
-//! When this feature is enabled, the SDK embeds 14-byte **markers** in the Wasm
+//! By default (v2 enabled), the SDK embeds 14-byte **markers** in the Wasm
 //! data section for each exported type and event. A marker consists of a
 //! `SpEcV1` magic prefix followed by 8 bytes of a SHA-256 hash of the spec
 //! entry's XDR.
@@ -78,42 +82,44 @@
 //!
 //! ### Changed Behaviour
 //!
-//! When this feature is enabled the following macros change behaviour:
+//! Relative to the legacy v1 behavior (which is restored by the
+//! `disable_spec_shaking_v2` feature), the following macros behave differently
+//! under the v2 default:
 //!
 //! #### [`contracttype`]
 //!
-//! Without this feature, spec entries are only generated for `pub` types (or
-//! when `export = true` is explicitly set). With this feature, spec entries and
-//! markers are generated for all types regardless of visibility, and post-build
-//! tooling removes entries that are not reachable from the contract interface.
-//! The `export` argument is a no-op under this feature and emits a deprecation
+//! Under v1, spec entries are only generated for `pub` types (or
+//! when `export = true` is explicitly set). Under the v2 default, spec entries
+//! and markers are generated for all types regardless of visibility, and
+//! post-build tooling removes entries that are not reachable from the contract
+//! interface. The `export` argument is a no-op under v2 and emits a deprecation
 //! warning at the macro call site; it will be removed in a future release.
 //!
 //! #### [`contracterror`]
 //!
-//! Same as [`contracttype`]: without this feature, spec entries are only
-//! generated for `pub` types. With this feature, post-build tooling removes
-//! unreachable error enum entries. The `export` argument is a no-op under this
-//! feature and emits a deprecation warning; it will be removed in a future
+//! Same as [`contracttype`]: under v1, spec entries are only
+//! generated for `pub` types. Under the v2 default, post-build tooling removes
+//! unreachable error enum entries. The `export` argument is a no-op under v2
+//! and emits a deprecation warning; it will be removed in a future
 //! release.
 //!
 //! #### [`contractevent`]
 //!
 //! Markers are embedded for all events, allowing post-build tools to strip
 //! spec entries for events that are never published at a contract boundary.
-//! The `export` argument is a no-op under this feature and emits a deprecation
+//! The `export` argument is a no-op under v2 and emits a deprecation
 //! warning; it will be removed in a future release.
 //!
 //! #### [`contractimport!`]
 //!
-//! Without this feature, [`contractimport!`] generates imported types with
+//! Under v1, [`contractimport!`] generates imported types with
 //! `export = false`. Imported types do not produce spec entries in the
 //! importing contract's spec. They are purely local Rust types used for
 //! serialization. The importing contract's spec only contains its own function
 //! definitions, and callers must look at the imported contract's spec to find
 //! the type definitions.
 //!
-//! With this feature, [`contractimport!`] generates imported types without
+//! Under the v2 default, [`contractimport!`] generates imported types without
 //! `export` controls. Imported types produce spec entries and markers in
 //! the importing contract, just like locally defined types. This changes the
 //! contract's spec to be self-contained — it includes the type definitions for
@@ -132,12 +138,14 @@
 //!
 //! ### Build Requirements
 //!
-//! This feature requires building with `stellar contract build` from
-//! `stellar-cli` v25.2.0 or newer. Building a contract for wasm (e.g. with
-//! `cargo build --target wasm32v1-none`) will produce a build error unless the
+//! Because spec shaking v2 is the default, building a contract requires
+//! `stellar contract build` from `stellar-cli` v25.2.0 or newer. Building a
+//! contract for wasm (e.g. with `cargo build --target wasm32v1-none`) will
+//! produce a build error unless the
 //! `SOROBAN_SDK_BUILD_SYSTEM_SUPPORTS_SPEC_SHAKING_V2` environment variable is
 //! set. The check only fires for wasm targets; native builds (e.g. unit tests)
-//! are unaffected.
+//! are unaffected. To avoid these requirements, opt out of v2 with the
+//! `disable_spec_shaking_v2` feature.
 //!
 //! [`contracttype`]: crate::contracttype
 //! [`contracterror`]: crate::contracterror

--- a/soroban-sdk/src/address.rs
+++ b/soroban-sdk/src/address.rs
@@ -215,11 +215,11 @@ impl TryFrom<Address> for AccountId {
 }
 
 #[cfg_attr(
-    feature = "experimental_spec_shaking_v2",
+    not(feature = "disable_spec_shaking_v2"),
     contracttype(crate_path = "crate")
 )]
 #[cfg_attr(
-    not(feature = "experimental_spec_shaking_v2"),
+    feature = "disable_spec_shaking_v2",
     contracttype(crate_path = "crate", export = false)
 )]
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/soroban-sdk/src/auth.rs
+++ b/soroban-sdk/src/auth.rs
@@ -12,11 +12,11 @@ use crate::{
 /// need to be authorized.
 #[derive(Clone)]
 #[cfg_attr(
-    feature = "experimental_spec_shaking_v2",
+    not(feature = "disable_spec_shaking_v2"),
     contracttype(crate_path = "crate")
 )]
 #[cfg_attr(
-    not(feature = "experimental_spec_shaking_v2"),
+    feature = "disable_spec_shaking_v2",
     contracttype(crate_path = "crate", export = false)
 )]
 pub enum Context {
@@ -34,11 +34,11 @@ pub enum Context {
 /// from `contract` function with `fn_name` name and `args` arguments.
 #[derive(Clone)]
 #[cfg_attr(
-    feature = "experimental_spec_shaking_v2",
+    not(feature = "disable_spec_shaking_v2"),
     contracttype(crate_path = "crate")
 )]
 #[cfg_attr(
-    not(feature = "experimental_spec_shaking_v2"),
+    feature = "disable_spec_shaking_v2",
     contracttype(crate_path = "crate", export = false)
 )]
 pub struct ContractContext {
@@ -51,11 +51,11 @@ pub struct ContractContext {
 /// new contract on behalf of authorizer address.
 #[derive(Clone)]
 #[cfg_attr(
-    feature = "experimental_spec_shaking_v2",
+    not(feature = "disable_spec_shaking_v2"),
     contracttype(crate_path = "crate")
 )]
 #[cfg_attr(
-    not(feature = "experimental_spec_shaking_v2"),
+    feature = "disable_spec_shaking_v2",
     contracttype(crate_path = "crate", export = false)
 )]
 pub struct CreateContractHostFnContext {
@@ -69,11 +69,11 @@ pub struct CreateContractHostFnContext {
 /// contract constructor arguments.
 #[derive(Clone)]
 #[cfg_attr(
-    feature = "experimental_spec_shaking_v2",
+    not(feature = "disable_spec_shaking_v2"),
     contracttype(crate_path = "crate")
 )]
 #[cfg_attr(
-    not(feature = "experimental_spec_shaking_v2"),
+    feature = "disable_spec_shaking_v2",
     contracttype(crate_path = "crate", export = false)
 )]
 pub struct CreateContractWithConstructorHostFnContext {
@@ -86,11 +86,11 @@ pub struct CreateContractWithConstructorHostFnContext {
 /// `CreateContractHostFnContext`.
 #[derive(Clone)]
 #[cfg_attr(
-    feature = "experimental_spec_shaking_v2",
+    not(feature = "disable_spec_shaking_v2"),
     contracttype(crate_path = "crate")
 )]
 #[cfg_attr(
-    not(feature = "experimental_spec_shaking_v2"),
+    feature = "disable_spec_shaking_v2",
     contracttype(crate_path = "crate", export = false)
 )]
 pub enum ContractExecutable {
@@ -106,11 +106,11 @@ pub enum ContractExecutable {
 /// current contract.
 #[derive(Clone)]
 #[cfg_attr(
-    feature = "experimental_spec_shaking_v2",
+    not(feature = "disable_spec_shaking_v2"),
     contracttype(crate_path = "crate")
 )]
 #[cfg_attr(
-    not(feature = "experimental_spec_shaking_v2"),
+    feature = "disable_spec_shaking_v2",
     contracttype(crate_path = "crate", export = false)
 )]
 pub enum InvokerContractAuthEntry {
@@ -125,11 +125,11 @@ pub enum InvokerContractAuthEntry {
 /// Value of contract node in InvokerContractAuthEntry tree.
 #[derive(Clone)]
 #[cfg_attr(
-    feature = "experimental_spec_shaking_v2",
+    not(feature = "disable_spec_shaking_v2"),
     contracttype(crate_path = "crate")
 )]
 #[cfg_attr(
-    not(feature = "experimental_spec_shaking_v2"),
+    feature = "disable_spec_shaking_v2",
     contracttype(crate_path = "crate", export = false)
 )]
 pub struct SubContractInvocation {

--- a/soroban-sdk/src/env.rs
+++ b/soroban-sdk/src/env.rs
@@ -290,7 +290,7 @@ impl Env {
     ///
     /// Equivalent to `panic!`, but with an error value instead of a string.
     #[doc(hidden)]
-    #[cfg(feature = "experimental_spec_shaking_v2")]
+    #[cfg(not(feature = "disable_spec_shaking_v2"))]
     #[inline(always)]
     pub fn panic_with_error<I>(&self, error: I) -> !
     where
@@ -304,7 +304,7 @@ impl Env {
     ///
     /// Equivalent to `panic!`, but with an error value instead of a string.
     #[doc(hidden)]
-    #[cfg(not(feature = "experimental_spec_shaking_v2"))]
+    #[cfg(feature = "disable_spec_shaking_v2")]
     #[inline(always)]
     pub fn panic_with_error(&self, error: impl Into<internal::Error>) -> ! {
         self.panic_with_error_inner(error.into())

--- a/soroban-sdk/src/into_val_for_contract_fn.rs
+++ b/soroban-sdk/src/into_val_for_contract_fn.rs
@@ -5,10 +5,11 @@
 //! The trait has a blanket implementation for all types that already implement
 //! IntoVal<Env, Val>.
 //!
-//! When the `experimental_spec_shaking_v2` feature is enabled, this trait also
-//! calls `SpecShakingMarker::spec_shaking_marker()` to ensure that type specs
-//! are included in the WASM when types are used at external boundaries
-//! (function return values).
+//! Spec shaking v2 is the default behavior; under it this trait also calls
+//! `SpecShakingMarker::spec_shaking_marker()` to ensure that type specs are
+//! included in the WASM when types are used at external boundaries (function
+//! return values). The `disable_spec_shaking_v2` feature opts out of this
+//! behavior.
 
 use crate::{Env, IntoVal, Val};
 
@@ -20,7 +21,7 @@ pub trait IntoValForContractFn {
     fn into_val_for_contract_fn(self, env: &Env) -> Val;
 }
 
-#[cfg(feature = "experimental_spec_shaking_v2")]
+#[cfg(not(feature = "disable_spec_shaking_v2"))]
 #[doc(hidden)]
 #[allow(deprecated)]
 impl<T> IntoValForContractFn for T
@@ -33,7 +34,7 @@ where
     }
 }
 
-#[cfg(not(feature = "experimental_spec_shaking_v2"))]
+#[cfg(feature = "disable_spec_shaking_v2")]
 #[doc(hidden)]
 #[allow(deprecated)]
 impl<T> IntoValForContractFn for T

--- a/soroban-sdk/src/lib.rs
+++ b/soroban-sdk/src/lib.rs
@@ -144,7 +144,7 @@ const _: () = {
     // needs to have its spec shaken. See soroban_spec::shaking for constants and version detection.
     // The contractmeta! macro requires string literals, so we assert the literals match the
     // constants defined in soroban_spec::shaking.
-    #[cfg(feature = "experimental_spec_shaking_v2")]
+    #[cfg(not(feature = "disable_spec_shaking_v2"))]
     contractmeta!(key = "rssdk_spec_shaking", val = "2");
 };
 
@@ -223,13 +223,14 @@ pub use soroban_sdk_macros::symbol_short;
 /// for the type. By default, spec entries are only generated for `pub` types
 /// (or when `export = true` is explicitly set).
 ///
-/// ### `experimental_spec_shaking_v2`
+/// ### Spec shaking v2
 ///
-/// When the [`experimental_spec_shaking_v2`][_features#experimental_spec_shaking_v2]
-/// feature is enabled, spec entries are generated for all types regardless of
+/// With spec shaking v2 (the default behavior; opt out with the
+/// [`disable_spec_shaking_v2`][_features#disable_spec_shaking_v2] feature),
+/// spec entries are generated for all types regardless of
 /// visibility, and markers are embedded that allow post-build tools to strip
 /// entries for errors that are neither used at a contract boundary nor thrown
-/// at one. The `export = ...` argument is a no-op under this feature and emits
+/// at one. The `export = ...` argument is a no-op under v2 and emits
 /// a deprecation warning at the macro call site; it will be removed in a future
 /// release. See [`_features`] for details.
 ///
@@ -338,13 +339,14 @@ pub use soroban_sdk_macros::contracterror;
 /// contract.
 /// - Types for all contract types defined in the contract.
 ///
-/// ### `experimental_spec_shaking_v2`
+/// ### Spec shaking v2
 ///
-/// When the [`experimental_spec_shaking_v2`][_features#experimental_spec_shaking_v2]
-/// feature is enabled, imported types are generated with `export = true` so
+/// With spec shaking v2 (the default behavior; opt out with the
+/// [`disable_spec_shaking_v2`][_features#disable_spec_shaking_v2] feature),
+/// imported types are generated with `export = true` so
 /// they produce spec entries and markers in the importing contract. Post-build
 /// tools strip entries for imported types that are not used at the importing
-/// contract's boundary. Without this feature, imported types use
+/// contract's boundary. When v2 is disabled, imported types use
 /// `export = false` and do not produce spec entries. See [`_features`] for
 /// details.
 ///
@@ -647,13 +649,14 @@ pub use soroban_sdk_macros::contractmeta;
 /// for the type. By default, spec entries are only generated for `pub` types
 /// (or when `export = true` is explicitly set).
 ///
-/// ### `experimental_spec_shaking_v2`
+/// ### Spec shaking v2
 ///
-/// When the [`experimental_spec_shaking_v2`][_features#experimental_spec_shaking_v2]
-/// feature is enabled, spec entries are generated for all types regardless of
+/// With spec shaking v2 (the default behavior; opt out with the
+/// [`disable_spec_shaking_v2`][_features#disable_spec_shaking_v2] feature),
+/// spec entries are generated for all types regardless of
 /// visibility, and markers are embedded that allow post-build tools to strip
 /// entries for types that are not used at a contract boundary. The
-/// `export = ...` argument is a no-op under this feature and emits a
+/// `export = ...` argument is a no-op under v2 and emits a
 /// deprecation warning at the macro call site; it will be removed in a future
 /// release. See [`_features`] for details.
 ///
@@ -804,12 +807,13 @@ pub use soroban_sdk_macros::contracttype;
 /// Includes the event in the contract spec so that clients can generate bindings
 /// for the type and downstream systems can understand the meaning of the event.
 ///
-/// ### `experimental_spec_shaking_v2`
+/// ### Spec shaking v2
 ///
-/// When the [`experimental_spec_shaking_v2`][_features#experimental_spec_shaking_v2]
-/// feature is enabled, markers are embedded that allow post-build tools to strip
+/// With spec shaking v2 (the default behavior; opt out with the
+/// [`disable_spec_shaking_v2`][_features#disable_spec_shaking_v2] feature),
+/// markers are embedded that allow post-build tools to strip
 /// spec entries for events that are never published at a contract boundary. The
-/// `export = ...` argument is a no-op under this feature and emits a
+/// `export = ...` argument is a no-op under v2 and emits a
 /// deprecation warning at the macro call site; it will be removed in a future
 /// release. See [`_features`] for details.
 ///
@@ -1231,9 +1235,9 @@ mod into_val_for_contract_fn;
 #[allow(deprecated)]
 pub use into_val_for_contract_fn::IntoValForContractFn;
 
-#[cfg(feature = "experimental_spec_shaking_v2")]
+#[cfg(not(feature = "disable_spec_shaking_v2"))]
 mod spec_shaking;
-#[cfg(feature = "experimental_spec_shaking_v2")]
+#[cfg(not(feature = "disable_spec_shaking_v2"))]
 #[doc(hidden)]
 pub use spec_shaking::SpecShakingMarker;
 

--- a/soroban-sdk/src/try_from_val_for_contract_fn.rs
+++ b/soroban-sdk/src/try_from_val_for_contract_fn.rs
@@ -14,9 +14,10 @@
 //! is most appropriate. For types that should only be used and converted to as
 //! part of contract function invocation, then this trait is appropriate.
 //!
-//! When the `experimental_spec_shaking_v2` feature is enabled, this trait also
-//! calls `SpecShakingMarker::spec_shaking_marker()` to ensure that type specs
-//! are included in the WASM when types are used at external boundaries.
+//! Spec shaking v2 is the default behavior; under it this trait also calls
+//! `SpecShakingMarker::spec_shaking_marker()` to ensure that type specs are
+//! included in the WASM when types are used at external boundaries. The
+//! `disable_spec_shaking_v2` feature opts out of this behavior.
 
 use crate::{env::internal::Env, Error, TryFromVal};
 use core::fmt::Debug;
@@ -30,7 +31,7 @@ pub trait TryFromValForContractFn<E: Env, V: ?Sized>: Sized {
     fn try_from_val_for_contract_fn(env: &E, v: &V) -> Result<Self, Self::Error>;
 }
 
-#[cfg(feature = "experimental_spec_shaking_v2")]
+#[cfg(not(feature = "disable_spec_shaking_v2"))]
 #[doc(hidden)]
 #[allow(deprecated)]
 impl<E: Env, T, U> TryFromValForContractFn<E, T> for U
@@ -44,7 +45,7 @@ where
     }
 }
 
-#[cfg(not(feature = "experimental_spec_shaking_v2"))]
+#[cfg(feature = "disable_spec_shaking_v2")]
 #[doc(hidden)]
 #[allow(deprecated)]
 impl<E: Env, T, U> TryFromValForContractFn<E, T> for U

--- a/tests-expanded/test_spec_lib_tests.rs
+++ b/tests-expanded/test_spec_lib_tests.rs
@@ -53,6 +53,14 @@ impl StructA {
         *b"\0\0\0\x01\0\0\0\0\0\0\0\0\0\0\0\x07StructA\0\0\0\0\x02\0\0\0\0\0\0\0\x02f1\0\0\0\0\0\x04\0\0\0\0\0\0\0\x02f2\0\0\0\0\0\x01"
     }
 }
+impl soroban_sdk::SpecShakingMarker for StructA {
+    #[doc(hidden)]
+    #[inline(always)]
+    fn spec_shaking_marker() {
+        <u32 as soroban_sdk::SpecShakingMarker>::spec_shaking_marker();
+        <bool as soroban_sdk::SpecShakingMarker>::spec_shaking_marker();
+    }
+}
 impl soroban_sdk::TryFromVal<soroban_sdk::Env, soroban_sdk::Val> for StructA {
     type Error = soroban_sdk::ConversionError;
     fn try_from_val(
@@ -459,6 +467,14 @@ pub static __SPEC_XDR_TYPE_STRUCTB: [u8; 60usize] = StructB::spec_xdr();
 impl StructB {
     pub const fn spec_xdr() -> [u8; 60usize] {
         *b"\0\0\0\x01\0\0\0\0\0\0\0\0\0\0\0\x07StructB\0\0\0\0\x02\0\0\0\0\0\0\0\x02f1\0\0\0\0\0\x07\0\0\0\0\0\0\0\x02f2\0\0\0\0\0\x10"
+    }
+}
+impl soroban_sdk::SpecShakingMarker for StructB {
+    #[doc(hidden)]
+    #[inline(always)]
+    fn spec_shaking_marker() {
+        <i64 as soroban_sdk::SpecShakingMarker>::spec_shaking_marker();
+        <soroban_sdk::String as soroban_sdk::SpecShakingMarker>::spec_shaking_marker();
     }
 }
 impl soroban_sdk::TryFromVal<soroban_sdk::Env, soroban_sdk::Val> for StructB {
@@ -869,6 +885,14 @@ impl StructC {
         *b"\0\0\0\x01\0\0\0\0\0\0\0\0\0\0\0\x07StructC\0\0\0\0\x02\0\0\0\0\0\0\0\x02f1\0\0\0\0\x03\xea\0\0\0\x04\0\0\0\0\0\0\0\x02f2\0\0\0\0\0\x13"
     }
 }
+impl soroban_sdk::SpecShakingMarker for StructC {
+    #[doc(hidden)]
+    #[inline(always)]
+    fn spec_shaking_marker() {
+        <Vec<u32> as soroban_sdk::SpecShakingMarker>::spec_shaking_marker();
+        <Address as soroban_sdk::SpecShakingMarker>::spec_shaking_marker();
+    }
+}
 impl soroban_sdk::TryFromVal<soroban_sdk::Env, soroban_sdk::Val> for StructC {
     type Error = soroban_sdk::ConversionError;
     fn try_from_val(
@@ -1273,6 +1297,14 @@ impl StructTupleA {
         *b"\0\0\0\x01\0\0\0\0\0\0\0\0\0\0\0\x0cStructTupleA\0\0\0\x02\0\0\0\0\0\0\0\x010\0\0\0\0\0\0\x07\0\0\0\0\0\0\0\x011\0\0\0\0\0\0\x07"
     }
 }
+impl soroban_sdk::SpecShakingMarker for StructTupleA {
+    #[doc(hidden)]
+    #[inline(always)]
+    fn spec_shaking_marker() {
+        <i64 as soroban_sdk::SpecShakingMarker>::spec_shaking_marker();
+        <i64 as soroban_sdk::SpecShakingMarker>::spec_shaking_marker();
+    }
+}
 impl soroban_sdk::TryFromVal<soroban_sdk::Env, soroban_sdk::Val> for StructTupleA {
     type Error = soroban_sdk::ConversionError;
     #[inline(always)]
@@ -1639,6 +1671,14 @@ pub static __SPEC_XDR_TYPE_STRUCTTUPLEB: [u8; 64usize] = StructTupleB::spec_xdr(
 impl StructTupleB {
     pub const fn spec_xdr() -> [u8; 64usize] {
         *b"\0\0\0\x01\0\0\0\0\0\0\0\0\0\0\0\x0cStructTupleB\0\0\0\x02\0\0\0\0\0\0\0\x010\0\0\0\0\0\0\n\0\0\0\0\0\0\0\x011\0\0\0\0\0\0\n"
+    }
+}
+impl soroban_sdk::SpecShakingMarker for StructTupleB {
+    #[doc(hidden)]
+    #[inline(always)]
+    fn spec_shaking_marker() {
+        <u128 as soroban_sdk::SpecShakingMarker>::spec_shaking_marker();
+        <u128 as soroban_sdk::SpecShakingMarker>::spec_shaking_marker();
     }
 }
 impl soroban_sdk::TryFromVal<soroban_sdk::Env, soroban_sdk::Val> for StructTupleB {
@@ -2008,6 +2048,14 @@ pub static __SPEC_XDR_TYPE_STRUCTTUPLEC: [u8; 64usize] = StructTupleC::spec_xdr(
 impl StructTupleC {
     pub const fn spec_xdr() -> [u8; 64usize] {
         *b"\0\0\0\x01\0\0\0\0\0\0\0\0\0\0\0\x0cStructTupleC\0\0\0\x02\0\0\0\0\0\0\0\x010\0\0\0\0\0\0\x13\0\0\0\0\0\0\0\x011\0\0\0\0\0\0\x0b"
+    }
+}
+impl soroban_sdk::SpecShakingMarker for StructTupleC {
+    #[doc(hidden)]
+    #[inline(always)]
+    fn spec_shaking_marker() {
+        <Address as soroban_sdk::SpecShakingMarker>::spec_shaking_marker();
+        <i128 as soroban_sdk::SpecShakingMarker>::spec_shaking_marker();
     }
 }
 impl soroban_sdk::TryFromVal<soroban_sdk::Env, soroban_sdk::Val> for StructTupleC {
@@ -2389,6 +2437,11 @@ impl EnumA {
     pub const fn spec_xdr() -> [u8; 76usize] {
         *b"\0\0\0\x02\0\0\0\0\0\0\0\0\0\0\0\x05EnumA\0\0\0\0\0\0\x03\0\0\0\0\0\0\0\0\0\0\0\x02V1\0\0\0\0\0\0\0\0\0\0\0\0\0\x02V2\0\0\0\0\0\0\0\0\0\0\0\0\0\x02V3\0\0"
     }
+}
+impl soroban_sdk::SpecShakingMarker for EnumA {
+    #[doc(hidden)]
+    #[inline(always)]
+    fn spec_shaking_marker() {}
 }
 impl soroban_sdk::TryFromVal<soroban_sdk::Env, soroban_sdk::Val> for EnumA {
     type Error = soroban_sdk::ConversionError;
@@ -2853,6 +2906,13 @@ pub static __SPEC_XDR_TYPE_ENUMB: [u8; 96usize] = EnumB::spec_xdr();
 impl EnumB {
     pub const fn spec_xdr() -> [u8; 96usize] {
         *b"\0\0\0\x02\0\0\0\0\0\0\0\0\0\0\0\x05EnumB\0\0\0\0\0\0\x03\0\0\0\0\0\0\0\0\0\0\0\x02V1\0\0\0\0\0\x01\0\0\0\0\0\0\0\x02V2\0\0\0\0\0\x01\0\0\0\x07\0\0\0\x01\0\0\0\0\0\0\0\x02V3\0\0\0\0\0\x02\0\0\0\x07\0\0\0\x07"
+    }
+}
+impl soroban_sdk::SpecShakingMarker for EnumB {
+    #[doc(hidden)]
+    #[inline(always)]
+    fn spec_shaking_marker() {
+        <i64 as soroban_sdk::SpecShakingMarker>::spec_shaking_marker();
     }
 }
 impl soroban_sdk::TryFromVal<soroban_sdk::Env, soroban_sdk::Val> for EnumB {
@@ -3442,6 +3502,14 @@ impl EnumC {
         *b"\0\0\0\x02\0\0\0\0\0\0\0\0\0\0\0\x05EnumC\0\0\0\0\0\0\x03\0\0\0\0\0\0\0\0\0\0\0\x02V1\0\0\0\0\0\x01\0\0\0\0\0\0\0\x02V2\0\0\0\0\0\x01\0\0\x07\xd0\0\0\0\x07StructA\0\0\0\0\x01\0\0\0\0\0\0\0\x02V3\0\0\0\0\0\x01\0\0\x07\xd0\0\0\0\x0cStructTupleA"
     }
 }
+impl soroban_sdk::SpecShakingMarker for EnumC {
+    #[doc(hidden)]
+    #[inline(always)]
+    fn spec_shaking_marker() {
+        <StructA as soroban_sdk::SpecShakingMarker>::spec_shaking_marker();
+        <StructTupleA as soroban_sdk::SpecShakingMarker>::spec_shaking_marker();
+    }
+}
 impl soroban_sdk::TryFromVal<soroban_sdk::Env, soroban_sdk::Val> for EnumC {
     type Error = soroban_sdk::ConversionError;
     #[inline(always)]
@@ -3980,6 +4048,11 @@ impl EnumIntA {
         *b"\0\0\0\x03\0\0\0\0\0\0\0\0\0\0\0\x08EnumIntA\0\0\0\x03\0\0\0\0\0\0\0\x02V1\0\0\0\0\0\x01\0\0\0\0\0\0\0\x02V2\0\0\0\0\0\x02\0\0\0\0\0\0\0\x02V3\0\0\0\0\0\x03"
     }
 }
+impl soroban_sdk::SpecShakingMarker for EnumIntA {
+    #[doc(hidden)]
+    #[inline(always)]
+    fn spec_shaking_marker() {}
+}
 impl soroban_sdk::TryFromVal<soroban_sdk::Env, soroban_sdk::Val> for EnumIntA {
     type Error = soroban_sdk::ConversionError;
     #[inline(always)]
@@ -4317,6 +4390,11 @@ impl EnumIntB {
     pub const fn spec_xdr() -> [u8; 76usize] {
         *b"\0\0\0\x03\0\0\0\0\0\0\0\0\0\0\0\x08EnumIntB\0\0\0\x03\0\0\0\0\0\0\0\x02V1\0\0\0\0\0\n\0\0\0\0\0\0\0\x02V2\0\0\0\0\0\x14\0\0\0\0\0\0\0\x02V3\0\0\0\0\0\x1e"
     }
+}
+impl soroban_sdk::SpecShakingMarker for EnumIntB {
+    #[doc(hidden)]
+    #[inline(always)]
+    fn spec_shaking_marker() {}
 }
 impl soroban_sdk::TryFromVal<soroban_sdk::Env, soroban_sdk::Val> for EnumIntB {
     type Error = soroban_sdk::ConversionError;
@@ -4656,6 +4734,11 @@ impl EnumIntC {
         *b"\0\0\0\x03\0\0\0\0\0\0\0\0\0\0\0\x08EnumIntC\0\0\0\x03\0\0\0\0\0\0\0\x02V1\0\0\0\0\0d\0\0\0\0\0\0\0\x02V2\0\0\0\0\0\xc8\0\0\0\0\0\0\0\x02V3\0\0\0\0\x01,"
     }
 }
+impl soroban_sdk::SpecShakingMarker for EnumIntC {
+    #[doc(hidden)]
+    #[inline(always)]
+    fn spec_shaking_marker() {}
+}
 impl soroban_sdk::TryFromVal<soroban_sdk::Env, soroban_sdk::Val> for EnumIntC {
     type Error = soroban_sdk::ConversionError;
     #[inline(always)]
@@ -4994,6 +5077,11 @@ impl ErrorA {
         *b"\0\0\0\x04\0\0\0\0\0\0\0\0\0\0\0\x06ErrorA\0\0\0\0\0\x03\0\0\0\0\0\0\0\x02E1\0\0\0\0\0\x01\0\0\0\0\0\0\0\x02E2\0\0\0\0\0\x02\0\0\0\0\0\0\0\x02E3\0\0\0\0\0\x03"
     }
 }
+impl soroban_sdk::SpecShakingMarker for ErrorA {
+    #[doc(hidden)]
+    #[inline(always)]
+    fn spec_shaking_marker() {}
+}
 impl TryFrom<soroban_sdk::Error> for ErrorA {
     type Error = soroban_sdk::Error;
     #[inline(always)]
@@ -5156,6 +5244,11 @@ impl ErrorB {
     pub const fn spec_xdr() -> [u8; 76usize] {
         *b"\0\0\0\x04\0\0\0\0\0\0\0\0\0\0\0\x06ErrorB\0\0\0\0\0\x03\0\0\0\0\0\0\0\x02E1\0\0\0\0\0\n\0\0\0\0\0\0\0\x02E2\0\0\0\0\0\x0b\0\0\0\0\0\0\0\x02E3\0\0\0\0\0\x0c"
     }
+}
+impl soroban_sdk::SpecShakingMarker for ErrorB {
+    #[doc(hidden)]
+    #[inline(always)]
+    fn spec_shaking_marker() {}
 }
 impl TryFrom<soroban_sdk::Error> for ErrorB {
     type Error = soroban_sdk::Error;
@@ -5320,6 +5413,11 @@ impl ErrorC {
         *b"\0\0\0\x04\0\0\0\0\0\0\0\0\0\0\0\x06ErrorC\0\0\0\0\0\x03\0\0\0\0\0\0\0\x02E1\0\0\0\0\0d\0\0\0\0\0\0\0\x02E2\0\0\0\0\0e\0\0\0\0\0\0\0\x02E3\0\0\0\0\0f"
     }
 }
+impl soroban_sdk::SpecShakingMarker for ErrorC {
+    #[doc(hidden)]
+    #[inline(always)]
+    fn spec_shaking_marker() {}
+}
 impl TryFrom<soroban_sdk::Error> for ErrorC {
     type Error = soroban_sdk::Error;
     #[inline(always)]
@@ -5479,6 +5577,14 @@ impl EventA {
         *b"\0\0\0\x05\0\0\0\0\0\0\0\0\0\0\0\x06EventA\0\0\0\0\0\x01\0\0\0\x07event_a\0\0\0\0\x02\0\0\0\0\0\0\0\x02f1\0\0\0\0\0\x13\0\0\0\x01\0\0\0\0\0\0\0\x02f2\0\0\0\0\0\x10\0\0\0\0\0\0\0\x02"
     }
 }
+impl soroban_sdk::SpecShakingMarker for EventA {
+    #[doc(hidden)]
+    #[inline(always)]
+    fn spec_shaking_marker() {
+        <Address as soroban_sdk::SpecShakingMarker>::spec_shaking_marker();
+        <soroban_sdk::String as soroban_sdk::SpecShakingMarker>::spec_shaking_marker();
+    }
+}
 impl soroban_sdk::Event for EventA {
     fn topics(&self, env: &soroban_sdk::Env) -> soroban_sdk::Vec<soroban_sdk::Val> {
         use soroban_sdk::IntoVal;
@@ -5506,6 +5612,7 @@ impl soroban_sdk::Event for EventA {
 }
 impl EventA {
     pub fn publish(&self, env: &soroban_sdk::Env) {
+        <Self as soroban_sdk::SpecShakingMarker>::spec_shaking_marker();
         <_ as soroban_sdk::Event>::publish(self, env);
     }
 }
@@ -5559,6 +5666,15 @@ impl EventB {
         *b"\0\0\0\x05\0\0\0\0\0\0\0\0\0\0\0\x06EventB\0\0\0\0\0\x01\0\0\0\x07event_b\0\0\0\0\x03\0\0\0\0\0\0\0\x02f1\0\0\0\0\0\x13\0\0\0\x01\0\0\0\0\0\0\0\x02f2\0\0\0\0\0\x13\0\0\0\x01\0\0\0\0\0\0\0\x02f3\0\0\0\0\0\x0b\0\0\0\0\0\0\0\x02"
     }
 }
+impl soroban_sdk::SpecShakingMarker for EventB {
+    #[doc(hidden)]
+    #[inline(always)]
+    fn spec_shaking_marker() {
+        <Address as soroban_sdk::SpecShakingMarker>::spec_shaking_marker();
+        <Address as soroban_sdk::SpecShakingMarker>::spec_shaking_marker();
+        <i128 as soroban_sdk::SpecShakingMarker>::spec_shaking_marker();
+    }
+}
 impl soroban_sdk::Event for EventB {
     fn topics(&self, env: &soroban_sdk::Env) -> soroban_sdk::Vec<soroban_sdk::Val> {
         use soroban_sdk::IntoVal;
@@ -5590,6 +5706,7 @@ impl soroban_sdk::Event for EventB {
 }
 impl EventB {
     pub fn publish(&self, env: &soroban_sdk::Env) {
+        <Self as soroban_sdk::SpecShakingMarker>::spec_shaking_marker();
         <_ as soroban_sdk::Event>::publish(self, env);
     }
 }
@@ -5643,6 +5760,15 @@ impl EventC {
         *b"\0\0\0\x05\0\0\0\0\0\0\0\0\0\0\0\x06EventC\0\0\0\0\0\x01\0\0\0\x07event_c\0\0\0\0\x03\0\0\0\0\0\0\0\x02f1\0\0\0\0\0\x11\0\0\0\x01\0\0\0\0\0\0\0\x02f2\0\0\0\0\0\x07\0\0\0\0\0\0\0\0\0\0\0\x02f3\0\0\0\0\0\x07\0\0\0\0\0\0\0\x02"
     }
 }
+impl soroban_sdk::SpecShakingMarker for EventC {
+    #[doc(hidden)]
+    #[inline(always)]
+    fn spec_shaking_marker() {
+        <soroban_sdk::Symbol as soroban_sdk::SpecShakingMarker>::spec_shaking_marker();
+        <i64 as soroban_sdk::SpecShakingMarker>::spec_shaking_marker();
+        <i64 as soroban_sdk::SpecShakingMarker>::spec_shaking_marker();
+    }
+}
 impl soroban_sdk::Event for EventC {
     fn topics(&self, env: &soroban_sdk::Env) -> soroban_sdk::Vec<soroban_sdk::Val> {
         use soroban_sdk::IntoVal;
@@ -5670,6 +5796,7 @@ impl soroban_sdk::Event for EventC {
 }
 impl EventC {
     pub fn publish(&self, env: &soroban_sdk::Env) {
+        <Self as soroban_sdk::SpecShakingMarker>::spec_shaking_marker();
         <_ as soroban_sdk::Event>::publish(self, env);
     }
 }

--- a/tests-expanded/test_spec_lib_wasm32v1-none.rs
+++ b/tests-expanded/test_spec_lib_wasm32v1-none.rs
@@ -54,6 +54,18 @@ impl StructA {
         *b"\0\0\0\x01\0\0\0\0\0\0\0\0\0\0\0\x07StructA\0\0\0\0\x02\0\0\0\0\0\0\0\x02f1\0\0\0\0\0\x04\0\0\0\0\0\0\0\x02f2\0\0\0\0\0\x01"
     }
 }
+impl soroban_sdk::SpecShakingMarker for StructA {
+    #[doc(hidden)]
+    #[inline(always)]
+    fn spec_shaking_marker() {
+        <u32 as soroban_sdk::SpecShakingMarker>::spec_shaking_marker();
+        <bool as soroban_sdk::SpecShakingMarker>::spec_shaking_marker();
+        {
+            static MARKER: [u8; 14usize] = *b"SpEcV1\xb6\x1c\xfd\xdfhY-d";
+            let _ = unsafe { ::core::ptr::read_volatile(MARKER.as_ptr()) };
+        }
+    }
+}
 impl soroban_sdk::TryFromVal<soroban_sdk::Env, soroban_sdk::Val> for StructA {
     type Error = soroban_sdk::ConversionError;
     fn try_from_val(
@@ -151,6 +163,18 @@ pub static __SPEC_XDR_TYPE_STRUCTB: [u8; 60usize] = StructB::spec_xdr();
 impl StructB {
     pub const fn spec_xdr() -> [u8; 60usize] {
         *b"\0\0\0\x01\0\0\0\0\0\0\0\0\0\0\0\x07StructB\0\0\0\0\x02\0\0\0\0\0\0\0\x02f1\0\0\0\0\0\x07\0\0\0\0\0\0\0\x02f2\0\0\0\0\0\x10"
+    }
+}
+impl soroban_sdk::SpecShakingMarker for StructB {
+    #[doc(hidden)]
+    #[inline(always)]
+    fn spec_shaking_marker() {
+        <i64 as soroban_sdk::SpecShakingMarker>::spec_shaking_marker();
+        <soroban_sdk::String as soroban_sdk::SpecShakingMarker>::spec_shaking_marker();
+        {
+            static MARKER: [u8; 14usize] = *b"SpEcV1\xf3\xc4\xd3\x8c\xc1w\xe9\x18";
+            let _ = unsafe { ::core::ptr::read_volatile(MARKER.as_ptr()) };
+        }
     }
 }
 impl soroban_sdk::TryFromVal<soroban_sdk::Env, soroban_sdk::Val> for StructB {
@@ -252,6 +276,18 @@ impl StructC {
         *b"\0\0\0\x01\0\0\0\0\0\0\0\0\0\0\0\x07StructC\0\0\0\0\x02\0\0\0\0\0\0\0\x02f1\0\0\0\0\x03\xea\0\0\0\x04\0\0\0\0\0\0\0\x02f2\0\0\0\0\0\x13"
     }
 }
+impl soroban_sdk::SpecShakingMarker for StructC {
+    #[doc(hidden)]
+    #[inline(always)]
+    fn spec_shaking_marker() {
+        <Vec<u32> as soroban_sdk::SpecShakingMarker>::spec_shaking_marker();
+        <Address as soroban_sdk::SpecShakingMarker>::spec_shaking_marker();
+        {
+            static MARKER: [u8; 14usize] = *b"SpEcV1\xa3\x16\n\x8f\xc9\x92\xd2\x11";
+            let _ = unsafe { ::core::ptr::read_volatile(MARKER.as_ptr()) };
+        }
+    }
+}
 impl soroban_sdk::TryFromVal<soroban_sdk::Env, soroban_sdk::Val> for StructC {
     type Error = soroban_sdk::ConversionError;
     fn try_from_val(
@@ -345,6 +381,18 @@ impl StructTupleA {
         *b"\0\0\0\x01\0\0\0\0\0\0\0\0\0\0\0\x0cStructTupleA\0\0\0\x02\0\0\0\0\0\0\0\x010\0\0\0\0\0\0\x07\0\0\0\0\0\0\0\x011\0\0\0\0\0\0\x07"
     }
 }
+impl soroban_sdk::SpecShakingMarker for StructTupleA {
+    #[doc(hidden)]
+    #[inline(always)]
+    fn spec_shaking_marker() {
+        <i64 as soroban_sdk::SpecShakingMarker>::spec_shaking_marker();
+        <i64 as soroban_sdk::SpecShakingMarker>::spec_shaking_marker();
+        {
+            static MARKER: [u8; 14usize] = *b"SpEcV1\xcf)\x97]S\xb2\xfd)";
+            let _ = unsafe { ::core::ptr::read_volatile(MARKER.as_ptr()) };
+        }
+    }
+}
 impl soroban_sdk::TryFromVal<soroban_sdk::Env, soroban_sdk::Val> for StructTupleA {
     type Error = soroban_sdk::ConversionError;
     #[inline(always)]
@@ -432,6 +480,18 @@ pub static __SPEC_XDR_TYPE_STRUCTTUPLEB: [u8; 64usize] = StructTupleB::spec_xdr(
 impl StructTupleB {
     pub const fn spec_xdr() -> [u8; 64usize] {
         *b"\0\0\0\x01\0\0\0\0\0\0\0\0\0\0\0\x0cStructTupleB\0\0\0\x02\0\0\0\0\0\0\0\x010\0\0\0\0\0\0\n\0\0\0\0\0\0\0\x011\0\0\0\0\0\0\n"
+    }
+}
+impl soroban_sdk::SpecShakingMarker for StructTupleB {
+    #[doc(hidden)]
+    #[inline(always)]
+    fn spec_shaking_marker() {
+        <u128 as soroban_sdk::SpecShakingMarker>::spec_shaking_marker();
+        <u128 as soroban_sdk::SpecShakingMarker>::spec_shaking_marker();
+        {
+            static MARKER: [u8; 14usize] = *b"SpEcV1x\xd98\x9c\x1ao\xac\x8c";
+            let _ = unsafe { ::core::ptr::read_volatile(MARKER.as_ptr()) };
+        }
     }
 }
 impl soroban_sdk::TryFromVal<soroban_sdk::Env, soroban_sdk::Val> for StructTupleB {
@@ -522,6 +582,18 @@ pub static __SPEC_XDR_TYPE_STRUCTTUPLEC: [u8; 64usize] = StructTupleC::spec_xdr(
 impl StructTupleC {
     pub const fn spec_xdr() -> [u8; 64usize] {
         *b"\0\0\0\x01\0\0\0\0\0\0\0\0\0\0\0\x0cStructTupleC\0\0\0\x02\0\0\0\0\0\0\0\x010\0\0\0\0\0\0\x13\0\0\0\0\0\0\0\x011\0\0\0\0\0\0\x0b"
+    }
+}
+impl soroban_sdk::SpecShakingMarker for StructTupleC {
+    #[doc(hidden)]
+    #[inline(always)]
+    fn spec_shaking_marker() {
+        <Address as soroban_sdk::SpecShakingMarker>::spec_shaking_marker();
+        <i128 as soroban_sdk::SpecShakingMarker>::spec_shaking_marker();
+        {
+            static MARKER: [u8; 14usize] = *b"SpEcV1\xc5=\x81\xc1\"\xafT\xd9";
+            let _ = unsafe { ::core::ptr::read_volatile(MARKER.as_ptr()) };
+        }
     }
 }
 impl soroban_sdk::TryFromVal<soroban_sdk::Env, soroban_sdk::Val> for StructTupleC {
@@ -623,6 +695,16 @@ pub static __SPEC_XDR_TYPE_ENUMA: [u8; 76usize] = EnumA::spec_xdr();
 impl EnumA {
     pub const fn spec_xdr() -> [u8; 76usize] {
         *b"\0\0\0\x02\0\0\0\0\0\0\0\0\0\0\0\x05EnumA\0\0\0\0\0\0\x03\0\0\0\0\0\0\0\0\0\0\0\x02V1\0\0\0\0\0\0\0\0\0\0\0\0\0\x02V2\0\0\0\0\0\0\0\0\0\0\0\0\0\x02V3\0\0"
+    }
+}
+impl soroban_sdk::SpecShakingMarker for EnumA {
+    #[doc(hidden)]
+    #[inline(always)]
+    fn spec_shaking_marker() {
+        {
+            static MARKER: [u8; 14usize] = *b"SpEcV1\xa2=N\xc1p\x95\x90\xb2";
+            let _ = unsafe { ::core::ptr::read_volatile(MARKER.as_ptr()) };
+        }
     }
 }
 impl soroban_sdk::TryFromVal<soroban_sdk::Env, soroban_sdk::Val> for EnumA {
@@ -770,6 +852,17 @@ pub static __SPEC_XDR_TYPE_ENUMB: [u8; 96usize] = EnumB::spec_xdr();
 impl EnumB {
     pub const fn spec_xdr() -> [u8; 96usize] {
         *b"\0\0\0\x02\0\0\0\0\0\0\0\0\0\0\0\x05EnumB\0\0\0\0\0\0\x03\0\0\0\0\0\0\0\0\0\0\0\x02V1\0\0\0\0\0\x01\0\0\0\0\0\0\0\x02V2\0\0\0\0\0\x01\0\0\0\x07\0\0\0\x01\0\0\0\0\0\0\0\x02V3\0\0\0\0\0\x02\0\0\0\x07\0\0\0\x07"
+    }
+}
+impl soroban_sdk::SpecShakingMarker for EnumB {
+    #[doc(hidden)]
+    #[inline(always)]
+    fn spec_shaking_marker() {
+        <i64 as soroban_sdk::SpecShakingMarker>::spec_shaking_marker();
+        {
+            static MARKER: [u8; 14usize] = *b"SpEcV1'\x1b\0DSH^\xcc";
+            let _ = unsafe { ::core::ptr::read_volatile(MARKER.as_ptr()) };
+        }
     }
 }
 impl soroban_sdk::TryFromVal<soroban_sdk::Env, soroban_sdk::Val> for EnumB {
@@ -931,6 +1024,18 @@ impl EnumC {
         *b"\0\0\0\x02\0\0\0\0\0\0\0\0\0\0\0\x05EnumC\0\0\0\0\0\0\x03\0\0\0\0\0\0\0\0\0\0\0\x02V1\0\0\0\0\0\x01\0\0\0\0\0\0\0\x02V2\0\0\0\0\0\x01\0\0\x07\xd0\0\0\0\x07StructA\0\0\0\0\x01\0\0\0\0\0\0\0\x02V3\0\0\0\0\0\x01\0\0\x07\xd0\0\0\0\x0cStructTupleA"
     }
 }
+impl soroban_sdk::SpecShakingMarker for EnumC {
+    #[doc(hidden)]
+    #[inline(always)]
+    fn spec_shaking_marker() {
+        <StructA as soroban_sdk::SpecShakingMarker>::spec_shaking_marker();
+        <StructTupleA as soroban_sdk::SpecShakingMarker>::spec_shaking_marker();
+        {
+            static MARKER: [u8; 14usize] = *b"SpEcV1\xa0\xdd\x8f\xdc\xc9W\xbe\xc2";
+            let _ = unsafe { ::core::ptr::read_volatile(MARKER.as_ptr()) };
+        }
+    }
+}
 impl soroban_sdk::TryFromVal<soroban_sdk::Env, soroban_sdk::Val> for EnumC {
     type Error = soroban_sdk::ConversionError;
     #[inline(always)]
@@ -1075,6 +1180,16 @@ impl EnumIntA {
         *b"\0\0\0\x03\0\0\0\0\0\0\0\0\0\0\0\x08EnumIntA\0\0\0\x03\0\0\0\0\0\0\0\x02V1\0\0\0\0\0\x01\0\0\0\0\0\0\0\x02V2\0\0\0\0\0\x02\0\0\0\0\0\0\0\x02V3\0\0\0\0\0\x03"
     }
 }
+impl soroban_sdk::SpecShakingMarker for EnumIntA {
+    #[doc(hidden)]
+    #[inline(always)]
+    fn spec_shaking_marker() {
+        {
+            static MARKER: [u8; 14usize] = *b"SpEcV1V]\x80\\~\x1a\x08/";
+            let _ = unsafe { ::core::ptr::read_volatile(MARKER.as_ptr()) };
+        }
+    }
+}
 impl soroban_sdk::TryFromVal<soroban_sdk::Env, soroban_sdk::Val> for EnumIntA {
     type Error = soroban_sdk::ConversionError;
     #[inline(always)]
@@ -1167,6 +1282,16 @@ pub static __SPEC_XDR_TYPE_ENUMINTB: [u8; 76usize] = EnumIntB::spec_xdr();
 impl EnumIntB {
     pub const fn spec_xdr() -> [u8; 76usize] {
         *b"\0\0\0\x03\0\0\0\0\0\0\0\0\0\0\0\x08EnumIntB\0\0\0\x03\0\0\0\0\0\0\0\x02V1\0\0\0\0\0\n\0\0\0\0\0\0\0\x02V2\0\0\0\0\0\x14\0\0\0\0\0\0\0\x02V3\0\0\0\0\0\x1e"
+    }
+}
+impl soroban_sdk::SpecShakingMarker for EnumIntB {
+    #[doc(hidden)]
+    #[inline(always)]
+    fn spec_shaking_marker() {
+        {
+            static MARKER: [u8; 14usize] = *b"SpEcV1,\x9c\xc0_\xed_)\x85";
+            let _ = unsafe { ::core::ptr::read_volatile(MARKER.as_ptr()) };
+        }
     }
 }
 impl soroban_sdk::TryFromVal<soroban_sdk::Env, soroban_sdk::Val> for EnumIntB {
@@ -1263,6 +1388,16 @@ impl EnumIntC {
         *b"\0\0\0\x03\0\0\0\0\0\0\0\0\0\0\0\x08EnumIntC\0\0\0\x03\0\0\0\0\0\0\0\x02V1\0\0\0\0\0d\0\0\0\0\0\0\0\x02V2\0\0\0\0\0\xc8\0\0\0\0\0\0\0\x02V3\0\0\0\0\x01,"
     }
 }
+impl soroban_sdk::SpecShakingMarker for EnumIntC {
+    #[doc(hidden)]
+    #[inline(always)]
+    fn spec_shaking_marker() {
+        {
+            static MARKER: [u8; 14usize] = *b"SpEcV1`\xca\xda\x19\xb9c\xf0/";
+            let _ = unsafe { ::core::ptr::read_volatile(MARKER.as_ptr()) };
+        }
+    }
+}
 impl soroban_sdk::TryFromVal<soroban_sdk::Env, soroban_sdk::Val> for EnumIntC {
     type Error = soroban_sdk::ConversionError;
     #[inline(always)]
@@ -1355,6 +1490,16 @@ pub static __SPEC_XDR_TYPE_ERRORA: [u8; 76usize] = ErrorA::spec_xdr();
 impl ErrorA {
     pub const fn spec_xdr() -> [u8; 76usize] {
         *b"\0\0\0\x04\0\0\0\0\0\0\0\0\0\0\0\x06ErrorA\0\0\0\0\0\x03\0\0\0\0\0\0\0\x02E1\0\0\0\0\0\x01\0\0\0\0\0\0\0\x02E2\0\0\0\0\0\x02\0\0\0\0\0\0\0\x02E3\0\0\0\0\0\x03"
+    }
+}
+impl soroban_sdk::SpecShakingMarker for ErrorA {
+    #[doc(hidden)]
+    #[inline(always)]
+    fn spec_shaking_marker() {
+        {
+            static MARKER: [u8; 14usize] = *b"SpEcV1\xe9R\xa7\xe8b\x99\xa2\xc3";
+            let _ = unsafe { ::core::ptr::read_volatile(MARKER.as_ptr()) };
+        }
     }
 }
 impl TryFrom<soroban_sdk::Error> for ErrorA {
@@ -1521,6 +1666,16 @@ impl ErrorB {
         *b"\0\0\0\x04\0\0\0\0\0\0\0\0\0\0\0\x06ErrorB\0\0\0\0\0\x03\0\0\0\0\0\0\0\x02E1\0\0\0\0\0\n\0\0\0\0\0\0\0\x02E2\0\0\0\0\0\x0b\0\0\0\0\0\0\0\x02E3\0\0\0\0\0\x0c"
     }
 }
+impl soroban_sdk::SpecShakingMarker for ErrorB {
+    #[doc(hidden)]
+    #[inline(always)]
+    fn spec_shaking_marker() {
+        {
+            static MARKER: [u8; 14usize] = *b"SpEcV1\x1d1\xd6\xfb\x88\xd2=\xe3";
+            let _ = unsafe { ::core::ptr::read_volatile(MARKER.as_ptr()) };
+        }
+    }
+}
 impl TryFrom<soroban_sdk::Error> for ErrorB {
     type Error = soroban_sdk::Error;
     #[inline(always)]
@@ -1685,6 +1840,16 @@ impl ErrorC {
         *b"\0\0\0\x04\0\0\0\0\0\0\0\0\0\0\0\x06ErrorC\0\0\0\0\0\x03\0\0\0\0\0\0\0\x02E1\0\0\0\0\0d\0\0\0\0\0\0\0\x02E2\0\0\0\0\0e\0\0\0\0\0\0\0\x02E3\0\0\0\0\0f"
     }
 }
+impl soroban_sdk::SpecShakingMarker for ErrorC {
+    #[doc(hidden)]
+    #[inline(always)]
+    fn spec_shaking_marker() {
+        {
+            static MARKER: [u8; 14usize] = *b"SpEcV1\xb9\x01\xafj\xe0c\xa3\r";
+            let _ = unsafe { ::core::ptr::read_volatile(MARKER.as_ptr()) };
+        }
+    }
+}
 impl TryFrom<soroban_sdk::Error> for ErrorC {
     type Error = soroban_sdk::Error;
     #[inline(always)]
@@ -1845,6 +2010,18 @@ impl EventA {
         *b"\0\0\0\x05\0\0\0\0\0\0\0\0\0\0\0\x06EventA\0\0\0\0\0\x01\0\0\0\x07event_a\0\0\0\0\x02\0\0\0\0\0\0\0\x02f1\0\0\0\0\0\x13\0\0\0\x01\0\0\0\0\0\0\0\x02f2\0\0\0\0\0\x10\0\0\0\0\0\0\0\x02"
     }
 }
+impl soroban_sdk::SpecShakingMarker for EventA {
+    #[doc(hidden)]
+    #[inline(always)]
+    fn spec_shaking_marker() {
+        <Address as soroban_sdk::SpecShakingMarker>::spec_shaking_marker();
+        <soroban_sdk::String as soroban_sdk::SpecShakingMarker>::spec_shaking_marker();
+        {
+            static MARKER: [u8; 14usize] = *b"SpEcV1K\xe6\x8ej\x19\x9en\xbd";
+            let _ = unsafe { ::core::ptr::read_volatile(MARKER.as_ptr()) };
+        }
+    }
+}
 impl soroban_sdk::Event for EventA {
     fn topics(&self, env: &soroban_sdk::Env) -> soroban_sdk::Vec<soroban_sdk::Val> {
         use soroban_sdk::IntoVal;
@@ -1872,6 +2049,7 @@ impl soroban_sdk::Event for EventA {
 }
 impl EventA {
     pub fn publish(&self, env: &soroban_sdk::Env) {
+        <Self as soroban_sdk::SpecShakingMarker>::spec_shaking_marker();
         <_ as soroban_sdk::Event>::publish(self, env);
     }
 }
@@ -1926,6 +2104,19 @@ impl EventB {
         *b"\0\0\0\x05\0\0\0\0\0\0\0\0\0\0\0\x06EventB\0\0\0\0\0\x01\0\0\0\x07event_b\0\0\0\0\x03\0\0\0\0\0\0\0\x02f1\0\0\0\0\0\x13\0\0\0\x01\0\0\0\0\0\0\0\x02f2\0\0\0\0\0\x13\0\0\0\x01\0\0\0\0\0\0\0\x02f3\0\0\0\0\0\x0b\0\0\0\0\0\0\0\x02"
     }
 }
+impl soroban_sdk::SpecShakingMarker for EventB {
+    #[doc(hidden)]
+    #[inline(always)]
+    fn spec_shaking_marker() {
+        <Address as soroban_sdk::SpecShakingMarker>::spec_shaking_marker();
+        <Address as soroban_sdk::SpecShakingMarker>::spec_shaking_marker();
+        <i128 as soroban_sdk::SpecShakingMarker>::spec_shaking_marker();
+        {
+            static MARKER: [u8; 14usize] = *b"SpEcV1\xe6\xaa\xefz\x17i$\x15";
+            let _ = unsafe { ::core::ptr::read_volatile(MARKER.as_ptr()) };
+        }
+    }
+}
 impl soroban_sdk::Event for EventB {
     fn topics(&self, env: &soroban_sdk::Env) -> soroban_sdk::Vec<soroban_sdk::Val> {
         use soroban_sdk::IntoVal;
@@ -1957,6 +2148,7 @@ impl soroban_sdk::Event for EventB {
 }
 impl EventB {
     pub fn publish(&self, env: &soroban_sdk::Env) {
+        <Self as soroban_sdk::SpecShakingMarker>::spec_shaking_marker();
         <_ as soroban_sdk::Event>::publish(self, env);
     }
 }
@@ -2011,6 +2203,19 @@ impl EventC {
         *b"\0\0\0\x05\0\0\0\0\0\0\0\0\0\0\0\x06EventC\0\0\0\0\0\x01\0\0\0\x07event_c\0\0\0\0\x03\0\0\0\0\0\0\0\x02f1\0\0\0\0\0\x11\0\0\0\x01\0\0\0\0\0\0\0\x02f2\0\0\0\0\0\x07\0\0\0\0\0\0\0\0\0\0\0\x02f3\0\0\0\0\0\x07\0\0\0\0\0\0\0\x02"
     }
 }
+impl soroban_sdk::SpecShakingMarker for EventC {
+    #[doc(hidden)]
+    #[inline(always)]
+    fn spec_shaking_marker() {
+        <soroban_sdk::Symbol as soroban_sdk::SpecShakingMarker>::spec_shaking_marker();
+        <i64 as soroban_sdk::SpecShakingMarker>::spec_shaking_marker();
+        <i64 as soroban_sdk::SpecShakingMarker>::spec_shaking_marker();
+        {
+            static MARKER: [u8; 14usize] = *b"SpEcV1\x16\xd6\xdf\xe7\xdb\xb4W@";
+            let _ = unsafe { ::core::ptr::read_volatile(MARKER.as_ptr()) };
+        }
+    }
+}
 impl soroban_sdk::Event for EventC {
     fn topics(&self, env: &soroban_sdk::Env) -> soroban_sdk::Vec<soroban_sdk::Val> {
         use soroban_sdk::IntoVal;
@@ -2038,6 +2243,7 @@ impl soroban_sdk::Event for EventC {
 }
 impl EventC {
     pub fn publish(&self, env: &soroban_sdk::Env) {
+        <Self as soroban_sdk::SpecShakingMarker>::spec_shaking_marker();
         <_ as soroban_sdk::Event>::publish(self, env);
     }
 }

--- a/tests-expanded/test_spec_shaking_v1_tests.rs
+++ b/tests-expanded/test_spec_shaking_v1_tests.rs
@@ -12309,7 +12309,7 @@ const _: () = {
     }
 };
 mod wasm_imported {
-    pub const WASM: &[u8] = b"\x00asm\x01\x00\x00\x00\x01*\x07`\x02~~\x01~`\x03~~~\x01~`\x01~\x01~`\x00\x01~`\x02\x7f\x7f\x01~`\x04\x7f\x7f\x7f\x7f\x01~`\x02\x7f~\x00\x02%\x06\x01b\x01j\x00\x00\x01x\x011\x00\x00\x01v\x01g\x00\x00\x01m\x019\x00\x01\x01i\x012\x00\x02\x01i\x011\x00\x02\x03\x0b\n\x03\x04\x03\x02\x00\x05\x00\x00\x06\x06\x05\x03\x01\x00\x11\x06!\x04\x7f\x01A\x80\x80\xc0\x00\x0b\x7f\x00A\x82\x80\xc0\x00\x0b\x7f\x00A\xa0\x80\xc0\x00\x0b\x7f\x00A\xa0\x80\xc0\x00\x0b\x07\x81\x01\n\x06memory\x02\x00\tfn_enum_a\x00\x06\rfn_enum_int_a\x00\x08\nfn_error_a\x00\t\nfn_event_a\x00\n\x0bfn_struct_a\x00\x0c\x11fn_struct_tuple_a\x00\r\x01_\x03\x01\n__data_end\x03\x02\x0b__heap_base\x03\x03\n\xbd\x08\n\x8b\x02\x03\x01\x7f\x01~\x03\x7f#\x80\x80\x80\x80\x00A\x10k\"\x00$\x80\x80\x80\x80\x00B\x00!\x01A~!\x02\x03~\x02@\x02@\x02@\x02@\x02@ \x02E\r\x00A\x01!\x03 \x02A\x82\x80\xc0\x80\x00j-\x00\x00\"\x04A\xdf\x00F\r\x04 \x04APjA\xff\x01qA\nI\r\x02 \x04A\xbf\x7fjA\xff\x01qA\x1aI\r\x03\x02@ \x04A\x9f\x7fjA\xff\x01qA\x1aO\r\x00 \x04AEj!\x03\x0c\x05\x0b \x00 \x04\xadB\x08\x86B\x01\x847\x03\x00A\x80\x80\xc0\x80\x00\xadB \x86B\x04\x84B\x84\x80\x80\x80 \x10\x80\x80\x80\x80\x00!\x01\x0c\x01\x0b \x00 \x01B\x08\x86B\x0e\x84\"\x017\x02\x04\x0b \x00 \x017\x03\x00 \x00A\x01\x10\x87\x80\x80\x80\x00!\x01 \x00A\x10j$\x80\x80\x80\x80\x00 \x01\x0f\x0b \x04ARj!\x03\x0c\x01\x0b \x04AKj!\x03\x0b \x01B\x06\x86 \x03\xadB\xff\x01\x83\x84!\x01 \x02A\x01j!\x02\x0c\x00\x0b\x0b\x1a\x00 \x00\xadB \x86B\x04\x84 \x01\xadB \x86B\x04\x84\x10\x82\x80\x80\x80\x00\x0b\x08\x00B\x84\x80\x80\x800\x0b*\x00\x02@ \x00B\xff\x01\x83B\x04Q\r\x00\x00\x0bB\x83\x80\x80\x80  \x00B\x84\x80\x80\x80p\x83 \x00B\x80\x80\x80\x80\x10T\x1b\x0b\xdc\x01\x01\x02\x7f#\x80\x80\x80\x80\x00A k\"\x02$\x80\x80\x80\x80\x00\x02@ \x00B\xff\x01\x83B\xcd\x00R\r\x00 \x01B\xff\x01\x83B\xc9\x00R\r\x00 \x02 \x007\x03\x08 \x02B\x8e\xcc\xc1\xfc\xac\xdd\xab\x017\x03\x00A\x00!\x03\x03@\x02@ \x03A\x10G\r\x00A\x00!\x03\x02@\x03@ \x03A\x10F\r\x01 \x02A\x10j \x03j \x02 \x03j)\x03\x007\x03\x00 \x03A\x08j!\x03\x0c\x00\x0b\x0b \x02A\x10jA\x02\x10\x87\x80\x80\x80\x00!\x00 \x02 \x017\x03\x10 \x00A\x98\x80\xc0\x80\x00A\x01 \x02A\x10jA\x01\x10\x8b\x80\x80\x80\x00\x10\x81\x80\x80\x80\x00\x1a \x02A j$\x80\x80\x80\x80\x00B\x02\x0f\x0b \x02A\x10j \x03jB\x027\x03\x00 \x03A\x08j!\x03\x0c\x00\x0b\x0b\x00\x0b.\x00\x02@ \x01 \x03F\r\x00\x00\x0b \x00\xadB \x86B\x04\x84 \x02\xadB \x86B\x04\x84 \x01\xadB \x86B\x04\x84\x10\x83\x80\x80\x80\x00\x0by\x01\x02\x7f#\x80\x80\x80\x80\x00A\x10k\"\x02$\x80\x80\x80\x80\x00\x02@ \x00B\xff\x01\x83B\x04R\r\x00A\x01A\x02A\x00 \x01\xa7A\xff\x01q\"\x03\x1b \x03A\x01F\x1b\"\x03A\x02F\r\x00 \x02 \x03\xad7\x03\x08 \x02 \x00B\x84\x80\x80\x80p\x837\x03\x00A\x88\x80\xc0\x80\x00A\x02 \x02A\x02\x10\x8b\x80\x80\x80\x00!\x00 \x02A\x10j$\x80\x80\x80\x80\x00 \x00\x0f\x0b\x00\x0b\xb2\x01\x01\x01\x7f#\x80\x80\x80\x80\x00A k\"\x02$\x80\x80\x80\x80\x00 \x02A\x10j \x00\x10\x8e\x80\x80\x80\x00\x02@ \x02(\x02\x10A\x01F\r\x00 \x02)\x03\x18!\x00 \x02A\x10j \x01\x10\x8e\x80\x80\x80\x00 \x02(\x02\x10A\x01F\r\x00 \x02)\x03\x18!\x01 \x02A\x10j \x00\x10\x8f\x80\x80\x80\x00 \x02(\x02\x10\r\x00 \x02)\x03\x18!\x00 \x02A\x10j \x01\x10\x8f\x80\x80\x80\x00 \x02(\x02\x10A\x01F\r\x00 \x02 \x02)\x03\x187\x03\x08 \x02 \x007\x03\x00 \x02A\x02\x10\x87\x80\x80\x80\x00!\x00 \x02A j$\x80\x80\x80\x80\x00 \x00\x0f\x0b\x00\x0b]\x02\x01\x7f\x01~\x02@\x02@ \x01\xa7A\xff\x01q\"\x02A\xc1\x00F\r\x00\x02@ \x02A\x07F\r\x00B\x01!\x03B\x83\x90\x80\x80\x80\x01!\x01\x0c\x02\x0b \x01B\x08\x87!\x01B\x00!\x03\x0c\x01\x0bB\x00!\x03 \x01\x10\x84\x80\x80\x80\x00!\x01\x0b \x00 \x037\x03\x00 \x00 \x017\x03\x08\x0bF\x00\x02@\x02@ \x01B\x80\x80\x80\x80\x80\x80\x80\xc0\x00|B\xff\xff\xff\xff\xff\xff\xff\xff\x00V\r\x00 \x01B\x08\x86B\x07\x84!\x01\x0c\x01\x0b \x01\x10\x85\x80\x80\x80\x00!\x01\x0b \x00B\x007\x03\x00 \x00 \x017\x03\x08\x0b\x0b)\x01\x00A\x80\x80\xc0\x00\x0b V2f1f2\x00\x00\x02\x00\x10\x00\x02\x00\x00\x00\x04\x00\x10\x00\x02\x00\x00\x00\x04\x00\x10\x00\x02\x00\x00\x00\x00\xbf\x0e\x0econtractspecv0\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\tfn_enum_a\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x07\xd0\x00\x00\x00\x05EnumA\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\nfn_error_a\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x05input\x00\x00\x00\x00\x00\x00\x04\x00\x00\x00\x01\x00\x00\x03\xe9\x00\x00\x00\x04\x00\x00\x07\xd0\x00\x00\x00\x06ErrorA\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\nfn_event_a\x00\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x02f1\x00\x00\x00\x00\x00\x13\x00\x00\x00\x00\x00\x00\x00\x02f2\x00\x00\x00\x00\x00\x10\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x0bfn_struct_a\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x02f1\x00\x00\x00\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00\x02f2\x00\x00\x00\x00\x00\x01\x00\x00\x00\x01\x00\x00\x07\xd0\x00\x00\x00\x07StructA\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\rfn_enum_int_a\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x07\xd0\x00\x00\x00\x08EnumIntA\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x11fn_struct_tuple_a\x00\x00\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x02f1\x00\x00\x00\x00\x00\x07\x00\x00\x00\x00\x00\x00\x00\x02f2\x00\x00\x00\x00\x00\x07\x00\x00\x00\x01\x00\x00\x07\xd0\x00\x00\x00\x0cStructTupleA\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x05EnumA\x00\x00\x00\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02V1\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02V2\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02V3\x00\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x05EnumB\x00\x00\x00\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02V1\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x02V2\x00\x00\x00\x00\x00\x01\x00\x00\x00\x07\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x02V3\x00\x00\x00\x00\x00\x02\x00\x00\x00\x07\x00\x00\x00\x07\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x05EnumC\x00\x00\x00\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02V1\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x02V2\x00\x00\x00\x00\x00\x01\x00\x00\x07\xd0\x00\x00\x00\x07StructA\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x02V3\x00\x00\x00\x00\x00\x01\x00\x00\x07\xd0\x00\x00\x00\x0cStructTupleA\x00\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x06ErrorA\x00\x00\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x02E1\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x02E2\x00\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x02E3\x00\x00\x00\x00\x00\x03\x00\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x06ErrorB\x00\x00\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x02E1\x00\x00\x00\x00\x00\n\x00\x00\x00\x00\x00\x00\x00\x02E2\x00\x00\x00\x00\x00\x0b\x00\x00\x00\x00\x00\x00\x00\x02E3\x00\x00\x00\x00\x00\x0c\x00\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x06ErrorC\x00\x00\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x02E1\x00\x00\x00\x00\x00d\x00\x00\x00\x00\x00\x00\x00\x02E2\x00\x00\x00\x00\x00e\x00\x00\x00\x00\x00\x00\x00\x02E3\x00\x00\x00\x00\x00f\x00\x00\x00\x05\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x06EventA\x00\x00\x00\x00\x00\x01\x00\x00\x00\x07event_a\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x02f1\x00\x00\x00\x00\x00\x13\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x02f2\x00\x00\x00\x00\x00\x10\x00\x00\x00\x00\x00\x00\x00\x02\x00\x00\x00\x05\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x06EventB\x00\x00\x00\x00\x00\x01\x00\x00\x00\x07event_b\x00\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x02f1\x00\x00\x00\x00\x00\x13\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x02f2\x00\x00\x00\x00\x00\x13\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x02f3\x00\x00\x00\x00\x00\x0b\x00\x00\x00\x00\x00\x00\x00\x02\x00\x00\x00\x05\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x06EventC\x00\x00\x00\x00\x00\x01\x00\x00\x00\x07event_c\x00\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x02f1\x00\x00\x00\x00\x00\x11\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x02f2\x00\x00\x00\x00\x00\x07\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02f3\x00\x00\x00\x00\x00\x07\x00\x00\x00\x00\x00\x00\x00\x02\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x07StructA\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x02f1\x00\x00\x00\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00\x02f2\x00\x00\x00\x00\x00\x01\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x07StructB\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x02f1\x00\x00\x00\x00\x00\x07\x00\x00\x00\x00\x00\x00\x00\x02f2\x00\x00\x00\x00\x00\x10\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x07StructC\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x02f1\x00\x00\x00\x00\x03\xea\x00\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00\x02f2\x00\x00\x00\x00\x00\x13\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x08EnumIntA\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x02V1\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x02V2\x00\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x02V3\x00\x00\x00\x00\x00\x03\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x08EnumIntB\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x02V1\x00\x00\x00\x00\x00\n\x00\x00\x00\x00\x00\x00\x00\x02V2\x00\x00\x00\x00\x00\x14\x00\x00\x00\x00\x00\x00\x00\x02V3\x00\x00\x00\x00\x00\x1e\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x08EnumIntC\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x02V1\x00\x00\x00\x00\x00d\x00\x00\x00\x00\x00\x00\x00\x02V2\x00\x00\x00\x00\x00\xc8\x00\x00\x00\x00\x00\x00\x00\x02V3\x00\x00\x00\x00\x01,\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x0cStructTupleA\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x010\x00\x00\x00\x00\x00\x00\x07\x00\x00\x00\x00\x00\x00\x00\x011\x00\x00\x00\x00\x00\x00\x07\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x0cStructTupleB\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x010\x00\x00\x00\x00\x00\x00\n\x00\x00\x00\x00\x00\x00\x00\x011\x00\x00\x00\x00\x00\x00\n\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x0cStructTupleC\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x010\x00\x00\x00\x00\x00\x00\x13\x00\x00\x00\x00\x00\x00\x00\x011\x00\x00\x00\x00\x00\x00\x0b\x00\x1e\x11contractenvmetav0\x00\x00\x00\x00\x00\x00\x00\x1a\x00\x00\x00\x00\x00+\x0econtractmetav0\x00\x00\x00\x00\x00\x00\x00\x05rsver\x00\x00\x00\x00\x00\x00\x061.91.0\x00\x00";
+    pub const WASM: &[u8] = b"\x00asm\x01\x00\x00\x00\x01*\x07`\x02~~\x01~`\x03~~~\x01~`\x01~\x01~`\x00\x01~`\x02\x7f\x7f\x01~`\x04\x7f\x7f\x7f\x7f\x01~`\x02\x7f~\x00\x02%\x06\x01b\x01j\x00\x00\x01x\x011\x00\x00\x01v\x01g\x00\x00\x01m\x019\x00\x01\x01i\x012\x00\x02\x01i\x011\x00\x02\x03\x0b\n\x03\x04\x03\x02\x00\x05\x00\x00\x06\x06\x05\x03\x01\x00\x11\x06!\x04\x7f\x01A\x80\x80\xc0\x00\x0b\x7f\x00A\x82\x80\xc0\x00\x0b\x7f\x00A\xf4\x80\xc0\x00\x0b\x7f\x00A\x80\x81\xc0\x00\x0b\x07\x81\x01\n\x06memory\x02\x00\tfn_enum_a\x00\x06\rfn_enum_int_a\x00\x08\nfn_error_a\x00\t\nfn_event_a\x00\n\x0bfn_struct_a\x00\x0c\x11fn_struct_tuple_a\x00\r\x01_\x03\x01\n__data_end\x03\x02\x0b__heap_base\x03\x03\n\xfa\x08\n\x95\x02\x03\x01\x7f\x01~\x03\x7f#\x80\x80\x80\x80\x00A\x10k\"\x00$\x80\x80\x80\x80\x00A\x00-\x00\x82\x80\xc0\x80\x00\x1aB\x00!\x01A~!\x02\x03~\x02@\x02@\x02@\x02@\x02@ \x02E\r\x00A\x01!\x03 \x02A\x82\x80\xc0\x80\x00j-\x00\x00\"\x04A\xdf\x00F\r\x04 \x04APjA\xff\x01qA\nI\r\x02 \x04A\xbf\x7fjA\xff\x01qA\x1aI\r\x03\x02@ \x04A\x9f\x7fjA\xff\x01qA\x1aO\r\x00 \x04AEj!\x03\x0c\x05\x0b \x00 \x04\xadB\x08\x86B\x01\x847\x03\x00A\x80\x80\xc0\x80\x00\xadB \x86B\x04\x84B\x84\x80\x80\x80 \x10\x80\x80\x80\x80\x00!\x01\x0c\x01\x0b \x00 \x01B\x08\x86B\x0e\x84\"\x017\x02\x04\x0b \x00 \x017\x03\x00 \x00A\x01\x10\x87\x80\x80\x80\x00!\x01 \x00A\x10j$\x80\x80\x80\x80\x00 \x01\x0f\x0b \x04ARj!\x03\x0c\x01\x0b \x04AKj!\x03\x0b \x01B\x06\x86 \x03\xadB\xff\x01\x83\x84!\x01 \x02A\x01j!\x02\x0c\x00\x0b\x0b\x1a\x00 \x00\xadB \x86B\x04\x84 \x01\xadB \x86B\x04\x84\x10\x82\x80\x80\x80\x00\x0b\x12\x00A\x00-\x00\xba\x80\xc0\x80\x00\x1aB\x84\x80\x80\x800\x0b4\x00\x02@ \x00B\xff\x01\x83B\x04Q\r\x00\x00\x0bA\x00-\x00\x90\x80\xc0\x80\x00\x1aB\x83\x80\x80\x80  \x00B\x84\x80\x80\x80p\x83 \x00B\x80\x80\x80\x80\x10T\x1b\x0b\xe6\x01\x01\x02\x7f#\x80\x80\x80\x80\x00A k\"\x02$\x80\x80\x80\x80\x00\x02@ \x00B\xff\x01\x83B\xcd\x00R\r\x00 \x01B\xff\x01\x83B\xc9\x00R\r\x00A\x00!\x03A\x00-\x00\x9e\x80\xc0\x80\x00\x1a \x02 \x007\x03\x08 \x02B\x8e\xcc\xc1\xfc\xac\xdd\xab\x017\x03\x00\x03@\x02@ \x03A\x10G\r\x00A\x00!\x03\x02@\x03@ \x03A\x10F\r\x01 \x02A\x10j \x03j \x02 \x03j)\x03\x007\x03\x00 \x03A\x08j!\x03\x0c\x00\x0b\x0b \x02A\x10jA\x02\x10\x87\x80\x80\x80\x00!\x00 \x02 \x017\x03\x10 \x00A\xec\x80\xc0\x80\x00A\x01 \x02A\x10jA\x01\x10\x8b\x80\x80\x80\x00\x10\x81\x80\x80\x80\x00\x1a \x02A j$\x80\x80\x80\x80\x00B\x02\x0f\x0b \x02A\x10j \x03jB\x027\x03\x00 \x03A\x08j!\x03\x0c\x00\x0b\x0b\x00\x0b.\x00\x02@ \x01 \x03F\r\x00\x00\x0b \x00\xadB \x86B\x04\x84 \x02\xadB \x86B\x04\x84 \x01\xadB \x86B\x04\x84\x10\x83\x80\x80\x80\x00\x0b\x83\x01\x01\x02\x7f#\x80\x80\x80\x80\x00A\x10k\"\x02$\x80\x80\x80\x80\x00\x02@ \x00B\xff\x01\x83B\x04R\r\x00A\x01A\x02A\x00 \x01\xa7A\xff\x01q\"\x03\x1b \x03A\x01F\x1b\"\x03A\x02F\r\x00A\x00-\x00\xac\x80\xc0\x80\x00\x1a \x02 \x03\xad7\x03\x08 \x02 \x00B\x84\x80\x80\x80p\x837\x03\x00A\xdc\x80\xc0\x80\x00A\x02 \x02A\x02\x10\x8b\x80\x80\x80\x00!\x00 \x02A\x10j$\x80\x80\x80\x80\x00 \x00\x0f\x0b\x00\x0b\xbc\x01\x01\x01\x7f#\x80\x80\x80\x80\x00A k\"\x02$\x80\x80\x80\x80\x00 \x02A\x10j \x00\x10\x8e\x80\x80\x80\x00\x02@ \x02(\x02\x10A\x01F\r\x00 \x02)\x03\x18!\x00 \x02A\x10j \x01\x10\x8e\x80\x80\x80\x00 \x02(\x02\x10A\x01F\r\x00 \x02)\x03\x18!\x01A\x00-\x00\xc8\x80\xc0\x80\x00\x1a \x02A\x10j \x00\x10\x8f\x80\x80\x80\x00 \x02(\x02\x10\r\x00 \x02)\x03\x18!\x00 \x02A\x10j \x01\x10\x8f\x80\x80\x80\x00 \x02(\x02\x10A\x01F\r\x00 \x02 \x02)\x03\x187\x03\x08 \x02 \x007\x03\x00 \x02A\x02\x10\x87\x80\x80\x80\x00!\x00 \x02A j$\x80\x80\x80\x80\x00 \x00\x0f\x0b\x00\x0b]\x02\x01\x7f\x01~\x02@\x02@ \x01\xa7A\xff\x01q\"\x02A\xc1\x00F\r\x00\x02@ \x02A\x07F\r\x00B\x01!\x03B\x83\x90\x80\x80\x80\x01!\x01\x0c\x02\x0b \x01B\x08\x87!\x01B\x00!\x03\x0c\x01\x0bB\x00!\x03 \x01\x10\x84\x80\x80\x80\x00!\x01\x0b \x00 \x037\x03\x00 \x00 \x017\x03\x08\x0bF\x00\x02@\x02@ \x01B\x80\x80\x80\x80\x80\x80\x80\xc0\x00|B\xff\xff\xff\xff\xff\xff\xff\xff\x00V\r\x00 \x01B\x08\x86B\x07\x84!\x01\x0c\x01\x0b \x01\x10\x85\x80\x80\x80\x00!\x01\x0b \x00B\x007\x03\x00 \x00 \x017\x03\x08\x0b\x0b}\x01\x00A\x80\x80\xc0\x00\x0btV2SpEcV1\xa2=N\xc1p\x95\x90\xb2SpEcV1\xe9R\xa7\xe8b\x99\xa2\xc3SpEcV1K\xe6\x8ej\x19\x9en\xbdSpEcV1\xb6\x1c\xfd\xdfhY-dSpEcV1V]\x80\\~\x1a\x08/SpEcV1\xcf)\x97]S\xb2\xfd)f1f2\x00\x00V\x00\x10\x00\x02\x00\x00\x00X\x00\x10\x00\x02\x00\x00\x00X\x00\x10\x00\x02\x00\x00\x00\x00\xd3#\x0econtractspecv0\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\tfn_enum_a\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x07\xd0\x00\x00\x00\x05EnumA\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\nfn_error_a\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x05input\x00\x00\x00\x00\x00\x00\x04\x00\x00\x00\x01\x00\x00\x03\xe9\x00\x00\x00\x04\x00\x00\x07\xd0\x00\x00\x00\x06ErrorA\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\nfn_event_a\x00\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x02f1\x00\x00\x00\x00\x00\x13\x00\x00\x00\x00\x00\x00\x00\x02f2\x00\x00\x00\x00\x00\x10\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x0bfn_struct_a\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x02f1\x00\x00\x00\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00\x02f2\x00\x00\x00\x00\x00\x01\x00\x00\x00\x01\x00\x00\x07\xd0\x00\x00\x00\x07StructA\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\rfn_enum_int_a\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x07\xd0\x00\x00\x00\x08EnumIntA\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x11fn_struct_tuple_a\x00\x00\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x02f1\x00\x00\x00\x00\x00\x07\x00\x00\x00\x00\x00\x00\x00\x02f2\x00\x00\x00\x00\x00\x07\x00\x00\x00\x01\x00\x00\x07\xd0\x00\x00\x00\x0cStructTupleA\x00\x00\x00\x02\x00\x00\x00\xe3Context of a single authorized call performed by an address.\n\nCustom account contracts that implement `__check_auth` special function\nreceive a list of `Context` values corresponding to all the calls that\nneed to be authorized.\x00\x00\x00\x00\x00\x00\x00\x00\x07Context\x00\x00\x00\x00\x03\x00\x00\x00\x01\x00\x00\x00\x14Contract invocation.\x00\x00\x00\x08Contract\x00\x00\x00\x01\x00\x00\x07\xd0\x00\x00\x00\x0fContractContext\x00\x00\x00\x00\x01\x00\x00\x00=Contract that has a constructor with no arguments is created.\x00\x00\x00\x00\x00\x00\x14CreateContractHostFn\x00\x00\x00\x01\x00\x00\x07\xd0\x00\x00\x00\x1bCreateContractHostFnContext\x00\x00\x00\x00\x01\x00\x00\x00DContract that has a constructor with 1 or more arguments is created.\x00\x00\x00\x1cCreateContractWithCtorHostFn\x00\x00\x00\x01\x00\x00\x07\xd0\x00\x00\x00*CreateContractWithConstructorHostFnContext\x00\x00\x00\x00\x00\x01\x00\x00\x00\xbdAuthorization context of a single contract call.\n\nThis struct corresponds to a `require_auth_for_args` call for an address\nfrom `contract` function with `fn_name` name and `args` arguments.\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x0fContractContext\x00\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x04args\x00\x00\x03\xea\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x08contract\x00\x00\x00\x13\x00\x00\x00\x00\x00\x00\x00\x07fn_name\x00\x00\x00\x00\x11\x00\x00\x00\x02\x00\x00\x00_Contract executable used for creating a new contract and used in\n`CreateContractHostFnContext`.\x00\x00\x00\x00\x00\x00\x00\x00\x12ContractExecutable\x00\x00\x00\x00\x00\x01\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x04Wasm\x00\x00\x00\x01\x00\x00\x03\xee\x00\x00\x00 \x00\x00\x00\x01\x00\x00\x008Value of contract node in InvokerContractAuthEntry tree.\x00\x00\x00\x00\x00\x00\x00\x15SubContractInvocation\x00\x00\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x07context\x00\x00\x00\x07\xd0\x00\x00\x00\x0fContractContext\x00\x00\x00\x00\x00\x00\x00\x00\x0fsub_invocations\x00\x00\x00\x03\xea\x00\x00\x07\xd0\x00\x00\x00\x18InvokerContractAuthEntry\x00\x00\x00\x02\x00\x00\x01/A node in the tree of authorizations performed on behalf of the current\ncontract as invoker of the contracts deeper in the call stack.\n\nThis is used as an argument of `authorize_as_current_contract` host function.\n\nThis tree corresponds `require_auth[_for_args]` calls on behalf of the\ncurrent contract.\x00\x00\x00\x00\x00\x00\x00\x00\x18InvokerContractAuthEntry\x00\x00\x00\x03\x00\x00\x00\x01\x00\x00\x00\x12Invoke a contract.\x00\x00\x00\x00\x00\x08Contract\x00\x00\x00\x01\x00\x00\x07\xd0\x00\x00\x00\x15SubContractInvocation\x00\x00\x00\x00\x00\x00\x01\x00\x00\x005Create a contract passing 0 arguments to constructor.\x00\x00\x00\x00\x00\x00\x14CreateContractHostFn\x00\x00\x00\x01\x00\x00\x07\xd0\x00\x00\x00\x1bCreateContractHostFnContext\x00\x00\x00\x00\x01\x00\x00\x00=Create a contract passing 0 or more arguments to constructor.\x00\x00\x00\x00\x00\x00\x1cCreateContractWithCtorHostFn\x00\x00\x00\x01\x00\x00\x07\xd0\x00\x00\x00*CreateContractWithConstructorHostFnContext\x00\x00\x00\x00\x00\x01\x00\x00\x00vAuthorization context for `create_contract` host function that creates a\nnew contract on behalf of authorizer address.\x00\x00\x00\x00\x00\x00\x00\x00\x00\x1bCreateContractHostFnContext\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\nexecutable\x00\x00\x00\x00\x07\xd0\x00\x00\x00\x12ContractExecutable\x00\x00\x00\x00\x00\x00\x00\x00\x00\x04salt\x00\x00\x03\xee\x00\x00\x00 \x00\x00\x00\x01\x00\x00\x00\xd6Authorization context for `create_contract` host function that creates a\nnew contract on behalf of authorizer address.\nThis is the same as `CreateContractHostFnContext`, but also has\ncontract constructor arguments.\x00\x00\x00\x00\x00\x00\x00\x00\x00*CreateContractWithConstructorHostFnContext\x00\x00\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x10constructor_args\x00\x00\x03\xea\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\nexecutable\x00\x00\x00\x00\x07\xd0\x00\x00\x00\x12ContractExecutable\x00\x00\x00\x00\x00\x00\x00\x00\x00\x04salt\x00\x00\x03\xee\x00\x00\x00 \x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\nExecutable\x00\x00\x00\x00\x00\x03\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x04Wasm\x00\x00\x00\x01\x00\x00\x03\xee\x00\x00\x00 \x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x0cStellarAsset\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x07Account\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x05EnumA\x00\x00\x00\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02V1\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02V2\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02V3\x00\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x05EnumB\x00\x00\x00\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02V1\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x02V2\x00\x00\x00\x00\x00\x01\x00\x00\x00\x07\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x02V3\x00\x00\x00\x00\x00\x02\x00\x00\x00\x07\x00\x00\x00\x07\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x05EnumC\x00\x00\x00\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02V1\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x02V2\x00\x00\x00\x00\x00\x01\x00\x00\x07\xd0\x00\x00\x00\x07StructA\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x02V3\x00\x00\x00\x00\x00\x01\x00\x00\x07\xd0\x00\x00\x00\x0cStructTupleA\x00\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x06ErrorA\x00\x00\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x02E1\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x02E2\x00\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x02E3\x00\x00\x00\x00\x00\x03\x00\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x06ErrorB\x00\x00\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x02E1\x00\x00\x00\x00\x00\n\x00\x00\x00\x00\x00\x00\x00\x02E2\x00\x00\x00\x00\x00\x0b\x00\x00\x00\x00\x00\x00\x00\x02E3\x00\x00\x00\x00\x00\x0c\x00\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x06ErrorC\x00\x00\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x02E1\x00\x00\x00\x00\x00d\x00\x00\x00\x00\x00\x00\x00\x02E2\x00\x00\x00\x00\x00e\x00\x00\x00\x00\x00\x00\x00\x02E3\x00\x00\x00\x00\x00f\x00\x00\x00\x05\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x06EventA\x00\x00\x00\x00\x00\x01\x00\x00\x00\x07event_a\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x02f1\x00\x00\x00\x00\x00\x13\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x02f2\x00\x00\x00\x00\x00\x10\x00\x00\x00\x00\x00\x00\x00\x02\x00\x00\x00\x05\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x06EventB\x00\x00\x00\x00\x00\x01\x00\x00\x00\x07event_b\x00\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x02f1\x00\x00\x00\x00\x00\x13\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x02f2\x00\x00\x00\x00\x00\x13\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x02f3\x00\x00\x00\x00\x00\x0b\x00\x00\x00\x00\x00\x00\x00\x02\x00\x00\x00\x05\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x06EventC\x00\x00\x00\x00\x00\x01\x00\x00\x00\x07event_c\x00\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x02f1\x00\x00\x00\x00\x00\x11\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x02f2\x00\x00\x00\x00\x00\x07\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02f3\x00\x00\x00\x00\x00\x07\x00\x00\x00\x00\x00\x00\x00\x02\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x07StructA\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x02f1\x00\x00\x00\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00\x02f2\x00\x00\x00\x00\x00\x01\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x07StructB\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x02f1\x00\x00\x00\x00\x00\x07\x00\x00\x00\x00\x00\x00\x00\x02f2\x00\x00\x00\x00\x00\x10\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x07StructC\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x02f1\x00\x00\x00\x00\x03\xea\x00\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00\x02f2\x00\x00\x00\x00\x00\x13\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x08EnumIntA\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x02V1\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x02V2\x00\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x02V3\x00\x00\x00\x00\x00\x03\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x08EnumIntB\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x02V1\x00\x00\x00\x00\x00\n\x00\x00\x00\x00\x00\x00\x00\x02V2\x00\x00\x00\x00\x00\x14\x00\x00\x00\x00\x00\x00\x00\x02V3\x00\x00\x00\x00\x00\x1e\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x08EnumIntC\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x02V1\x00\x00\x00\x00\x00d\x00\x00\x00\x00\x00\x00\x00\x02V2\x00\x00\x00\x00\x00\xc8\x00\x00\x00\x00\x00\x00\x00\x02V3\x00\x00\x00\x00\x01,\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x0cStructTupleA\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x010\x00\x00\x00\x00\x00\x00\x07\x00\x00\x00\x00\x00\x00\x00\x011\x00\x00\x00\x00\x00\x00\x07\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x0cStructTupleB\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x010\x00\x00\x00\x00\x00\x00\n\x00\x00\x00\x00\x00\x00\x00\x011\x00\x00\x00\x00\x00\x00\n\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x0cStructTupleC\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x010\x00\x00\x00\x00\x00\x00\x13\x00\x00\x00\x00\x00\x00\x00\x011\x00\x00\x00\x00\x00\x00\x0b\x00\x1e\x11contractenvmetav0\x00\x00\x00\x00\x00\x00\x00\x1a\x00\x00\x00\x00\x00O\x0econtractmetav0\x00\x00\x00\x00\x00\x00\x00\x05rsver\x00\x00\x00\x00\x00\x00\x061.91.0\x00\x00\x00\x00\x00\x00\x00\x00\x00\x12rssdk_spec_shaking\x00\x00\x00\x00\x00\x012\x00\x00\x00";
     pub trait Contract {
         fn fn_enum_a(env: soroban_sdk::Env) -> EnumA;
         fn fn_error_a(env: soroban_sdk::Env, input: u32) -> Result<u32, ErrorA>;
@@ -12927,6 +12927,2040 @@ mod wasm_imported {
             (f1, f2)
         }
     }
+    pub struct ContractContext {
+        pub args: soroban_sdk::Vec<soroban_sdk::Val>,
+        pub contract: soroban_sdk::Address,
+        pub fn_name: soroban_sdk::Symbol,
+    }
+    #[automatically_derived]
+    impl ::core::fmt::Debug for ContractContext {
+        #[inline]
+        fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+            ::core::fmt::Formatter::debug_struct_field3_finish(
+                f,
+                "ContractContext",
+                "args",
+                &self.args,
+                "contract",
+                &self.contract,
+                "fn_name",
+                &&self.fn_name,
+            )
+        }
+    }
+    #[automatically_derived]
+    impl ::core::clone::Clone for ContractContext {
+        #[inline]
+        fn clone(&self) -> ContractContext {
+            ContractContext {
+                args: ::core::clone::Clone::clone(&self.args),
+                contract: ::core::clone::Clone::clone(&self.contract),
+                fn_name: ::core::clone::Clone::clone(&self.fn_name),
+            }
+        }
+    }
+    #[automatically_derived]
+    impl ::core::cmp::Eq for ContractContext {
+        #[inline]
+        #[doc(hidden)]
+        #[coverage(off)]
+        fn assert_receiver_is_total_eq(&self) -> () {
+            let _: ::core::cmp::AssertParamIsEq<soroban_sdk::Vec<soroban_sdk::Val>>;
+            let _: ::core::cmp::AssertParamIsEq<soroban_sdk::Address>;
+            let _: ::core::cmp::AssertParamIsEq<soroban_sdk::Symbol>;
+        }
+    }
+    #[automatically_derived]
+    impl ::core::marker::StructuralPartialEq for ContractContext {}
+    #[automatically_derived]
+    impl ::core::cmp::PartialEq for ContractContext {
+        #[inline]
+        fn eq(&self, other: &ContractContext) -> bool {
+            self.args == other.args
+                && self.contract == other.contract
+                && self.fn_name == other.fn_name
+        }
+    }
+    #[automatically_derived]
+    impl ::core::cmp::Ord for ContractContext {
+        #[inline]
+        fn cmp(&self, other: &ContractContext) -> ::core::cmp::Ordering {
+            match ::core::cmp::Ord::cmp(&self.args, &other.args) {
+                ::core::cmp::Ordering::Equal => {
+                    match ::core::cmp::Ord::cmp(&self.contract, &other.contract) {
+                        ::core::cmp::Ordering::Equal => {
+                            ::core::cmp::Ord::cmp(&self.fn_name, &other.fn_name)
+                        }
+                        cmp => cmp,
+                    }
+                }
+                cmp => cmp,
+            }
+        }
+    }
+    #[automatically_derived]
+    impl ::core::cmp::PartialOrd for ContractContext {
+        #[inline]
+        fn partial_cmp(
+            &self,
+            other: &ContractContext,
+        ) -> ::core::option::Option<::core::cmp::Ordering> {
+            match ::core::cmp::PartialOrd::partial_cmp(&self.args, &other.args) {
+                ::core::option::Option::Some(::core::cmp::Ordering::Equal) => {
+                    match ::core::cmp::PartialOrd::partial_cmp(&self.contract, &other.contract) {
+                        ::core::option::Option::Some(::core::cmp::Ordering::Equal) => {
+                            ::core::cmp::PartialOrd::partial_cmp(&self.fn_name, &other.fn_name)
+                        }
+                        cmp => cmp,
+                    }
+                }
+                cmp => cmp,
+            }
+        }
+    }
+    impl soroban_sdk::TryFromVal<soroban_sdk::Env, soroban_sdk::Val> for ContractContext {
+        type Error = soroban_sdk::ConversionError;
+        fn try_from_val(
+            env: &soroban_sdk::Env,
+            val: &soroban_sdk::Val,
+        ) -> Result<Self, soroban_sdk::ConversionError> {
+            use soroban_sdk::{ConversionError, EnvBase, MapObject, TryIntoVal, Val};
+            const KEYS: [&'static str; 3usize] = ["args", "contract", "fn_name"];
+            let mut vals: [Val; 3usize] = [Val::VOID.to_val(); 3usize];
+            let map: MapObject = val.try_into().map_err(|_| ConversionError)?;
+            env.map_unpack_to_slice(map, &KEYS, &mut vals)
+                .map_err(|_| ConversionError)?;
+            Ok(Self {
+                args: vals[0]
+                    .try_into_val(env)
+                    .map_err(|_| soroban_sdk::ConversionError)?,
+                contract: vals[1]
+                    .try_into_val(env)
+                    .map_err(|_| soroban_sdk::ConversionError)?,
+                fn_name: vals[2]
+                    .try_into_val(env)
+                    .map_err(|_| soroban_sdk::ConversionError)?,
+            })
+        }
+    }
+    impl soroban_sdk::TryFromVal<soroban_sdk::Env, ContractContext> for soroban_sdk::Val {
+        type Error = soroban_sdk::ConversionError;
+        fn try_from_val(
+            env: &soroban_sdk::Env,
+            val: &ContractContext,
+        ) -> Result<Self, soroban_sdk::ConversionError> {
+            use soroban_sdk::{ConversionError, EnvBase, TryIntoVal, Val};
+            const KEYS: [&'static str; 3usize] = ["args", "contract", "fn_name"];
+            let vals: [Val; 3usize] = [
+                (&val.args).try_into_val(env).map_err(|_| ConversionError)?,
+                (&val.contract)
+                    .try_into_val(env)
+                    .map_err(|_| ConversionError)?,
+                (&val.fn_name)
+                    .try_into_val(env)
+                    .map_err(|_| ConversionError)?,
+            ];
+            Ok(env
+                .map_new_from_slices(&KEYS, &vals)
+                .map_err(|_| ConversionError)?
+                .into())
+        }
+    }
+    impl soroban_sdk::TryFromVal<soroban_sdk::Env, &ContractContext> for soroban_sdk::Val {
+        type Error = soroban_sdk::ConversionError;
+        #[inline(always)]
+        fn try_from_val(
+            env: &soroban_sdk::Env,
+            val: &&ContractContext,
+        ) -> Result<Self, soroban_sdk::ConversionError> {
+            <_ as soroban_sdk::TryFromVal<soroban_sdk::Env, ContractContext>>::try_from_val(
+                env, *val,
+            )
+        }
+    }
+    impl soroban_sdk::TryFromVal<soroban_sdk::Env, soroban_sdk::xdr::ScMap> for ContractContext {
+        type Error = soroban_sdk::xdr::Error;
+        #[inline(always)]
+        fn try_from_val(
+            env: &soroban_sdk::Env,
+            val: &soroban_sdk::xdr::ScMap,
+        ) -> Result<Self, soroban_sdk::xdr::Error> {
+            use soroban_sdk::xdr::Validate;
+            use soroban_sdk::TryIntoVal;
+            let map = val;
+            if map.len() != 3usize {
+                return Err(soroban_sdk::xdr::Error::Invalid);
+            }
+            map.validate()?;
+            Ok(Self {
+                args: {
+                    let key: soroban_sdk::xdr::ScVal = soroban_sdk::xdr::ScSymbol(
+                        "args"
+                            .try_into()
+                            .map_err(|_| soroban_sdk::xdr::Error::Invalid)?,
+                    )
+                    .into();
+                    let idx = map
+                        .binary_search_by_key(&key, |entry| entry.key.clone())
+                        .map_err(|_| soroban_sdk::xdr::Error::Invalid)?;
+                    let rv: soroban_sdk::Val = (&map[idx].val.clone())
+                        .try_into_val(env)
+                        .map_err(|_| soroban_sdk::xdr::Error::Invalid)?;
+                    rv.try_into_val(env)
+                        .map_err(|_| soroban_sdk::xdr::Error::Invalid)?
+                },
+                contract: {
+                    let key: soroban_sdk::xdr::ScVal = soroban_sdk::xdr::ScSymbol(
+                        "contract"
+                            .try_into()
+                            .map_err(|_| soroban_sdk::xdr::Error::Invalid)?,
+                    )
+                    .into();
+                    let idx = map
+                        .binary_search_by_key(&key, |entry| entry.key.clone())
+                        .map_err(|_| soroban_sdk::xdr::Error::Invalid)?;
+                    let rv: soroban_sdk::Val = (&map[idx].val.clone())
+                        .try_into_val(env)
+                        .map_err(|_| soroban_sdk::xdr::Error::Invalid)?;
+                    rv.try_into_val(env)
+                        .map_err(|_| soroban_sdk::xdr::Error::Invalid)?
+                },
+                fn_name: {
+                    let key: soroban_sdk::xdr::ScVal = soroban_sdk::xdr::ScSymbol(
+                        "fn_name"
+                            .try_into()
+                            .map_err(|_| soroban_sdk::xdr::Error::Invalid)?,
+                    )
+                    .into();
+                    let idx = map
+                        .binary_search_by_key(&key, |entry| entry.key.clone())
+                        .map_err(|_| soroban_sdk::xdr::Error::Invalid)?;
+                    let rv: soroban_sdk::Val = (&map[idx].val.clone())
+                        .try_into_val(env)
+                        .map_err(|_| soroban_sdk::xdr::Error::Invalid)?;
+                    rv.try_into_val(env)
+                        .map_err(|_| soroban_sdk::xdr::Error::Invalid)?
+                },
+            })
+        }
+    }
+    impl soroban_sdk::TryFromVal<soroban_sdk::Env, soroban_sdk::xdr::ScVal> for ContractContext {
+        type Error = soroban_sdk::xdr::Error;
+        #[inline(always)]
+        fn try_from_val(
+            env: &soroban_sdk::Env,
+            val: &soroban_sdk::xdr::ScVal,
+        ) -> Result<Self, soroban_sdk::xdr::Error> {
+            if let soroban_sdk::xdr::ScVal::Map(Some(map)) = val {
+                <_ as soroban_sdk::TryFromVal<_, _>>::try_from_val(env, map)
+            } else {
+                Err(soroban_sdk::xdr::Error::Invalid)
+            }
+        }
+    }
+    impl TryFrom<&ContractContext> for soroban_sdk::xdr::ScMap {
+        type Error = soroban_sdk::xdr::Error;
+        #[inline(always)]
+        fn try_from(val: &ContractContext) -> Result<Self, soroban_sdk::xdr::Error> {
+            extern crate alloc;
+            use soroban_sdk::TryFromVal;
+            soroban_sdk::xdr::ScMap::sorted_from(<[_]>::into_vec(::alloc::boxed::box_new([
+                soroban_sdk::xdr::ScMapEntry {
+                    key: soroban_sdk::xdr::ScSymbol(
+                        "args"
+                            .try_into()
+                            .map_err(|_| soroban_sdk::xdr::Error::Invalid)?,
+                    )
+                    .into(),
+                    val: (&val.args)
+                        .try_into()
+                        .map_err(|_| soroban_sdk::xdr::Error::Invalid)?,
+                },
+                soroban_sdk::xdr::ScMapEntry {
+                    key: soroban_sdk::xdr::ScSymbol(
+                        "contract"
+                            .try_into()
+                            .map_err(|_| soroban_sdk::xdr::Error::Invalid)?,
+                    )
+                    .into(),
+                    val: (&val.contract)
+                        .try_into()
+                        .map_err(|_| soroban_sdk::xdr::Error::Invalid)?,
+                },
+                soroban_sdk::xdr::ScMapEntry {
+                    key: soroban_sdk::xdr::ScSymbol(
+                        "fn_name"
+                            .try_into()
+                            .map_err(|_| soroban_sdk::xdr::Error::Invalid)?,
+                    )
+                    .into(),
+                    val: (&val.fn_name)
+                        .try_into()
+                        .map_err(|_| soroban_sdk::xdr::Error::Invalid)?,
+                },
+            ])))
+        }
+    }
+    impl TryFrom<ContractContext> for soroban_sdk::xdr::ScMap {
+        type Error = soroban_sdk::xdr::Error;
+        #[inline(always)]
+        fn try_from(val: ContractContext) -> Result<Self, soroban_sdk::xdr::Error> {
+            (&val).try_into()
+        }
+    }
+    impl TryFrom<&ContractContext> for soroban_sdk::xdr::ScVal {
+        type Error = soroban_sdk::xdr::Error;
+        #[inline(always)]
+        fn try_from(val: &ContractContext) -> Result<Self, soroban_sdk::xdr::Error> {
+            Ok(soroban_sdk::xdr::ScVal::Map(Some(val.try_into()?)))
+        }
+    }
+    impl TryFrom<ContractContext> for soroban_sdk::xdr::ScVal {
+        type Error = soroban_sdk::xdr::Error;
+        #[inline(always)]
+        fn try_from(val: ContractContext) -> Result<Self, soroban_sdk::xdr::Error> {
+            (&val).try_into()
+        }
+    }
+    const _: () = {
+        use soroban_sdk::testutils::arbitrary::arbitrary;
+        use soroban_sdk::testutils::arbitrary::std;
+        pub struct ArbitraryContractContext {
+            args: <soroban_sdk::Vec<
+                soroban_sdk::Val,
+            > as soroban_sdk::testutils::arbitrary::SorobanArbitrary>::Prototype,
+            contract: <soroban_sdk::Address as soroban_sdk::testutils::arbitrary::SorobanArbitrary>::Prototype,
+            fn_name: <soroban_sdk::Symbol as soroban_sdk::testutils::arbitrary::SorobanArbitrary>::Prototype,
+        }
+        #[automatically_derived]
+        impl ::core::fmt::Debug for ArbitraryContractContext {
+            #[inline]
+            fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+                ::core::fmt::Formatter::debug_struct_field3_finish(
+                    f,
+                    "ArbitraryContractContext",
+                    "args",
+                    &self.args,
+                    "contract",
+                    &self.contract,
+                    "fn_name",
+                    &&self.fn_name,
+                )
+            }
+        }
+        #[automatically_derived]
+        impl ::core::clone::Clone for ArbitraryContractContext {
+            #[inline]
+            fn clone(&self) -> ArbitraryContractContext {
+                ArbitraryContractContext {
+                    args: ::core::clone::Clone::clone(&self.args),
+                    contract: ::core::clone::Clone::clone(&self.contract),
+                    fn_name: ::core::clone::Clone::clone(&self.fn_name),
+                }
+            }
+        }
+        #[automatically_derived]
+        impl ::core::cmp::Eq for ArbitraryContractContext {
+            #[inline]
+            #[doc(hidden)]
+            #[coverage(off)]
+            fn assert_receiver_is_total_eq(&self) -> () {
+                let _: ::core::cmp::AssertParamIsEq<
+                    <soroban_sdk::Vec<
+                        soroban_sdk::Val,
+                    > as soroban_sdk::testutils::arbitrary::SorobanArbitrary>::Prototype,
+                >;
+                let _: ::core::cmp::AssertParamIsEq<
+                    <soroban_sdk::Address as soroban_sdk::testutils::arbitrary::SorobanArbitrary>::Prototype,
+                >;
+                let _: ::core::cmp::AssertParamIsEq<
+                    <soroban_sdk::Symbol as soroban_sdk::testutils::arbitrary::SorobanArbitrary>::Prototype,
+                >;
+            }
+        }
+        #[automatically_derived]
+        impl ::core::marker::StructuralPartialEq for ArbitraryContractContext {}
+        #[automatically_derived]
+        impl ::core::cmp::PartialEq for ArbitraryContractContext {
+            #[inline]
+            fn eq(&self, other: &ArbitraryContractContext) -> bool {
+                self.args == other.args
+                    && self.contract == other.contract
+                    && self.fn_name == other.fn_name
+            }
+        }
+        #[automatically_derived]
+        impl ::core::cmp::Ord for ArbitraryContractContext {
+            #[inline]
+            fn cmp(&self, other: &ArbitraryContractContext) -> ::core::cmp::Ordering {
+                match ::core::cmp::Ord::cmp(&self.args, &other.args) {
+                    ::core::cmp::Ordering::Equal => {
+                        match ::core::cmp::Ord::cmp(&self.contract, &other.contract) {
+                            ::core::cmp::Ordering::Equal => {
+                                ::core::cmp::Ord::cmp(&self.fn_name, &other.fn_name)
+                            }
+                            cmp => cmp,
+                        }
+                    }
+                    cmp => cmp,
+                }
+            }
+        }
+        #[automatically_derived]
+        impl ::core::cmp::PartialOrd for ArbitraryContractContext {
+            #[inline]
+            fn partial_cmp(
+                &self,
+                other: &ArbitraryContractContext,
+            ) -> ::core::option::Option<::core::cmp::Ordering> {
+                match ::core::cmp::PartialOrd::partial_cmp(&self.args, &other.args) {
+                    ::core::option::Option::Some(::core::cmp::Ordering::Equal) => {
+                        match ::core::cmp::PartialOrd::partial_cmp(&self.contract, &other.contract)
+                        {
+                            ::core::option::Option::Some(::core::cmp::Ordering::Equal) => {
+                                ::core::cmp::PartialOrd::partial_cmp(&self.fn_name, &other.fn_name)
+                            }
+                            cmp => cmp,
+                        }
+                    }
+                    cmp => cmp,
+                }
+            }
+        }
+        const _: () = {
+            #[allow(non_upper_case_globals)]
+            const RECURSIVE_COUNT_ArbitraryContractContext: ::std::thread::LocalKey<
+                std::cell::Cell<u32>,
+            > = {
+                #[inline]
+                fn __init() -> std::cell::Cell<u32> {
+                    std::cell::Cell::new(0)
+                }
+                unsafe {
+                    ::std::thread::LocalKey::new(
+                        const {
+                            if ::std::mem::needs_drop::<std::cell::Cell<u32>>() {
+                                |init| {
+                                    #[thread_local]
+                                    static VAL: ::std::thread::local_impl::LazyStorage<
+                                        std::cell::Cell<u32>,
+                                        (),
+                                    > = ::std::thread::local_impl::LazyStorage::new();
+                                    VAL.get_or_init(init, __init)
+                                }
+                            } else {
+                                |init| {
+                                    #[thread_local]
+                                    static VAL: ::std::thread::local_impl::LazyStorage<
+                                        std::cell::Cell<u32>,
+                                        !,
+                                    > = ::std::thread::local_impl::LazyStorage::new();
+                                    VAL.get_or_init(init, __init)
+                                }
+                            }
+                        },
+                    )
+                }
+            };
+            #[automatically_derived]
+            impl<'arbitrary> arbitrary::Arbitrary<'arbitrary> for ArbitraryContractContext {
+                fn arbitrary(
+                    u: &mut arbitrary::Unstructured<'arbitrary>,
+                ) -> arbitrary::Result<Self> {
+                    let guard_against_recursion = u.is_empty();
+                    if guard_against_recursion {
+                        RECURSIVE_COUNT_ArbitraryContractContext.with(|count| {
+                            if count.get() > 0 {
+                                return Err(arbitrary::Error::NotEnoughData);
+                            }
+                            count.set(count.get() + 1);
+                            Ok(())
+                        })?;
+                    }
+                    let result = (|| {
+                        Ok(ArbitraryContractContext {
+                            args: arbitrary::Arbitrary::arbitrary(u)?,
+                            contract: arbitrary::Arbitrary::arbitrary(u)?,
+                            fn_name: arbitrary::Arbitrary::arbitrary(u)?,
+                        })
+                    })();
+                    if guard_against_recursion {
+                        RECURSIVE_COUNT_ArbitraryContractContext.with(|count| {
+                            count.set(count.get() - 1);
+                        });
+                    }
+                    result
+                }
+                fn arbitrary_take_rest(
+                    mut u: arbitrary::Unstructured<'arbitrary>,
+                ) -> arbitrary::Result<Self> {
+                    let guard_against_recursion = u.is_empty();
+                    if guard_against_recursion {
+                        RECURSIVE_COUNT_ArbitraryContractContext.with(|count| {
+                            if count.get() > 0 {
+                                return Err(arbitrary::Error::NotEnoughData);
+                            }
+                            count.set(count.get() + 1);
+                            Ok(())
+                        })?;
+                    }
+                    let result = (|| {
+                        Ok(ArbitraryContractContext {
+                            args: arbitrary::Arbitrary::arbitrary(&mut u)?,
+                            contract: arbitrary::Arbitrary::arbitrary(&mut u)?,
+                            fn_name: arbitrary::Arbitrary::arbitrary_take_rest(u)?,
+                        })
+                    })();
+                    if guard_against_recursion {
+                        RECURSIVE_COUNT_ArbitraryContractContext.with(|count| {
+                            count.set(count.get() - 1);
+                        });
+                    }
+                    result
+                }
+                #[inline]
+                fn size_hint(depth: usize) -> (usize, Option<usize>) {
+                    arbitrary::size_hint::recursion_guard(depth, |depth| {
+                        arbitrary::size_hint::and_all(
+                            &[
+                                <<soroban_sdk::Vec<
+                                    soroban_sdk::Val,
+                                > as soroban_sdk::testutils::arbitrary::SorobanArbitrary>::Prototype as arbitrary::Arbitrary>::size_hint(
+                                    depth,
+                                ),
+                                <<soroban_sdk::Address as soroban_sdk::testutils::arbitrary::SorobanArbitrary>::Prototype as arbitrary::Arbitrary>::size_hint(
+                                    depth,
+                                ),
+                                <<soroban_sdk::Symbol as soroban_sdk::testutils::arbitrary::SorobanArbitrary>::Prototype as arbitrary::Arbitrary>::size_hint(
+                                    depth,
+                                ),
+                            ],
+                        )
+                    })
+                }
+            }
+        };
+        impl soroban_sdk::testutils::arbitrary::SorobanArbitrary for ContractContext {
+            type Prototype = ArbitraryContractContext;
+        }
+        impl soroban_sdk::TryFromVal<soroban_sdk::Env, ArbitraryContractContext> for ContractContext {
+            type Error = soroban_sdk::ConversionError;
+            fn try_from_val(
+                env: &soroban_sdk::Env,
+                v: &ArbitraryContractContext,
+            ) -> std::result::Result<Self, Self::Error> {
+                Ok(ContractContext {
+                    args: soroban_sdk::IntoVal::into_val(&v.args, env),
+                    contract: soroban_sdk::IntoVal::into_val(&v.contract, env),
+                    fn_name: soroban_sdk::IntoVal::into_val(&v.fn_name, env),
+                })
+            }
+        }
+    };
+    pub struct SubContractInvocation {
+        pub context: ContractContext,
+        pub sub_invocations: soroban_sdk::Vec<InvokerContractAuthEntry>,
+    }
+    #[automatically_derived]
+    impl ::core::fmt::Debug for SubContractInvocation {
+        #[inline]
+        fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+            ::core::fmt::Formatter::debug_struct_field2_finish(
+                f,
+                "SubContractInvocation",
+                "context",
+                &self.context,
+                "sub_invocations",
+                &&self.sub_invocations,
+            )
+        }
+    }
+    #[automatically_derived]
+    impl ::core::clone::Clone for SubContractInvocation {
+        #[inline]
+        fn clone(&self) -> SubContractInvocation {
+            SubContractInvocation {
+                context: ::core::clone::Clone::clone(&self.context),
+                sub_invocations: ::core::clone::Clone::clone(&self.sub_invocations),
+            }
+        }
+    }
+    #[automatically_derived]
+    impl ::core::cmp::Eq for SubContractInvocation {
+        #[inline]
+        #[doc(hidden)]
+        #[coverage(off)]
+        fn assert_receiver_is_total_eq(&self) -> () {
+            let _: ::core::cmp::AssertParamIsEq<ContractContext>;
+            let _: ::core::cmp::AssertParamIsEq<soroban_sdk::Vec<InvokerContractAuthEntry>>;
+        }
+    }
+    #[automatically_derived]
+    impl ::core::marker::StructuralPartialEq for SubContractInvocation {}
+    #[automatically_derived]
+    impl ::core::cmp::PartialEq for SubContractInvocation {
+        #[inline]
+        fn eq(&self, other: &SubContractInvocation) -> bool {
+            self.context == other.context && self.sub_invocations == other.sub_invocations
+        }
+    }
+    #[automatically_derived]
+    impl ::core::cmp::Ord for SubContractInvocation {
+        #[inline]
+        fn cmp(&self, other: &SubContractInvocation) -> ::core::cmp::Ordering {
+            match ::core::cmp::Ord::cmp(&self.context, &other.context) {
+                ::core::cmp::Ordering::Equal => {
+                    ::core::cmp::Ord::cmp(&self.sub_invocations, &other.sub_invocations)
+                }
+                cmp => cmp,
+            }
+        }
+    }
+    #[automatically_derived]
+    impl ::core::cmp::PartialOrd for SubContractInvocation {
+        #[inline]
+        fn partial_cmp(
+            &self,
+            other: &SubContractInvocation,
+        ) -> ::core::option::Option<::core::cmp::Ordering> {
+            match ::core::cmp::PartialOrd::partial_cmp(&self.context, &other.context) {
+                ::core::option::Option::Some(::core::cmp::Ordering::Equal) => {
+                    ::core::cmp::PartialOrd::partial_cmp(
+                        &self.sub_invocations,
+                        &other.sub_invocations,
+                    )
+                }
+                cmp => cmp,
+            }
+        }
+    }
+    impl soroban_sdk::TryFromVal<soroban_sdk::Env, soroban_sdk::Val> for SubContractInvocation {
+        type Error = soroban_sdk::ConversionError;
+        fn try_from_val(
+            env: &soroban_sdk::Env,
+            val: &soroban_sdk::Val,
+        ) -> Result<Self, soroban_sdk::ConversionError> {
+            use soroban_sdk::{ConversionError, EnvBase, MapObject, TryIntoVal, Val};
+            const KEYS: [&'static str; 2usize] = ["context", "sub_invocations"];
+            let mut vals: [Val; 2usize] = [Val::VOID.to_val(); 2usize];
+            let map: MapObject = val.try_into().map_err(|_| ConversionError)?;
+            env.map_unpack_to_slice(map, &KEYS, &mut vals)
+                .map_err(|_| ConversionError)?;
+            Ok(Self {
+                context: vals[0]
+                    .try_into_val(env)
+                    .map_err(|_| soroban_sdk::ConversionError)?,
+                sub_invocations: vals[1]
+                    .try_into_val(env)
+                    .map_err(|_| soroban_sdk::ConversionError)?,
+            })
+        }
+    }
+    impl soroban_sdk::TryFromVal<soroban_sdk::Env, SubContractInvocation> for soroban_sdk::Val {
+        type Error = soroban_sdk::ConversionError;
+        fn try_from_val(
+            env: &soroban_sdk::Env,
+            val: &SubContractInvocation,
+        ) -> Result<Self, soroban_sdk::ConversionError> {
+            use soroban_sdk::{ConversionError, EnvBase, TryIntoVal, Val};
+            const KEYS: [&'static str; 2usize] = ["context", "sub_invocations"];
+            let vals: [Val; 2usize] = [
+                (&val.context)
+                    .try_into_val(env)
+                    .map_err(|_| ConversionError)?,
+                (&val.sub_invocations)
+                    .try_into_val(env)
+                    .map_err(|_| ConversionError)?,
+            ];
+            Ok(env
+                .map_new_from_slices(&KEYS, &vals)
+                .map_err(|_| ConversionError)?
+                .into())
+        }
+    }
+    impl soroban_sdk::TryFromVal<soroban_sdk::Env, &SubContractInvocation> for soroban_sdk::Val {
+        type Error = soroban_sdk::ConversionError;
+        #[inline(always)]
+        fn try_from_val(
+            env: &soroban_sdk::Env,
+            val: &&SubContractInvocation,
+        ) -> Result<Self, soroban_sdk::ConversionError> {
+            <_ as soroban_sdk::TryFromVal<soroban_sdk::Env, SubContractInvocation>>::try_from_val(
+                env, *val,
+            )
+        }
+    }
+    impl soroban_sdk::TryFromVal<soroban_sdk::Env, soroban_sdk::xdr::ScMap> for SubContractInvocation {
+        type Error = soroban_sdk::xdr::Error;
+        #[inline(always)]
+        fn try_from_val(
+            env: &soroban_sdk::Env,
+            val: &soroban_sdk::xdr::ScMap,
+        ) -> Result<Self, soroban_sdk::xdr::Error> {
+            use soroban_sdk::xdr::Validate;
+            use soroban_sdk::TryIntoVal;
+            let map = val;
+            if map.len() != 2usize {
+                return Err(soroban_sdk::xdr::Error::Invalid);
+            }
+            map.validate()?;
+            Ok(Self {
+                context: {
+                    let key: soroban_sdk::xdr::ScVal = soroban_sdk::xdr::ScSymbol(
+                        "context"
+                            .try_into()
+                            .map_err(|_| soroban_sdk::xdr::Error::Invalid)?,
+                    )
+                    .into();
+                    let idx = map
+                        .binary_search_by_key(&key, |entry| entry.key.clone())
+                        .map_err(|_| soroban_sdk::xdr::Error::Invalid)?;
+                    let rv: soroban_sdk::Val = (&map[idx].val.clone())
+                        .try_into_val(env)
+                        .map_err(|_| soroban_sdk::xdr::Error::Invalid)?;
+                    rv.try_into_val(env)
+                        .map_err(|_| soroban_sdk::xdr::Error::Invalid)?
+                },
+                sub_invocations: {
+                    let key: soroban_sdk::xdr::ScVal = soroban_sdk::xdr::ScSymbol(
+                        "sub_invocations"
+                            .try_into()
+                            .map_err(|_| soroban_sdk::xdr::Error::Invalid)?,
+                    )
+                    .into();
+                    let idx = map
+                        .binary_search_by_key(&key, |entry| entry.key.clone())
+                        .map_err(|_| soroban_sdk::xdr::Error::Invalid)?;
+                    let rv: soroban_sdk::Val = (&map[idx].val.clone())
+                        .try_into_val(env)
+                        .map_err(|_| soroban_sdk::xdr::Error::Invalid)?;
+                    rv.try_into_val(env)
+                        .map_err(|_| soroban_sdk::xdr::Error::Invalid)?
+                },
+            })
+        }
+    }
+    impl soroban_sdk::TryFromVal<soroban_sdk::Env, soroban_sdk::xdr::ScVal> for SubContractInvocation {
+        type Error = soroban_sdk::xdr::Error;
+        #[inline(always)]
+        fn try_from_val(
+            env: &soroban_sdk::Env,
+            val: &soroban_sdk::xdr::ScVal,
+        ) -> Result<Self, soroban_sdk::xdr::Error> {
+            if let soroban_sdk::xdr::ScVal::Map(Some(map)) = val {
+                <_ as soroban_sdk::TryFromVal<_, _>>::try_from_val(env, map)
+            } else {
+                Err(soroban_sdk::xdr::Error::Invalid)
+            }
+        }
+    }
+    impl TryFrom<&SubContractInvocation> for soroban_sdk::xdr::ScMap {
+        type Error = soroban_sdk::xdr::Error;
+        #[inline(always)]
+        fn try_from(val: &SubContractInvocation) -> Result<Self, soroban_sdk::xdr::Error> {
+            extern crate alloc;
+            use soroban_sdk::TryFromVal;
+            soroban_sdk::xdr::ScMap::sorted_from(<[_]>::into_vec(::alloc::boxed::box_new([
+                soroban_sdk::xdr::ScMapEntry {
+                    key: soroban_sdk::xdr::ScSymbol(
+                        "context"
+                            .try_into()
+                            .map_err(|_| soroban_sdk::xdr::Error::Invalid)?,
+                    )
+                    .into(),
+                    val: (&val.context)
+                        .try_into()
+                        .map_err(|_| soroban_sdk::xdr::Error::Invalid)?,
+                },
+                soroban_sdk::xdr::ScMapEntry {
+                    key: soroban_sdk::xdr::ScSymbol(
+                        "sub_invocations"
+                            .try_into()
+                            .map_err(|_| soroban_sdk::xdr::Error::Invalid)?,
+                    )
+                    .into(),
+                    val: (&val.sub_invocations)
+                        .try_into()
+                        .map_err(|_| soroban_sdk::xdr::Error::Invalid)?,
+                },
+            ])))
+        }
+    }
+    impl TryFrom<SubContractInvocation> for soroban_sdk::xdr::ScMap {
+        type Error = soroban_sdk::xdr::Error;
+        #[inline(always)]
+        fn try_from(val: SubContractInvocation) -> Result<Self, soroban_sdk::xdr::Error> {
+            (&val).try_into()
+        }
+    }
+    impl TryFrom<&SubContractInvocation> for soroban_sdk::xdr::ScVal {
+        type Error = soroban_sdk::xdr::Error;
+        #[inline(always)]
+        fn try_from(val: &SubContractInvocation) -> Result<Self, soroban_sdk::xdr::Error> {
+            Ok(soroban_sdk::xdr::ScVal::Map(Some(val.try_into()?)))
+        }
+    }
+    impl TryFrom<SubContractInvocation> for soroban_sdk::xdr::ScVal {
+        type Error = soroban_sdk::xdr::Error;
+        #[inline(always)]
+        fn try_from(val: SubContractInvocation) -> Result<Self, soroban_sdk::xdr::Error> {
+            (&val).try_into()
+        }
+    }
+    const _: () = {
+        use soroban_sdk::testutils::arbitrary::arbitrary;
+        use soroban_sdk::testutils::arbitrary::std;
+        pub struct ArbitrarySubContractInvocation {
+            context: <ContractContext as soroban_sdk::testutils::arbitrary::SorobanArbitrary>::Prototype,
+            sub_invocations: <soroban_sdk::Vec<
+                InvokerContractAuthEntry,
+            > as soroban_sdk::testutils::arbitrary::SorobanArbitrary>::Prototype,
+        }
+        #[automatically_derived]
+        impl ::core::fmt::Debug for ArbitrarySubContractInvocation {
+            #[inline]
+            fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+                ::core::fmt::Formatter::debug_struct_field2_finish(
+                    f,
+                    "ArbitrarySubContractInvocation",
+                    "context",
+                    &self.context,
+                    "sub_invocations",
+                    &&self.sub_invocations,
+                )
+            }
+        }
+        #[automatically_derived]
+        impl ::core::clone::Clone for ArbitrarySubContractInvocation {
+            #[inline]
+            fn clone(&self) -> ArbitrarySubContractInvocation {
+                ArbitrarySubContractInvocation {
+                    context: ::core::clone::Clone::clone(&self.context),
+                    sub_invocations: ::core::clone::Clone::clone(&self.sub_invocations),
+                }
+            }
+        }
+        #[automatically_derived]
+        impl ::core::cmp::Eq for ArbitrarySubContractInvocation {
+            #[inline]
+            #[doc(hidden)]
+            #[coverage(off)]
+            fn assert_receiver_is_total_eq(&self) -> () {
+                let _: ::core::cmp::AssertParamIsEq<
+                    <ContractContext as soroban_sdk::testutils::arbitrary::SorobanArbitrary>::Prototype,
+                >;
+                let _: ::core::cmp::AssertParamIsEq<
+                    <soroban_sdk::Vec<
+                        InvokerContractAuthEntry,
+                    > as soroban_sdk::testutils::arbitrary::SorobanArbitrary>::Prototype,
+                >;
+            }
+        }
+        #[automatically_derived]
+        impl ::core::marker::StructuralPartialEq for ArbitrarySubContractInvocation {}
+        #[automatically_derived]
+        impl ::core::cmp::PartialEq for ArbitrarySubContractInvocation {
+            #[inline]
+            fn eq(&self, other: &ArbitrarySubContractInvocation) -> bool {
+                self.context == other.context && self.sub_invocations == other.sub_invocations
+            }
+        }
+        #[automatically_derived]
+        impl ::core::cmp::Ord for ArbitrarySubContractInvocation {
+            #[inline]
+            fn cmp(&self, other: &ArbitrarySubContractInvocation) -> ::core::cmp::Ordering {
+                match ::core::cmp::Ord::cmp(&self.context, &other.context) {
+                    ::core::cmp::Ordering::Equal => {
+                        ::core::cmp::Ord::cmp(&self.sub_invocations, &other.sub_invocations)
+                    }
+                    cmp => cmp,
+                }
+            }
+        }
+        #[automatically_derived]
+        impl ::core::cmp::PartialOrd for ArbitrarySubContractInvocation {
+            #[inline]
+            fn partial_cmp(
+                &self,
+                other: &ArbitrarySubContractInvocation,
+            ) -> ::core::option::Option<::core::cmp::Ordering> {
+                match ::core::cmp::PartialOrd::partial_cmp(&self.context, &other.context) {
+                    ::core::option::Option::Some(::core::cmp::Ordering::Equal) => {
+                        ::core::cmp::PartialOrd::partial_cmp(
+                            &self.sub_invocations,
+                            &other.sub_invocations,
+                        )
+                    }
+                    cmp => cmp,
+                }
+            }
+        }
+        const _: () = {
+            #[allow(non_upper_case_globals)]
+            const RECURSIVE_COUNT_ArbitrarySubContractInvocation: ::std::thread::LocalKey<
+                std::cell::Cell<u32>,
+            > = {
+                #[inline]
+                fn __init() -> std::cell::Cell<u32> {
+                    std::cell::Cell::new(0)
+                }
+                unsafe {
+                    ::std::thread::LocalKey::new(
+                        const {
+                            if ::std::mem::needs_drop::<std::cell::Cell<u32>>() {
+                                |init| {
+                                    #[thread_local]
+                                    static VAL: ::std::thread::local_impl::LazyStorage<
+                                        std::cell::Cell<u32>,
+                                        (),
+                                    > = ::std::thread::local_impl::LazyStorage::new();
+                                    VAL.get_or_init(init, __init)
+                                }
+                            } else {
+                                |init| {
+                                    #[thread_local]
+                                    static VAL: ::std::thread::local_impl::LazyStorage<
+                                        std::cell::Cell<u32>,
+                                        !,
+                                    > = ::std::thread::local_impl::LazyStorage::new();
+                                    VAL.get_or_init(init, __init)
+                                }
+                            }
+                        },
+                    )
+                }
+            };
+            #[automatically_derived]
+            impl<'arbitrary> arbitrary::Arbitrary<'arbitrary> for ArbitrarySubContractInvocation {
+                fn arbitrary(
+                    u: &mut arbitrary::Unstructured<'arbitrary>,
+                ) -> arbitrary::Result<Self> {
+                    let guard_against_recursion = u.is_empty();
+                    if guard_against_recursion {
+                        RECURSIVE_COUNT_ArbitrarySubContractInvocation.with(|count| {
+                            if count.get() > 0 {
+                                return Err(arbitrary::Error::NotEnoughData);
+                            }
+                            count.set(count.get() + 1);
+                            Ok(())
+                        })?;
+                    }
+                    let result = (|| {
+                        Ok(ArbitrarySubContractInvocation {
+                            context: arbitrary::Arbitrary::arbitrary(u)?,
+                            sub_invocations: arbitrary::Arbitrary::arbitrary(u)?,
+                        })
+                    })();
+                    if guard_against_recursion {
+                        RECURSIVE_COUNT_ArbitrarySubContractInvocation.with(|count| {
+                            count.set(count.get() - 1);
+                        });
+                    }
+                    result
+                }
+                fn arbitrary_take_rest(
+                    mut u: arbitrary::Unstructured<'arbitrary>,
+                ) -> arbitrary::Result<Self> {
+                    let guard_against_recursion = u.is_empty();
+                    if guard_against_recursion {
+                        RECURSIVE_COUNT_ArbitrarySubContractInvocation.with(|count| {
+                            if count.get() > 0 {
+                                return Err(arbitrary::Error::NotEnoughData);
+                            }
+                            count.set(count.get() + 1);
+                            Ok(())
+                        })?;
+                    }
+                    let result = (|| {
+                        Ok(ArbitrarySubContractInvocation {
+                            context: arbitrary::Arbitrary::arbitrary(&mut u)?,
+                            sub_invocations: arbitrary::Arbitrary::arbitrary_take_rest(u)?,
+                        })
+                    })();
+                    if guard_against_recursion {
+                        RECURSIVE_COUNT_ArbitrarySubContractInvocation.with(|count| {
+                            count.set(count.get() - 1);
+                        });
+                    }
+                    result
+                }
+                #[inline]
+                fn size_hint(depth: usize) -> (usize, Option<usize>) {
+                    arbitrary::size_hint::recursion_guard(depth, |depth| {
+                        arbitrary::size_hint::and_all(
+                            &[
+                                <<ContractContext as soroban_sdk::testutils::arbitrary::SorobanArbitrary>::Prototype as arbitrary::Arbitrary>::size_hint(
+                                    depth,
+                                ),
+                                <<soroban_sdk::Vec<
+                                    InvokerContractAuthEntry,
+                                > as soroban_sdk::testutils::arbitrary::SorobanArbitrary>::Prototype as arbitrary::Arbitrary>::size_hint(
+                                    depth,
+                                ),
+                            ],
+                        )
+                    })
+                }
+            }
+        };
+        impl soroban_sdk::testutils::arbitrary::SorobanArbitrary for SubContractInvocation {
+            type Prototype = ArbitrarySubContractInvocation;
+        }
+        impl soroban_sdk::TryFromVal<soroban_sdk::Env, ArbitrarySubContractInvocation>
+            for SubContractInvocation
+        {
+            type Error = soroban_sdk::ConversionError;
+            fn try_from_val(
+                env: &soroban_sdk::Env,
+                v: &ArbitrarySubContractInvocation,
+            ) -> std::result::Result<Self, Self::Error> {
+                Ok(SubContractInvocation {
+                    context: soroban_sdk::IntoVal::into_val(&v.context, env),
+                    sub_invocations: soroban_sdk::IntoVal::into_val(&v.sub_invocations, env),
+                })
+            }
+        }
+    };
+    pub struct CreateContractHostFnContext {
+        pub executable: ContractExecutable,
+        pub salt: soroban_sdk::BytesN<32>,
+    }
+    #[automatically_derived]
+    impl ::core::fmt::Debug for CreateContractHostFnContext {
+        #[inline]
+        fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+            ::core::fmt::Formatter::debug_struct_field2_finish(
+                f,
+                "CreateContractHostFnContext",
+                "executable",
+                &self.executable,
+                "salt",
+                &&self.salt,
+            )
+        }
+    }
+    #[automatically_derived]
+    impl ::core::clone::Clone for CreateContractHostFnContext {
+        #[inline]
+        fn clone(&self) -> CreateContractHostFnContext {
+            CreateContractHostFnContext {
+                executable: ::core::clone::Clone::clone(&self.executable),
+                salt: ::core::clone::Clone::clone(&self.salt),
+            }
+        }
+    }
+    #[automatically_derived]
+    impl ::core::cmp::Eq for CreateContractHostFnContext {
+        #[inline]
+        #[doc(hidden)]
+        #[coverage(off)]
+        fn assert_receiver_is_total_eq(&self) -> () {
+            let _: ::core::cmp::AssertParamIsEq<ContractExecutable>;
+            let _: ::core::cmp::AssertParamIsEq<soroban_sdk::BytesN<32>>;
+        }
+    }
+    #[automatically_derived]
+    impl ::core::marker::StructuralPartialEq for CreateContractHostFnContext {}
+    #[automatically_derived]
+    impl ::core::cmp::PartialEq for CreateContractHostFnContext {
+        #[inline]
+        fn eq(&self, other: &CreateContractHostFnContext) -> bool {
+            self.executable == other.executable && self.salt == other.salt
+        }
+    }
+    #[automatically_derived]
+    impl ::core::cmp::Ord for CreateContractHostFnContext {
+        #[inline]
+        fn cmp(&self, other: &CreateContractHostFnContext) -> ::core::cmp::Ordering {
+            match ::core::cmp::Ord::cmp(&self.executable, &other.executable) {
+                ::core::cmp::Ordering::Equal => ::core::cmp::Ord::cmp(&self.salt, &other.salt),
+                cmp => cmp,
+            }
+        }
+    }
+    #[automatically_derived]
+    impl ::core::cmp::PartialOrd for CreateContractHostFnContext {
+        #[inline]
+        fn partial_cmp(
+            &self,
+            other: &CreateContractHostFnContext,
+        ) -> ::core::option::Option<::core::cmp::Ordering> {
+            match ::core::cmp::PartialOrd::partial_cmp(&self.executable, &other.executable) {
+                ::core::option::Option::Some(::core::cmp::Ordering::Equal) => {
+                    ::core::cmp::PartialOrd::partial_cmp(&self.salt, &other.salt)
+                }
+                cmp => cmp,
+            }
+        }
+    }
+    impl soroban_sdk::TryFromVal<soroban_sdk::Env, soroban_sdk::Val> for CreateContractHostFnContext {
+        type Error = soroban_sdk::ConversionError;
+        fn try_from_val(
+            env: &soroban_sdk::Env,
+            val: &soroban_sdk::Val,
+        ) -> Result<Self, soroban_sdk::ConversionError> {
+            use soroban_sdk::{ConversionError, EnvBase, MapObject, TryIntoVal, Val};
+            const KEYS: [&'static str; 2usize] = ["executable", "salt"];
+            let mut vals: [Val; 2usize] = [Val::VOID.to_val(); 2usize];
+            let map: MapObject = val.try_into().map_err(|_| ConversionError)?;
+            env.map_unpack_to_slice(map, &KEYS, &mut vals)
+                .map_err(|_| ConversionError)?;
+            Ok(Self {
+                executable: vals[0]
+                    .try_into_val(env)
+                    .map_err(|_| soroban_sdk::ConversionError)?,
+                salt: vals[1]
+                    .try_into_val(env)
+                    .map_err(|_| soroban_sdk::ConversionError)?,
+            })
+        }
+    }
+    impl soroban_sdk::TryFromVal<soroban_sdk::Env, CreateContractHostFnContext> for soroban_sdk::Val {
+        type Error = soroban_sdk::ConversionError;
+        fn try_from_val(
+            env: &soroban_sdk::Env,
+            val: &CreateContractHostFnContext,
+        ) -> Result<Self, soroban_sdk::ConversionError> {
+            use soroban_sdk::{ConversionError, EnvBase, TryIntoVal, Val};
+            const KEYS: [&'static str; 2usize] = ["executable", "salt"];
+            let vals: [Val; 2usize] = [
+                (&val.executable)
+                    .try_into_val(env)
+                    .map_err(|_| ConversionError)?,
+                (&val.salt).try_into_val(env).map_err(|_| ConversionError)?,
+            ];
+            Ok(env
+                .map_new_from_slices(&KEYS, &vals)
+                .map_err(|_| ConversionError)?
+                .into())
+        }
+    }
+    impl soroban_sdk::TryFromVal<soroban_sdk::Env, &CreateContractHostFnContext> for soroban_sdk::Val {
+        type Error = soroban_sdk::ConversionError;
+        #[inline(always)]
+        fn try_from_val(
+            env: &soroban_sdk::Env,
+            val: &&CreateContractHostFnContext,
+        ) -> Result<Self, soroban_sdk::ConversionError> {
+            <_ as soroban_sdk::TryFromVal<
+                soroban_sdk::Env,
+                CreateContractHostFnContext,
+            >>::try_from_val(env, *val)
+        }
+    }
+    impl soroban_sdk::TryFromVal<soroban_sdk::Env, soroban_sdk::xdr::ScMap>
+        for CreateContractHostFnContext
+    {
+        type Error = soroban_sdk::xdr::Error;
+        #[inline(always)]
+        fn try_from_val(
+            env: &soroban_sdk::Env,
+            val: &soroban_sdk::xdr::ScMap,
+        ) -> Result<Self, soroban_sdk::xdr::Error> {
+            use soroban_sdk::xdr::Validate;
+            use soroban_sdk::TryIntoVal;
+            let map = val;
+            if map.len() != 2usize {
+                return Err(soroban_sdk::xdr::Error::Invalid);
+            }
+            map.validate()?;
+            Ok(Self {
+                executable: {
+                    let key: soroban_sdk::xdr::ScVal = soroban_sdk::xdr::ScSymbol(
+                        "executable"
+                            .try_into()
+                            .map_err(|_| soroban_sdk::xdr::Error::Invalid)?,
+                    )
+                    .into();
+                    let idx = map
+                        .binary_search_by_key(&key, |entry| entry.key.clone())
+                        .map_err(|_| soroban_sdk::xdr::Error::Invalid)?;
+                    let rv: soroban_sdk::Val = (&map[idx].val.clone())
+                        .try_into_val(env)
+                        .map_err(|_| soroban_sdk::xdr::Error::Invalid)?;
+                    rv.try_into_val(env)
+                        .map_err(|_| soroban_sdk::xdr::Error::Invalid)?
+                },
+                salt: {
+                    let key: soroban_sdk::xdr::ScVal = soroban_sdk::xdr::ScSymbol(
+                        "salt"
+                            .try_into()
+                            .map_err(|_| soroban_sdk::xdr::Error::Invalid)?,
+                    )
+                    .into();
+                    let idx = map
+                        .binary_search_by_key(&key, |entry| entry.key.clone())
+                        .map_err(|_| soroban_sdk::xdr::Error::Invalid)?;
+                    let rv: soroban_sdk::Val = (&map[idx].val.clone())
+                        .try_into_val(env)
+                        .map_err(|_| soroban_sdk::xdr::Error::Invalid)?;
+                    rv.try_into_val(env)
+                        .map_err(|_| soroban_sdk::xdr::Error::Invalid)?
+                },
+            })
+        }
+    }
+    impl soroban_sdk::TryFromVal<soroban_sdk::Env, soroban_sdk::xdr::ScVal>
+        for CreateContractHostFnContext
+    {
+        type Error = soroban_sdk::xdr::Error;
+        #[inline(always)]
+        fn try_from_val(
+            env: &soroban_sdk::Env,
+            val: &soroban_sdk::xdr::ScVal,
+        ) -> Result<Self, soroban_sdk::xdr::Error> {
+            if let soroban_sdk::xdr::ScVal::Map(Some(map)) = val {
+                <_ as soroban_sdk::TryFromVal<_, _>>::try_from_val(env, map)
+            } else {
+                Err(soroban_sdk::xdr::Error::Invalid)
+            }
+        }
+    }
+    impl TryFrom<&CreateContractHostFnContext> for soroban_sdk::xdr::ScMap {
+        type Error = soroban_sdk::xdr::Error;
+        #[inline(always)]
+        fn try_from(val: &CreateContractHostFnContext) -> Result<Self, soroban_sdk::xdr::Error> {
+            extern crate alloc;
+            use soroban_sdk::TryFromVal;
+            soroban_sdk::xdr::ScMap::sorted_from(<[_]>::into_vec(::alloc::boxed::box_new([
+                soroban_sdk::xdr::ScMapEntry {
+                    key: soroban_sdk::xdr::ScSymbol(
+                        "executable"
+                            .try_into()
+                            .map_err(|_| soroban_sdk::xdr::Error::Invalid)?,
+                    )
+                    .into(),
+                    val: (&val.executable)
+                        .try_into()
+                        .map_err(|_| soroban_sdk::xdr::Error::Invalid)?,
+                },
+                soroban_sdk::xdr::ScMapEntry {
+                    key: soroban_sdk::xdr::ScSymbol(
+                        "salt"
+                            .try_into()
+                            .map_err(|_| soroban_sdk::xdr::Error::Invalid)?,
+                    )
+                    .into(),
+                    val: (&val.salt)
+                        .try_into()
+                        .map_err(|_| soroban_sdk::xdr::Error::Invalid)?,
+                },
+            ])))
+        }
+    }
+    impl TryFrom<CreateContractHostFnContext> for soroban_sdk::xdr::ScMap {
+        type Error = soroban_sdk::xdr::Error;
+        #[inline(always)]
+        fn try_from(val: CreateContractHostFnContext) -> Result<Self, soroban_sdk::xdr::Error> {
+            (&val).try_into()
+        }
+    }
+    impl TryFrom<&CreateContractHostFnContext> for soroban_sdk::xdr::ScVal {
+        type Error = soroban_sdk::xdr::Error;
+        #[inline(always)]
+        fn try_from(val: &CreateContractHostFnContext) -> Result<Self, soroban_sdk::xdr::Error> {
+            Ok(soroban_sdk::xdr::ScVal::Map(Some(val.try_into()?)))
+        }
+    }
+    impl TryFrom<CreateContractHostFnContext> for soroban_sdk::xdr::ScVal {
+        type Error = soroban_sdk::xdr::Error;
+        #[inline(always)]
+        fn try_from(val: CreateContractHostFnContext) -> Result<Self, soroban_sdk::xdr::Error> {
+            (&val).try_into()
+        }
+    }
+    const _: () = {
+        use soroban_sdk::testutils::arbitrary::arbitrary;
+        use soroban_sdk::testutils::arbitrary::std;
+        pub struct ArbitraryCreateContractHostFnContext {
+            executable: <ContractExecutable as soroban_sdk::testutils::arbitrary::SorobanArbitrary>::Prototype,
+            salt: <soroban_sdk::BytesN<
+                32,
+            > as soroban_sdk::testutils::arbitrary::SorobanArbitrary>::Prototype,
+        }
+        #[automatically_derived]
+        impl ::core::fmt::Debug for ArbitraryCreateContractHostFnContext {
+            #[inline]
+            fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+                ::core::fmt::Formatter::debug_struct_field2_finish(
+                    f,
+                    "ArbitraryCreateContractHostFnContext",
+                    "executable",
+                    &self.executable,
+                    "salt",
+                    &&self.salt,
+                )
+            }
+        }
+        #[automatically_derived]
+        impl ::core::clone::Clone for ArbitraryCreateContractHostFnContext {
+            #[inline]
+            fn clone(&self) -> ArbitraryCreateContractHostFnContext {
+                ArbitraryCreateContractHostFnContext {
+                    executable: ::core::clone::Clone::clone(&self.executable),
+                    salt: ::core::clone::Clone::clone(&self.salt),
+                }
+            }
+        }
+        #[automatically_derived]
+        impl ::core::cmp::Eq for ArbitraryCreateContractHostFnContext {
+            #[inline]
+            #[doc(hidden)]
+            #[coverage(off)]
+            fn assert_receiver_is_total_eq(&self) -> () {
+                let _: ::core::cmp::AssertParamIsEq<
+                    <ContractExecutable as soroban_sdk::testutils::arbitrary::SorobanArbitrary>::Prototype,
+                >;
+                let _: ::core::cmp::AssertParamIsEq<
+                    <soroban_sdk::BytesN<
+                        32,
+                    > as soroban_sdk::testutils::arbitrary::SorobanArbitrary>::Prototype,
+                >;
+            }
+        }
+        #[automatically_derived]
+        impl ::core::marker::StructuralPartialEq for ArbitraryCreateContractHostFnContext {}
+        #[automatically_derived]
+        impl ::core::cmp::PartialEq for ArbitraryCreateContractHostFnContext {
+            #[inline]
+            fn eq(&self, other: &ArbitraryCreateContractHostFnContext) -> bool {
+                self.executable == other.executable && self.salt == other.salt
+            }
+        }
+        #[automatically_derived]
+        impl ::core::cmp::Ord for ArbitraryCreateContractHostFnContext {
+            #[inline]
+            fn cmp(&self, other: &ArbitraryCreateContractHostFnContext) -> ::core::cmp::Ordering {
+                match ::core::cmp::Ord::cmp(&self.executable, &other.executable) {
+                    ::core::cmp::Ordering::Equal => ::core::cmp::Ord::cmp(&self.salt, &other.salt),
+                    cmp => cmp,
+                }
+            }
+        }
+        #[automatically_derived]
+        impl ::core::cmp::PartialOrd for ArbitraryCreateContractHostFnContext {
+            #[inline]
+            fn partial_cmp(
+                &self,
+                other: &ArbitraryCreateContractHostFnContext,
+            ) -> ::core::option::Option<::core::cmp::Ordering> {
+                match ::core::cmp::PartialOrd::partial_cmp(&self.executable, &other.executable) {
+                    ::core::option::Option::Some(::core::cmp::Ordering::Equal) => {
+                        ::core::cmp::PartialOrd::partial_cmp(&self.salt, &other.salt)
+                    }
+                    cmp => cmp,
+                }
+            }
+        }
+        const _: () = {
+            #[allow(non_upper_case_globals)]
+            const RECURSIVE_COUNT_ArbitraryCreateContractHostFnContext: ::std::thread::LocalKey<
+                std::cell::Cell<u32>,
+            > = {
+                #[inline]
+                fn __init() -> std::cell::Cell<u32> {
+                    std::cell::Cell::new(0)
+                }
+                unsafe {
+                    ::std::thread::LocalKey::new(
+                        const {
+                            if ::std::mem::needs_drop::<std::cell::Cell<u32>>() {
+                                |init| {
+                                    #[thread_local]
+                                    static VAL: ::std::thread::local_impl::LazyStorage<
+                                        std::cell::Cell<u32>,
+                                        (),
+                                    > = ::std::thread::local_impl::LazyStorage::new();
+                                    VAL.get_or_init(init, __init)
+                                }
+                            } else {
+                                |init| {
+                                    #[thread_local]
+                                    static VAL: ::std::thread::local_impl::LazyStorage<
+                                        std::cell::Cell<u32>,
+                                        !,
+                                    > = ::std::thread::local_impl::LazyStorage::new();
+                                    VAL.get_or_init(init, __init)
+                                }
+                            }
+                        },
+                    )
+                }
+            };
+            #[automatically_derived]
+            impl<'arbitrary> arbitrary::Arbitrary<'arbitrary> for ArbitraryCreateContractHostFnContext {
+                fn arbitrary(
+                    u: &mut arbitrary::Unstructured<'arbitrary>,
+                ) -> arbitrary::Result<Self> {
+                    let guard_against_recursion = u.is_empty();
+                    if guard_against_recursion {
+                        RECURSIVE_COUNT_ArbitraryCreateContractHostFnContext.with(|count| {
+                            if count.get() > 0 {
+                                return Err(arbitrary::Error::NotEnoughData);
+                            }
+                            count.set(count.get() + 1);
+                            Ok(())
+                        })?;
+                    }
+                    let result = (|| {
+                        Ok(ArbitraryCreateContractHostFnContext {
+                            executable: arbitrary::Arbitrary::arbitrary(u)?,
+                            salt: arbitrary::Arbitrary::arbitrary(u)?,
+                        })
+                    })();
+                    if guard_against_recursion {
+                        RECURSIVE_COUNT_ArbitraryCreateContractHostFnContext.with(|count| {
+                            count.set(count.get() - 1);
+                        });
+                    }
+                    result
+                }
+                fn arbitrary_take_rest(
+                    mut u: arbitrary::Unstructured<'arbitrary>,
+                ) -> arbitrary::Result<Self> {
+                    let guard_against_recursion = u.is_empty();
+                    if guard_against_recursion {
+                        RECURSIVE_COUNT_ArbitraryCreateContractHostFnContext.with(|count| {
+                            if count.get() > 0 {
+                                return Err(arbitrary::Error::NotEnoughData);
+                            }
+                            count.set(count.get() + 1);
+                            Ok(())
+                        })?;
+                    }
+                    let result = (|| {
+                        Ok(ArbitraryCreateContractHostFnContext {
+                            executable: arbitrary::Arbitrary::arbitrary(&mut u)?,
+                            salt: arbitrary::Arbitrary::arbitrary_take_rest(u)?,
+                        })
+                    })();
+                    if guard_against_recursion {
+                        RECURSIVE_COUNT_ArbitraryCreateContractHostFnContext.with(|count| {
+                            count.set(count.get() - 1);
+                        });
+                    }
+                    result
+                }
+                #[inline]
+                fn size_hint(depth: usize) -> (usize, Option<usize>) {
+                    arbitrary::size_hint::recursion_guard(depth, |depth| {
+                        arbitrary::size_hint::and_all(
+                            &[
+                                <<ContractExecutable as soroban_sdk::testutils::arbitrary::SorobanArbitrary>::Prototype as arbitrary::Arbitrary>::size_hint(
+                                    depth,
+                                ),
+                                <<soroban_sdk::BytesN<
+                                    32,
+                                > as soroban_sdk::testutils::arbitrary::SorobanArbitrary>::Prototype as arbitrary::Arbitrary>::size_hint(
+                                    depth,
+                                ),
+                            ],
+                        )
+                    })
+                }
+            }
+        };
+        impl soroban_sdk::testutils::arbitrary::SorobanArbitrary for CreateContractHostFnContext {
+            type Prototype = ArbitraryCreateContractHostFnContext;
+        }
+        impl soroban_sdk::TryFromVal<soroban_sdk::Env, ArbitraryCreateContractHostFnContext>
+            for CreateContractHostFnContext
+        {
+            type Error = soroban_sdk::ConversionError;
+            fn try_from_val(
+                env: &soroban_sdk::Env,
+                v: &ArbitraryCreateContractHostFnContext,
+            ) -> std::result::Result<Self, Self::Error> {
+                Ok(CreateContractHostFnContext {
+                    executable: soroban_sdk::IntoVal::into_val(&v.executable, env),
+                    salt: soroban_sdk::IntoVal::into_val(&v.salt, env),
+                })
+            }
+        }
+    };
+    pub struct CreateContractWithConstructorHostFnContext {
+        pub constructor_args: soroban_sdk::Vec<soroban_sdk::Val>,
+        pub executable: ContractExecutable,
+        pub salt: soroban_sdk::BytesN<32>,
+    }
+    #[automatically_derived]
+    impl ::core::fmt::Debug for CreateContractWithConstructorHostFnContext {
+        #[inline]
+        fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+            ::core::fmt::Formatter::debug_struct_field3_finish(
+                f,
+                "CreateContractWithConstructorHostFnContext",
+                "constructor_args",
+                &self.constructor_args,
+                "executable",
+                &self.executable,
+                "salt",
+                &&self.salt,
+            )
+        }
+    }
+    #[automatically_derived]
+    impl ::core::clone::Clone for CreateContractWithConstructorHostFnContext {
+        #[inline]
+        fn clone(&self) -> CreateContractWithConstructorHostFnContext {
+            CreateContractWithConstructorHostFnContext {
+                constructor_args: ::core::clone::Clone::clone(&self.constructor_args),
+                executable: ::core::clone::Clone::clone(&self.executable),
+                salt: ::core::clone::Clone::clone(&self.salt),
+            }
+        }
+    }
+    #[automatically_derived]
+    impl ::core::cmp::Eq for CreateContractWithConstructorHostFnContext {
+        #[inline]
+        #[doc(hidden)]
+        #[coverage(off)]
+        fn assert_receiver_is_total_eq(&self) -> () {
+            let _: ::core::cmp::AssertParamIsEq<soroban_sdk::Vec<soroban_sdk::Val>>;
+            let _: ::core::cmp::AssertParamIsEq<ContractExecutable>;
+            let _: ::core::cmp::AssertParamIsEq<soroban_sdk::BytesN<32>>;
+        }
+    }
+    #[automatically_derived]
+    impl ::core::marker::StructuralPartialEq for CreateContractWithConstructorHostFnContext {}
+    #[automatically_derived]
+    impl ::core::cmp::PartialEq for CreateContractWithConstructorHostFnContext {
+        #[inline]
+        fn eq(&self, other: &CreateContractWithConstructorHostFnContext) -> bool {
+            self.constructor_args == other.constructor_args
+                && self.executable == other.executable
+                && self.salt == other.salt
+        }
+    }
+    #[automatically_derived]
+    impl ::core::cmp::Ord for CreateContractWithConstructorHostFnContext {
+        #[inline]
+        fn cmp(&self, other: &CreateContractWithConstructorHostFnContext) -> ::core::cmp::Ordering {
+            match ::core::cmp::Ord::cmp(&self.constructor_args, &other.constructor_args) {
+                ::core::cmp::Ordering::Equal => {
+                    match ::core::cmp::Ord::cmp(&self.executable, &other.executable) {
+                        ::core::cmp::Ordering::Equal => {
+                            ::core::cmp::Ord::cmp(&self.salt, &other.salt)
+                        }
+                        cmp => cmp,
+                    }
+                }
+                cmp => cmp,
+            }
+        }
+    }
+    #[automatically_derived]
+    impl ::core::cmp::PartialOrd for CreateContractWithConstructorHostFnContext {
+        #[inline]
+        fn partial_cmp(
+            &self,
+            other: &CreateContractWithConstructorHostFnContext,
+        ) -> ::core::option::Option<::core::cmp::Ordering> {
+            match ::core::cmp::PartialOrd::partial_cmp(
+                &self.constructor_args,
+                &other.constructor_args,
+            ) {
+                ::core::option::Option::Some(::core::cmp::Ordering::Equal) => {
+                    match ::core::cmp::PartialOrd::partial_cmp(&self.executable, &other.executable)
+                    {
+                        ::core::option::Option::Some(::core::cmp::Ordering::Equal) => {
+                            ::core::cmp::PartialOrd::partial_cmp(&self.salt, &other.salt)
+                        }
+                        cmp => cmp,
+                    }
+                }
+                cmp => cmp,
+            }
+        }
+    }
+    impl soroban_sdk::TryFromVal<soroban_sdk::Env, soroban_sdk::Val>
+        for CreateContractWithConstructorHostFnContext
+    {
+        type Error = soroban_sdk::ConversionError;
+        fn try_from_val(
+            env: &soroban_sdk::Env,
+            val: &soroban_sdk::Val,
+        ) -> Result<Self, soroban_sdk::ConversionError> {
+            use soroban_sdk::{ConversionError, EnvBase, MapObject, TryIntoVal, Val};
+            const KEYS: [&'static str; 3usize] = ["constructor_args", "executable", "salt"];
+            let mut vals: [Val; 3usize] = [Val::VOID.to_val(); 3usize];
+            let map: MapObject = val.try_into().map_err(|_| ConversionError)?;
+            env.map_unpack_to_slice(map, &KEYS, &mut vals)
+                .map_err(|_| ConversionError)?;
+            Ok(Self {
+                constructor_args: vals[0]
+                    .try_into_val(env)
+                    .map_err(|_| soroban_sdk::ConversionError)?,
+                executable: vals[1]
+                    .try_into_val(env)
+                    .map_err(|_| soroban_sdk::ConversionError)?,
+                salt: vals[2]
+                    .try_into_val(env)
+                    .map_err(|_| soroban_sdk::ConversionError)?,
+            })
+        }
+    }
+    impl soroban_sdk::TryFromVal<soroban_sdk::Env, CreateContractWithConstructorHostFnContext>
+        for soroban_sdk::Val
+    {
+        type Error = soroban_sdk::ConversionError;
+        fn try_from_val(
+            env: &soroban_sdk::Env,
+            val: &CreateContractWithConstructorHostFnContext,
+        ) -> Result<Self, soroban_sdk::ConversionError> {
+            use soroban_sdk::{ConversionError, EnvBase, TryIntoVal, Val};
+            const KEYS: [&'static str; 3usize] = ["constructor_args", "executable", "salt"];
+            let vals: [Val; 3usize] = [
+                (&val.constructor_args)
+                    .try_into_val(env)
+                    .map_err(|_| ConversionError)?,
+                (&val.executable)
+                    .try_into_val(env)
+                    .map_err(|_| ConversionError)?,
+                (&val.salt).try_into_val(env).map_err(|_| ConversionError)?,
+            ];
+            Ok(env
+                .map_new_from_slices(&KEYS, &vals)
+                .map_err(|_| ConversionError)?
+                .into())
+        }
+    }
+    impl soroban_sdk::TryFromVal<soroban_sdk::Env, &CreateContractWithConstructorHostFnContext>
+        for soroban_sdk::Val
+    {
+        type Error = soroban_sdk::ConversionError;
+        #[inline(always)]
+        fn try_from_val(
+            env: &soroban_sdk::Env,
+            val: &&CreateContractWithConstructorHostFnContext,
+        ) -> Result<Self, soroban_sdk::ConversionError> {
+            <_ as soroban_sdk::TryFromVal<
+                soroban_sdk::Env,
+                CreateContractWithConstructorHostFnContext,
+            >>::try_from_val(env, *val)
+        }
+    }
+    impl soroban_sdk::TryFromVal<soroban_sdk::Env, soroban_sdk::xdr::ScMap>
+        for CreateContractWithConstructorHostFnContext
+    {
+        type Error = soroban_sdk::xdr::Error;
+        #[inline(always)]
+        fn try_from_val(
+            env: &soroban_sdk::Env,
+            val: &soroban_sdk::xdr::ScMap,
+        ) -> Result<Self, soroban_sdk::xdr::Error> {
+            use soroban_sdk::xdr::Validate;
+            use soroban_sdk::TryIntoVal;
+            let map = val;
+            if map.len() != 3usize {
+                return Err(soroban_sdk::xdr::Error::Invalid);
+            }
+            map.validate()?;
+            Ok(Self {
+                constructor_args: {
+                    let key: soroban_sdk::xdr::ScVal = soroban_sdk::xdr::ScSymbol(
+                        "constructor_args"
+                            .try_into()
+                            .map_err(|_| soroban_sdk::xdr::Error::Invalid)?,
+                    )
+                    .into();
+                    let idx = map
+                        .binary_search_by_key(&key, |entry| entry.key.clone())
+                        .map_err(|_| soroban_sdk::xdr::Error::Invalid)?;
+                    let rv: soroban_sdk::Val = (&map[idx].val.clone())
+                        .try_into_val(env)
+                        .map_err(|_| soroban_sdk::xdr::Error::Invalid)?;
+                    rv.try_into_val(env)
+                        .map_err(|_| soroban_sdk::xdr::Error::Invalid)?
+                },
+                executable: {
+                    let key: soroban_sdk::xdr::ScVal = soroban_sdk::xdr::ScSymbol(
+                        "executable"
+                            .try_into()
+                            .map_err(|_| soroban_sdk::xdr::Error::Invalid)?,
+                    )
+                    .into();
+                    let idx = map
+                        .binary_search_by_key(&key, |entry| entry.key.clone())
+                        .map_err(|_| soroban_sdk::xdr::Error::Invalid)?;
+                    let rv: soroban_sdk::Val = (&map[idx].val.clone())
+                        .try_into_val(env)
+                        .map_err(|_| soroban_sdk::xdr::Error::Invalid)?;
+                    rv.try_into_val(env)
+                        .map_err(|_| soroban_sdk::xdr::Error::Invalid)?
+                },
+                salt: {
+                    let key: soroban_sdk::xdr::ScVal = soroban_sdk::xdr::ScSymbol(
+                        "salt"
+                            .try_into()
+                            .map_err(|_| soroban_sdk::xdr::Error::Invalid)?,
+                    )
+                    .into();
+                    let idx = map
+                        .binary_search_by_key(&key, |entry| entry.key.clone())
+                        .map_err(|_| soroban_sdk::xdr::Error::Invalid)?;
+                    let rv: soroban_sdk::Val = (&map[idx].val.clone())
+                        .try_into_val(env)
+                        .map_err(|_| soroban_sdk::xdr::Error::Invalid)?;
+                    rv.try_into_val(env)
+                        .map_err(|_| soroban_sdk::xdr::Error::Invalid)?
+                },
+            })
+        }
+    }
+    impl soroban_sdk::TryFromVal<soroban_sdk::Env, soroban_sdk::xdr::ScVal>
+        for CreateContractWithConstructorHostFnContext
+    {
+        type Error = soroban_sdk::xdr::Error;
+        #[inline(always)]
+        fn try_from_val(
+            env: &soroban_sdk::Env,
+            val: &soroban_sdk::xdr::ScVal,
+        ) -> Result<Self, soroban_sdk::xdr::Error> {
+            if let soroban_sdk::xdr::ScVal::Map(Some(map)) = val {
+                <_ as soroban_sdk::TryFromVal<_, _>>::try_from_val(env, map)
+            } else {
+                Err(soroban_sdk::xdr::Error::Invalid)
+            }
+        }
+    }
+    impl TryFrom<&CreateContractWithConstructorHostFnContext> for soroban_sdk::xdr::ScMap {
+        type Error = soroban_sdk::xdr::Error;
+        #[inline(always)]
+        fn try_from(
+            val: &CreateContractWithConstructorHostFnContext,
+        ) -> Result<Self, soroban_sdk::xdr::Error> {
+            extern crate alloc;
+            use soroban_sdk::TryFromVal;
+            soroban_sdk::xdr::ScMap::sorted_from(<[_]>::into_vec(::alloc::boxed::box_new([
+                soroban_sdk::xdr::ScMapEntry {
+                    key: soroban_sdk::xdr::ScSymbol(
+                        "constructor_args"
+                            .try_into()
+                            .map_err(|_| soroban_sdk::xdr::Error::Invalid)?,
+                    )
+                    .into(),
+                    val: (&val.constructor_args)
+                        .try_into()
+                        .map_err(|_| soroban_sdk::xdr::Error::Invalid)?,
+                },
+                soroban_sdk::xdr::ScMapEntry {
+                    key: soroban_sdk::xdr::ScSymbol(
+                        "executable"
+                            .try_into()
+                            .map_err(|_| soroban_sdk::xdr::Error::Invalid)?,
+                    )
+                    .into(),
+                    val: (&val.executable)
+                        .try_into()
+                        .map_err(|_| soroban_sdk::xdr::Error::Invalid)?,
+                },
+                soroban_sdk::xdr::ScMapEntry {
+                    key: soroban_sdk::xdr::ScSymbol(
+                        "salt"
+                            .try_into()
+                            .map_err(|_| soroban_sdk::xdr::Error::Invalid)?,
+                    )
+                    .into(),
+                    val: (&val.salt)
+                        .try_into()
+                        .map_err(|_| soroban_sdk::xdr::Error::Invalid)?,
+                },
+            ])))
+        }
+    }
+    impl TryFrom<CreateContractWithConstructorHostFnContext> for soroban_sdk::xdr::ScMap {
+        type Error = soroban_sdk::xdr::Error;
+        #[inline(always)]
+        fn try_from(
+            val: CreateContractWithConstructorHostFnContext,
+        ) -> Result<Self, soroban_sdk::xdr::Error> {
+            (&val).try_into()
+        }
+    }
+    impl TryFrom<&CreateContractWithConstructorHostFnContext> for soroban_sdk::xdr::ScVal {
+        type Error = soroban_sdk::xdr::Error;
+        #[inline(always)]
+        fn try_from(
+            val: &CreateContractWithConstructorHostFnContext,
+        ) -> Result<Self, soroban_sdk::xdr::Error> {
+            Ok(soroban_sdk::xdr::ScVal::Map(Some(val.try_into()?)))
+        }
+    }
+    impl TryFrom<CreateContractWithConstructorHostFnContext> for soroban_sdk::xdr::ScVal {
+        type Error = soroban_sdk::xdr::Error;
+        #[inline(always)]
+        fn try_from(
+            val: CreateContractWithConstructorHostFnContext,
+        ) -> Result<Self, soroban_sdk::xdr::Error> {
+            (&val).try_into()
+        }
+    }
+    const _: () = {
+        use soroban_sdk::testutils::arbitrary::arbitrary;
+        use soroban_sdk::testutils::arbitrary::std;
+        pub struct ArbitraryCreateContractWithConstructorHostFnContext {
+            constructor_args: <soroban_sdk::Vec<
+                soroban_sdk::Val,
+            > as soroban_sdk::testutils::arbitrary::SorobanArbitrary>::Prototype,
+            executable: <ContractExecutable as soroban_sdk::testutils::arbitrary::SorobanArbitrary>::Prototype,
+            salt: <soroban_sdk::BytesN<
+                32,
+            > as soroban_sdk::testutils::arbitrary::SorobanArbitrary>::Prototype,
+        }
+        #[automatically_derived]
+        impl ::core::fmt::Debug for ArbitraryCreateContractWithConstructorHostFnContext {
+            #[inline]
+            fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+                ::core::fmt::Formatter::debug_struct_field3_finish(
+                    f,
+                    "ArbitraryCreateContractWithConstructorHostFnContext",
+                    "constructor_args",
+                    &self.constructor_args,
+                    "executable",
+                    &self.executable,
+                    "salt",
+                    &&self.salt,
+                )
+            }
+        }
+        #[automatically_derived]
+        impl ::core::clone::Clone for ArbitraryCreateContractWithConstructorHostFnContext {
+            #[inline]
+            fn clone(&self) -> ArbitraryCreateContractWithConstructorHostFnContext {
+                ArbitraryCreateContractWithConstructorHostFnContext {
+                    constructor_args: ::core::clone::Clone::clone(&self.constructor_args),
+                    executable: ::core::clone::Clone::clone(&self.executable),
+                    salt: ::core::clone::Clone::clone(&self.salt),
+                }
+            }
+        }
+        #[automatically_derived]
+        impl ::core::cmp::Eq for ArbitraryCreateContractWithConstructorHostFnContext {
+            #[inline]
+            #[doc(hidden)]
+            #[coverage(off)]
+            fn assert_receiver_is_total_eq(&self) -> () {
+                let _: ::core::cmp::AssertParamIsEq<
+                    <soroban_sdk::Vec<
+                        soroban_sdk::Val,
+                    > as soroban_sdk::testutils::arbitrary::SorobanArbitrary>::Prototype,
+                >;
+                let _: ::core::cmp::AssertParamIsEq<
+                    <ContractExecutable as soroban_sdk::testutils::arbitrary::SorobanArbitrary>::Prototype,
+                >;
+                let _: ::core::cmp::AssertParamIsEq<
+                    <soroban_sdk::BytesN<
+                        32,
+                    > as soroban_sdk::testutils::arbitrary::SorobanArbitrary>::Prototype,
+                >;
+            }
+        }
+        #[automatically_derived]
+        impl ::core::marker::StructuralPartialEq for ArbitraryCreateContractWithConstructorHostFnContext {}
+        #[automatically_derived]
+        impl ::core::cmp::PartialEq for ArbitraryCreateContractWithConstructorHostFnContext {
+            #[inline]
+            fn eq(&self, other: &ArbitraryCreateContractWithConstructorHostFnContext) -> bool {
+                self.constructor_args == other.constructor_args
+                    && self.executable == other.executable
+                    && self.salt == other.salt
+            }
+        }
+        #[automatically_derived]
+        impl ::core::cmp::Ord for ArbitraryCreateContractWithConstructorHostFnContext {
+            #[inline]
+            fn cmp(
+                &self,
+                other: &ArbitraryCreateContractWithConstructorHostFnContext,
+            ) -> ::core::cmp::Ordering {
+                match ::core::cmp::Ord::cmp(&self.constructor_args, &other.constructor_args) {
+                    ::core::cmp::Ordering::Equal => {
+                        match ::core::cmp::Ord::cmp(&self.executable, &other.executable) {
+                            ::core::cmp::Ordering::Equal => {
+                                ::core::cmp::Ord::cmp(&self.salt, &other.salt)
+                            }
+                            cmp => cmp,
+                        }
+                    }
+                    cmp => cmp,
+                }
+            }
+        }
+        #[automatically_derived]
+        impl ::core::cmp::PartialOrd for ArbitraryCreateContractWithConstructorHostFnContext {
+            #[inline]
+            fn partial_cmp(
+                &self,
+                other: &ArbitraryCreateContractWithConstructorHostFnContext,
+            ) -> ::core::option::Option<::core::cmp::Ordering> {
+                match ::core::cmp::PartialOrd::partial_cmp(
+                    &self.constructor_args,
+                    &other.constructor_args,
+                ) {
+                    ::core::option::Option::Some(::core::cmp::Ordering::Equal) => {
+                        match ::core::cmp::PartialOrd::partial_cmp(
+                            &self.executable,
+                            &other.executable,
+                        ) {
+                            ::core::option::Option::Some(::core::cmp::Ordering::Equal) => {
+                                ::core::cmp::PartialOrd::partial_cmp(&self.salt, &other.salt)
+                            }
+                            cmp => cmp,
+                        }
+                    }
+                    cmp => cmp,
+                }
+            }
+        }
+        const _: () = {
+            #[allow(non_upper_case_globals)]
+            const RECURSIVE_COUNT_ArbitraryCreateContractWithConstructorHostFnContext:
+                ::std::thread::LocalKey<std::cell::Cell<u32>> = {
+                #[inline]
+                fn __init() -> std::cell::Cell<u32> {
+                    std::cell::Cell::new(0)
+                }
+                unsafe {
+                    ::std::thread::LocalKey::new(
+                        const {
+                            if ::std::mem::needs_drop::<std::cell::Cell<u32>>() {
+                                |init| {
+                                    #[thread_local]
+                                    static VAL: ::std::thread::local_impl::LazyStorage<
+                                        std::cell::Cell<u32>,
+                                        (),
+                                    > = ::std::thread::local_impl::LazyStorage::new();
+                                    VAL.get_or_init(init, __init)
+                                }
+                            } else {
+                                |init| {
+                                    #[thread_local]
+                                    static VAL: ::std::thread::local_impl::LazyStorage<
+                                        std::cell::Cell<u32>,
+                                        !,
+                                    > = ::std::thread::local_impl::LazyStorage::new();
+                                    VAL.get_or_init(init, __init)
+                                }
+                            }
+                        },
+                    )
+                }
+            };
+            #[automatically_derived]
+            impl<'arbitrary> arbitrary::Arbitrary<'arbitrary>
+                for ArbitraryCreateContractWithConstructorHostFnContext
+            {
+                fn arbitrary(
+                    u: &mut arbitrary::Unstructured<'arbitrary>,
+                ) -> arbitrary::Result<Self> {
+                    let guard_against_recursion = u.is_empty();
+                    if guard_against_recursion {
+                        RECURSIVE_COUNT_ArbitraryCreateContractWithConstructorHostFnContext.with(
+                            |count| {
+                                if count.get() > 0 {
+                                    return Err(arbitrary::Error::NotEnoughData);
+                                }
+                                count.set(count.get() + 1);
+                                Ok(())
+                            },
+                        )?;
+                    }
+                    let result = (|| {
+                        Ok(ArbitraryCreateContractWithConstructorHostFnContext {
+                            constructor_args: arbitrary::Arbitrary::arbitrary(u)?,
+                            executable: arbitrary::Arbitrary::arbitrary(u)?,
+                            salt: arbitrary::Arbitrary::arbitrary(u)?,
+                        })
+                    })();
+                    if guard_against_recursion {
+                        RECURSIVE_COUNT_ArbitraryCreateContractWithConstructorHostFnContext.with(
+                            |count| {
+                                count.set(count.get() - 1);
+                            },
+                        );
+                    }
+                    result
+                }
+                fn arbitrary_take_rest(
+                    mut u: arbitrary::Unstructured<'arbitrary>,
+                ) -> arbitrary::Result<Self> {
+                    let guard_against_recursion = u.is_empty();
+                    if guard_against_recursion {
+                        RECURSIVE_COUNT_ArbitraryCreateContractWithConstructorHostFnContext.with(
+                            |count| {
+                                if count.get() > 0 {
+                                    return Err(arbitrary::Error::NotEnoughData);
+                                }
+                                count.set(count.get() + 1);
+                                Ok(())
+                            },
+                        )?;
+                    }
+                    let result = (|| {
+                        Ok(ArbitraryCreateContractWithConstructorHostFnContext {
+                            constructor_args: arbitrary::Arbitrary::arbitrary(&mut u)?,
+                            executable: arbitrary::Arbitrary::arbitrary(&mut u)?,
+                            salt: arbitrary::Arbitrary::arbitrary_take_rest(u)?,
+                        })
+                    })();
+                    if guard_against_recursion {
+                        RECURSIVE_COUNT_ArbitraryCreateContractWithConstructorHostFnContext.with(
+                            |count| {
+                                count.set(count.get() - 1);
+                            },
+                        );
+                    }
+                    result
+                }
+                #[inline]
+                fn size_hint(depth: usize) -> (usize, Option<usize>) {
+                    arbitrary::size_hint::recursion_guard(depth, |depth| {
+                        arbitrary::size_hint::and_all(
+                            &[
+                                <<soroban_sdk::Vec<
+                                    soroban_sdk::Val,
+                                > as soroban_sdk::testutils::arbitrary::SorobanArbitrary>::Prototype as arbitrary::Arbitrary>::size_hint(
+                                    depth,
+                                ),
+                                <<ContractExecutable as soroban_sdk::testutils::arbitrary::SorobanArbitrary>::Prototype as arbitrary::Arbitrary>::size_hint(
+                                    depth,
+                                ),
+                                <<soroban_sdk::BytesN<
+                                    32,
+                                > as soroban_sdk::testutils::arbitrary::SorobanArbitrary>::Prototype as arbitrary::Arbitrary>::size_hint(
+                                    depth,
+                                ),
+                            ],
+                        )
+                    })
+                }
+            }
+        };
+        impl soroban_sdk::testutils::arbitrary::SorobanArbitrary
+            for CreateContractWithConstructorHostFnContext
+        {
+            type Prototype = ArbitraryCreateContractWithConstructorHostFnContext;
+        }
+        impl
+            soroban_sdk::TryFromVal<
+                soroban_sdk::Env,
+                ArbitraryCreateContractWithConstructorHostFnContext,
+            > for CreateContractWithConstructorHostFnContext
+        {
+            type Error = soroban_sdk::ConversionError;
+            fn try_from_val(
+                env: &soroban_sdk::Env,
+                v: &ArbitraryCreateContractWithConstructorHostFnContext,
+            ) -> std::result::Result<Self, Self::Error> {
+                Ok(CreateContractWithConstructorHostFnContext {
+                    constructor_args: soroban_sdk::IntoVal::into_val(&v.constructor_args, env),
+                    executable: soroban_sdk::IntoVal::into_val(&v.executable, env),
+                    salt: soroban_sdk::IntoVal::into_val(&v.salt, env),
+                })
+            }
+        }
+    };
     pub struct StructA {
         pub f1: u32,
         pub f2: bool,
@@ -15382,6 +17416,2470 @@ mod wasm_imported {
                     soroban_sdk::IntoVal::into_val(&v.0, env),
                     soroban_sdk::IntoVal::into_val(&v.1, env),
                 ))
+            }
+        }
+    };
+    pub enum Context {
+        Contract(ContractContext),
+        CreateContractHostFn(CreateContractHostFnContext),
+        CreateContractWithCtorHostFn(CreateContractWithConstructorHostFnContext),
+    }
+    #[automatically_derived]
+    impl ::core::fmt::Debug for Context {
+        #[inline]
+        fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+            match self {
+                Context::Contract(__self_0) => {
+                    ::core::fmt::Formatter::debug_tuple_field1_finish(f, "Contract", &__self_0)
+                }
+                Context::CreateContractHostFn(__self_0) => {
+                    ::core::fmt::Formatter::debug_tuple_field1_finish(
+                        f,
+                        "CreateContractHostFn",
+                        &__self_0,
+                    )
+                }
+                Context::CreateContractWithCtorHostFn(__self_0) => {
+                    ::core::fmt::Formatter::debug_tuple_field1_finish(
+                        f,
+                        "CreateContractWithCtorHostFn",
+                        &__self_0,
+                    )
+                }
+            }
+        }
+    }
+    #[automatically_derived]
+    impl ::core::clone::Clone for Context {
+        #[inline]
+        fn clone(&self) -> Context {
+            match self {
+                Context::Contract(__self_0) => {
+                    Context::Contract(::core::clone::Clone::clone(__self_0))
+                }
+                Context::CreateContractHostFn(__self_0) => {
+                    Context::CreateContractHostFn(::core::clone::Clone::clone(__self_0))
+                }
+                Context::CreateContractWithCtorHostFn(__self_0) => {
+                    Context::CreateContractWithCtorHostFn(::core::clone::Clone::clone(__self_0))
+                }
+            }
+        }
+    }
+    #[automatically_derived]
+    impl ::core::cmp::Eq for Context {
+        #[inline]
+        #[doc(hidden)]
+        #[coverage(off)]
+        fn assert_receiver_is_total_eq(&self) -> () {
+            let _: ::core::cmp::AssertParamIsEq<ContractContext>;
+            let _: ::core::cmp::AssertParamIsEq<CreateContractHostFnContext>;
+            let _: ::core::cmp::AssertParamIsEq<CreateContractWithConstructorHostFnContext>;
+        }
+    }
+    #[automatically_derived]
+    impl ::core::marker::StructuralPartialEq for Context {}
+    #[automatically_derived]
+    impl ::core::cmp::PartialEq for Context {
+        #[inline]
+        fn eq(&self, other: &Context) -> bool {
+            let __self_discr = ::core::intrinsics::discriminant_value(self);
+            let __arg1_discr = ::core::intrinsics::discriminant_value(other);
+            __self_discr == __arg1_discr
+                && match (self, other) {
+                    (Context::Contract(__self_0), Context::Contract(__arg1_0)) => {
+                        __self_0 == __arg1_0
+                    }
+                    (
+                        Context::CreateContractHostFn(__self_0),
+                        Context::CreateContractHostFn(__arg1_0),
+                    ) => __self_0 == __arg1_0,
+                    (
+                        Context::CreateContractWithCtorHostFn(__self_0),
+                        Context::CreateContractWithCtorHostFn(__arg1_0),
+                    ) => __self_0 == __arg1_0,
+                    _ => unsafe { ::core::intrinsics::unreachable() },
+                }
+        }
+    }
+    #[automatically_derived]
+    impl ::core::cmp::Ord for Context {
+        #[inline]
+        fn cmp(&self, other: &Context) -> ::core::cmp::Ordering {
+            let __self_discr = ::core::intrinsics::discriminant_value(self);
+            let __arg1_discr = ::core::intrinsics::discriminant_value(other);
+            match ::core::cmp::Ord::cmp(&__self_discr, &__arg1_discr) {
+                ::core::cmp::Ordering::Equal => match (self, other) {
+                    (Context::Contract(__self_0), Context::Contract(__arg1_0)) => {
+                        ::core::cmp::Ord::cmp(__self_0, __arg1_0)
+                    }
+                    (
+                        Context::CreateContractHostFn(__self_0),
+                        Context::CreateContractHostFn(__arg1_0),
+                    ) => ::core::cmp::Ord::cmp(__self_0, __arg1_0),
+                    (
+                        Context::CreateContractWithCtorHostFn(__self_0),
+                        Context::CreateContractWithCtorHostFn(__arg1_0),
+                    ) => ::core::cmp::Ord::cmp(__self_0, __arg1_0),
+                    _ => unsafe { ::core::intrinsics::unreachable() },
+                },
+                cmp => cmp,
+            }
+        }
+    }
+    #[automatically_derived]
+    impl ::core::cmp::PartialOrd for Context {
+        #[inline]
+        fn partial_cmp(&self, other: &Context) -> ::core::option::Option<::core::cmp::Ordering> {
+            let __self_discr = ::core::intrinsics::discriminant_value(self);
+            let __arg1_discr = ::core::intrinsics::discriminant_value(other);
+            match (self, other) {
+                (Context::Contract(__self_0), Context::Contract(__arg1_0)) => {
+                    ::core::cmp::PartialOrd::partial_cmp(__self_0, __arg1_0)
+                }
+                (
+                    Context::CreateContractHostFn(__self_0),
+                    Context::CreateContractHostFn(__arg1_0),
+                ) => ::core::cmp::PartialOrd::partial_cmp(__self_0, __arg1_0),
+                (
+                    Context::CreateContractWithCtorHostFn(__self_0),
+                    Context::CreateContractWithCtorHostFn(__arg1_0),
+                ) => ::core::cmp::PartialOrd::partial_cmp(__self_0, __arg1_0),
+                _ => ::core::cmp::PartialOrd::partial_cmp(&__self_discr, &__arg1_discr),
+            }
+        }
+    }
+    impl soroban_sdk::TryFromVal<soroban_sdk::Env, soroban_sdk::Val> for Context {
+        type Error = soroban_sdk::ConversionError;
+        #[inline(always)]
+        fn try_from_val(
+            env: &soroban_sdk::Env,
+            val: &soroban_sdk::Val,
+        ) -> Result<Self, soroban_sdk::ConversionError> {
+            use soroban_sdk::{EnvBase, TryFromVal, TryIntoVal};
+            const CASES: &'static [&'static str] = &[
+                "Contract",
+                "CreateContractHostFn",
+                "CreateContractWithCtorHostFn",
+            ];
+            let vec: soroban_sdk::Vec<soroban_sdk::Val> = val.try_into_val(env)?;
+            let mut iter = vec.try_iter();
+            let discriminant: soroban_sdk::Symbol = iter
+                .next()
+                .ok_or(soroban_sdk::ConversionError)??
+                .try_into_val(env)
+                .map_err(|_| soroban_sdk::ConversionError)?;
+            Ok(
+                match u32::from(env.symbol_index_in_strs(discriminant.to_symbol_val(), CASES)?)
+                    as usize
+                {
+                    0 => {
+                        if iter.len() > 1usize {
+                            return Err(soroban_sdk::ConversionError);
+                        }
+                        Self::Contract(
+                            iter.next()
+                                .ok_or(soroban_sdk::ConversionError)??
+                                .try_into_val(env)?,
+                        )
+                    }
+                    1 => {
+                        if iter.len() > 1usize {
+                            return Err(soroban_sdk::ConversionError);
+                        }
+                        Self::CreateContractHostFn(
+                            iter.next()
+                                .ok_or(soroban_sdk::ConversionError)??
+                                .try_into_val(env)?,
+                        )
+                    }
+                    2 => {
+                        if iter.len() > 1usize {
+                            return Err(soroban_sdk::ConversionError);
+                        }
+                        Self::CreateContractWithCtorHostFn(
+                            iter.next()
+                                .ok_or(soroban_sdk::ConversionError)??
+                                .try_into_val(env)?,
+                        )
+                    }
+                    _ => Err(soroban_sdk::ConversionError {})?,
+                },
+            )
+        }
+    }
+    impl soroban_sdk::TryFromVal<soroban_sdk::Env, Context> for soroban_sdk::Val {
+        type Error = soroban_sdk::ConversionError;
+        #[inline(always)]
+        fn try_from_val(
+            env: &soroban_sdk::Env,
+            val: &Context,
+        ) -> Result<Self, soroban_sdk::ConversionError> {
+            use soroban_sdk::{TryFromVal, TryIntoVal};
+            match val {
+                Context::Contract(ref value0) => {
+                    let tup: (soroban_sdk::Val, soroban_sdk::Val) = (
+                        soroban_sdk::Symbol::try_from_val(env, &"Contract")?.to_val(),
+                        value0.try_into_val(env)?,
+                    );
+                    tup.try_into_val(env).map_err(Into::into)
+                }
+                Context::CreateContractHostFn(ref value0) => {
+                    let tup: (soroban_sdk::Val, soroban_sdk::Val) = (
+                        soroban_sdk::Symbol::try_from_val(env, &"CreateContractHostFn")?.to_val(),
+                        value0.try_into_val(env)?,
+                    );
+                    tup.try_into_val(env).map_err(Into::into)
+                }
+                Context::CreateContractWithCtorHostFn(ref value0) => {
+                    let tup: (soroban_sdk::Val, soroban_sdk::Val) = (
+                        soroban_sdk::Symbol::try_from_val(env, &"CreateContractWithCtorHostFn")?
+                            .to_val(),
+                        value0.try_into_val(env)?,
+                    );
+                    tup.try_into_val(env).map_err(Into::into)
+                }
+            }
+        }
+    }
+    impl soroban_sdk::TryFromVal<soroban_sdk::Env, &Context> for soroban_sdk::Val {
+        type Error = soroban_sdk::ConversionError;
+        #[inline(always)]
+        fn try_from_val(
+            env: &soroban_sdk::Env,
+            val: &&Context,
+        ) -> Result<Self, soroban_sdk::ConversionError> {
+            <_ as soroban_sdk::TryFromVal<soroban_sdk::Env, Context>>::try_from_val(env, *val)
+        }
+    }
+    impl soroban_sdk::TryFromVal<soroban_sdk::Env, soroban_sdk::xdr::ScVec> for Context {
+        type Error = soroban_sdk::xdr::Error;
+        #[inline(always)]
+        fn try_from_val(
+            env: &soroban_sdk::Env,
+            val: &soroban_sdk::xdr::ScVec,
+        ) -> Result<Self, soroban_sdk::xdr::Error> {
+            use soroban_sdk::xdr::Validate;
+            use soroban_sdk::TryIntoVal;
+            let vec = val;
+            let mut iter = vec.iter();
+            let discriminant: soroban_sdk::xdr::ScSymbol = iter
+                .next()
+                .ok_or(soroban_sdk::xdr::Error::Invalid)?
+                .clone()
+                .try_into()
+                .map_err(|_| soroban_sdk::xdr::Error::Invalid)?;
+            let discriminant_name: &str = &discriminant.to_utf8_string()?;
+            Ok(match discriminant_name {
+                "Contract" => {
+                    if iter.len() > 1usize {
+                        return Err(soroban_sdk::xdr::Error::Invalid);
+                    }
+                    let rv0: soroban_sdk::Val = iter
+                        .next()
+                        .ok_or(soroban_sdk::xdr::Error::Invalid)?
+                        .try_into_val(env)
+                        .map_err(|_| soroban_sdk::xdr::Error::Invalid)?;
+                    Self::Contract(
+                        rv0.try_into_val(env)
+                            .map_err(|_| soroban_sdk::xdr::Error::Invalid)?,
+                    )
+                }
+                "CreateContractHostFn" => {
+                    if iter.len() > 1usize {
+                        return Err(soroban_sdk::xdr::Error::Invalid);
+                    }
+                    let rv0: soroban_sdk::Val = iter
+                        .next()
+                        .ok_or(soroban_sdk::xdr::Error::Invalid)?
+                        .try_into_val(env)
+                        .map_err(|_| soroban_sdk::xdr::Error::Invalid)?;
+                    Self::CreateContractHostFn(
+                        rv0.try_into_val(env)
+                            .map_err(|_| soroban_sdk::xdr::Error::Invalid)?,
+                    )
+                }
+                "CreateContractWithCtorHostFn" => {
+                    if iter.len() > 1usize {
+                        return Err(soroban_sdk::xdr::Error::Invalid);
+                    }
+                    let rv0: soroban_sdk::Val = iter
+                        .next()
+                        .ok_or(soroban_sdk::xdr::Error::Invalid)?
+                        .try_into_val(env)
+                        .map_err(|_| soroban_sdk::xdr::Error::Invalid)?;
+                    Self::CreateContractWithCtorHostFn(
+                        rv0.try_into_val(env)
+                            .map_err(|_| soroban_sdk::xdr::Error::Invalid)?,
+                    )
+                }
+                _ => Err(soroban_sdk::xdr::Error::Invalid)?,
+            })
+        }
+    }
+    impl soroban_sdk::TryFromVal<soroban_sdk::Env, soroban_sdk::xdr::ScVal> for Context {
+        type Error = soroban_sdk::xdr::Error;
+        #[inline(always)]
+        fn try_from_val(
+            env: &soroban_sdk::Env,
+            val: &soroban_sdk::xdr::ScVal,
+        ) -> Result<Self, soroban_sdk::xdr::Error> {
+            if let soroban_sdk::xdr::ScVal::Vec(Some(vec)) = val {
+                <_ as soroban_sdk::TryFromVal<_, _>>::try_from_val(env, vec)
+            } else {
+                Err(soroban_sdk::xdr::Error::Invalid)
+            }
+        }
+    }
+    impl TryFrom<&Context> for soroban_sdk::xdr::ScVec {
+        type Error = soroban_sdk::xdr::Error;
+        #[inline(always)]
+        fn try_from(val: &Context) -> Result<Self, soroban_sdk::xdr::Error> {
+            extern crate alloc;
+            Ok(match val {
+                Context::Contract(value0) => (
+                    soroban_sdk::xdr::ScSymbol(
+                        "Contract"
+                            .try_into()
+                            .map_err(|_| soroban_sdk::xdr::Error::Invalid)?,
+                    ),
+                    value0,
+                )
+                    .try_into()
+                    .map_err(|_| soroban_sdk::xdr::Error::Invalid)?,
+                Context::CreateContractHostFn(value0) => (
+                    soroban_sdk::xdr::ScSymbol(
+                        "CreateContractHostFn"
+                            .try_into()
+                            .map_err(|_| soroban_sdk::xdr::Error::Invalid)?,
+                    ),
+                    value0,
+                )
+                    .try_into()
+                    .map_err(|_| soroban_sdk::xdr::Error::Invalid)?,
+                Context::CreateContractWithCtorHostFn(value0) => (
+                    soroban_sdk::xdr::ScSymbol(
+                        "CreateContractWithCtorHostFn"
+                            .try_into()
+                            .map_err(|_| soroban_sdk::xdr::Error::Invalid)?,
+                    ),
+                    value0,
+                )
+                    .try_into()
+                    .map_err(|_| soroban_sdk::xdr::Error::Invalid)?,
+            })
+        }
+    }
+    impl TryFrom<Context> for soroban_sdk::xdr::ScVec {
+        type Error = soroban_sdk::xdr::Error;
+        #[inline(always)]
+        fn try_from(val: Context) -> Result<Self, soroban_sdk::xdr::Error> {
+            (&val).try_into()
+        }
+    }
+    impl TryFrom<&Context> for soroban_sdk::xdr::ScVal {
+        type Error = soroban_sdk::xdr::Error;
+        #[inline(always)]
+        fn try_from(val: &Context) -> Result<Self, soroban_sdk::xdr::Error> {
+            Ok(soroban_sdk::xdr::ScVal::Vec(Some(val.try_into()?)))
+        }
+    }
+    impl TryFrom<Context> for soroban_sdk::xdr::ScVal {
+        type Error = soroban_sdk::xdr::Error;
+        #[inline(always)]
+        fn try_from(val: Context) -> Result<Self, soroban_sdk::xdr::Error> {
+            (&val).try_into()
+        }
+    }
+    const _: () = {
+        use soroban_sdk::testutils::arbitrary::arbitrary;
+        use soroban_sdk::testutils::arbitrary::std;
+        pub enum ArbitraryContext {
+            Contract(
+                <ContractContext as soroban_sdk::testutils::arbitrary::SorobanArbitrary>::Prototype,
+            ),
+            CreateContractHostFn(
+                <CreateContractHostFnContext as soroban_sdk::testutils::arbitrary::SorobanArbitrary>::Prototype,
+            ),
+            CreateContractWithCtorHostFn(
+                <CreateContractWithConstructorHostFnContext as soroban_sdk::testutils::arbitrary::SorobanArbitrary>::Prototype,
+            ),
+        }
+        #[automatically_derived]
+        impl ::core::fmt::Debug for ArbitraryContext {
+            #[inline]
+            fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+                match self {
+                    ArbitraryContext::Contract(__self_0) => {
+                        ::core::fmt::Formatter::debug_tuple_field1_finish(f, "Contract", &__self_0)
+                    }
+                    ArbitraryContext::CreateContractHostFn(__self_0) => {
+                        ::core::fmt::Formatter::debug_tuple_field1_finish(
+                            f,
+                            "CreateContractHostFn",
+                            &__self_0,
+                        )
+                    }
+                    ArbitraryContext::CreateContractWithCtorHostFn(__self_0) => {
+                        ::core::fmt::Formatter::debug_tuple_field1_finish(
+                            f,
+                            "CreateContractWithCtorHostFn",
+                            &__self_0,
+                        )
+                    }
+                }
+            }
+        }
+        #[automatically_derived]
+        impl ::core::clone::Clone for ArbitraryContext {
+            #[inline]
+            fn clone(&self) -> ArbitraryContext {
+                match self {
+                    ArbitraryContext::Contract(__self_0) => {
+                        ArbitraryContext::Contract(::core::clone::Clone::clone(__self_0))
+                    }
+                    ArbitraryContext::CreateContractHostFn(__self_0) => {
+                        ArbitraryContext::CreateContractHostFn(::core::clone::Clone::clone(
+                            __self_0,
+                        ))
+                    }
+                    ArbitraryContext::CreateContractWithCtorHostFn(__self_0) => {
+                        ArbitraryContext::CreateContractWithCtorHostFn(::core::clone::Clone::clone(
+                            __self_0,
+                        ))
+                    }
+                }
+            }
+        }
+        #[automatically_derived]
+        impl ::core::cmp::Eq for ArbitraryContext {
+            #[inline]
+            #[doc(hidden)]
+            #[coverage(off)]
+            fn assert_receiver_is_total_eq(&self) -> () {
+                let _: ::core::cmp::AssertParamIsEq<
+                    <ContractContext as soroban_sdk::testutils::arbitrary::SorobanArbitrary>::Prototype,
+                >;
+                let _: ::core::cmp::AssertParamIsEq<
+                    <CreateContractHostFnContext as soroban_sdk::testutils::arbitrary::SorobanArbitrary>::Prototype,
+                >;
+                let _: ::core::cmp::AssertParamIsEq<
+                    <CreateContractWithConstructorHostFnContext as soroban_sdk::testutils::arbitrary::SorobanArbitrary>::Prototype,
+                >;
+            }
+        }
+        #[automatically_derived]
+        impl ::core::marker::StructuralPartialEq for ArbitraryContext {}
+        #[automatically_derived]
+        impl ::core::cmp::PartialEq for ArbitraryContext {
+            #[inline]
+            fn eq(&self, other: &ArbitraryContext) -> bool {
+                let __self_discr = ::core::intrinsics::discriminant_value(self);
+                let __arg1_discr = ::core::intrinsics::discriminant_value(other);
+                __self_discr == __arg1_discr
+                    && match (self, other) {
+                        (
+                            ArbitraryContext::Contract(__self_0),
+                            ArbitraryContext::Contract(__arg1_0),
+                        ) => __self_0 == __arg1_0,
+                        (
+                            ArbitraryContext::CreateContractHostFn(__self_0),
+                            ArbitraryContext::CreateContractHostFn(__arg1_0),
+                        ) => __self_0 == __arg1_0,
+                        (
+                            ArbitraryContext::CreateContractWithCtorHostFn(__self_0),
+                            ArbitraryContext::CreateContractWithCtorHostFn(__arg1_0),
+                        ) => __self_0 == __arg1_0,
+                        _ => unsafe { ::core::intrinsics::unreachable() },
+                    }
+            }
+        }
+        #[automatically_derived]
+        impl ::core::cmp::Ord for ArbitraryContext {
+            #[inline]
+            fn cmp(&self, other: &ArbitraryContext) -> ::core::cmp::Ordering {
+                let __self_discr = ::core::intrinsics::discriminant_value(self);
+                let __arg1_discr = ::core::intrinsics::discriminant_value(other);
+                match ::core::cmp::Ord::cmp(&__self_discr, &__arg1_discr) {
+                    ::core::cmp::Ordering::Equal => match (self, other) {
+                        (
+                            ArbitraryContext::Contract(__self_0),
+                            ArbitraryContext::Contract(__arg1_0),
+                        ) => ::core::cmp::Ord::cmp(__self_0, __arg1_0),
+                        (
+                            ArbitraryContext::CreateContractHostFn(__self_0),
+                            ArbitraryContext::CreateContractHostFn(__arg1_0),
+                        ) => ::core::cmp::Ord::cmp(__self_0, __arg1_0),
+                        (
+                            ArbitraryContext::CreateContractWithCtorHostFn(__self_0),
+                            ArbitraryContext::CreateContractWithCtorHostFn(__arg1_0),
+                        ) => ::core::cmp::Ord::cmp(__self_0, __arg1_0),
+                        _ => unsafe { ::core::intrinsics::unreachable() },
+                    },
+                    cmp => cmp,
+                }
+            }
+        }
+        #[automatically_derived]
+        impl ::core::cmp::PartialOrd for ArbitraryContext {
+            #[inline]
+            fn partial_cmp(
+                &self,
+                other: &ArbitraryContext,
+            ) -> ::core::option::Option<::core::cmp::Ordering> {
+                let __self_discr = ::core::intrinsics::discriminant_value(self);
+                let __arg1_discr = ::core::intrinsics::discriminant_value(other);
+                match (self, other) {
+                    (
+                        ArbitraryContext::Contract(__self_0),
+                        ArbitraryContext::Contract(__arg1_0),
+                    ) => ::core::cmp::PartialOrd::partial_cmp(__self_0, __arg1_0),
+                    (
+                        ArbitraryContext::CreateContractHostFn(__self_0),
+                        ArbitraryContext::CreateContractHostFn(__arg1_0),
+                    ) => ::core::cmp::PartialOrd::partial_cmp(__self_0, __arg1_0),
+                    (
+                        ArbitraryContext::CreateContractWithCtorHostFn(__self_0),
+                        ArbitraryContext::CreateContractWithCtorHostFn(__arg1_0),
+                    ) => ::core::cmp::PartialOrd::partial_cmp(__self_0, __arg1_0),
+                    _ => ::core::cmp::PartialOrd::partial_cmp(&__self_discr, &__arg1_discr),
+                }
+            }
+        }
+        const _: () = {
+            #[allow(non_upper_case_globals)]
+            const RECURSIVE_COUNT_ArbitraryContext: ::std::thread::LocalKey<std::cell::Cell<u32>> = {
+                #[inline]
+                fn __init() -> std::cell::Cell<u32> {
+                    std::cell::Cell::new(0)
+                }
+                unsafe {
+                    ::std::thread::LocalKey::new(
+                        const {
+                            if ::std::mem::needs_drop::<std::cell::Cell<u32>>() {
+                                |init| {
+                                    #[thread_local]
+                                    static VAL: ::std::thread::local_impl::LazyStorage<
+                                        std::cell::Cell<u32>,
+                                        (),
+                                    > = ::std::thread::local_impl::LazyStorage::new();
+                                    VAL.get_or_init(init, __init)
+                                }
+                            } else {
+                                |init| {
+                                    #[thread_local]
+                                    static VAL: ::std::thread::local_impl::LazyStorage<
+                                        std::cell::Cell<u32>,
+                                        !,
+                                    > = ::std::thread::local_impl::LazyStorage::new();
+                                    VAL.get_or_init(init, __init)
+                                }
+                            }
+                        },
+                    )
+                }
+            };
+            #[automatically_derived]
+            impl<'arbitrary> arbitrary::Arbitrary<'arbitrary> for ArbitraryContext {
+                fn arbitrary(
+                    u: &mut arbitrary::Unstructured<'arbitrary>,
+                ) -> arbitrary::Result<Self> {
+                    let guard_against_recursion = u.is_empty();
+                    if guard_against_recursion {
+                        RECURSIVE_COUNT_ArbitraryContext.with(|count| {
+                            if count.get() > 0 {
+                                return Err(arbitrary::Error::NotEnoughData);
+                            }
+                            count.set(count.get() + 1);
+                            Ok(())
+                        })?;
+                    }
+                    let result = (|| {
+                        Ok(
+                            match (u64::from(<u32 as arbitrary::Arbitrary>::arbitrary(u)?) * 3u64)
+                                >> 32
+                            {
+                                0u64 => {
+                                    ArbitraryContext::Contract(arbitrary::Arbitrary::arbitrary(u)?)
+                                }
+                                1u64 => ArbitraryContext::CreateContractHostFn(
+                                    arbitrary::Arbitrary::arbitrary(u)?,
+                                ),
+                                2u64 => ArbitraryContext::CreateContractWithCtorHostFn(
+                                    arbitrary::Arbitrary::arbitrary(u)?,
+                                ),
+                                _ => ::core::panicking::panic(
+                                    "internal error: entered unreachable code",
+                                ),
+                            },
+                        )
+                    })();
+                    if guard_against_recursion {
+                        RECURSIVE_COUNT_ArbitraryContext.with(|count| {
+                            count.set(count.get() - 1);
+                        });
+                    }
+                    result
+                }
+                fn arbitrary_take_rest(
+                    mut u: arbitrary::Unstructured<'arbitrary>,
+                ) -> arbitrary::Result<Self> {
+                    let guard_against_recursion = u.is_empty();
+                    if guard_against_recursion {
+                        RECURSIVE_COUNT_ArbitraryContext.with(|count| {
+                            if count.get() > 0 {
+                                return Err(arbitrary::Error::NotEnoughData);
+                            }
+                            count.set(count.get() + 1);
+                            Ok(())
+                        })?;
+                    }
+                    let result = (|| {
+                        Ok(
+                            match (u64::from(<u32 as arbitrary::Arbitrary>::arbitrary(&mut u)?)
+                                * 3u64)
+                                >> 32
+                            {
+                                0u64 => ArbitraryContext::Contract(
+                                    arbitrary::Arbitrary::arbitrary_take_rest(u)?,
+                                ),
+                                1u64 => ArbitraryContext::CreateContractHostFn(
+                                    arbitrary::Arbitrary::arbitrary_take_rest(u)?,
+                                ),
+                                2u64 => ArbitraryContext::CreateContractWithCtorHostFn(
+                                    arbitrary::Arbitrary::arbitrary_take_rest(u)?,
+                                ),
+                                _ => ::core::panicking::panic(
+                                    "internal error: entered unreachable code",
+                                ),
+                            },
+                        )
+                    })();
+                    if guard_against_recursion {
+                        RECURSIVE_COUNT_ArbitraryContext.with(|count| {
+                            count.set(count.get() - 1);
+                        });
+                    }
+                    result
+                }
+                #[inline]
+                fn size_hint(depth: usize) -> (usize, Option<usize>) {
+                    arbitrary::size_hint::and(
+                        <u32 as arbitrary::Arbitrary>::size_hint(depth),
+                        arbitrary::size_hint::recursion_guard(depth, |depth| {
+                            arbitrary::size_hint::or_all(
+                                    &[
+                                        arbitrary::size_hint::and_all(
+                                            &[
+                                                <<ContractContext as soroban_sdk::testutils::arbitrary::SorobanArbitrary>::Prototype as arbitrary::Arbitrary>::size_hint(
+                                                    depth,
+                                                ),
+                                            ],
+                                        ),
+                                        arbitrary::size_hint::and_all(
+                                            &[
+                                                <<CreateContractHostFnContext as soroban_sdk::testutils::arbitrary::SorobanArbitrary>::Prototype as arbitrary::Arbitrary>::size_hint(
+                                                    depth,
+                                                ),
+                                            ],
+                                        ),
+                                        arbitrary::size_hint::and_all(
+                                            &[
+                                                <<CreateContractWithConstructorHostFnContext as soroban_sdk::testutils::arbitrary::SorobanArbitrary>::Prototype as arbitrary::Arbitrary>::size_hint(
+                                                    depth,
+                                                ),
+                                            ],
+                                        ),
+                                    ],
+                                )
+                        }),
+                    )
+                }
+            }
+        };
+        impl soroban_sdk::testutils::arbitrary::SorobanArbitrary for Context {
+            type Prototype = ArbitraryContext;
+        }
+        impl soroban_sdk::TryFromVal<soroban_sdk::Env, ArbitraryContext> for Context {
+            type Error = soroban_sdk::ConversionError;
+            fn try_from_val(
+                env: &soroban_sdk::Env,
+                v: &ArbitraryContext,
+            ) -> std::result::Result<Self, Self::Error> {
+                Ok(match v {
+                    ArbitraryContext::Contract(field_0) => {
+                        Context::Contract(soroban_sdk::IntoVal::into_val(field_0, env))
+                    }
+                    ArbitraryContext::CreateContractHostFn(field_0) => {
+                        Context::CreateContractHostFn(soroban_sdk::IntoVal::into_val(field_0, env))
+                    }
+                    ArbitraryContext::CreateContractWithCtorHostFn(field_0) => {
+                        Context::CreateContractWithCtorHostFn(soroban_sdk::IntoVal::into_val(
+                            field_0, env,
+                        ))
+                    }
+                })
+            }
+        }
+    };
+    pub enum ContractExecutable {
+        Wasm(soroban_sdk::BytesN<32>),
+    }
+    #[automatically_derived]
+    impl ::core::fmt::Debug for ContractExecutable {
+        #[inline]
+        fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+            match self {
+                ContractExecutable::Wasm(__self_0) => {
+                    ::core::fmt::Formatter::debug_tuple_field1_finish(f, "Wasm", &__self_0)
+                }
+            }
+        }
+    }
+    #[automatically_derived]
+    impl ::core::clone::Clone for ContractExecutable {
+        #[inline]
+        fn clone(&self) -> ContractExecutable {
+            match self {
+                ContractExecutable::Wasm(__self_0) => {
+                    ContractExecutable::Wasm(::core::clone::Clone::clone(__self_0))
+                }
+            }
+        }
+    }
+    #[automatically_derived]
+    impl ::core::cmp::Eq for ContractExecutable {
+        #[inline]
+        #[doc(hidden)]
+        #[coverage(off)]
+        fn assert_receiver_is_total_eq(&self) -> () {
+            let _: ::core::cmp::AssertParamIsEq<soroban_sdk::BytesN<32>>;
+        }
+    }
+    #[automatically_derived]
+    impl ::core::marker::StructuralPartialEq for ContractExecutable {}
+    #[automatically_derived]
+    impl ::core::cmp::PartialEq for ContractExecutable {
+        #[inline]
+        fn eq(&self, other: &ContractExecutable) -> bool {
+            match (self, other) {
+                (ContractExecutable::Wasm(__self_0), ContractExecutable::Wasm(__arg1_0)) => {
+                    __self_0 == __arg1_0
+                }
+            }
+        }
+    }
+    #[automatically_derived]
+    impl ::core::cmp::Ord for ContractExecutable {
+        #[inline]
+        fn cmp(&self, other: &ContractExecutable) -> ::core::cmp::Ordering {
+            match (self, other) {
+                (ContractExecutable::Wasm(__self_0), ContractExecutable::Wasm(__arg1_0)) => {
+                    ::core::cmp::Ord::cmp(__self_0, __arg1_0)
+                }
+            }
+        }
+    }
+    #[automatically_derived]
+    impl ::core::cmp::PartialOrd for ContractExecutable {
+        #[inline]
+        fn partial_cmp(
+            &self,
+            other: &ContractExecutable,
+        ) -> ::core::option::Option<::core::cmp::Ordering> {
+            match (self, other) {
+                (ContractExecutable::Wasm(__self_0), ContractExecutable::Wasm(__arg1_0)) => {
+                    ::core::cmp::PartialOrd::partial_cmp(__self_0, __arg1_0)
+                }
+            }
+        }
+    }
+    impl soroban_sdk::TryFromVal<soroban_sdk::Env, soroban_sdk::Val> for ContractExecutable {
+        type Error = soroban_sdk::ConversionError;
+        #[inline(always)]
+        fn try_from_val(
+            env: &soroban_sdk::Env,
+            val: &soroban_sdk::Val,
+        ) -> Result<Self, soroban_sdk::ConversionError> {
+            use soroban_sdk::{EnvBase, TryFromVal, TryIntoVal};
+            const CASES: &'static [&'static str] = &["Wasm"];
+            let vec: soroban_sdk::Vec<soroban_sdk::Val> = val.try_into_val(env)?;
+            let mut iter = vec.try_iter();
+            let discriminant: soroban_sdk::Symbol = iter
+                .next()
+                .ok_or(soroban_sdk::ConversionError)??
+                .try_into_val(env)
+                .map_err(|_| soroban_sdk::ConversionError)?;
+            Ok(
+                match u32::from(env.symbol_index_in_strs(discriminant.to_symbol_val(), CASES)?)
+                    as usize
+                {
+                    0 => {
+                        if iter.len() > 1usize {
+                            return Err(soroban_sdk::ConversionError);
+                        }
+                        Self::Wasm(
+                            iter.next()
+                                .ok_or(soroban_sdk::ConversionError)??
+                                .try_into_val(env)?,
+                        )
+                    }
+                    _ => Err(soroban_sdk::ConversionError {})?,
+                },
+            )
+        }
+    }
+    impl soroban_sdk::TryFromVal<soroban_sdk::Env, ContractExecutable> for soroban_sdk::Val {
+        type Error = soroban_sdk::ConversionError;
+        #[inline(always)]
+        fn try_from_val(
+            env: &soroban_sdk::Env,
+            val: &ContractExecutable,
+        ) -> Result<Self, soroban_sdk::ConversionError> {
+            use soroban_sdk::{TryFromVal, TryIntoVal};
+            match val {
+                ContractExecutable::Wasm(ref value0) => {
+                    let tup: (soroban_sdk::Val, soroban_sdk::Val) = (
+                        soroban_sdk::Symbol::try_from_val(env, &"Wasm")?.to_val(),
+                        value0.try_into_val(env)?,
+                    );
+                    tup.try_into_val(env).map_err(Into::into)
+                }
+            }
+        }
+    }
+    impl soroban_sdk::TryFromVal<soroban_sdk::Env, &ContractExecutable> for soroban_sdk::Val {
+        type Error = soroban_sdk::ConversionError;
+        #[inline(always)]
+        fn try_from_val(
+            env: &soroban_sdk::Env,
+            val: &&ContractExecutable,
+        ) -> Result<Self, soroban_sdk::ConversionError> {
+            <_ as soroban_sdk::TryFromVal<soroban_sdk::Env, ContractExecutable>>::try_from_val(
+                env, *val,
+            )
+        }
+    }
+    impl soroban_sdk::TryFromVal<soroban_sdk::Env, soroban_sdk::xdr::ScVec> for ContractExecutable {
+        type Error = soroban_sdk::xdr::Error;
+        #[inline(always)]
+        fn try_from_val(
+            env: &soroban_sdk::Env,
+            val: &soroban_sdk::xdr::ScVec,
+        ) -> Result<Self, soroban_sdk::xdr::Error> {
+            use soroban_sdk::xdr::Validate;
+            use soroban_sdk::TryIntoVal;
+            let vec = val;
+            let mut iter = vec.iter();
+            let discriminant: soroban_sdk::xdr::ScSymbol = iter
+                .next()
+                .ok_or(soroban_sdk::xdr::Error::Invalid)?
+                .clone()
+                .try_into()
+                .map_err(|_| soroban_sdk::xdr::Error::Invalid)?;
+            let discriminant_name: &str = &discriminant.to_utf8_string()?;
+            Ok(match discriminant_name {
+                "Wasm" => {
+                    if iter.len() > 1usize {
+                        return Err(soroban_sdk::xdr::Error::Invalid);
+                    }
+                    let rv0: soroban_sdk::Val = iter
+                        .next()
+                        .ok_or(soroban_sdk::xdr::Error::Invalid)?
+                        .try_into_val(env)
+                        .map_err(|_| soroban_sdk::xdr::Error::Invalid)?;
+                    Self::Wasm(
+                        rv0.try_into_val(env)
+                            .map_err(|_| soroban_sdk::xdr::Error::Invalid)?,
+                    )
+                }
+                _ => Err(soroban_sdk::xdr::Error::Invalid)?,
+            })
+        }
+    }
+    impl soroban_sdk::TryFromVal<soroban_sdk::Env, soroban_sdk::xdr::ScVal> for ContractExecutable {
+        type Error = soroban_sdk::xdr::Error;
+        #[inline(always)]
+        fn try_from_val(
+            env: &soroban_sdk::Env,
+            val: &soroban_sdk::xdr::ScVal,
+        ) -> Result<Self, soroban_sdk::xdr::Error> {
+            if let soroban_sdk::xdr::ScVal::Vec(Some(vec)) = val {
+                <_ as soroban_sdk::TryFromVal<_, _>>::try_from_val(env, vec)
+            } else {
+                Err(soroban_sdk::xdr::Error::Invalid)
+            }
+        }
+    }
+    impl TryFrom<&ContractExecutable> for soroban_sdk::xdr::ScVec {
+        type Error = soroban_sdk::xdr::Error;
+        #[inline(always)]
+        fn try_from(val: &ContractExecutable) -> Result<Self, soroban_sdk::xdr::Error> {
+            extern crate alloc;
+            Ok(match val {
+                ContractExecutable::Wasm(value0) => (
+                    soroban_sdk::xdr::ScSymbol(
+                        "Wasm"
+                            .try_into()
+                            .map_err(|_| soroban_sdk::xdr::Error::Invalid)?,
+                    ),
+                    value0,
+                )
+                    .try_into()
+                    .map_err(|_| soroban_sdk::xdr::Error::Invalid)?,
+            })
+        }
+    }
+    impl TryFrom<ContractExecutable> for soroban_sdk::xdr::ScVec {
+        type Error = soroban_sdk::xdr::Error;
+        #[inline(always)]
+        fn try_from(val: ContractExecutable) -> Result<Self, soroban_sdk::xdr::Error> {
+            (&val).try_into()
+        }
+    }
+    impl TryFrom<&ContractExecutable> for soroban_sdk::xdr::ScVal {
+        type Error = soroban_sdk::xdr::Error;
+        #[inline(always)]
+        fn try_from(val: &ContractExecutable) -> Result<Self, soroban_sdk::xdr::Error> {
+            Ok(soroban_sdk::xdr::ScVal::Vec(Some(val.try_into()?)))
+        }
+    }
+    impl TryFrom<ContractExecutable> for soroban_sdk::xdr::ScVal {
+        type Error = soroban_sdk::xdr::Error;
+        #[inline(always)]
+        fn try_from(val: ContractExecutable) -> Result<Self, soroban_sdk::xdr::Error> {
+            (&val).try_into()
+        }
+    }
+    const _: () = {
+        use soroban_sdk::testutils::arbitrary::arbitrary;
+        use soroban_sdk::testutils::arbitrary::std;
+        pub enum ArbitraryContractExecutable {
+            Wasm(
+                <soroban_sdk::BytesN<
+                    32,
+                > as soroban_sdk::testutils::arbitrary::SorobanArbitrary>::Prototype,
+            ),
+        }
+        #[automatically_derived]
+        impl ::core::fmt::Debug for ArbitraryContractExecutable {
+            #[inline]
+            fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+                match self {
+                    ArbitraryContractExecutable::Wasm(__self_0) => {
+                        ::core::fmt::Formatter::debug_tuple_field1_finish(f, "Wasm", &__self_0)
+                    }
+                }
+            }
+        }
+        #[automatically_derived]
+        impl ::core::clone::Clone for ArbitraryContractExecutable {
+            #[inline]
+            fn clone(&self) -> ArbitraryContractExecutable {
+                match self {
+                    ArbitraryContractExecutable::Wasm(__self_0) => {
+                        ArbitraryContractExecutable::Wasm(::core::clone::Clone::clone(__self_0))
+                    }
+                }
+            }
+        }
+        #[automatically_derived]
+        impl ::core::cmp::Eq for ArbitraryContractExecutable {
+            #[inline]
+            #[doc(hidden)]
+            #[coverage(off)]
+            fn assert_receiver_is_total_eq(&self) -> () {
+                let _: ::core::cmp::AssertParamIsEq<
+                    <soroban_sdk::BytesN<
+                        32,
+                    > as soroban_sdk::testutils::arbitrary::SorobanArbitrary>::Prototype,
+                >;
+            }
+        }
+        #[automatically_derived]
+        impl ::core::marker::StructuralPartialEq for ArbitraryContractExecutable {}
+        #[automatically_derived]
+        impl ::core::cmp::PartialEq for ArbitraryContractExecutable {
+            #[inline]
+            fn eq(&self, other: &ArbitraryContractExecutable) -> bool {
+                match (self, other) {
+                    (
+                        ArbitraryContractExecutable::Wasm(__self_0),
+                        ArbitraryContractExecutable::Wasm(__arg1_0),
+                    ) => __self_0 == __arg1_0,
+                }
+            }
+        }
+        #[automatically_derived]
+        impl ::core::cmp::Ord for ArbitraryContractExecutable {
+            #[inline]
+            fn cmp(&self, other: &ArbitraryContractExecutable) -> ::core::cmp::Ordering {
+                match (self, other) {
+                    (
+                        ArbitraryContractExecutable::Wasm(__self_0),
+                        ArbitraryContractExecutable::Wasm(__arg1_0),
+                    ) => ::core::cmp::Ord::cmp(__self_0, __arg1_0),
+                }
+            }
+        }
+        #[automatically_derived]
+        impl ::core::cmp::PartialOrd for ArbitraryContractExecutable {
+            #[inline]
+            fn partial_cmp(
+                &self,
+                other: &ArbitraryContractExecutable,
+            ) -> ::core::option::Option<::core::cmp::Ordering> {
+                match (self, other) {
+                    (
+                        ArbitraryContractExecutable::Wasm(__self_0),
+                        ArbitraryContractExecutable::Wasm(__arg1_0),
+                    ) => ::core::cmp::PartialOrd::partial_cmp(__self_0, __arg1_0),
+                }
+            }
+        }
+        const _: () = {
+            #[allow(non_upper_case_globals)]
+            const RECURSIVE_COUNT_ArbitraryContractExecutable: ::std::thread::LocalKey<
+                std::cell::Cell<u32>,
+            > = {
+                #[inline]
+                fn __init() -> std::cell::Cell<u32> {
+                    std::cell::Cell::new(0)
+                }
+                unsafe {
+                    ::std::thread::LocalKey::new(
+                        const {
+                            if ::std::mem::needs_drop::<std::cell::Cell<u32>>() {
+                                |init| {
+                                    #[thread_local]
+                                    static VAL: ::std::thread::local_impl::LazyStorage<
+                                        std::cell::Cell<u32>,
+                                        (),
+                                    > = ::std::thread::local_impl::LazyStorage::new();
+                                    VAL.get_or_init(init, __init)
+                                }
+                            } else {
+                                |init| {
+                                    #[thread_local]
+                                    static VAL: ::std::thread::local_impl::LazyStorage<
+                                        std::cell::Cell<u32>,
+                                        !,
+                                    > = ::std::thread::local_impl::LazyStorage::new();
+                                    VAL.get_or_init(init, __init)
+                                }
+                            }
+                        },
+                    )
+                }
+            };
+            #[automatically_derived]
+            impl<'arbitrary> arbitrary::Arbitrary<'arbitrary> for ArbitraryContractExecutable {
+                fn arbitrary(
+                    u: &mut arbitrary::Unstructured<'arbitrary>,
+                ) -> arbitrary::Result<Self> {
+                    let guard_against_recursion = u.is_empty();
+                    if guard_against_recursion {
+                        RECURSIVE_COUNT_ArbitraryContractExecutable.with(|count| {
+                            if count.get() > 0 {
+                                return Err(arbitrary::Error::NotEnoughData);
+                            }
+                            count.set(count.get() + 1);
+                            Ok(())
+                        })?;
+                    }
+                    let result = (|| {
+                        Ok(
+                            match (u64::from(<u32 as arbitrary::Arbitrary>::arbitrary(u)?) * 1u64)
+                                >> 32
+                            {
+                                0u64 => ArbitraryContractExecutable::Wasm(
+                                    arbitrary::Arbitrary::arbitrary(u)?,
+                                ),
+                                _ => ::core::panicking::panic(
+                                    "internal error: entered unreachable code",
+                                ),
+                            },
+                        )
+                    })();
+                    if guard_against_recursion {
+                        RECURSIVE_COUNT_ArbitraryContractExecutable.with(|count| {
+                            count.set(count.get() - 1);
+                        });
+                    }
+                    result
+                }
+                fn arbitrary_take_rest(
+                    mut u: arbitrary::Unstructured<'arbitrary>,
+                ) -> arbitrary::Result<Self> {
+                    let guard_against_recursion = u.is_empty();
+                    if guard_against_recursion {
+                        RECURSIVE_COUNT_ArbitraryContractExecutable.with(|count| {
+                            if count.get() > 0 {
+                                return Err(arbitrary::Error::NotEnoughData);
+                            }
+                            count.set(count.get() + 1);
+                            Ok(())
+                        })?;
+                    }
+                    let result = (|| {
+                        Ok(
+                            match (u64::from(<u32 as arbitrary::Arbitrary>::arbitrary(&mut u)?)
+                                * 1u64)
+                                >> 32
+                            {
+                                0u64 => ArbitraryContractExecutable::Wasm(
+                                    arbitrary::Arbitrary::arbitrary_take_rest(u)?,
+                                ),
+                                _ => ::core::panicking::panic(
+                                    "internal error: entered unreachable code",
+                                ),
+                            },
+                        )
+                    })();
+                    if guard_against_recursion {
+                        RECURSIVE_COUNT_ArbitraryContractExecutable.with(|count| {
+                            count.set(count.get() - 1);
+                        });
+                    }
+                    result
+                }
+                #[inline]
+                fn size_hint(depth: usize) -> (usize, Option<usize>) {
+                    arbitrary::size_hint::and(
+                        <u32 as arbitrary::Arbitrary>::size_hint(depth),
+                        arbitrary::size_hint::recursion_guard(depth, |depth| {
+                            arbitrary::size_hint::or_all(
+                                    &[
+                                        arbitrary::size_hint::and_all(
+                                            &[
+                                                <<soroban_sdk::BytesN<
+                                                    32,
+                                                > as soroban_sdk::testutils::arbitrary::SorobanArbitrary>::Prototype as arbitrary::Arbitrary>::size_hint(
+                                                    depth,
+                                                ),
+                                            ],
+                                        ),
+                                    ],
+                                )
+                        }),
+                    )
+                }
+            }
+        };
+        impl soroban_sdk::testutils::arbitrary::SorobanArbitrary for ContractExecutable {
+            type Prototype = ArbitraryContractExecutable;
+        }
+        impl soroban_sdk::TryFromVal<soroban_sdk::Env, ArbitraryContractExecutable> for ContractExecutable {
+            type Error = soroban_sdk::ConversionError;
+            fn try_from_val(
+                env: &soroban_sdk::Env,
+                v: &ArbitraryContractExecutable,
+            ) -> std::result::Result<Self, Self::Error> {
+                Ok(match v {
+                    ArbitraryContractExecutable::Wasm(field_0) => {
+                        ContractExecutable::Wasm(soroban_sdk::IntoVal::into_val(field_0, env))
+                    }
+                })
+            }
+        }
+    };
+    pub enum InvokerContractAuthEntry {
+        Contract(SubContractInvocation),
+        CreateContractHostFn(CreateContractHostFnContext),
+        CreateContractWithCtorHostFn(CreateContractWithConstructorHostFnContext),
+    }
+    #[automatically_derived]
+    impl ::core::fmt::Debug for InvokerContractAuthEntry {
+        #[inline]
+        fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+            match self {
+                InvokerContractAuthEntry::Contract(__self_0) => {
+                    ::core::fmt::Formatter::debug_tuple_field1_finish(f, "Contract", &__self_0)
+                }
+                InvokerContractAuthEntry::CreateContractHostFn(__self_0) => {
+                    ::core::fmt::Formatter::debug_tuple_field1_finish(
+                        f,
+                        "CreateContractHostFn",
+                        &__self_0,
+                    )
+                }
+                InvokerContractAuthEntry::CreateContractWithCtorHostFn(__self_0) => {
+                    ::core::fmt::Formatter::debug_tuple_field1_finish(
+                        f,
+                        "CreateContractWithCtorHostFn",
+                        &__self_0,
+                    )
+                }
+            }
+        }
+    }
+    #[automatically_derived]
+    impl ::core::clone::Clone for InvokerContractAuthEntry {
+        #[inline]
+        fn clone(&self) -> InvokerContractAuthEntry {
+            match self {
+                InvokerContractAuthEntry::Contract(__self_0) => {
+                    InvokerContractAuthEntry::Contract(::core::clone::Clone::clone(__self_0))
+                }
+                InvokerContractAuthEntry::CreateContractHostFn(__self_0) => {
+                    InvokerContractAuthEntry::CreateContractHostFn(::core::clone::Clone::clone(
+                        __self_0,
+                    ))
+                }
+                InvokerContractAuthEntry::CreateContractWithCtorHostFn(__self_0) => {
+                    InvokerContractAuthEntry::CreateContractWithCtorHostFn(
+                        ::core::clone::Clone::clone(__self_0),
+                    )
+                }
+            }
+        }
+    }
+    #[automatically_derived]
+    impl ::core::cmp::Eq for InvokerContractAuthEntry {
+        #[inline]
+        #[doc(hidden)]
+        #[coverage(off)]
+        fn assert_receiver_is_total_eq(&self) -> () {
+            let _: ::core::cmp::AssertParamIsEq<SubContractInvocation>;
+            let _: ::core::cmp::AssertParamIsEq<CreateContractHostFnContext>;
+            let _: ::core::cmp::AssertParamIsEq<CreateContractWithConstructorHostFnContext>;
+        }
+    }
+    #[automatically_derived]
+    impl ::core::marker::StructuralPartialEq for InvokerContractAuthEntry {}
+    #[automatically_derived]
+    impl ::core::cmp::PartialEq for InvokerContractAuthEntry {
+        #[inline]
+        fn eq(&self, other: &InvokerContractAuthEntry) -> bool {
+            let __self_discr = ::core::intrinsics::discriminant_value(self);
+            let __arg1_discr = ::core::intrinsics::discriminant_value(other);
+            __self_discr == __arg1_discr
+                && match (self, other) {
+                    (
+                        InvokerContractAuthEntry::Contract(__self_0),
+                        InvokerContractAuthEntry::Contract(__arg1_0),
+                    ) => __self_0 == __arg1_0,
+                    (
+                        InvokerContractAuthEntry::CreateContractHostFn(__self_0),
+                        InvokerContractAuthEntry::CreateContractHostFn(__arg1_0),
+                    ) => __self_0 == __arg1_0,
+                    (
+                        InvokerContractAuthEntry::CreateContractWithCtorHostFn(__self_0),
+                        InvokerContractAuthEntry::CreateContractWithCtorHostFn(__arg1_0),
+                    ) => __self_0 == __arg1_0,
+                    _ => unsafe { ::core::intrinsics::unreachable() },
+                }
+        }
+    }
+    #[automatically_derived]
+    impl ::core::cmp::Ord for InvokerContractAuthEntry {
+        #[inline]
+        fn cmp(&self, other: &InvokerContractAuthEntry) -> ::core::cmp::Ordering {
+            let __self_discr = ::core::intrinsics::discriminant_value(self);
+            let __arg1_discr = ::core::intrinsics::discriminant_value(other);
+            match ::core::cmp::Ord::cmp(&__self_discr, &__arg1_discr) {
+                ::core::cmp::Ordering::Equal => match (self, other) {
+                    (
+                        InvokerContractAuthEntry::Contract(__self_0),
+                        InvokerContractAuthEntry::Contract(__arg1_0),
+                    ) => ::core::cmp::Ord::cmp(__self_0, __arg1_0),
+                    (
+                        InvokerContractAuthEntry::CreateContractHostFn(__self_0),
+                        InvokerContractAuthEntry::CreateContractHostFn(__arg1_0),
+                    ) => ::core::cmp::Ord::cmp(__self_0, __arg1_0),
+                    (
+                        InvokerContractAuthEntry::CreateContractWithCtorHostFn(__self_0),
+                        InvokerContractAuthEntry::CreateContractWithCtorHostFn(__arg1_0),
+                    ) => ::core::cmp::Ord::cmp(__self_0, __arg1_0),
+                    _ => unsafe { ::core::intrinsics::unreachable() },
+                },
+                cmp => cmp,
+            }
+        }
+    }
+    #[automatically_derived]
+    impl ::core::cmp::PartialOrd for InvokerContractAuthEntry {
+        #[inline]
+        fn partial_cmp(
+            &self,
+            other: &InvokerContractAuthEntry,
+        ) -> ::core::option::Option<::core::cmp::Ordering> {
+            let __self_discr = ::core::intrinsics::discriminant_value(self);
+            let __arg1_discr = ::core::intrinsics::discriminant_value(other);
+            match (self, other) {
+                (
+                    InvokerContractAuthEntry::Contract(__self_0),
+                    InvokerContractAuthEntry::Contract(__arg1_0),
+                ) => ::core::cmp::PartialOrd::partial_cmp(__self_0, __arg1_0),
+                (
+                    InvokerContractAuthEntry::CreateContractHostFn(__self_0),
+                    InvokerContractAuthEntry::CreateContractHostFn(__arg1_0),
+                ) => ::core::cmp::PartialOrd::partial_cmp(__self_0, __arg1_0),
+                (
+                    InvokerContractAuthEntry::CreateContractWithCtorHostFn(__self_0),
+                    InvokerContractAuthEntry::CreateContractWithCtorHostFn(__arg1_0),
+                ) => ::core::cmp::PartialOrd::partial_cmp(__self_0, __arg1_0),
+                _ => ::core::cmp::PartialOrd::partial_cmp(&__self_discr, &__arg1_discr),
+            }
+        }
+    }
+    impl soroban_sdk::TryFromVal<soroban_sdk::Env, soroban_sdk::Val> for InvokerContractAuthEntry {
+        type Error = soroban_sdk::ConversionError;
+        #[inline(always)]
+        fn try_from_val(
+            env: &soroban_sdk::Env,
+            val: &soroban_sdk::Val,
+        ) -> Result<Self, soroban_sdk::ConversionError> {
+            use soroban_sdk::{EnvBase, TryFromVal, TryIntoVal};
+            const CASES: &'static [&'static str] = &[
+                "Contract",
+                "CreateContractHostFn",
+                "CreateContractWithCtorHostFn",
+            ];
+            let vec: soroban_sdk::Vec<soroban_sdk::Val> = val.try_into_val(env)?;
+            let mut iter = vec.try_iter();
+            let discriminant: soroban_sdk::Symbol = iter
+                .next()
+                .ok_or(soroban_sdk::ConversionError)??
+                .try_into_val(env)
+                .map_err(|_| soroban_sdk::ConversionError)?;
+            Ok(
+                match u32::from(env.symbol_index_in_strs(discriminant.to_symbol_val(), CASES)?)
+                    as usize
+                {
+                    0 => {
+                        if iter.len() > 1usize {
+                            return Err(soroban_sdk::ConversionError);
+                        }
+                        Self::Contract(
+                            iter.next()
+                                .ok_or(soroban_sdk::ConversionError)??
+                                .try_into_val(env)?,
+                        )
+                    }
+                    1 => {
+                        if iter.len() > 1usize {
+                            return Err(soroban_sdk::ConversionError);
+                        }
+                        Self::CreateContractHostFn(
+                            iter.next()
+                                .ok_or(soroban_sdk::ConversionError)??
+                                .try_into_val(env)?,
+                        )
+                    }
+                    2 => {
+                        if iter.len() > 1usize {
+                            return Err(soroban_sdk::ConversionError);
+                        }
+                        Self::CreateContractWithCtorHostFn(
+                            iter.next()
+                                .ok_or(soroban_sdk::ConversionError)??
+                                .try_into_val(env)?,
+                        )
+                    }
+                    _ => Err(soroban_sdk::ConversionError {})?,
+                },
+            )
+        }
+    }
+    impl soroban_sdk::TryFromVal<soroban_sdk::Env, InvokerContractAuthEntry> for soroban_sdk::Val {
+        type Error = soroban_sdk::ConversionError;
+        #[inline(always)]
+        fn try_from_val(
+            env: &soroban_sdk::Env,
+            val: &InvokerContractAuthEntry,
+        ) -> Result<Self, soroban_sdk::ConversionError> {
+            use soroban_sdk::{TryFromVal, TryIntoVal};
+            match val {
+                InvokerContractAuthEntry::Contract(ref value0) => {
+                    let tup: (soroban_sdk::Val, soroban_sdk::Val) = (
+                        soroban_sdk::Symbol::try_from_val(env, &"Contract")?.to_val(),
+                        value0.try_into_val(env)?,
+                    );
+                    tup.try_into_val(env).map_err(Into::into)
+                }
+                InvokerContractAuthEntry::CreateContractHostFn(ref value0) => {
+                    let tup: (soroban_sdk::Val, soroban_sdk::Val) = (
+                        soroban_sdk::Symbol::try_from_val(env, &"CreateContractHostFn")?.to_val(),
+                        value0.try_into_val(env)?,
+                    );
+                    tup.try_into_val(env).map_err(Into::into)
+                }
+                InvokerContractAuthEntry::CreateContractWithCtorHostFn(ref value0) => {
+                    let tup: (soroban_sdk::Val, soroban_sdk::Val) = (
+                        soroban_sdk::Symbol::try_from_val(env, &"CreateContractWithCtorHostFn")?
+                            .to_val(),
+                        value0.try_into_val(env)?,
+                    );
+                    tup.try_into_val(env).map_err(Into::into)
+                }
+            }
+        }
+    }
+    impl soroban_sdk::TryFromVal<soroban_sdk::Env, &InvokerContractAuthEntry> for soroban_sdk::Val {
+        type Error = soroban_sdk::ConversionError;
+        #[inline(always)]
+        fn try_from_val(
+            env: &soroban_sdk::Env,
+            val: &&InvokerContractAuthEntry,
+        ) -> Result<Self, soroban_sdk::ConversionError> {
+            <_ as soroban_sdk::TryFromVal<soroban_sdk::Env, InvokerContractAuthEntry>>::try_from_val(
+                env, *val,
+            )
+        }
+    }
+    impl soroban_sdk::TryFromVal<soroban_sdk::Env, soroban_sdk::xdr::ScVec>
+        for InvokerContractAuthEntry
+    {
+        type Error = soroban_sdk::xdr::Error;
+        #[inline(always)]
+        fn try_from_val(
+            env: &soroban_sdk::Env,
+            val: &soroban_sdk::xdr::ScVec,
+        ) -> Result<Self, soroban_sdk::xdr::Error> {
+            use soroban_sdk::xdr::Validate;
+            use soroban_sdk::TryIntoVal;
+            let vec = val;
+            let mut iter = vec.iter();
+            let discriminant: soroban_sdk::xdr::ScSymbol = iter
+                .next()
+                .ok_or(soroban_sdk::xdr::Error::Invalid)?
+                .clone()
+                .try_into()
+                .map_err(|_| soroban_sdk::xdr::Error::Invalid)?;
+            let discriminant_name: &str = &discriminant.to_utf8_string()?;
+            Ok(match discriminant_name {
+                "Contract" => {
+                    if iter.len() > 1usize {
+                        return Err(soroban_sdk::xdr::Error::Invalid);
+                    }
+                    let rv0: soroban_sdk::Val = iter
+                        .next()
+                        .ok_or(soroban_sdk::xdr::Error::Invalid)?
+                        .try_into_val(env)
+                        .map_err(|_| soroban_sdk::xdr::Error::Invalid)?;
+                    Self::Contract(
+                        rv0.try_into_val(env)
+                            .map_err(|_| soroban_sdk::xdr::Error::Invalid)?,
+                    )
+                }
+                "CreateContractHostFn" => {
+                    if iter.len() > 1usize {
+                        return Err(soroban_sdk::xdr::Error::Invalid);
+                    }
+                    let rv0: soroban_sdk::Val = iter
+                        .next()
+                        .ok_or(soroban_sdk::xdr::Error::Invalid)?
+                        .try_into_val(env)
+                        .map_err(|_| soroban_sdk::xdr::Error::Invalid)?;
+                    Self::CreateContractHostFn(
+                        rv0.try_into_val(env)
+                            .map_err(|_| soroban_sdk::xdr::Error::Invalid)?,
+                    )
+                }
+                "CreateContractWithCtorHostFn" => {
+                    if iter.len() > 1usize {
+                        return Err(soroban_sdk::xdr::Error::Invalid);
+                    }
+                    let rv0: soroban_sdk::Val = iter
+                        .next()
+                        .ok_or(soroban_sdk::xdr::Error::Invalid)?
+                        .try_into_val(env)
+                        .map_err(|_| soroban_sdk::xdr::Error::Invalid)?;
+                    Self::CreateContractWithCtorHostFn(
+                        rv0.try_into_val(env)
+                            .map_err(|_| soroban_sdk::xdr::Error::Invalid)?,
+                    )
+                }
+                _ => Err(soroban_sdk::xdr::Error::Invalid)?,
+            })
+        }
+    }
+    impl soroban_sdk::TryFromVal<soroban_sdk::Env, soroban_sdk::xdr::ScVal>
+        for InvokerContractAuthEntry
+    {
+        type Error = soroban_sdk::xdr::Error;
+        #[inline(always)]
+        fn try_from_val(
+            env: &soroban_sdk::Env,
+            val: &soroban_sdk::xdr::ScVal,
+        ) -> Result<Self, soroban_sdk::xdr::Error> {
+            if let soroban_sdk::xdr::ScVal::Vec(Some(vec)) = val {
+                <_ as soroban_sdk::TryFromVal<_, _>>::try_from_val(env, vec)
+            } else {
+                Err(soroban_sdk::xdr::Error::Invalid)
+            }
+        }
+    }
+    impl TryFrom<&InvokerContractAuthEntry> for soroban_sdk::xdr::ScVec {
+        type Error = soroban_sdk::xdr::Error;
+        #[inline(always)]
+        fn try_from(val: &InvokerContractAuthEntry) -> Result<Self, soroban_sdk::xdr::Error> {
+            extern crate alloc;
+            Ok(match val {
+                InvokerContractAuthEntry::Contract(value0) => (
+                    soroban_sdk::xdr::ScSymbol(
+                        "Contract"
+                            .try_into()
+                            .map_err(|_| soroban_sdk::xdr::Error::Invalid)?,
+                    ),
+                    value0,
+                )
+                    .try_into()
+                    .map_err(|_| soroban_sdk::xdr::Error::Invalid)?,
+                InvokerContractAuthEntry::CreateContractHostFn(value0) => (
+                    soroban_sdk::xdr::ScSymbol(
+                        "CreateContractHostFn"
+                            .try_into()
+                            .map_err(|_| soroban_sdk::xdr::Error::Invalid)?,
+                    ),
+                    value0,
+                )
+                    .try_into()
+                    .map_err(|_| soroban_sdk::xdr::Error::Invalid)?,
+                InvokerContractAuthEntry::CreateContractWithCtorHostFn(value0) => (
+                    soroban_sdk::xdr::ScSymbol(
+                        "CreateContractWithCtorHostFn"
+                            .try_into()
+                            .map_err(|_| soroban_sdk::xdr::Error::Invalid)?,
+                    ),
+                    value0,
+                )
+                    .try_into()
+                    .map_err(|_| soroban_sdk::xdr::Error::Invalid)?,
+            })
+        }
+    }
+    impl TryFrom<InvokerContractAuthEntry> for soroban_sdk::xdr::ScVec {
+        type Error = soroban_sdk::xdr::Error;
+        #[inline(always)]
+        fn try_from(val: InvokerContractAuthEntry) -> Result<Self, soroban_sdk::xdr::Error> {
+            (&val).try_into()
+        }
+    }
+    impl TryFrom<&InvokerContractAuthEntry> for soroban_sdk::xdr::ScVal {
+        type Error = soroban_sdk::xdr::Error;
+        #[inline(always)]
+        fn try_from(val: &InvokerContractAuthEntry) -> Result<Self, soroban_sdk::xdr::Error> {
+            Ok(soroban_sdk::xdr::ScVal::Vec(Some(val.try_into()?)))
+        }
+    }
+    impl TryFrom<InvokerContractAuthEntry> for soroban_sdk::xdr::ScVal {
+        type Error = soroban_sdk::xdr::Error;
+        #[inline(always)]
+        fn try_from(val: InvokerContractAuthEntry) -> Result<Self, soroban_sdk::xdr::Error> {
+            (&val).try_into()
+        }
+    }
+    const _: () = {
+        use soroban_sdk::testutils::arbitrary::arbitrary;
+        use soroban_sdk::testutils::arbitrary::std;
+        pub enum ArbitraryInvokerContractAuthEntry {
+            Contract(
+                <SubContractInvocation as soroban_sdk::testutils::arbitrary::SorobanArbitrary>::Prototype,
+            ),
+            CreateContractHostFn(
+                <CreateContractHostFnContext as soroban_sdk::testutils::arbitrary::SorobanArbitrary>::Prototype,
+            ),
+            CreateContractWithCtorHostFn(
+                <CreateContractWithConstructorHostFnContext as soroban_sdk::testutils::arbitrary::SorobanArbitrary>::Prototype,
+            ),
+        }
+        #[automatically_derived]
+        impl ::core::fmt::Debug for ArbitraryInvokerContractAuthEntry {
+            #[inline]
+            fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+                match self {
+                    ArbitraryInvokerContractAuthEntry::Contract(__self_0) => {
+                        ::core::fmt::Formatter::debug_tuple_field1_finish(f, "Contract", &__self_0)
+                    }
+                    ArbitraryInvokerContractAuthEntry::CreateContractHostFn(__self_0) => {
+                        ::core::fmt::Formatter::debug_tuple_field1_finish(
+                            f,
+                            "CreateContractHostFn",
+                            &__self_0,
+                        )
+                    }
+                    ArbitraryInvokerContractAuthEntry::CreateContractWithCtorHostFn(__self_0) => {
+                        ::core::fmt::Formatter::debug_tuple_field1_finish(
+                            f,
+                            "CreateContractWithCtorHostFn",
+                            &__self_0,
+                        )
+                    }
+                }
+            }
+        }
+        #[automatically_derived]
+        impl ::core::clone::Clone for ArbitraryInvokerContractAuthEntry {
+            #[inline]
+            fn clone(&self) -> ArbitraryInvokerContractAuthEntry {
+                match self {
+                    ArbitraryInvokerContractAuthEntry::Contract(__self_0) => {
+                        ArbitraryInvokerContractAuthEntry::Contract(::core::clone::Clone::clone(
+                            __self_0,
+                        ))
+                    }
+                    ArbitraryInvokerContractAuthEntry::CreateContractHostFn(__self_0) => {
+                        ArbitraryInvokerContractAuthEntry::CreateContractHostFn(
+                            ::core::clone::Clone::clone(__self_0),
+                        )
+                    }
+                    ArbitraryInvokerContractAuthEntry::CreateContractWithCtorHostFn(__self_0) => {
+                        ArbitraryInvokerContractAuthEntry::CreateContractWithCtorHostFn(
+                            ::core::clone::Clone::clone(__self_0),
+                        )
+                    }
+                }
+            }
+        }
+        #[automatically_derived]
+        impl ::core::cmp::Eq for ArbitraryInvokerContractAuthEntry {
+            #[inline]
+            #[doc(hidden)]
+            #[coverage(off)]
+            fn assert_receiver_is_total_eq(&self) -> () {
+                let _: ::core::cmp::AssertParamIsEq<
+                    <SubContractInvocation as soroban_sdk::testutils::arbitrary::SorobanArbitrary>::Prototype,
+                >;
+                let _: ::core::cmp::AssertParamIsEq<
+                    <CreateContractHostFnContext as soroban_sdk::testutils::arbitrary::SorobanArbitrary>::Prototype,
+                >;
+                let _: ::core::cmp::AssertParamIsEq<
+                    <CreateContractWithConstructorHostFnContext as soroban_sdk::testutils::arbitrary::SorobanArbitrary>::Prototype,
+                >;
+            }
+        }
+        #[automatically_derived]
+        impl ::core::marker::StructuralPartialEq for ArbitraryInvokerContractAuthEntry {}
+        #[automatically_derived]
+        impl ::core::cmp::PartialEq for ArbitraryInvokerContractAuthEntry {
+            #[inline]
+            fn eq(&self, other: &ArbitraryInvokerContractAuthEntry) -> bool {
+                let __self_discr = ::core::intrinsics::discriminant_value(self);
+                let __arg1_discr = ::core::intrinsics::discriminant_value(other);
+                __self_discr == __arg1_discr
+                    && match (self, other) {
+                        (
+                            ArbitraryInvokerContractAuthEntry::Contract(__self_0),
+                            ArbitraryInvokerContractAuthEntry::Contract(__arg1_0),
+                        ) => __self_0 == __arg1_0,
+                        (
+                            ArbitraryInvokerContractAuthEntry::CreateContractHostFn(__self_0),
+                            ArbitraryInvokerContractAuthEntry::CreateContractHostFn(__arg1_0),
+                        ) => __self_0 == __arg1_0,
+                        (
+                            ArbitraryInvokerContractAuthEntry::CreateContractWithCtorHostFn(
+                                __self_0,
+                            ),
+                            ArbitraryInvokerContractAuthEntry::CreateContractWithCtorHostFn(
+                                __arg1_0,
+                            ),
+                        ) => __self_0 == __arg1_0,
+                        _ => unsafe { ::core::intrinsics::unreachable() },
+                    }
+            }
+        }
+        #[automatically_derived]
+        impl ::core::cmp::Ord for ArbitraryInvokerContractAuthEntry {
+            #[inline]
+            fn cmp(&self, other: &ArbitraryInvokerContractAuthEntry) -> ::core::cmp::Ordering {
+                let __self_discr = ::core::intrinsics::discriminant_value(self);
+                let __arg1_discr = ::core::intrinsics::discriminant_value(other);
+                match ::core::cmp::Ord::cmp(&__self_discr, &__arg1_discr) {
+                    ::core::cmp::Ordering::Equal => match (self, other) {
+                        (
+                            ArbitraryInvokerContractAuthEntry::Contract(__self_0),
+                            ArbitraryInvokerContractAuthEntry::Contract(__arg1_0),
+                        ) => ::core::cmp::Ord::cmp(__self_0, __arg1_0),
+                        (
+                            ArbitraryInvokerContractAuthEntry::CreateContractHostFn(__self_0),
+                            ArbitraryInvokerContractAuthEntry::CreateContractHostFn(__arg1_0),
+                        ) => ::core::cmp::Ord::cmp(__self_0, __arg1_0),
+                        (
+                            ArbitraryInvokerContractAuthEntry::CreateContractWithCtorHostFn(
+                                __self_0,
+                            ),
+                            ArbitraryInvokerContractAuthEntry::CreateContractWithCtorHostFn(
+                                __arg1_0,
+                            ),
+                        ) => ::core::cmp::Ord::cmp(__self_0, __arg1_0),
+                        _ => unsafe { ::core::intrinsics::unreachable() },
+                    },
+                    cmp => cmp,
+                }
+            }
+        }
+        #[automatically_derived]
+        impl ::core::cmp::PartialOrd for ArbitraryInvokerContractAuthEntry {
+            #[inline]
+            fn partial_cmp(
+                &self,
+                other: &ArbitraryInvokerContractAuthEntry,
+            ) -> ::core::option::Option<::core::cmp::Ordering> {
+                let __self_discr = ::core::intrinsics::discriminant_value(self);
+                let __arg1_discr = ::core::intrinsics::discriminant_value(other);
+                match (self, other) {
+                    (
+                        ArbitraryInvokerContractAuthEntry::Contract(__self_0),
+                        ArbitraryInvokerContractAuthEntry::Contract(__arg1_0),
+                    ) => ::core::cmp::PartialOrd::partial_cmp(__self_0, __arg1_0),
+                    (
+                        ArbitraryInvokerContractAuthEntry::CreateContractHostFn(__self_0),
+                        ArbitraryInvokerContractAuthEntry::CreateContractHostFn(__arg1_0),
+                    ) => ::core::cmp::PartialOrd::partial_cmp(__self_0, __arg1_0),
+                    (
+                        ArbitraryInvokerContractAuthEntry::CreateContractWithCtorHostFn(__self_0),
+                        ArbitraryInvokerContractAuthEntry::CreateContractWithCtorHostFn(__arg1_0),
+                    ) => ::core::cmp::PartialOrd::partial_cmp(__self_0, __arg1_0),
+                    _ => ::core::cmp::PartialOrd::partial_cmp(&__self_discr, &__arg1_discr),
+                }
+            }
+        }
+        const _: () = {
+            #[allow(non_upper_case_globals)]
+            const RECURSIVE_COUNT_ArbitraryInvokerContractAuthEntry: ::std::thread::LocalKey<
+                std::cell::Cell<u32>,
+            > = {
+                #[inline]
+                fn __init() -> std::cell::Cell<u32> {
+                    std::cell::Cell::new(0)
+                }
+                unsafe {
+                    ::std::thread::LocalKey::new(
+                        const {
+                            if ::std::mem::needs_drop::<std::cell::Cell<u32>>() {
+                                |init| {
+                                    #[thread_local]
+                                    static VAL: ::std::thread::local_impl::LazyStorage<
+                                        std::cell::Cell<u32>,
+                                        (),
+                                    > = ::std::thread::local_impl::LazyStorage::new();
+                                    VAL.get_or_init(init, __init)
+                                }
+                            } else {
+                                |init| {
+                                    #[thread_local]
+                                    static VAL: ::std::thread::local_impl::LazyStorage<
+                                        std::cell::Cell<u32>,
+                                        !,
+                                    > = ::std::thread::local_impl::LazyStorage::new();
+                                    VAL.get_or_init(init, __init)
+                                }
+                            }
+                        },
+                    )
+                }
+            };
+            #[automatically_derived]
+            impl<'arbitrary> arbitrary::Arbitrary<'arbitrary> for ArbitraryInvokerContractAuthEntry {
+                fn arbitrary(
+                    u: &mut arbitrary::Unstructured<'arbitrary>,
+                ) -> arbitrary::Result<Self> {
+                    let guard_against_recursion = u.is_empty();
+                    if guard_against_recursion {
+                        RECURSIVE_COUNT_ArbitraryInvokerContractAuthEntry.with(|count| {
+                            if count.get() > 0 {
+                                return Err(arbitrary::Error::NotEnoughData);
+                            }
+                            count.set(count.get() + 1);
+                            Ok(())
+                        })?;
+                    }
+                    let result = (|| {
+                        Ok(
+                            match (u64::from(<u32 as arbitrary::Arbitrary>::arbitrary(u)?) * 3u64)
+                                >> 32
+                            {
+                                0u64 => ArbitraryInvokerContractAuthEntry::Contract(
+                                    arbitrary::Arbitrary::arbitrary(u)?,
+                                ),
+                                1u64 => ArbitraryInvokerContractAuthEntry::CreateContractHostFn(
+                                    arbitrary::Arbitrary::arbitrary(u)?,
+                                ),
+                                2u64 => {
+                                    ArbitraryInvokerContractAuthEntry::CreateContractWithCtorHostFn(
+                                        arbitrary::Arbitrary::arbitrary(u)?,
+                                    )
+                                }
+                                _ => ::core::panicking::panic(
+                                    "internal error: entered unreachable code",
+                                ),
+                            },
+                        )
+                    })();
+                    if guard_against_recursion {
+                        RECURSIVE_COUNT_ArbitraryInvokerContractAuthEntry.with(|count| {
+                            count.set(count.get() - 1);
+                        });
+                    }
+                    result
+                }
+                fn arbitrary_take_rest(
+                    mut u: arbitrary::Unstructured<'arbitrary>,
+                ) -> arbitrary::Result<Self> {
+                    let guard_against_recursion = u.is_empty();
+                    if guard_against_recursion {
+                        RECURSIVE_COUNT_ArbitraryInvokerContractAuthEntry.with(|count| {
+                            if count.get() > 0 {
+                                return Err(arbitrary::Error::NotEnoughData);
+                            }
+                            count.set(count.get() + 1);
+                            Ok(())
+                        })?;
+                    }
+                    let result = (|| {
+                        Ok(
+                            match (u64::from(<u32 as arbitrary::Arbitrary>::arbitrary(&mut u)?)
+                                * 3u64)
+                                >> 32
+                            {
+                                0u64 => ArbitraryInvokerContractAuthEntry::Contract(
+                                    arbitrary::Arbitrary::arbitrary_take_rest(u)?,
+                                ),
+                                1u64 => ArbitraryInvokerContractAuthEntry::CreateContractHostFn(
+                                    arbitrary::Arbitrary::arbitrary_take_rest(u)?,
+                                ),
+                                2u64 => {
+                                    ArbitraryInvokerContractAuthEntry::CreateContractWithCtorHostFn(
+                                        arbitrary::Arbitrary::arbitrary_take_rest(u)?,
+                                    )
+                                }
+                                _ => ::core::panicking::panic(
+                                    "internal error: entered unreachable code",
+                                ),
+                            },
+                        )
+                    })();
+                    if guard_against_recursion {
+                        RECURSIVE_COUNT_ArbitraryInvokerContractAuthEntry.with(|count| {
+                            count.set(count.get() - 1);
+                        });
+                    }
+                    result
+                }
+                #[inline]
+                fn size_hint(depth: usize) -> (usize, Option<usize>) {
+                    arbitrary::size_hint::and(
+                        <u32 as arbitrary::Arbitrary>::size_hint(depth),
+                        arbitrary::size_hint::recursion_guard(depth, |depth| {
+                            arbitrary::size_hint::or_all(
+                                    &[
+                                        arbitrary::size_hint::and_all(
+                                            &[
+                                                <<SubContractInvocation as soroban_sdk::testutils::arbitrary::SorobanArbitrary>::Prototype as arbitrary::Arbitrary>::size_hint(
+                                                    depth,
+                                                ),
+                                            ],
+                                        ),
+                                        arbitrary::size_hint::and_all(
+                                            &[
+                                                <<CreateContractHostFnContext as soroban_sdk::testutils::arbitrary::SorobanArbitrary>::Prototype as arbitrary::Arbitrary>::size_hint(
+                                                    depth,
+                                                ),
+                                            ],
+                                        ),
+                                        arbitrary::size_hint::and_all(
+                                            &[
+                                                <<CreateContractWithConstructorHostFnContext as soroban_sdk::testutils::arbitrary::SorobanArbitrary>::Prototype as arbitrary::Arbitrary>::size_hint(
+                                                    depth,
+                                                ),
+                                            ],
+                                        ),
+                                    ],
+                                )
+                        }),
+                    )
+                }
+            }
+        };
+        impl soroban_sdk::testutils::arbitrary::SorobanArbitrary for InvokerContractAuthEntry {
+            type Prototype = ArbitraryInvokerContractAuthEntry;
+        }
+        impl soroban_sdk::TryFromVal<soroban_sdk::Env, ArbitraryInvokerContractAuthEntry>
+            for InvokerContractAuthEntry
+        {
+            type Error = soroban_sdk::ConversionError;
+            fn try_from_val(
+                env: &soroban_sdk::Env,
+                v: &ArbitraryInvokerContractAuthEntry,
+            ) -> std::result::Result<Self, Self::Error> {
+                Ok(match v {
+                    ArbitraryInvokerContractAuthEntry::Contract(field_0) => {
+                        InvokerContractAuthEntry::Contract(soroban_sdk::IntoVal::into_val(
+                            field_0, env,
+                        ))
+                    }
+                    ArbitraryInvokerContractAuthEntry::CreateContractHostFn(field_0) => {
+                        InvokerContractAuthEntry::CreateContractHostFn(
+                            soroban_sdk::IntoVal::into_val(field_0, env),
+                        )
+                    }
+                    ArbitraryInvokerContractAuthEntry::CreateContractWithCtorHostFn(field_0) => {
+                        InvokerContractAuthEntry::CreateContractWithCtorHostFn(
+                            soroban_sdk::IntoVal::into_val(field_0, env),
+                        )
+                    }
+                })
+            }
+        }
+    };
+    pub enum Executable {
+        Wasm(soroban_sdk::BytesN<32>),
+        StellarAsset,
+        Account,
+    }
+    #[automatically_derived]
+    impl ::core::fmt::Debug for Executable {
+        #[inline]
+        fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+            match self {
+                Executable::Wasm(__self_0) => {
+                    ::core::fmt::Formatter::debug_tuple_field1_finish(f, "Wasm", &__self_0)
+                }
+                Executable::StellarAsset => ::core::fmt::Formatter::write_str(f, "StellarAsset"),
+                Executable::Account => ::core::fmt::Formatter::write_str(f, "Account"),
+            }
+        }
+    }
+    #[automatically_derived]
+    impl ::core::clone::Clone for Executable {
+        #[inline]
+        fn clone(&self) -> Executable {
+            match self {
+                Executable::Wasm(__self_0) => {
+                    Executable::Wasm(::core::clone::Clone::clone(__self_0))
+                }
+                Executable::StellarAsset => Executable::StellarAsset,
+                Executable::Account => Executable::Account,
+            }
+        }
+    }
+    #[automatically_derived]
+    impl ::core::cmp::Eq for Executable {
+        #[inline]
+        #[doc(hidden)]
+        #[coverage(off)]
+        fn assert_receiver_is_total_eq(&self) -> () {
+            let _: ::core::cmp::AssertParamIsEq<soroban_sdk::BytesN<32>>;
+        }
+    }
+    #[automatically_derived]
+    impl ::core::marker::StructuralPartialEq for Executable {}
+    #[automatically_derived]
+    impl ::core::cmp::PartialEq for Executable {
+        #[inline]
+        fn eq(&self, other: &Executable) -> bool {
+            let __self_discr = ::core::intrinsics::discriminant_value(self);
+            let __arg1_discr = ::core::intrinsics::discriminant_value(other);
+            __self_discr == __arg1_discr
+                && match (self, other) {
+                    (Executable::Wasm(__self_0), Executable::Wasm(__arg1_0)) => {
+                        __self_0 == __arg1_0
+                    }
+                    _ => true,
+                }
+        }
+    }
+    #[automatically_derived]
+    impl ::core::cmp::Ord for Executable {
+        #[inline]
+        fn cmp(&self, other: &Executable) -> ::core::cmp::Ordering {
+            let __self_discr = ::core::intrinsics::discriminant_value(self);
+            let __arg1_discr = ::core::intrinsics::discriminant_value(other);
+            match ::core::cmp::Ord::cmp(&__self_discr, &__arg1_discr) {
+                ::core::cmp::Ordering::Equal => match (self, other) {
+                    (Executable::Wasm(__self_0), Executable::Wasm(__arg1_0)) => {
+                        ::core::cmp::Ord::cmp(__self_0, __arg1_0)
+                    }
+                    _ => ::core::cmp::Ordering::Equal,
+                },
+                cmp => cmp,
+            }
+        }
+    }
+    #[automatically_derived]
+    impl ::core::cmp::PartialOrd for Executable {
+        #[inline]
+        fn partial_cmp(&self, other: &Executable) -> ::core::option::Option<::core::cmp::Ordering> {
+            let __self_discr = ::core::intrinsics::discriminant_value(self);
+            let __arg1_discr = ::core::intrinsics::discriminant_value(other);
+            match (self, other) {
+                (Executable::Wasm(__self_0), Executable::Wasm(__arg1_0)) => {
+                    ::core::cmp::PartialOrd::partial_cmp(__self_0, __arg1_0)
+                }
+                _ => ::core::cmp::PartialOrd::partial_cmp(&__self_discr, &__arg1_discr),
+            }
+        }
+    }
+    impl soroban_sdk::TryFromVal<soroban_sdk::Env, soroban_sdk::Val> for Executable {
+        type Error = soroban_sdk::ConversionError;
+        #[inline(always)]
+        fn try_from_val(
+            env: &soroban_sdk::Env,
+            val: &soroban_sdk::Val,
+        ) -> Result<Self, soroban_sdk::ConversionError> {
+            use soroban_sdk::{EnvBase, TryFromVal, TryIntoVal};
+            const CASES: &'static [&'static str] = &["Wasm", "StellarAsset", "Account"];
+            let vec: soroban_sdk::Vec<soroban_sdk::Val> = val.try_into_val(env)?;
+            let mut iter = vec.try_iter();
+            let discriminant: soroban_sdk::Symbol = iter
+                .next()
+                .ok_or(soroban_sdk::ConversionError)??
+                .try_into_val(env)
+                .map_err(|_| soroban_sdk::ConversionError)?;
+            Ok(
+                match u32::from(env.symbol_index_in_strs(discriminant.to_symbol_val(), CASES)?)
+                    as usize
+                {
+                    0 => {
+                        if iter.len() > 1usize {
+                            return Err(soroban_sdk::ConversionError);
+                        }
+                        Self::Wasm(
+                            iter.next()
+                                .ok_or(soroban_sdk::ConversionError)??
+                                .try_into_val(env)?,
+                        )
+                    }
+                    1 => {
+                        if iter.len() > 0 {
+                            return Err(soroban_sdk::ConversionError);
+                        }
+                        Self::StellarAsset
+                    }
+                    2 => {
+                        if iter.len() > 0 {
+                            return Err(soroban_sdk::ConversionError);
+                        }
+                        Self::Account
+                    }
+                    _ => Err(soroban_sdk::ConversionError {})?,
+                },
+            )
+        }
+    }
+    impl soroban_sdk::TryFromVal<soroban_sdk::Env, Executable> for soroban_sdk::Val {
+        type Error = soroban_sdk::ConversionError;
+        #[inline(always)]
+        fn try_from_val(
+            env: &soroban_sdk::Env,
+            val: &Executable,
+        ) -> Result<Self, soroban_sdk::ConversionError> {
+            use soroban_sdk::{TryFromVal, TryIntoVal};
+            match val {
+                Executable::Wasm(ref value0) => {
+                    let tup: (soroban_sdk::Val, soroban_sdk::Val) = (
+                        soroban_sdk::Symbol::try_from_val(env, &"Wasm")?.to_val(),
+                        value0.try_into_val(env)?,
+                    );
+                    tup.try_into_val(env).map_err(Into::into)
+                }
+                Executable::StellarAsset => {
+                    let tup: (soroban_sdk::Val,) =
+                        (soroban_sdk::Symbol::try_from_val(env, &"StellarAsset")?.to_val(),);
+                    tup.try_into_val(env).map_err(Into::into)
+                }
+                Executable::Account => {
+                    let tup: (soroban_sdk::Val,) =
+                        (soroban_sdk::Symbol::try_from_val(env, &"Account")?.to_val(),);
+                    tup.try_into_val(env).map_err(Into::into)
+                }
+            }
+        }
+    }
+    impl soroban_sdk::TryFromVal<soroban_sdk::Env, &Executable> for soroban_sdk::Val {
+        type Error = soroban_sdk::ConversionError;
+        #[inline(always)]
+        fn try_from_val(
+            env: &soroban_sdk::Env,
+            val: &&Executable,
+        ) -> Result<Self, soroban_sdk::ConversionError> {
+            <_ as soroban_sdk::TryFromVal<soroban_sdk::Env, Executable>>::try_from_val(env, *val)
+        }
+    }
+    impl soroban_sdk::TryFromVal<soroban_sdk::Env, soroban_sdk::xdr::ScVec> for Executable {
+        type Error = soroban_sdk::xdr::Error;
+        #[inline(always)]
+        fn try_from_val(
+            env: &soroban_sdk::Env,
+            val: &soroban_sdk::xdr::ScVec,
+        ) -> Result<Self, soroban_sdk::xdr::Error> {
+            use soroban_sdk::xdr::Validate;
+            use soroban_sdk::TryIntoVal;
+            let vec = val;
+            let mut iter = vec.iter();
+            let discriminant: soroban_sdk::xdr::ScSymbol = iter
+                .next()
+                .ok_or(soroban_sdk::xdr::Error::Invalid)?
+                .clone()
+                .try_into()
+                .map_err(|_| soroban_sdk::xdr::Error::Invalid)?;
+            let discriminant_name: &str = &discriminant.to_utf8_string()?;
+            Ok(match discriminant_name {
+                "Wasm" => {
+                    if iter.len() > 1usize {
+                        return Err(soroban_sdk::xdr::Error::Invalid);
+                    }
+                    let rv0: soroban_sdk::Val = iter
+                        .next()
+                        .ok_or(soroban_sdk::xdr::Error::Invalid)?
+                        .try_into_val(env)
+                        .map_err(|_| soroban_sdk::xdr::Error::Invalid)?;
+                    Self::Wasm(
+                        rv0.try_into_val(env)
+                            .map_err(|_| soroban_sdk::xdr::Error::Invalid)?,
+                    )
+                }
+                "StellarAsset" => {
+                    if iter.len() > 0 {
+                        return Err(soroban_sdk::xdr::Error::Invalid);
+                    }
+                    Self::StellarAsset
+                }
+                "Account" => {
+                    if iter.len() > 0 {
+                        return Err(soroban_sdk::xdr::Error::Invalid);
+                    }
+                    Self::Account
+                }
+                _ => Err(soroban_sdk::xdr::Error::Invalid)?,
+            })
+        }
+    }
+    impl soroban_sdk::TryFromVal<soroban_sdk::Env, soroban_sdk::xdr::ScVal> for Executable {
+        type Error = soroban_sdk::xdr::Error;
+        #[inline(always)]
+        fn try_from_val(
+            env: &soroban_sdk::Env,
+            val: &soroban_sdk::xdr::ScVal,
+        ) -> Result<Self, soroban_sdk::xdr::Error> {
+            if let soroban_sdk::xdr::ScVal::Vec(Some(vec)) = val {
+                <_ as soroban_sdk::TryFromVal<_, _>>::try_from_val(env, vec)
+            } else {
+                Err(soroban_sdk::xdr::Error::Invalid)
+            }
+        }
+    }
+    impl TryFrom<&Executable> for soroban_sdk::xdr::ScVec {
+        type Error = soroban_sdk::xdr::Error;
+        #[inline(always)]
+        fn try_from(val: &Executable) -> Result<Self, soroban_sdk::xdr::Error> {
+            extern crate alloc;
+            Ok(match val {
+                Executable::Wasm(value0) => (
+                    soroban_sdk::xdr::ScSymbol(
+                        "Wasm"
+                            .try_into()
+                            .map_err(|_| soroban_sdk::xdr::Error::Invalid)?,
+                    ),
+                    value0,
+                )
+                    .try_into()
+                    .map_err(|_| soroban_sdk::xdr::Error::Invalid)?,
+                Executable::StellarAsset => {
+                    let symbol = soroban_sdk::xdr::ScSymbol(
+                        "StellarAsset"
+                            .try_into()
+                            .map_err(|_| soroban_sdk::xdr::Error::Invalid)?,
+                    );
+                    let val = soroban_sdk::xdr::ScVal::Symbol(symbol);
+                    (val,)
+                        .try_into()
+                        .map_err(|_| soroban_sdk::xdr::Error::Invalid)?
+                }
+                Executable::Account => {
+                    let symbol = soroban_sdk::xdr::ScSymbol(
+                        "Account"
+                            .try_into()
+                            .map_err(|_| soroban_sdk::xdr::Error::Invalid)?,
+                    );
+                    let val = soroban_sdk::xdr::ScVal::Symbol(symbol);
+                    (val,)
+                        .try_into()
+                        .map_err(|_| soroban_sdk::xdr::Error::Invalid)?
+                }
+            })
+        }
+    }
+    impl TryFrom<Executable> for soroban_sdk::xdr::ScVec {
+        type Error = soroban_sdk::xdr::Error;
+        #[inline(always)]
+        fn try_from(val: Executable) -> Result<Self, soroban_sdk::xdr::Error> {
+            (&val).try_into()
+        }
+    }
+    impl TryFrom<&Executable> for soroban_sdk::xdr::ScVal {
+        type Error = soroban_sdk::xdr::Error;
+        #[inline(always)]
+        fn try_from(val: &Executable) -> Result<Self, soroban_sdk::xdr::Error> {
+            Ok(soroban_sdk::xdr::ScVal::Vec(Some(val.try_into()?)))
+        }
+    }
+    impl TryFrom<Executable> for soroban_sdk::xdr::ScVal {
+        type Error = soroban_sdk::xdr::Error;
+        #[inline(always)]
+        fn try_from(val: Executable) -> Result<Self, soroban_sdk::xdr::Error> {
+            (&val).try_into()
+        }
+    }
+    const _: () = {
+        use soroban_sdk::testutils::arbitrary::arbitrary;
+        use soroban_sdk::testutils::arbitrary::std;
+        pub enum ArbitraryExecutable {
+            Wasm(
+                <soroban_sdk::BytesN<
+                    32,
+                > as soroban_sdk::testutils::arbitrary::SorobanArbitrary>::Prototype,
+            ),
+            StellarAsset,
+            Account,
+        }
+        #[automatically_derived]
+        impl ::core::fmt::Debug for ArbitraryExecutable {
+            #[inline]
+            fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+                match self {
+                    ArbitraryExecutable::Wasm(__self_0) => {
+                        ::core::fmt::Formatter::debug_tuple_field1_finish(f, "Wasm", &__self_0)
+                    }
+                    ArbitraryExecutable::StellarAsset => {
+                        ::core::fmt::Formatter::write_str(f, "StellarAsset")
+                    }
+                    ArbitraryExecutable::Account => ::core::fmt::Formatter::write_str(f, "Account"),
+                }
+            }
+        }
+        #[automatically_derived]
+        impl ::core::clone::Clone for ArbitraryExecutable {
+            #[inline]
+            fn clone(&self) -> ArbitraryExecutable {
+                match self {
+                    ArbitraryExecutable::Wasm(__self_0) => {
+                        ArbitraryExecutable::Wasm(::core::clone::Clone::clone(__self_0))
+                    }
+                    ArbitraryExecutable::StellarAsset => ArbitraryExecutable::StellarAsset,
+                    ArbitraryExecutable::Account => ArbitraryExecutable::Account,
+                }
+            }
+        }
+        #[automatically_derived]
+        impl ::core::cmp::Eq for ArbitraryExecutable {
+            #[inline]
+            #[doc(hidden)]
+            #[coverage(off)]
+            fn assert_receiver_is_total_eq(&self) -> () {
+                let _: ::core::cmp::AssertParamIsEq<
+                    <soroban_sdk::BytesN<
+                        32,
+                    > as soroban_sdk::testutils::arbitrary::SorobanArbitrary>::Prototype,
+                >;
+            }
+        }
+        #[automatically_derived]
+        impl ::core::marker::StructuralPartialEq for ArbitraryExecutable {}
+        #[automatically_derived]
+        impl ::core::cmp::PartialEq for ArbitraryExecutable {
+            #[inline]
+            fn eq(&self, other: &ArbitraryExecutable) -> bool {
+                let __self_discr = ::core::intrinsics::discriminant_value(self);
+                let __arg1_discr = ::core::intrinsics::discriminant_value(other);
+                __self_discr == __arg1_discr
+                    && match (self, other) {
+                        (
+                            ArbitraryExecutable::Wasm(__self_0),
+                            ArbitraryExecutable::Wasm(__arg1_0),
+                        ) => __self_0 == __arg1_0,
+                        _ => true,
+                    }
+            }
+        }
+        #[automatically_derived]
+        impl ::core::cmp::Ord for ArbitraryExecutable {
+            #[inline]
+            fn cmp(&self, other: &ArbitraryExecutable) -> ::core::cmp::Ordering {
+                let __self_discr = ::core::intrinsics::discriminant_value(self);
+                let __arg1_discr = ::core::intrinsics::discriminant_value(other);
+                match ::core::cmp::Ord::cmp(&__self_discr, &__arg1_discr) {
+                    ::core::cmp::Ordering::Equal => match (self, other) {
+                        (
+                            ArbitraryExecutable::Wasm(__self_0),
+                            ArbitraryExecutable::Wasm(__arg1_0),
+                        ) => ::core::cmp::Ord::cmp(__self_0, __arg1_0),
+                        _ => ::core::cmp::Ordering::Equal,
+                    },
+                    cmp => cmp,
+                }
+            }
+        }
+        #[automatically_derived]
+        impl ::core::cmp::PartialOrd for ArbitraryExecutable {
+            #[inline]
+            fn partial_cmp(
+                &self,
+                other: &ArbitraryExecutable,
+            ) -> ::core::option::Option<::core::cmp::Ordering> {
+                let __self_discr = ::core::intrinsics::discriminant_value(self);
+                let __arg1_discr = ::core::intrinsics::discriminant_value(other);
+                match (self, other) {
+                    (ArbitraryExecutable::Wasm(__self_0), ArbitraryExecutable::Wasm(__arg1_0)) => {
+                        ::core::cmp::PartialOrd::partial_cmp(__self_0, __arg1_0)
+                    }
+                    _ => ::core::cmp::PartialOrd::partial_cmp(&__self_discr, &__arg1_discr),
+                }
+            }
+        }
+        const _: () = {
+            #[allow(non_upper_case_globals)]
+            const RECURSIVE_COUNT_ArbitraryExecutable: ::std::thread::LocalKey<
+                std::cell::Cell<u32>,
+            > = {
+                #[inline]
+                fn __init() -> std::cell::Cell<u32> {
+                    std::cell::Cell::new(0)
+                }
+                unsafe {
+                    ::std::thread::LocalKey::new(
+                        const {
+                            if ::std::mem::needs_drop::<std::cell::Cell<u32>>() {
+                                |init| {
+                                    #[thread_local]
+                                    static VAL: ::std::thread::local_impl::LazyStorage<
+                                        std::cell::Cell<u32>,
+                                        (),
+                                    > = ::std::thread::local_impl::LazyStorage::new();
+                                    VAL.get_or_init(init, __init)
+                                }
+                            } else {
+                                |init| {
+                                    #[thread_local]
+                                    static VAL: ::std::thread::local_impl::LazyStorage<
+                                        std::cell::Cell<u32>,
+                                        !,
+                                    > = ::std::thread::local_impl::LazyStorage::new();
+                                    VAL.get_or_init(init, __init)
+                                }
+                            }
+                        },
+                    )
+                }
+            };
+            #[automatically_derived]
+            impl<'arbitrary> arbitrary::Arbitrary<'arbitrary> for ArbitraryExecutable {
+                fn arbitrary(
+                    u: &mut arbitrary::Unstructured<'arbitrary>,
+                ) -> arbitrary::Result<Self> {
+                    let guard_against_recursion = u.is_empty();
+                    if guard_against_recursion {
+                        RECURSIVE_COUNT_ArbitraryExecutable.with(|count| {
+                            if count.get() > 0 {
+                                return Err(arbitrary::Error::NotEnoughData);
+                            }
+                            count.set(count.get() + 1);
+                            Ok(())
+                        })?;
+                    }
+                    let result = (|| {
+                        Ok(
+                            match (u64::from(<u32 as arbitrary::Arbitrary>::arbitrary(u)?) * 3u64)
+                                >> 32
+                            {
+                                0u64 => {
+                                    ArbitraryExecutable::Wasm(arbitrary::Arbitrary::arbitrary(u)?)
+                                }
+                                1u64 => ArbitraryExecutable::StellarAsset,
+                                2u64 => ArbitraryExecutable::Account,
+                                _ => ::core::panicking::panic(
+                                    "internal error: entered unreachable code",
+                                ),
+                            },
+                        )
+                    })();
+                    if guard_against_recursion {
+                        RECURSIVE_COUNT_ArbitraryExecutable.with(|count| {
+                            count.set(count.get() - 1);
+                        });
+                    }
+                    result
+                }
+                fn arbitrary_take_rest(
+                    mut u: arbitrary::Unstructured<'arbitrary>,
+                ) -> arbitrary::Result<Self> {
+                    let guard_against_recursion = u.is_empty();
+                    if guard_against_recursion {
+                        RECURSIVE_COUNT_ArbitraryExecutable.with(|count| {
+                            if count.get() > 0 {
+                                return Err(arbitrary::Error::NotEnoughData);
+                            }
+                            count.set(count.get() + 1);
+                            Ok(())
+                        })?;
+                    }
+                    let result = (|| {
+                        Ok(
+                            match (u64::from(<u32 as arbitrary::Arbitrary>::arbitrary(&mut u)?)
+                                * 3u64)
+                                >> 32
+                            {
+                                0u64 => ArbitraryExecutable::Wasm(
+                                    arbitrary::Arbitrary::arbitrary_take_rest(u)?,
+                                ),
+                                1u64 => ArbitraryExecutable::StellarAsset,
+                                2u64 => ArbitraryExecutable::Account,
+                                _ => ::core::panicking::panic(
+                                    "internal error: entered unreachable code",
+                                ),
+                            },
+                        )
+                    })();
+                    if guard_against_recursion {
+                        RECURSIVE_COUNT_ArbitraryExecutable.with(|count| {
+                            count.set(count.get() - 1);
+                        });
+                    }
+                    result
+                }
+                #[inline]
+                fn size_hint(depth: usize) -> (usize, Option<usize>) {
+                    arbitrary::size_hint::and(
+                        <u32 as arbitrary::Arbitrary>::size_hint(depth),
+                        arbitrary::size_hint::recursion_guard(depth, |depth| {
+                            arbitrary::size_hint::or_all(
+                                    &[
+                                        arbitrary::size_hint::and_all(
+                                            &[
+                                                <<soroban_sdk::BytesN<
+                                                    32,
+                                                > as soroban_sdk::testutils::arbitrary::SorobanArbitrary>::Prototype as arbitrary::Arbitrary>::size_hint(
+                                                    depth,
+                                                ),
+                                            ],
+                                        ),
+                                        arbitrary::size_hint::and_all(&[]),
+                                        arbitrary::size_hint::and_all(&[]),
+                                    ],
+                                )
+                        }),
+                    )
+                }
+            }
+        };
+        impl soroban_sdk::testutils::arbitrary::SorobanArbitrary for Executable {
+            type Prototype = ArbitraryExecutable;
+        }
+        impl soroban_sdk::TryFromVal<soroban_sdk::Env, ArbitraryExecutable> for Executable {
+            type Error = soroban_sdk::ConversionError;
+            fn try_from_val(
+                env: &soroban_sdk::Env,
+                v: &ArbitraryExecutable,
+            ) -> std::result::Result<Self, Self::Error> {
+                Ok(match v {
+                    ArbitraryExecutable::Wasm(field_0) => {
+                        Executable::Wasm(soroban_sdk::IntoVal::into_val(field_0, env))
+                    }
+                    ArbitraryExecutable::StellarAsset => Executable::StellarAsset,
+                    ArbitraryExecutable::Account => Executable::Account,
+                })
             }
         }
     };
@@ -26028,7 +30526,7 @@ mod test {
         if !markers.is_empty() {
             {
                 ::core::panicking::panic_fmt(format_args!(
-                    "no markers should be present without experimental_spec_shaking_v2, found {0}",
+                    "no markers should be present under disable_spec_shaking_v2 (v1), found {0}",
                     markers.len(),
                 ));
             }

--- a/tests-expanded/test_spec_shaking_v1_wasm32v1-none.rs
+++ b/tests-expanded/test_spec_shaking_v1_wasm32v1-none.rs
@@ -4143,7 +4143,7 @@ impl soroban_sdk::TryFromVal<soroban_sdk::Env, &UsedLeaf> for soroban_sdk::Val {
     }
 }
 mod wasm_imported {
-    pub const WASM: &[u8] = b"\x00asm\x01\x00\x00\x00\x01*\x07`\x02~~\x01~`\x03~~~\x01~`\x01~\x01~`\x00\x01~`\x02\x7f\x7f\x01~`\x04\x7f\x7f\x7f\x7f\x01~`\x02\x7f~\x00\x02%\x06\x01b\x01j\x00\x00\x01x\x011\x00\x00\x01v\x01g\x00\x00\x01m\x019\x00\x01\x01i\x012\x00\x02\x01i\x011\x00\x02\x03\x0b\n\x03\x04\x03\x02\x00\x05\x00\x00\x06\x06\x05\x03\x01\x00\x11\x06!\x04\x7f\x01A\x80\x80\xc0\x00\x0b\x7f\x00A\x82\x80\xc0\x00\x0b\x7f\x00A\xa0\x80\xc0\x00\x0b\x7f\x00A\xa0\x80\xc0\x00\x0b\x07\x81\x01\n\x06memory\x02\x00\tfn_enum_a\x00\x06\rfn_enum_int_a\x00\x08\nfn_error_a\x00\t\nfn_event_a\x00\n\x0bfn_struct_a\x00\x0c\x11fn_struct_tuple_a\x00\r\x01_\x03\x01\n__data_end\x03\x02\x0b__heap_base\x03\x03\n\xbd\x08\n\x8b\x02\x03\x01\x7f\x01~\x03\x7f#\x80\x80\x80\x80\x00A\x10k\"\x00$\x80\x80\x80\x80\x00B\x00!\x01A~!\x02\x03~\x02@\x02@\x02@\x02@\x02@ \x02E\r\x00A\x01!\x03 \x02A\x82\x80\xc0\x80\x00j-\x00\x00\"\x04A\xdf\x00F\r\x04 \x04APjA\xff\x01qA\nI\r\x02 \x04A\xbf\x7fjA\xff\x01qA\x1aI\r\x03\x02@ \x04A\x9f\x7fjA\xff\x01qA\x1aO\r\x00 \x04AEj!\x03\x0c\x05\x0b \x00 \x04\xadB\x08\x86B\x01\x847\x03\x00A\x80\x80\xc0\x80\x00\xadB \x86B\x04\x84B\x84\x80\x80\x80 \x10\x80\x80\x80\x80\x00!\x01\x0c\x01\x0b \x00 \x01B\x08\x86B\x0e\x84\"\x017\x02\x04\x0b \x00 \x017\x03\x00 \x00A\x01\x10\x87\x80\x80\x80\x00!\x01 \x00A\x10j$\x80\x80\x80\x80\x00 \x01\x0f\x0b \x04ARj!\x03\x0c\x01\x0b \x04AKj!\x03\x0b \x01B\x06\x86 \x03\xadB\xff\x01\x83\x84!\x01 \x02A\x01j!\x02\x0c\x00\x0b\x0b\x1a\x00 \x00\xadB \x86B\x04\x84 \x01\xadB \x86B\x04\x84\x10\x82\x80\x80\x80\x00\x0b\x08\x00B\x84\x80\x80\x800\x0b*\x00\x02@ \x00B\xff\x01\x83B\x04Q\r\x00\x00\x0bB\x83\x80\x80\x80  \x00B\x84\x80\x80\x80p\x83 \x00B\x80\x80\x80\x80\x10T\x1b\x0b\xdc\x01\x01\x02\x7f#\x80\x80\x80\x80\x00A k\"\x02$\x80\x80\x80\x80\x00\x02@ \x00B\xff\x01\x83B\xcd\x00R\r\x00 \x01B\xff\x01\x83B\xc9\x00R\r\x00 \x02 \x007\x03\x08 \x02B\x8e\xcc\xc1\xfc\xac\xdd\xab\x017\x03\x00A\x00!\x03\x03@\x02@ \x03A\x10G\r\x00A\x00!\x03\x02@\x03@ \x03A\x10F\r\x01 \x02A\x10j \x03j \x02 \x03j)\x03\x007\x03\x00 \x03A\x08j!\x03\x0c\x00\x0b\x0b \x02A\x10jA\x02\x10\x87\x80\x80\x80\x00!\x00 \x02 \x017\x03\x10 \x00A\x98\x80\xc0\x80\x00A\x01 \x02A\x10jA\x01\x10\x8b\x80\x80\x80\x00\x10\x81\x80\x80\x80\x00\x1a \x02A j$\x80\x80\x80\x80\x00B\x02\x0f\x0b \x02A\x10j \x03jB\x027\x03\x00 \x03A\x08j!\x03\x0c\x00\x0b\x0b\x00\x0b.\x00\x02@ \x01 \x03F\r\x00\x00\x0b \x00\xadB \x86B\x04\x84 \x02\xadB \x86B\x04\x84 \x01\xadB \x86B\x04\x84\x10\x83\x80\x80\x80\x00\x0by\x01\x02\x7f#\x80\x80\x80\x80\x00A\x10k\"\x02$\x80\x80\x80\x80\x00\x02@ \x00B\xff\x01\x83B\x04R\r\x00A\x01A\x02A\x00 \x01\xa7A\xff\x01q\"\x03\x1b \x03A\x01F\x1b\"\x03A\x02F\r\x00 \x02 \x03\xad7\x03\x08 \x02 \x00B\x84\x80\x80\x80p\x837\x03\x00A\x88\x80\xc0\x80\x00A\x02 \x02A\x02\x10\x8b\x80\x80\x80\x00!\x00 \x02A\x10j$\x80\x80\x80\x80\x00 \x00\x0f\x0b\x00\x0b\xb2\x01\x01\x01\x7f#\x80\x80\x80\x80\x00A k\"\x02$\x80\x80\x80\x80\x00 \x02A\x10j \x00\x10\x8e\x80\x80\x80\x00\x02@ \x02(\x02\x10A\x01F\r\x00 \x02)\x03\x18!\x00 \x02A\x10j \x01\x10\x8e\x80\x80\x80\x00 \x02(\x02\x10A\x01F\r\x00 \x02)\x03\x18!\x01 \x02A\x10j \x00\x10\x8f\x80\x80\x80\x00 \x02(\x02\x10\r\x00 \x02)\x03\x18!\x00 \x02A\x10j \x01\x10\x8f\x80\x80\x80\x00 \x02(\x02\x10A\x01F\r\x00 \x02 \x02)\x03\x187\x03\x08 \x02 \x007\x03\x00 \x02A\x02\x10\x87\x80\x80\x80\x00!\x00 \x02A j$\x80\x80\x80\x80\x00 \x00\x0f\x0b\x00\x0b]\x02\x01\x7f\x01~\x02@\x02@ \x01\xa7A\xff\x01q\"\x02A\xc1\x00F\r\x00\x02@ \x02A\x07F\r\x00B\x01!\x03B\x83\x90\x80\x80\x80\x01!\x01\x0c\x02\x0b \x01B\x08\x87!\x01B\x00!\x03\x0c\x01\x0bB\x00!\x03 \x01\x10\x84\x80\x80\x80\x00!\x01\x0b \x00 \x037\x03\x00 \x00 \x017\x03\x08\x0bF\x00\x02@\x02@ \x01B\x80\x80\x80\x80\x80\x80\x80\xc0\x00|B\xff\xff\xff\xff\xff\xff\xff\xff\x00V\r\x00 \x01B\x08\x86B\x07\x84!\x01\x0c\x01\x0b \x01\x10\x85\x80\x80\x80\x00!\x01\x0b \x00B\x007\x03\x00 \x00 \x017\x03\x08\x0b\x0b)\x01\x00A\x80\x80\xc0\x00\x0b V2f1f2\x00\x00\x02\x00\x10\x00\x02\x00\x00\x00\x04\x00\x10\x00\x02\x00\x00\x00\x04\x00\x10\x00\x02\x00\x00\x00\x00\xbf\x0e\x0econtractspecv0\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\tfn_enum_a\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x07\xd0\x00\x00\x00\x05EnumA\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\nfn_error_a\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x05input\x00\x00\x00\x00\x00\x00\x04\x00\x00\x00\x01\x00\x00\x03\xe9\x00\x00\x00\x04\x00\x00\x07\xd0\x00\x00\x00\x06ErrorA\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\nfn_event_a\x00\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x02f1\x00\x00\x00\x00\x00\x13\x00\x00\x00\x00\x00\x00\x00\x02f2\x00\x00\x00\x00\x00\x10\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x0bfn_struct_a\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x02f1\x00\x00\x00\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00\x02f2\x00\x00\x00\x00\x00\x01\x00\x00\x00\x01\x00\x00\x07\xd0\x00\x00\x00\x07StructA\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\rfn_enum_int_a\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x07\xd0\x00\x00\x00\x08EnumIntA\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x11fn_struct_tuple_a\x00\x00\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x02f1\x00\x00\x00\x00\x00\x07\x00\x00\x00\x00\x00\x00\x00\x02f2\x00\x00\x00\x00\x00\x07\x00\x00\x00\x01\x00\x00\x07\xd0\x00\x00\x00\x0cStructTupleA\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x05EnumA\x00\x00\x00\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02V1\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02V2\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02V3\x00\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x05EnumB\x00\x00\x00\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02V1\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x02V2\x00\x00\x00\x00\x00\x01\x00\x00\x00\x07\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x02V3\x00\x00\x00\x00\x00\x02\x00\x00\x00\x07\x00\x00\x00\x07\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x05EnumC\x00\x00\x00\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02V1\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x02V2\x00\x00\x00\x00\x00\x01\x00\x00\x07\xd0\x00\x00\x00\x07StructA\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x02V3\x00\x00\x00\x00\x00\x01\x00\x00\x07\xd0\x00\x00\x00\x0cStructTupleA\x00\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x06ErrorA\x00\x00\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x02E1\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x02E2\x00\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x02E3\x00\x00\x00\x00\x00\x03\x00\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x06ErrorB\x00\x00\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x02E1\x00\x00\x00\x00\x00\n\x00\x00\x00\x00\x00\x00\x00\x02E2\x00\x00\x00\x00\x00\x0b\x00\x00\x00\x00\x00\x00\x00\x02E3\x00\x00\x00\x00\x00\x0c\x00\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x06ErrorC\x00\x00\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x02E1\x00\x00\x00\x00\x00d\x00\x00\x00\x00\x00\x00\x00\x02E2\x00\x00\x00\x00\x00e\x00\x00\x00\x00\x00\x00\x00\x02E3\x00\x00\x00\x00\x00f\x00\x00\x00\x05\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x06EventA\x00\x00\x00\x00\x00\x01\x00\x00\x00\x07event_a\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x02f1\x00\x00\x00\x00\x00\x13\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x02f2\x00\x00\x00\x00\x00\x10\x00\x00\x00\x00\x00\x00\x00\x02\x00\x00\x00\x05\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x06EventB\x00\x00\x00\x00\x00\x01\x00\x00\x00\x07event_b\x00\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x02f1\x00\x00\x00\x00\x00\x13\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x02f2\x00\x00\x00\x00\x00\x13\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x02f3\x00\x00\x00\x00\x00\x0b\x00\x00\x00\x00\x00\x00\x00\x02\x00\x00\x00\x05\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x06EventC\x00\x00\x00\x00\x00\x01\x00\x00\x00\x07event_c\x00\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x02f1\x00\x00\x00\x00\x00\x11\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x02f2\x00\x00\x00\x00\x00\x07\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02f3\x00\x00\x00\x00\x00\x07\x00\x00\x00\x00\x00\x00\x00\x02\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x07StructA\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x02f1\x00\x00\x00\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00\x02f2\x00\x00\x00\x00\x00\x01\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x07StructB\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x02f1\x00\x00\x00\x00\x00\x07\x00\x00\x00\x00\x00\x00\x00\x02f2\x00\x00\x00\x00\x00\x10\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x07StructC\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x02f1\x00\x00\x00\x00\x03\xea\x00\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00\x02f2\x00\x00\x00\x00\x00\x13\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x08EnumIntA\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x02V1\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x02V2\x00\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x02V3\x00\x00\x00\x00\x00\x03\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x08EnumIntB\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x02V1\x00\x00\x00\x00\x00\n\x00\x00\x00\x00\x00\x00\x00\x02V2\x00\x00\x00\x00\x00\x14\x00\x00\x00\x00\x00\x00\x00\x02V3\x00\x00\x00\x00\x00\x1e\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x08EnumIntC\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x02V1\x00\x00\x00\x00\x00d\x00\x00\x00\x00\x00\x00\x00\x02V2\x00\x00\x00\x00\x00\xc8\x00\x00\x00\x00\x00\x00\x00\x02V3\x00\x00\x00\x00\x01,\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x0cStructTupleA\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x010\x00\x00\x00\x00\x00\x00\x07\x00\x00\x00\x00\x00\x00\x00\x011\x00\x00\x00\x00\x00\x00\x07\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x0cStructTupleB\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x010\x00\x00\x00\x00\x00\x00\n\x00\x00\x00\x00\x00\x00\x00\x011\x00\x00\x00\x00\x00\x00\n\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x0cStructTupleC\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x010\x00\x00\x00\x00\x00\x00\x13\x00\x00\x00\x00\x00\x00\x00\x011\x00\x00\x00\x00\x00\x00\x0b\x00\x1e\x11contractenvmetav0\x00\x00\x00\x00\x00\x00\x00\x1a\x00\x00\x00\x00\x00+\x0econtractmetav0\x00\x00\x00\x00\x00\x00\x00\x05rsver\x00\x00\x00\x00\x00\x00\x061.91.0\x00\x00";
+    pub const WASM: &[u8] = b"\x00asm\x01\x00\x00\x00\x01*\x07`\x02~~\x01~`\x03~~~\x01~`\x01~\x01~`\x00\x01~`\x02\x7f\x7f\x01~`\x04\x7f\x7f\x7f\x7f\x01~`\x02\x7f~\x00\x02%\x06\x01b\x01j\x00\x00\x01x\x011\x00\x00\x01v\x01g\x00\x00\x01m\x019\x00\x01\x01i\x012\x00\x02\x01i\x011\x00\x02\x03\x0b\n\x03\x04\x03\x02\x00\x05\x00\x00\x06\x06\x05\x03\x01\x00\x11\x06!\x04\x7f\x01A\x80\x80\xc0\x00\x0b\x7f\x00A\x82\x80\xc0\x00\x0b\x7f\x00A\xf4\x80\xc0\x00\x0b\x7f\x00A\x80\x81\xc0\x00\x0b\x07\x81\x01\n\x06memory\x02\x00\tfn_enum_a\x00\x06\rfn_enum_int_a\x00\x08\nfn_error_a\x00\t\nfn_event_a\x00\n\x0bfn_struct_a\x00\x0c\x11fn_struct_tuple_a\x00\r\x01_\x03\x01\n__data_end\x03\x02\x0b__heap_base\x03\x03\n\xfa\x08\n\x95\x02\x03\x01\x7f\x01~\x03\x7f#\x80\x80\x80\x80\x00A\x10k\"\x00$\x80\x80\x80\x80\x00A\x00-\x00\x82\x80\xc0\x80\x00\x1aB\x00!\x01A~!\x02\x03~\x02@\x02@\x02@\x02@\x02@ \x02E\r\x00A\x01!\x03 \x02A\x82\x80\xc0\x80\x00j-\x00\x00\"\x04A\xdf\x00F\r\x04 \x04APjA\xff\x01qA\nI\r\x02 \x04A\xbf\x7fjA\xff\x01qA\x1aI\r\x03\x02@ \x04A\x9f\x7fjA\xff\x01qA\x1aO\r\x00 \x04AEj!\x03\x0c\x05\x0b \x00 \x04\xadB\x08\x86B\x01\x847\x03\x00A\x80\x80\xc0\x80\x00\xadB \x86B\x04\x84B\x84\x80\x80\x80 \x10\x80\x80\x80\x80\x00!\x01\x0c\x01\x0b \x00 \x01B\x08\x86B\x0e\x84\"\x017\x02\x04\x0b \x00 \x017\x03\x00 \x00A\x01\x10\x87\x80\x80\x80\x00!\x01 \x00A\x10j$\x80\x80\x80\x80\x00 \x01\x0f\x0b \x04ARj!\x03\x0c\x01\x0b \x04AKj!\x03\x0b \x01B\x06\x86 \x03\xadB\xff\x01\x83\x84!\x01 \x02A\x01j!\x02\x0c\x00\x0b\x0b\x1a\x00 \x00\xadB \x86B\x04\x84 \x01\xadB \x86B\x04\x84\x10\x82\x80\x80\x80\x00\x0b\x12\x00A\x00-\x00\xba\x80\xc0\x80\x00\x1aB\x84\x80\x80\x800\x0b4\x00\x02@ \x00B\xff\x01\x83B\x04Q\r\x00\x00\x0bA\x00-\x00\x90\x80\xc0\x80\x00\x1aB\x83\x80\x80\x80  \x00B\x84\x80\x80\x80p\x83 \x00B\x80\x80\x80\x80\x10T\x1b\x0b\xe6\x01\x01\x02\x7f#\x80\x80\x80\x80\x00A k\"\x02$\x80\x80\x80\x80\x00\x02@ \x00B\xff\x01\x83B\xcd\x00R\r\x00 \x01B\xff\x01\x83B\xc9\x00R\r\x00A\x00!\x03A\x00-\x00\x9e\x80\xc0\x80\x00\x1a \x02 \x007\x03\x08 \x02B\x8e\xcc\xc1\xfc\xac\xdd\xab\x017\x03\x00\x03@\x02@ \x03A\x10G\r\x00A\x00!\x03\x02@\x03@ \x03A\x10F\r\x01 \x02A\x10j \x03j \x02 \x03j)\x03\x007\x03\x00 \x03A\x08j!\x03\x0c\x00\x0b\x0b \x02A\x10jA\x02\x10\x87\x80\x80\x80\x00!\x00 \x02 \x017\x03\x10 \x00A\xec\x80\xc0\x80\x00A\x01 \x02A\x10jA\x01\x10\x8b\x80\x80\x80\x00\x10\x81\x80\x80\x80\x00\x1a \x02A j$\x80\x80\x80\x80\x00B\x02\x0f\x0b \x02A\x10j \x03jB\x027\x03\x00 \x03A\x08j!\x03\x0c\x00\x0b\x0b\x00\x0b.\x00\x02@ \x01 \x03F\r\x00\x00\x0b \x00\xadB \x86B\x04\x84 \x02\xadB \x86B\x04\x84 \x01\xadB \x86B\x04\x84\x10\x83\x80\x80\x80\x00\x0b\x83\x01\x01\x02\x7f#\x80\x80\x80\x80\x00A\x10k\"\x02$\x80\x80\x80\x80\x00\x02@ \x00B\xff\x01\x83B\x04R\r\x00A\x01A\x02A\x00 \x01\xa7A\xff\x01q\"\x03\x1b \x03A\x01F\x1b\"\x03A\x02F\r\x00A\x00-\x00\xac\x80\xc0\x80\x00\x1a \x02 \x03\xad7\x03\x08 \x02 \x00B\x84\x80\x80\x80p\x837\x03\x00A\xdc\x80\xc0\x80\x00A\x02 \x02A\x02\x10\x8b\x80\x80\x80\x00!\x00 \x02A\x10j$\x80\x80\x80\x80\x00 \x00\x0f\x0b\x00\x0b\xbc\x01\x01\x01\x7f#\x80\x80\x80\x80\x00A k\"\x02$\x80\x80\x80\x80\x00 \x02A\x10j \x00\x10\x8e\x80\x80\x80\x00\x02@ \x02(\x02\x10A\x01F\r\x00 \x02)\x03\x18!\x00 \x02A\x10j \x01\x10\x8e\x80\x80\x80\x00 \x02(\x02\x10A\x01F\r\x00 \x02)\x03\x18!\x01A\x00-\x00\xc8\x80\xc0\x80\x00\x1a \x02A\x10j \x00\x10\x8f\x80\x80\x80\x00 \x02(\x02\x10\r\x00 \x02)\x03\x18!\x00 \x02A\x10j \x01\x10\x8f\x80\x80\x80\x00 \x02(\x02\x10A\x01F\r\x00 \x02 \x02)\x03\x187\x03\x08 \x02 \x007\x03\x00 \x02A\x02\x10\x87\x80\x80\x80\x00!\x00 \x02A j$\x80\x80\x80\x80\x00 \x00\x0f\x0b\x00\x0b]\x02\x01\x7f\x01~\x02@\x02@ \x01\xa7A\xff\x01q\"\x02A\xc1\x00F\r\x00\x02@ \x02A\x07F\r\x00B\x01!\x03B\x83\x90\x80\x80\x80\x01!\x01\x0c\x02\x0b \x01B\x08\x87!\x01B\x00!\x03\x0c\x01\x0bB\x00!\x03 \x01\x10\x84\x80\x80\x80\x00!\x01\x0b \x00 \x037\x03\x00 \x00 \x017\x03\x08\x0bF\x00\x02@\x02@ \x01B\x80\x80\x80\x80\x80\x80\x80\xc0\x00|B\xff\xff\xff\xff\xff\xff\xff\xff\x00V\r\x00 \x01B\x08\x86B\x07\x84!\x01\x0c\x01\x0b \x01\x10\x85\x80\x80\x80\x00!\x01\x0b \x00B\x007\x03\x00 \x00 \x017\x03\x08\x0b\x0b}\x01\x00A\x80\x80\xc0\x00\x0btV2SpEcV1\xa2=N\xc1p\x95\x90\xb2SpEcV1\xe9R\xa7\xe8b\x99\xa2\xc3SpEcV1K\xe6\x8ej\x19\x9en\xbdSpEcV1\xb6\x1c\xfd\xdfhY-dSpEcV1V]\x80\\~\x1a\x08/SpEcV1\xcf)\x97]S\xb2\xfd)f1f2\x00\x00V\x00\x10\x00\x02\x00\x00\x00X\x00\x10\x00\x02\x00\x00\x00X\x00\x10\x00\x02\x00\x00\x00\x00\xd3#\x0econtractspecv0\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\tfn_enum_a\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x07\xd0\x00\x00\x00\x05EnumA\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\nfn_error_a\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x05input\x00\x00\x00\x00\x00\x00\x04\x00\x00\x00\x01\x00\x00\x03\xe9\x00\x00\x00\x04\x00\x00\x07\xd0\x00\x00\x00\x06ErrorA\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\nfn_event_a\x00\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x02f1\x00\x00\x00\x00\x00\x13\x00\x00\x00\x00\x00\x00\x00\x02f2\x00\x00\x00\x00\x00\x10\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x0bfn_struct_a\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x02f1\x00\x00\x00\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00\x02f2\x00\x00\x00\x00\x00\x01\x00\x00\x00\x01\x00\x00\x07\xd0\x00\x00\x00\x07StructA\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\rfn_enum_int_a\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x07\xd0\x00\x00\x00\x08EnumIntA\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x11fn_struct_tuple_a\x00\x00\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x02f1\x00\x00\x00\x00\x00\x07\x00\x00\x00\x00\x00\x00\x00\x02f2\x00\x00\x00\x00\x00\x07\x00\x00\x00\x01\x00\x00\x07\xd0\x00\x00\x00\x0cStructTupleA\x00\x00\x00\x02\x00\x00\x00\xe3Context of a single authorized call performed by an address.\n\nCustom account contracts that implement `__check_auth` special function\nreceive a list of `Context` values corresponding to all the calls that\nneed to be authorized.\x00\x00\x00\x00\x00\x00\x00\x00\x07Context\x00\x00\x00\x00\x03\x00\x00\x00\x01\x00\x00\x00\x14Contract invocation.\x00\x00\x00\x08Contract\x00\x00\x00\x01\x00\x00\x07\xd0\x00\x00\x00\x0fContractContext\x00\x00\x00\x00\x01\x00\x00\x00=Contract that has a constructor with no arguments is created.\x00\x00\x00\x00\x00\x00\x14CreateContractHostFn\x00\x00\x00\x01\x00\x00\x07\xd0\x00\x00\x00\x1bCreateContractHostFnContext\x00\x00\x00\x00\x01\x00\x00\x00DContract that has a constructor with 1 or more arguments is created.\x00\x00\x00\x1cCreateContractWithCtorHostFn\x00\x00\x00\x01\x00\x00\x07\xd0\x00\x00\x00*CreateContractWithConstructorHostFnContext\x00\x00\x00\x00\x00\x01\x00\x00\x00\xbdAuthorization context of a single contract call.\n\nThis struct corresponds to a `require_auth_for_args` call for an address\nfrom `contract` function with `fn_name` name and `args` arguments.\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x0fContractContext\x00\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x04args\x00\x00\x03\xea\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x08contract\x00\x00\x00\x13\x00\x00\x00\x00\x00\x00\x00\x07fn_name\x00\x00\x00\x00\x11\x00\x00\x00\x02\x00\x00\x00_Contract executable used for creating a new contract and used in\n`CreateContractHostFnContext`.\x00\x00\x00\x00\x00\x00\x00\x00\x12ContractExecutable\x00\x00\x00\x00\x00\x01\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x04Wasm\x00\x00\x00\x01\x00\x00\x03\xee\x00\x00\x00 \x00\x00\x00\x01\x00\x00\x008Value of contract node in InvokerContractAuthEntry tree.\x00\x00\x00\x00\x00\x00\x00\x15SubContractInvocation\x00\x00\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x07context\x00\x00\x00\x07\xd0\x00\x00\x00\x0fContractContext\x00\x00\x00\x00\x00\x00\x00\x00\x0fsub_invocations\x00\x00\x00\x03\xea\x00\x00\x07\xd0\x00\x00\x00\x18InvokerContractAuthEntry\x00\x00\x00\x02\x00\x00\x01/A node in the tree of authorizations performed on behalf of the current\ncontract as invoker of the contracts deeper in the call stack.\n\nThis is used as an argument of `authorize_as_current_contract` host function.\n\nThis tree corresponds `require_auth[_for_args]` calls on behalf of the\ncurrent contract.\x00\x00\x00\x00\x00\x00\x00\x00\x18InvokerContractAuthEntry\x00\x00\x00\x03\x00\x00\x00\x01\x00\x00\x00\x12Invoke a contract.\x00\x00\x00\x00\x00\x08Contract\x00\x00\x00\x01\x00\x00\x07\xd0\x00\x00\x00\x15SubContractInvocation\x00\x00\x00\x00\x00\x00\x01\x00\x00\x005Create a contract passing 0 arguments to constructor.\x00\x00\x00\x00\x00\x00\x14CreateContractHostFn\x00\x00\x00\x01\x00\x00\x07\xd0\x00\x00\x00\x1bCreateContractHostFnContext\x00\x00\x00\x00\x01\x00\x00\x00=Create a contract passing 0 or more arguments to constructor.\x00\x00\x00\x00\x00\x00\x1cCreateContractWithCtorHostFn\x00\x00\x00\x01\x00\x00\x07\xd0\x00\x00\x00*CreateContractWithConstructorHostFnContext\x00\x00\x00\x00\x00\x01\x00\x00\x00vAuthorization context for `create_contract` host function that creates a\nnew contract on behalf of authorizer address.\x00\x00\x00\x00\x00\x00\x00\x00\x00\x1bCreateContractHostFnContext\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\nexecutable\x00\x00\x00\x00\x07\xd0\x00\x00\x00\x12ContractExecutable\x00\x00\x00\x00\x00\x00\x00\x00\x00\x04salt\x00\x00\x03\xee\x00\x00\x00 \x00\x00\x00\x01\x00\x00\x00\xd6Authorization context for `create_contract` host function that creates a\nnew contract on behalf of authorizer address.\nThis is the same as `CreateContractHostFnContext`, but also has\ncontract constructor arguments.\x00\x00\x00\x00\x00\x00\x00\x00\x00*CreateContractWithConstructorHostFnContext\x00\x00\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x10constructor_args\x00\x00\x03\xea\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\nexecutable\x00\x00\x00\x00\x07\xd0\x00\x00\x00\x12ContractExecutable\x00\x00\x00\x00\x00\x00\x00\x00\x00\x04salt\x00\x00\x03\xee\x00\x00\x00 \x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\nExecutable\x00\x00\x00\x00\x00\x03\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x04Wasm\x00\x00\x00\x01\x00\x00\x03\xee\x00\x00\x00 \x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x0cStellarAsset\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x07Account\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x05EnumA\x00\x00\x00\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02V1\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02V2\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02V3\x00\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x05EnumB\x00\x00\x00\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02V1\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x02V2\x00\x00\x00\x00\x00\x01\x00\x00\x00\x07\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x02V3\x00\x00\x00\x00\x00\x02\x00\x00\x00\x07\x00\x00\x00\x07\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x05EnumC\x00\x00\x00\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02V1\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x02V2\x00\x00\x00\x00\x00\x01\x00\x00\x07\xd0\x00\x00\x00\x07StructA\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x02V3\x00\x00\x00\x00\x00\x01\x00\x00\x07\xd0\x00\x00\x00\x0cStructTupleA\x00\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x06ErrorA\x00\x00\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x02E1\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x02E2\x00\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x02E3\x00\x00\x00\x00\x00\x03\x00\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x06ErrorB\x00\x00\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x02E1\x00\x00\x00\x00\x00\n\x00\x00\x00\x00\x00\x00\x00\x02E2\x00\x00\x00\x00\x00\x0b\x00\x00\x00\x00\x00\x00\x00\x02E3\x00\x00\x00\x00\x00\x0c\x00\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x06ErrorC\x00\x00\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x02E1\x00\x00\x00\x00\x00d\x00\x00\x00\x00\x00\x00\x00\x02E2\x00\x00\x00\x00\x00e\x00\x00\x00\x00\x00\x00\x00\x02E3\x00\x00\x00\x00\x00f\x00\x00\x00\x05\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x06EventA\x00\x00\x00\x00\x00\x01\x00\x00\x00\x07event_a\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x02f1\x00\x00\x00\x00\x00\x13\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x02f2\x00\x00\x00\x00\x00\x10\x00\x00\x00\x00\x00\x00\x00\x02\x00\x00\x00\x05\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x06EventB\x00\x00\x00\x00\x00\x01\x00\x00\x00\x07event_b\x00\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x02f1\x00\x00\x00\x00\x00\x13\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x02f2\x00\x00\x00\x00\x00\x13\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x02f3\x00\x00\x00\x00\x00\x0b\x00\x00\x00\x00\x00\x00\x00\x02\x00\x00\x00\x05\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x06EventC\x00\x00\x00\x00\x00\x01\x00\x00\x00\x07event_c\x00\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x02f1\x00\x00\x00\x00\x00\x11\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x02f2\x00\x00\x00\x00\x00\x07\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02f3\x00\x00\x00\x00\x00\x07\x00\x00\x00\x00\x00\x00\x00\x02\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x07StructA\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x02f1\x00\x00\x00\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00\x02f2\x00\x00\x00\x00\x00\x01\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x07StructB\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x02f1\x00\x00\x00\x00\x00\x07\x00\x00\x00\x00\x00\x00\x00\x02f2\x00\x00\x00\x00\x00\x10\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x07StructC\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x02f1\x00\x00\x00\x00\x03\xea\x00\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00\x02f2\x00\x00\x00\x00\x00\x13\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x08EnumIntA\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x02V1\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x02V2\x00\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x02V3\x00\x00\x00\x00\x00\x03\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x08EnumIntB\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x02V1\x00\x00\x00\x00\x00\n\x00\x00\x00\x00\x00\x00\x00\x02V2\x00\x00\x00\x00\x00\x14\x00\x00\x00\x00\x00\x00\x00\x02V3\x00\x00\x00\x00\x00\x1e\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x08EnumIntC\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x02V1\x00\x00\x00\x00\x00d\x00\x00\x00\x00\x00\x00\x00\x02V2\x00\x00\x00\x00\x00\xc8\x00\x00\x00\x00\x00\x00\x00\x02V3\x00\x00\x00\x00\x01,\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x0cStructTupleA\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x010\x00\x00\x00\x00\x00\x00\x07\x00\x00\x00\x00\x00\x00\x00\x011\x00\x00\x00\x00\x00\x00\x07\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x0cStructTupleB\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x010\x00\x00\x00\x00\x00\x00\n\x00\x00\x00\x00\x00\x00\x00\x011\x00\x00\x00\x00\x00\x00\n\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x0cStructTupleC\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x010\x00\x00\x00\x00\x00\x00\x13\x00\x00\x00\x00\x00\x00\x00\x011\x00\x00\x00\x00\x00\x00\x0b\x00\x1e\x11contractenvmetav0\x00\x00\x00\x00\x00\x00\x00\x1a\x00\x00\x00\x00\x00O\x0econtractmetav0\x00\x00\x00\x00\x00\x00\x00\x05rsver\x00\x00\x00\x00\x00\x00\x061.91.0\x00\x00\x00\x00\x00\x00\x00\x00\x00\x12rssdk_spec_shaking\x00\x00\x00\x00\x00\x012\x00\x00\x00";
     pub trait Contract {
         fn fn_enum_a(env: soroban_sdk::Env) -> EnumA;
         fn fn_error_a(env: soroban_sdk::Env, input: u32) -> Result<u32, ErrorA>;
@@ -4400,6 +4400,579 @@ mod wasm_imported {
         #[allow(clippy::unused_unit)]
         pub fn fn_struct_tuple_a<'i>(f1: &'i i64, f2: &'i i64) -> (&'i i64, &'i i64) {
             (f1, f2)
+        }
+    }
+    pub struct ContractContext {
+        pub args: soroban_sdk::Vec<soroban_sdk::Val>,
+        pub contract: soroban_sdk::Address,
+        pub fn_name: soroban_sdk::Symbol,
+    }
+    #[automatically_derived]
+    impl ::core::fmt::Debug for ContractContext {
+        #[inline]
+        fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+            ::core::fmt::Formatter::debug_struct_field3_finish(
+                f,
+                "ContractContext",
+                "args",
+                &self.args,
+                "contract",
+                &self.contract,
+                "fn_name",
+                &&self.fn_name,
+            )
+        }
+    }
+    #[automatically_derived]
+    impl ::core::clone::Clone for ContractContext {
+        #[inline]
+        fn clone(&self) -> ContractContext {
+            ContractContext {
+                args: ::core::clone::Clone::clone(&self.args),
+                contract: ::core::clone::Clone::clone(&self.contract),
+                fn_name: ::core::clone::Clone::clone(&self.fn_name),
+            }
+        }
+    }
+    #[automatically_derived]
+    impl ::core::cmp::Eq for ContractContext {
+        #[inline]
+        #[doc(hidden)]
+        #[coverage(off)]
+        fn assert_receiver_is_total_eq(&self) -> () {
+            let _: ::core::cmp::AssertParamIsEq<soroban_sdk::Vec<soroban_sdk::Val>>;
+            let _: ::core::cmp::AssertParamIsEq<soroban_sdk::Address>;
+            let _: ::core::cmp::AssertParamIsEq<soroban_sdk::Symbol>;
+        }
+    }
+    #[automatically_derived]
+    impl ::core::marker::StructuralPartialEq for ContractContext {}
+    #[automatically_derived]
+    impl ::core::cmp::PartialEq for ContractContext {
+        #[inline]
+        fn eq(&self, other: &ContractContext) -> bool {
+            self.args == other.args
+                && self.contract == other.contract
+                && self.fn_name == other.fn_name
+        }
+    }
+    #[automatically_derived]
+    impl ::core::cmp::Ord for ContractContext {
+        #[inline]
+        fn cmp(&self, other: &ContractContext) -> ::core::cmp::Ordering {
+            match ::core::cmp::Ord::cmp(&self.args, &other.args) {
+                ::core::cmp::Ordering::Equal => {
+                    match ::core::cmp::Ord::cmp(&self.contract, &other.contract) {
+                        ::core::cmp::Ordering::Equal => {
+                            ::core::cmp::Ord::cmp(&self.fn_name, &other.fn_name)
+                        }
+                        cmp => cmp,
+                    }
+                }
+                cmp => cmp,
+            }
+        }
+    }
+    #[automatically_derived]
+    impl ::core::cmp::PartialOrd for ContractContext {
+        #[inline]
+        fn partial_cmp(
+            &self,
+            other: &ContractContext,
+        ) -> ::core::option::Option<::core::cmp::Ordering> {
+            match ::core::cmp::PartialOrd::partial_cmp(&self.args, &other.args) {
+                ::core::option::Option::Some(::core::cmp::Ordering::Equal) => {
+                    match ::core::cmp::PartialOrd::partial_cmp(&self.contract, &other.contract) {
+                        ::core::option::Option::Some(::core::cmp::Ordering::Equal) => {
+                            ::core::cmp::PartialOrd::partial_cmp(&self.fn_name, &other.fn_name)
+                        }
+                        cmp => cmp,
+                    }
+                }
+                cmp => cmp,
+            }
+        }
+    }
+    impl soroban_sdk::TryFromVal<soroban_sdk::Env, soroban_sdk::Val> for ContractContext {
+        type Error = soroban_sdk::ConversionError;
+        fn try_from_val(
+            env: &soroban_sdk::Env,
+            val: &soroban_sdk::Val,
+        ) -> Result<Self, soroban_sdk::ConversionError> {
+            use soroban_sdk::{ConversionError, EnvBase, MapObject, TryIntoVal, Val};
+            const KEYS: [&'static str; 3usize] = ["args", "contract", "fn_name"];
+            let mut vals: [Val; 3usize] = [Val::VOID.to_val(); 3usize];
+            let map: MapObject = val.try_into().map_err(|_| ConversionError)?;
+            env.map_unpack_to_slice(map, &KEYS, &mut vals)
+                .map_err(|_| ConversionError)?;
+            Ok(Self {
+                args: vals[0]
+                    .try_into_val(env)
+                    .map_err(|_| soroban_sdk::ConversionError)?,
+                contract: vals[1]
+                    .try_into_val(env)
+                    .map_err(|_| soroban_sdk::ConversionError)?,
+                fn_name: vals[2]
+                    .try_into_val(env)
+                    .map_err(|_| soroban_sdk::ConversionError)?,
+            })
+        }
+    }
+    impl soroban_sdk::TryFromVal<soroban_sdk::Env, ContractContext> for soroban_sdk::Val {
+        type Error = soroban_sdk::ConversionError;
+        fn try_from_val(
+            env: &soroban_sdk::Env,
+            val: &ContractContext,
+        ) -> Result<Self, soroban_sdk::ConversionError> {
+            use soroban_sdk::{ConversionError, EnvBase, TryIntoVal, Val};
+            const KEYS: [&'static str; 3usize] = ["args", "contract", "fn_name"];
+            let vals: [Val; 3usize] = [
+                (&val.args).try_into_val(env).map_err(|_| ConversionError)?,
+                (&val.contract)
+                    .try_into_val(env)
+                    .map_err(|_| ConversionError)?,
+                (&val.fn_name)
+                    .try_into_val(env)
+                    .map_err(|_| ConversionError)?,
+            ];
+            Ok(env
+                .map_new_from_slices(&KEYS, &vals)
+                .map_err(|_| ConversionError)?
+                .into())
+        }
+    }
+    impl soroban_sdk::TryFromVal<soroban_sdk::Env, &ContractContext> for soroban_sdk::Val {
+        type Error = soroban_sdk::ConversionError;
+        #[inline(always)]
+        fn try_from_val(
+            env: &soroban_sdk::Env,
+            val: &&ContractContext,
+        ) -> Result<Self, soroban_sdk::ConversionError> {
+            <_ as soroban_sdk::TryFromVal<soroban_sdk::Env, ContractContext>>::try_from_val(
+                env, *val,
+            )
+        }
+    }
+    pub struct SubContractInvocation {
+        pub context: ContractContext,
+        pub sub_invocations: soroban_sdk::Vec<InvokerContractAuthEntry>,
+    }
+    #[automatically_derived]
+    impl ::core::fmt::Debug for SubContractInvocation {
+        #[inline]
+        fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+            ::core::fmt::Formatter::debug_struct_field2_finish(
+                f,
+                "SubContractInvocation",
+                "context",
+                &self.context,
+                "sub_invocations",
+                &&self.sub_invocations,
+            )
+        }
+    }
+    #[automatically_derived]
+    impl ::core::clone::Clone for SubContractInvocation {
+        #[inline]
+        fn clone(&self) -> SubContractInvocation {
+            SubContractInvocation {
+                context: ::core::clone::Clone::clone(&self.context),
+                sub_invocations: ::core::clone::Clone::clone(&self.sub_invocations),
+            }
+        }
+    }
+    #[automatically_derived]
+    impl ::core::cmp::Eq for SubContractInvocation {
+        #[inline]
+        #[doc(hidden)]
+        #[coverage(off)]
+        fn assert_receiver_is_total_eq(&self) -> () {
+            let _: ::core::cmp::AssertParamIsEq<ContractContext>;
+            let _: ::core::cmp::AssertParamIsEq<soroban_sdk::Vec<InvokerContractAuthEntry>>;
+        }
+    }
+    #[automatically_derived]
+    impl ::core::marker::StructuralPartialEq for SubContractInvocation {}
+    #[automatically_derived]
+    impl ::core::cmp::PartialEq for SubContractInvocation {
+        #[inline]
+        fn eq(&self, other: &SubContractInvocation) -> bool {
+            self.context == other.context && self.sub_invocations == other.sub_invocations
+        }
+    }
+    #[automatically_derived]
+    impl ::core::cmp::Ord for SubContractInvocation {
+        #[inline]
+        fn cmp(&self, other: &SubContractInvocation) -> ::core::cmp::Ordering {
+            match ::core::cmp::Ord::cmp(&self.context, &other.context) {
+                ::core::cmp::Ordering::Equal => {
+                    ::core::cmp::Ord::cmp(&self.sub_invocations, &other.sub_invocations)
+                }
+                cmp => cmp,
+            }
+        }
+    }
+    #[automatically_derived]
+    impl ::core::cmp::PartialOrd for SubContractInvocation {
+        #[inline]
+        fn partial_cmp(
+            &self,
+            other: &SubContractInvocation,
+        ) -> ::core::option::Option<::core::cmp::Ordering> {
+            match ::core::cmp::PartialOrd::partial_cmp(&self.context, &other.context) {
+                ::core::option::Option::Some(::core::cmp::Ordering::Equal) => {
+                    ::core::cmp::PartialOrd::partial_cmp(
+                        &self.sub_invocations,
+                        &other.sub_invocations,
+                    )
+                }
+                cmp => cmp,
+            }
+        }
+    }
+    impl soroban_sdk::TryFromVal<soroban_sdk::Env, soroban_sdk::Val> for SubContractInvocation {
+        type Error = soroban_sdk::ConversionError;
+        fn try_from_val(
+            env: &soroban_sdk::Env,
+            val: &soroban_sdk::Val,
+        ) -> Result<Self, soroban_sdk::ConversionError> {
+            use soroban_sdk::{ConversionError, EnvBase, MapObject, TryIntoVal, Val};
+            const KEYS: [&'static str; 2usize] = ["context", "sub_invocations"];
+            let mut vals: [Val; 2usize] = [Val::VOID.to_val(); 2usize];
+            let map: MapObject = val.try_into().map_err(|_| ConversionError)?;
+            env.map_unpack_to_slice(map, &KEYS, &mut vals)
+                .map_err(|_| ConversionError)?;
+            Ok(Self {
+                context: vals[0]
+                    .try_into_val(env)
+                    .map_err(|_| soroban_sdk::ConversionError)?,
+                sub_invocations: vals[1]
+                    .try_into_val(env)
+                    .map_err(|_| soroban_sdk::ConversionError)?,
+            })
+        }
+    }
+    impl soroban_sdk::TryFromVal<soroban_sdk::Env, SubContractInvocation> for soroban_sdk::Val {
+        type Error = soroban_sdk::ConversionError;
+        fn try_from_val(
+            env: &soroban_sdk::Env,
+            val: &SubContractInvocation,
+        ) -> Result<Self, soroban_sdk::ConversionError> {
+            use soroban_sdk::{ConversionError, EnvBase, TryIntoVal, Val};
+            const KEYS: [&'static str; 2usize] = ["context", "sub_invocations"];
+            let vals: [Val; 2usize] = [
+                (&val.context)
+                    .try_into_val(env)
+                    .map_err(|_| ConversionError)?,
+                (&val.sub_invocations)
+                    .try_into_val(env)
+                    .map_err(|_| ConversionError)?,
+            ];
+            Ok(env
+                .map_new_from_slices(&KEYS, &vals)
+                .map_err(|_| ConversionError)?
+                .into())
+        }
+    }
+    impl soroban_sdk::TryFromVal<soroban_sdk::Env, &SubContractInvocation> for soroban_sdk::Val {
+        type Error = soroban_sdk::ConversionError;
+        #[inline(always)]
+        fn try_from_val(
+            env: &soroban_sdk::Env,
+            val: &&SubContractInvocation,
+        ) -> Result<Self, soroban_sdk::ConversionError> {
+            <_ as soroban_sdk::TryFromVal<soroban_sdk::Env, SubContractInvocation>>::try_from_val(
+                env, *val,
+            )
+        }
+    }
+    pub struct CreateContractHostFnContext {
+        pub executable: ContractExecutable,
+        pub salt: soroban_sdk::BytesN<32>,
+    }
+    #[automatically_derived]
+    impl ::core::fmt::Debug for CreateContractHostFnContext {
+        #[inline]
+        fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+            ::core::fmt::Formatter::debug_struct_field2_finish(
+                f,
+                "CreateContractHostFnContext",
+                "executable",
+                &self.executable,
+                "salt",
+                &&self.salt,
+            )
+        }
+    }
+    #[automatically_derived]
+    impl ::core::clone::Clone for CreateContractHostFnContext {
+        #[inline]
+        fn clone(&self) -> CreateContractHostFnContext {
+            CreateContractHostFnContext {
+                executable: ::core::clone::Clone::clone(&self.executable),
+                salt: ::core::clone::Clone::clone(&self.salt),
+            }
+        }
+    }
+    #[automatically_derived]
+    impl ::core::cmp::Eq for CreateContractHostFnContext {
+        #[inline]
+        #[doc(hidden)]
+        #[coverage(off)]
+        fn assert_receiver_is_total_eq(&self) -> () {
+            let _: ::core::cmp::AssertParamIsEq<ContractExecutable>;
+            let _: ::core::cmp::AssertParamIsEq<soroban_sdk::BytesN<32>>;
+        }
+    }
+    #[automatically_derived]
+    impl ::core::marker::StructuralPartialEq for CreateContractHostFnContext {}
+    #[automatically_derived]
+    impl ::core::cmp::PartialEq for CreateContractHostFnContext {
+        #[inline]
+        fn eq(&self, other: &CreateContractHostFnContext) -> bool {
+            self.executable == other.executable && self.salt == other.salt
+        }
+    }
+    #[automatically_derived]
+    impl ::core::cmp::Ord for CreateContractHostFnContext {
+        #[inline]
+        fn cmp(&self, other: &CreateContractHostFnContext) -> ::core::cmp::Ordering {
+            match ::core::cmp::Ord::cmp(&self.executable, &other.executable) {
+                ::core::cmp::Ordering::Equal => ::core::cmp::Ord::cmp(&self.salt, &other.salt),
+                cmp => cmp,
+            }
+        }
+    }
+    #[automatically_derived]
+    impl ::core::cmp::PartialOrd for CreateContractHostFnContext {
+        #[inline]
+        fn partial_cmp(
+            &self,
+            other: &CreateContractHostFnContext,
+        ) -> ::core::option::Option<::core::cmp::Ordering> {
+            match ::core::cmp::PartialOrd::partial_cmp(&self.executable, &other.executable) {
+                ::core::option::Option::Some(::core::cmp::Ordering::Equal) => {
+                    ::core::cmp::PartialOrd::partial_cmp(&self.salt, &other.salt)
+                }
+                cmp => cmp,
+            }
+        }
+    }
+    impl soroban_sdk::TryFromVal<soroban_sdk::Env, soroban_sdk::Val> for CreateContractHostFnContext {
+        type Error = soroban_sdk::ConversionError;
+        fn try_from_val(
+            env: &soroban_sdk::Env,
+            val: &soroban_sdk::Val,
+        ) -> Result<Self, soroban_sdk::ConversionError> {
+            use soroban_sdk::{ConversionError, EnvBase, MapObject, TryIntoVal, Val};
+            const KEYS: [&'static str; 2usize] = ["executable", "salt"];
+            let mut vals: [Val; 2usize] = [Val::VOID.to_val(); 2usize];
+            let map: MapObject = val.try_into().map_err(|_| ConversionError)?;
+            env.map_unpack_to_slice(map, &KEYS, &mut vals)
+                .map_err(|_| ConversionError)?;
+            Ok(Self {
+                executable: vals[0]
+                    .try_into_val(env)
+                    .map_err(|_| soroban_sdk::ConversionError)?,
+                salt: vals[1]
+                    .try_into_val(env)
+                    .map_err(|_| soroban_sdk::ConversionError)?,
+            })
+        }
+    }
+    impl soroban_sdk::TryFromVal<soroban_sdk::Env, CreateContractHostFnContext> for soroban_sdk::Val {
+        type Error = soroban_sdk::ConversionError;
+        fn try_from_val(
+            env: &soroban_sdk::Env,
+            val: &CreateContractHostFnContext,
+        ) -> Result<Self, soroban_sdk::ConversionError> {
+            use soroban_sdk::{ConversionError, EnvBase, TryIntoVal, Val};
+            const KEYS: [&'static str; 2usize] = ["executable", "salt"];
+            let vals: [Val; 2usize] = [
+                (&val.executable)
+                    .try_into_val(env)
+                    .map_err(|_| ConversionError)?,
+                (&val.salt).try_into_val(env).map_err(|_| ConversionError)?,
+            ];
+            Ok(env
+                .map_new_from_slices(&KEYS, &vals)
+                .map_err(|_| ConversionError)?
+                .into())
+        }
+    }
+    impl soroban_sdk::TryFromVal<soroban_sdk::Env, &CreateContractHostFnContext> for soroban_sdk::Val {
+        type Error = soroban_sdk::ConversionError;
+        #[inline(always)]
+        fn try_from_val(
+            env: &soroban_sdk::Env,
+            val: &&CreateContractHostFnContext,
+        ) -> Result<Self, soroban_sdk::ConversionError> {
+            <_ as soroban_sdk::TryFromVal<
+                soroban_sdk::Env,
+                CreateContractHostFnContext,
+            >>::try_from_val(env, *val)
+        }
+    }
+    pub struct CreateContractWithConstructorHostFnContext {
+        pub constructor_args: soroban_sdk::Vec<soroban_sdk::Val>,
+        pub executable: ContractExecutable,
+        pub salt: soroban_sdk::BytesN<32>,
+    }
+    #[automatically_derived]
+    impl ::core::fmt::Debug for CreateContractWithConstructorHostFnContext {
+        #[inline]
+        fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+            ::core::fmt::Formatter::debug_struct_field3_finish(
+                f,
+                "CreateContractWithConstructorHostFnContext",
+                "constructor_args",
+                &self.constructor_args,
+                "executable",
+                &self.executable,
+                "salt",
+                &&self.salt,
+            )
+        }
+    }
+    #[automatically_derived]
+    impl ::core::clone::Clone for CreateContractWithConstructorHostFnContext {
+        #[inline]
+        fn clone(&self) -> CreateContractWithConstructorHostFnContext {
+            CreateContractWithConstructorHostFnContext {
+                constructor_args: ::core::clone::Clone::clone(&self.constructor_args),
+                executable: ::core::clone::Clone::clone(&self.executable),
+                salt: ::core::clone::Clone::clone(&self.salt),
+            }
+        }
+    }
+    #[automatically_derived]
+    impl ::core::cmp::Eq for CreateContractWithConstructorHostFnContext {
+        #[inline]
+        #[doc(hidden)]
+        #[coverage(off)]
+        fn assert_receiver_is_total_eq(&self) -> () {
+            let _: ::core::cmp::AssertParamIsEq<soroban_sdk::Vec<soroban_sdk::Val>>;
+            let _: ::core::cmp::AssertParamIsEq<ContractExecutable>;
+            let _: ::core::cmp::AssertParamIsEq<soroban_sdk::BytesN<32>>;
+        }
+    }
+    #[automatically_derived]
+    impl ::core::marker::StructuralPartialEq for CreateContractWithConstructorHostFnContext {}
+    #[automatically_derived]
+    impl ::core::cmp::PartialEq for CreateContractWithConstructorHostFnContext {
+        #[inline]
+        fn eq(&self, other: &CreateContractWithConstructorHostFnContext) -> bool {
+            self.constructor_args == other.constructor_args
+                && self.executable == other.executable
+                && self.salt == other.salt
+        }
+    }
+    #[automatically_derived]
+    impl ::core::cmp::Ord for CreateContractWithConstructorHostFnContext {
+        #[inline]
+        fn cmp(&self, other: &CreateContractWithConstructorHostFnContext) -> ::core::cmp::Ordering {
+            match ::core::cmp::Ord::cmp(&self.constructor_args, &other.constructor_args) {
+                ::core::cmp::Ordering::Equal => {
+                    match ::core::cmp::Ord::cmp(&self.executable, &other.executable) {
+                        ::core::cmp::Ordering::Equal => {
+                            ::core::cmp::Ord::cmp(&self.salt, &other.salt)
+                        }
+                        cmp => cmp,
+                    }
+                }
+                cmp => cmp,
+            }
+        }
+    }
+    #[automatically_derived]
+    impl ::core::cmp::PartialOrd for CreateContractWithConstructorHostFnContext {
+        #[inline]
+        fn partial_cmp(
+            &self,
+            other: &CreateContractWithConstructorHostFnContext,
+        ) -> ::core::option::Option<::core::cmp::Ordering> {
+            match ::core::cmp::PartialOrd::partial_cmp(
+                &self.constructor_args,
+                &other.constructor_args,
+            ) {
+                ::core::option::Option::Some(::core::cmp::Ordering::Equal) => {
+                    match ::core::cmp::PartialOrd::partial_cmp(&self.executable, &other.executable)
+                    {
+                        ::core::option::Option::Some(::core::cmp::Ordering::Equal) => {
+                            ::core::cmp::PartialOrd::partial_cmp(&self.salt, &other.salt)
+                        }
+                        cmp => cmp,
+                    }
+                }
+                cmp => cmp,
+            }
+        }
+    }
+    impl soroban_sdk::TryFromVal<soroban_sdk::Env, soroban_sdk::Val>
+        for CreateContractWithConstructorHostFnContext
+    {
+        type Error = soroban_sdk::ConversionError;
+        fn try_from_val(
+            env: &soroban_sdk::Env,
+            val: &soroban_sdk::Val,
+        ) -> Result<Self, soroban_sdk::ConversionError> {
+            use soroban_sdk::{ConversionError, EnvBase, MapObject, TryIntoVal, Val};
+            const KEYS: [&'static str; 3usize] = ["constructor_args", "executable", "salt"];
+            let mut vals: [Val; 3usize] = [Val::VOID.to_val(); 3usize];
+            let map: MapObject = val.try_into().map_err(|_| ConversionError)?;
+            env.map_unpack_to_slice(map, &KEYS, &mut vals)
+                .map_err(|_| ConversionError)?;
+            Ok(Self {
+                constructor_args: vals[0]
+                    .try_into_val(env)
+                    .map_err(|_| soroban_sdk::ConversionError)?,
+                executable: vals[1]
+                    .try_into_val(env)
+                    .map_err(|_| soroban_sdk::ConversionError)?,
+                salt: vals[2]
+                    .try_into_val(env)
+                    .map_err(|_| soroban_sdk::ConversionError)?,
+            })
+        }
+    }
+    impl soroban_sdk::TryFromVal<soroban_sdk::Env, CreateContractWithConstructorHostFnContext>
+        for soroban_sdk::Val
+    {
+        type Error = soroban_sdk::ConversionError;
+        fn try_from_val(
+            env: &soroban_sdk::Env,
+            val: &CreateContractWithConstructorHostFnContext,
+        ) -> Result<Self, soroban_sdk::ConversionError> {
+            use soroban_sdk::{ConversionError, EnvBase, TryIntoVal, Val};
+            const KEYS: [&'static str; 3usize] = ["constructor_args", "executable", "salt"];
+            let vals: [Val; 3usize] = [
+                (&val.constructor_args)
+                    .try_into_val(env)
+                    .map_err(|_| ConversionError)?,
+                (&val.executable)
+                    .try_into_val(env)
+                    .map_err(|_| ConversionError)?,
+                (&val.salt).try_into_val(env).map_err(|_| ConversionError)?,
+            ];
+            Ok(env
+                .map_new_from_slices(&KEYS, &vals)
+                .map_err(|_| ConversionError)?
+                .into())
+        }
+    }
+    impl soroban_sdk::TryFromVal<soroban_sdk::Env, &CreateContractWithConstructorHostFnContext>
+        for soroban_sdk::Val
+    {
+        type Error = soroban_sdk::ConversionError;
+        #[inline(always)]
+        fn try_from_val(
+            env: &soroban_sdk::Env,
+            val: &&CreateContractWithConstructorHostFnContext,
+        ) -> Result<Self, soroban_sdk::ConversionError> {
+            <_ as soroban_sdk::TryFromVal<
+                soroban_sdk::Env,
+                CreateContractWithConstructorHostFnContext,
+            >>::try_from_val(env, *val)
         }
     }
     pub struct StructA {
@@ -5064,6 +5637,796 @@ mod wasm_imported {
             val: &&StructTupleC,
         ) -> Result<Self, soroban_sdk::ConversionError> {
             <_ as soroban_sdk::TryFromVal<soroban_sdk::Env, StructTupleC>>::try_from_val(env, *val)
+        }
+    }
+    pub enum Context {
+        Contract(ContractContext),
+        CreateContractHostFn(CreateContractHostFnContext),
+        CreateContractWithCtorHostFn(CreateContractWithConstructorHostFnContext),
+    }
+    #[automatically_derived]
+    impl ::core::fmt::Debug for Context {
+        #[inline]
+        fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+            match self {
+                Context::Contract(__self_0) => {
+                    ::core::fmt::Formatter::debug_tuple_field1_finish(f, "Contract", &__self_0)
+                }
+                Context::CreateContractHostFn(__self_0) => {
+                    ::core::fmt::Formatter::debug_tuple_field1_finish(
+                        f,
+                        "CreateContractHostFn",
+                        &__self_0,
+                    )
+                }
+                Context::CreateContractWithCtorHostFn(__self_0) => {
+                    ::core::fmt::Formatter::debug_tuple_field1_finish(
+                        f,
+                        "CreateContractWithCtorHostFn",
+                        &__self_0,
+                    )
+                }
+            }
+        }
+    }
+    #[automatically_derived]
+    impl ::core::clone::Clone for Context {
+        #[inline]
+        fn clone(&self) -> Context {
+            match self {
+                Context::Contract(__self_0) => {
+                    Context::Contract(::core::clone::Clone::clone(__self_0))
+                }
+                Context::CreateContractHostFn(__self_0) => {
+                    Context::CreateContractHostFn(::core::clone::Clone::clone(__self_0))
+                }
+                Context::CreateContractWithCtorHostFn(__self_0) => {
+                    Context::CreateContractWithCtorHostFn(::core::clone::Clone::clone(__self_0))
+                }
+            }
+        }
+    }
+    #[automatically_derived]
+    impl ::core::cmp::Eq for Context {
+        #[inline]
+        #[doc(hidden)]
+        #[coverage(off)]
+        fn assert_receiver_is_total_eq(&self) -> () {
+            let _: ::core::cmp::AssertParamIsEq<ContractContext>;
+            let _: ::core::cmp::AssertParamIsEq<CreateContractHostFnContext>;
+            let _: ::core::cmp::AssertParamIsEq<CreateContractWithConstructorHostFnContext>;
+        }
+    }
+    #[automatically_derived]
+    impl ::core::marker::StructuralPartialEq for Context {}
+    #[automatically_derived]
+    impl ::core::cmp::PartialEq for Context {
+        #[inline]
+        fn eq(&self, other: &Context) -> bool {
+            let __self_discr = ::core::intrinsics::discriminant_value(self);
+            let __arg1_discr = ::core::intrinsics::discriminant_value(other);
+            __self_discr == __arg1_discr
+                && match (self, other) {
+                    (Context::Contract(__self_0), Context::Contract(__arg1_0)) => {
+                        __self_0 == __arg1_0
+                    }
+                    (
+                        Context::CreateContractHostFn(__self_0),
+                        Context::CreateContractHostFn(__arg1_0),
+                    ) => __self_0 == __arg1_0,
+                    (
+                        Context::CreateContractWithCtorHostFn(__self_0),
+                        Context::CreateContractWithCtorHostFn(__arg1_0),
+                    ) => __self_0 == __arg1_0,
+                    _ => unsafe { ::core::intrinsics::unreachable() },
+                }
+        }
+    }
+    #[automatically_derived]
+    impl ::core::cmp::Ord for Context {
+        #[inline]
+        fn cmp(&self, other: &Context) -> ::core::cmp::Ordering {
+            let __self_discr = ::core::intrinsics::discriminant_value(self);
+            let __arg1_discr = ::core::intrinsics::discriminant_value(other);
+            match ::core::cmp::Ord::cmp(&__self_discr, &__arg1_discr) {
+                ::core::cmp::Ordering::Equal => match (self, other) {
+                    (Context::Contract(__self_0), Context::Contract(__arg1_0)) => {
+                        ::core::cmp::Ord::cmp(__self_0, __arg1_0)
+                    }
+                    (
+                        Context::CreateContractHostFn(__self_0),
+                        Context::CreateContractHostFn(__arg1_0),
+                    ) => ::core::cmp::Ord::cmp(__self_0, __arg1_0),
+                    (
+                        Context::CreateContractWithCtorHostFn(__self_0),
+                        Context::CreateContractWithCtorHostFn(__arg1_0),
+                    ) => ::core::cmp::Ord::cmp(__self_0, __arg1_0),
+                    _ => unsafe { ::core::intrinsics::unreachable() },
+                },
+                cmp => cmp,
+            }
+        }
+    }
+    #[automatically_derived]
+    impl ::core::cmp::PartialOrd for Context {
+        #[inline]
+        fn partial_cmp(&self, other: &Context) -> ::core::option::Option<::core::cmp::Ordering> {
+            let __self_discr = ::core::intrinsics::discriminant_value(self);
+            let __arg1_discr = ::core::intrinsics::discriminant_value(other);
+            match (self, other) {
+                (Context::Contract(__self_0), Context::Contract(__arg1_0)) => {
+                    ::core::cmp::PartialOrd::partial_cmp(__self_0, __arg1_0)
+                }
+                (
+                    Context::CreateContractHostFn(__self_0),
+                    Context::CreateContractHostFn(__arg1_0),
+                ) => ::core::cmp::PartialOrd::partial_cmp(__self_0, __arg1_0),
+                (
+                    Context::CreateContractWithCtorHostFn(__self_0),
+                    Context::CreateContractWithCtorHostFn(__arg1_0),
+                ) => ::core::cmp::PartialOrd::partial_cmp(__self_0, __arg1_0),
+                _ => ::core::cmp::PartialOrd::partial_cmp(&__self_discr, &__arg1_discr),
+            }
+        }
+    }
+    impl soroban_sdk::TryFromVal<soroban_sdk::Env, soroban_sdk::Val> for Context {
+        type Error = soroban_sdk::ConversionError;
+        #[inline(always)]
+        fn try_from_val(
+            env: &soroban_sdk::Env,
+            val: &soroban_sdk::Val,
+        ) -> Result<Self, soroban_sdk::ConversionError> {
+            use soroban_sdk::{EnvBase, TryFromVal, TryIntoVal};
+            const CASES: &'static [&'static str] = &[
+                "Contract",
+                "CreateContractHostFn",
+                "CreateContractWithCtorHostFn",
+            ];
+            let vec: soroban_sdk::Vec<soroban_sdk::Val> = val.try_into_val(env)?;
+            let mut iter = vec.try_iter();
+            let discriminant: soroban_sdk::Symbol = iter
+                .next()
+                .ok_or(soroban_sdk::ConversionError)??
+                .try_into_val(env)
+                .map_err(|_| soroban_sdk::ConversionError)?;
+            Ok(
+                match u32::from(env.symbol_index_in_strs(discriminant.to_symbol_val(), CASES)?)
+                    as usize
+                {
+                    0 => {
+                        if iter.len() > 1usize {
+                            return Err(soroban_sdk::ConversionError);
+                        }
+                        Self::Contract(
+                            iter.next()
+                                .ok_or(soroban_sdk::ConversionError)??
+                                .try_into_val(env)?,
+                        )
+                    }
+                    1 => {
+                        if iter.len() > 1usize {
+                            return Err(soroban_sdk::ConversionError);
+                        }
+                        Self::CreateContractHostFn(
+                            iter.next()
+                                .ok_or(soroban_sdk::ConversionError)??
+                                .try_into_val(env)?,
+                        )
+                    }
+                    2 => {
+                        if iter.len() > 1usize {
+                            return Err(soroban_sdk::ConversionError);
+                        }
+                        Self::CreateContractWithCtorHostFn(
+                            iter.next()
+                                .ok_or(soroban_sdk::ConversionError)??
+                                .try_into_val(env)?,
+                        )
+                    }
+                    _ => Err(soroban_sdk::ConversionError {})?,
+                },
+            )
+        }
+    }
+    impl soroban_sdk::TryFromVal<soroban_sdk::Env, Context> for soroban_sdk::Val {
+        type Error = soroban_sdk::ConversionError;
+        #[inline(always)]
+        fn try_from_val(
+            env: &soroban_sdk::Env,
+            val: &Context,
+        ) -> Result<Self, soroban_sdk::ConversionError> {
+            use soroban_sdk::{TryFromVal, TryIntoVal};
+            match val {
+                Context::Contract(ref value0) => {
+                    let tup: (soroban_sdk::Val, soroban_sdk::Val) = (
+                        soroban_sdk::Symbol::try_from_val(env, &"Contract")?.to_val(),
+                        value0.try_into_val(env)?,
+                    );
+                    tup.try_into_val(env).map_err(Into::into)
+                }
+                Context::CreateContractHostFn(ref value0) => {
+                    let tup: (soroban_sdk::Val, soroban_sdk::Val) = (
+                        soroban_sdk::Symbol::try_from_val(env, &"CreateContractHostFn")?.to_val(),
+                        value0.try_into_val(env)?,
+                    );
+                    tup.try_into_val(env).map_err(Into::into)
+                }
+                Context::CreateContractWithCtorHostFn(ref value0) => {
+                    let tup: (soroban_sdk::Val, soroban_sdk::Val) = (
+                        soroban_sdk::Symbol::try_from_val(env, &"CreateContractWithCtorHostFn")?
+                            .to_val(),
+                        value0.try_into_val(env)?,
+                    );
+                    tup.try_into_val(env).map_err(Into::into)
+                }
+            }
+        }
+    }
+    impl soroban_sdk::TryFromVal<soroban_sdk::Env, &Context> for soroban_sdk::Val {
+        type Error = soroban_sdk::ConversionError;
+        #[inline(always)]
+        fn try_from_val(
+            env: &soroban_sdk::Env,
+            val: &&Context,
+        ) -> Result<Self, soroban_sdk::ConversionError> {
+            <_ as soroban_sdk::TryFromVal<soroban_sdk::Env, Context>>::try_from_val(env, *val)
+        }
+    }
+    pub enum ContractExecutable {
+        Wasm(soroban_sdk::BytesN<32>),
+    }
+    #[automatically_derived]
+    impl ::core::fmt::Debug for ContractExecutable {
+        #[inline]
+        fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+            match self {
+                ContractExecutable::Wasm(__self_0) => {
+                    ::core::fmt::Formatter::debug_tuple_field1_finish(f, "Wasm", &__self_0)
+                }
+            }
+        }
+    }
+    #[automatically_derived]
+    impl ::core::clone::Clone for ContractExecutable {
+        #[inline]
+        fn clone(&self) -> ContractExecutable {
+            match self {
+                ContractExecutable::Wasm(__self_0) => {
+                    ContractExecutable::Wasm(::core::clone::Clone::clone(__self_0))
+                }
+            }
+        }
+    }
+    #[automatically_derived]
+    impl ::core::cmp::Eq for ContractExecutable {
+        #[inline]
+        #[doc(hidden)]
+        #[coverage(off)]
+        fn assert_receiver_is_total_eq(&self) -> () {
+            let _: ::core::cmp::AssertParamIsEq<soroban_sdk::BytesN<32>>;
+        }
+    }
+    #[automatically_derived]
+    impl ::core::marker::StructuralPartialEq for ContractExecutable {}
+    #[automatically_derived]
+    impl ::core::cmp::PartialEq for ContractExecutable {
+        #[inline]
+        fn eq(&self, other: &ContractExecutable) -> bool {
+            match (self, other) {
+                (ContractExecutable::Wasm(__self_0), ContractExecutable::Wasm(__arg1_0)) => {
+                    __self_0 == __arg1_0
+                }
+            }
+        }
+    }
+    #[automatically_derived]
+    impl ::core::cmp::Ord for ContractExecutable {
+        #[inline]
+        fn cmp(&self, other: &ContractExecutable) -> ::core::cmp::Ordering {
+            match (self, other) {
+                (ContractExecutable::Wasm(__self_0), ContractExecutable::Wasm(__arg1_0)) => {
+                    ::core::cmp::Ord::cmp(__self_0, __arg1_0)
+                }
+            }
+        }
+    }
+    #[automatically_derived]
+    impl ::core::cmp::PartialOrd for ContractExecutable {
+        #[inline]
+        fn partial_cmp(
+            &self,
+            other: &ContractExecutable,
+        ) -> ::core::option::Option<::core::cmp::Ordering> {
+            match (self, other) {
+                (ContractExecutable::Wasm(__self_0), ContractExecutable::Wasm(__arg1_0)) => {
+                    ::core::cmp::PartialOrd::partial_cmp(__self_0, __arg1_0)
+                }
+            }
+        }
+    }
+    impl soroban_sdk::TryFromVal<soroban_sdk::Env, soroban_sdk::Val> for ContractExecutable {
+        type Error = soroban_sdk::ConversionError;
+        #[inline(always)]
+        fn try_from_val(
+            env: &soroban_sdk::Env,
+            val: &soroban_sdk::Val,
+        ) -> Result<Self, soroban_sdk::ConversionError> {
+            use soroban_sdk::{EnvBase, TryFromVal, TryIntoVal};
+            const CASES: &'static [&'static str] = &["Wasm"];
+            let vec: soroban_sdk::Vec<soroban_sdk::Val> = val.try_into_val(env)?;
+            let mut iter = vec.try_iter();
+            let discriminant: soroban_sdk::Symbol = iter
+                .next()
+                .ok_or(soroban_sdk::ConversionError)??
+                .try_into_val(env)
+                .map_err(|_| soroban_sdk::ConversionError)?;
+            Ok(
+                match u32::from(env.symbol_index_in_strs(discriminant.to_symbol_val(), CASES)?)
+                    as usize
+                {
+                    0 => {
+                        if iter.len() > 1usize {
+                            return Err(soroban_sdk::ConversionError);
+                        }
+                        Self::Wasm(
+                            iter.next()
+                                .ok_or(soroban_sdk::ConversionError)??
+                                .try_into_val(env)?,
+                        )
+                    }
+                    _ => Err(soroban_sdk::ConversionError {})?,
+                },
+            )
+        }
+    }
+    impl soroban_sdk::TryFromVal<soroban_sdk::Env, ContractExecutable> for soroban_sdk::Val {
+        type Error = soroban_sdk::ConversionError;
+        #[inline(always)]
+        fn try_from_val(
+            env: &soroban_sdk::Env,
+            val: &ContractExecutable,
+        ) -> Result<Self, soroban_sdk::ConversionError> {
+            use soroban_sdk::{TryFromVal, TryIntoVal};
+            match val {
+                ContractExecutable::Wasm(ref value0) => {
+                    let tup: (soroban_sdk::Val, soroban_sdk::Val) = (
+                        soroban_sdk::Symbol::try_from_val(env, &"Wasm")?.to_val(),
+                        value0.try_into_val(env)?,
+                    );
+                    tup.try_into_val(env).map_err(Into::into)
+                }
+            }
+        }
+    }
+    impl soroban_sdk::TryFromVal<soroban_sdk::Env, &ContractExecutable> for soroban_sdk::Val {
+        type Error = soroban_sdk::ConversionError;
+        #[inline(always)]
+        fn try_from_val(
+            env: &soroban_sdk::Env,
+            val: &&ContractExecutable,
+        ) -> Result<Self, soroban_sdk::ConversionError> {
+            <_ as soroban_sdk::TryFromVal<soroban_sdk::Env, ContractExecutable>>::try_from_val(
+                env, *val,
+            )
+        }
+    }
+    pub enum InvokerContractAuthEntry {
+        Contract(SubContractInvocation),
+        CreateContractHostFn(CreateContractHostFnContext),
+        CreateContractWithCtorHostFn(CreateContractWithConstructorHostFnContext),
+    }
+    #[automatically_derived]
+    impl ::core::fmt::Debug for InvokerContractAuthEntry {
+        #[inline]
+        fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+            match self {
+                InvokerContractAuthEntry::Contract(__self_0) => {
+                    ::core::fmt::Formatter::debug_tuple_field1_finish(f, "Contract", &__self_0)
+                }
+                InvokerContractAuthEntry::CreateContractHostFn(__self_0) => {
+                    ::core::fmt::Formatter::debug_tuple_field1_finish(
+                        f,
+                        "CreateContractHostFn",
+                        &__self_0,
+                    )
+                }
+                InvokerContractAuthEntry::CreateContractWithCtorHostFn(__self_0) => {
+                    ::core::fmt::Formatter::debug_tuple_field1_finish(
+                        f,
+                        "CreateContractWithCtorHostFn",
+                        &__self_0,
+                    )
+                }
+            }
+        }
+    }
+    #[automatically_derived]
+    impl ::core::clone::Clone for InvokerContractAuthEntry {
+        #[inline]
+        fn clone(&self) -> InvokerContractAuthEntry {
+            match self {
+                InvokerContractAuthEntry::Contract(__self_0) => {
+                    InvokerContractAuthEntry::Contract(::core::clone::Clone::clone(__self_0))
+                }
+                InvokerContractAuthEntry::CreateContractHostFn(__self_0) => {
+                    InvokerContractAuthEntry::CreateContractHostFn(::core::clone::Clone::clone(
+                        __self_0,
+                    ))
+                }
+                InvokerContractAuthEntry::CreateContractWithCtorHostFn(__self_0) => {
+                    InvokerContractAuthEntry::CreateContractWithCtorHostFn(
+                        ::core::clone::Clone::clone(__self_0),
+                    )
+                }
+            }
+        }
+    }
+    #[automatically_derived]
+    impl ::core::cmp::Eq for InvokerContractAuthEntry {
+        #[inline]
+        #[doc(hidden)]
+        #[coverage(off)]
+        fn assert_receiver_is_total_eq(&self) -> () {
+            let _: ::core::cmp::AssertParamIsEq<SubContractInvocation>;
+            let _: ::core::cmp::AssertParamIsEq<CreateContractHostFnContext>;
+            let _: ::core::cmp::AssertParamIsEq<CreateContractWithConstructorHostFnContext>;
+        }
+    }
+    #[automatically_derived]
+    impl ::core::marker::StructuralPartialEq for InvokerContractAuthEntry {}
+    #[automatically_derived]
+    impl ::core::cmp::PartialEq for InvokerContractAuthEntry {
+        #[inline]
+        fn eq(&self, other: &InvokerContractAuthEntry) -> bool {
+            let __self_discr = ::core::intrinsics::discriminant_value(self);
+            let __arg1_discr = ::core::intrinsics::discriminant_value(other);
+            __self_discr == __arg1_discr
+                && match (self, other) {
+                    (
+                        InvokerContractAuthEntry::Contract(__self_0),
+                        InvokerContractAuthEntry::Contract(__arg1_0),
+                    ) => __self_0 == __arg1_0,
+                    (
+                        InvokerContractAuthEntry::CreateContractHostFn(__self_0),
+                        InvokerContractAuthEntry::CreateContractHostFn(__arg1_0),
+                    ) => __self_0 == __arg1_0,
+                    (
+                        InvokerContractAuthEntry::CreateContractWithCtorHostFn(__self_0),
+                        InvokerContractAuthEntry::CreateContractWithCtorHostFn(__arg1_0),
+                    ) => __self_0 == __arg1_0,
+                    _ => unsafe { ::core::intrinsics::unreachable() },
+                }
+        }
+    }
+    #[automatically_derived]
+    impl ::core::cmp::Ord for InvokerContractAuthEntry {
+        #[inline]
+        fn cmp(&self, other: &InvokerContractAuthEntry) -> ::core::cmp::Ordering {
+            let __self_discr = ::core::intrinsics::discriminant_value(self);
+            let __arg1_discr = ::core::intrinsics::discriminant_value(other);
+            match ::core::cmp::Ord::cmp(&__self_discr, &__arg1_discr) {
+                ::core::cmp::Ordering::Equal => match (self, other) {
+                    (
+                        InvokerContractAuthEntry::Contract(__self_0),
+                        InvokerContractAuthEntry::Contract(__arg1_0),
+                    ) => ::core::cmp::Ord::cmp(__self_0, __arg1_0),
+                    (
+                        InvokerContractAuthEntry::CreateContractHostFn(__self_0),
+                        InvokerContractAuthEntry::CreateContractHostFn(__arg1_0),
+                    ) => ::core::cmp::Ord::cmp(__self_0, __arg1_0),
+                    (
+                        InvokerContractAuthEntry::CreateContractWithCtorHostFn(__self_0),
+                        InvokerContractAuthEntry::CreateContractWithCtorHostFn(__arg1_0),
+                    ) => ::core::cmp::Ord::cmp(__self_0, __arg1_0),
+                    _ => unsafe { ::core::intrinsics::unreachable() },
+                },
+                cmp => cmp,
+            }
+        }
+    }
+    #[automatically_derived]
+    impl ::core::cmp::PartialOrd for InvokerContractAuthEntry {
+        #[inline]
+        fn partial_cmp(
+            &self,
+            other: &InvokerContractAuthEntry,
+        ) -> ::core::option::Option<::core::cmp::Ordering> {
+            let __self_discr = ::core::intrinsics::discriminant_value(self);
+            let __arg1_discr = ::core::intrinsics::discriminant_value(other);
+            match (self, other) {
+                (
+                    InvokerContractAuthEntry::Contract(__self_0),
+                    InvokerContractAuthEntry::Contract(__arg1_0),
+                ) => ::core::cmp::PartialOrd::partial_cmp(__self_0, __arg1_0),
+                (
+                    InvokerContractAuthEntry::CreateContractHostFn(__self_0),
+                    InvokerContractAuthEntry::CreateContractHostFn(__arg1_0),
+                ) => ::core::cmp::PartialOrd::partial_cmp(__self_0, __arg1_0),
+                (
+                    InvokerContractAuthEntry::CreateContractWithCtorHostFn(__self_0),
+                    InvokerContractAuthEntry::CreateContractWithCtorHostFn(__arg1_0),
+                ) => ::core::cmp::PartialOrd::partial_cmp(__self_0, __arg1_0),
+                _ => ::core::cmp::PartialOrd::partial_cmp(&__self_discr, &__arg1_discr),
+            }
+        }
+    }
+    impl soroban_sdk::TryFromVal<soroban_sdk::Env, soroban_sdk::Val> for InvokerContractAuthEntry {
+        type Error = soroban_sdk::ConversionError;
+        #[inline(always)]
+        fn try_from_val(
+            env: &soroban_sdk::Env,
+            val: &soroban_sdk::Val,
+        ) -> Result<Self, soroban_sdk::ConversionError> {
+            use soroban_sdk::{EnvBase, TryFromVal, TryIntoVal};
+            const CASES: &'static [&'static str] = &[
+                "Contract",
+                "CreateContractHostFn",
+                "CreateContractWithCtorHostFn",
+            ];
+            let vec: soroban_sdk::Vec<soroban_sdk::Val> = val.try_into_val(env)?;
+            let mut iter = vec.try_iter();
+            let discriminant: soroban_sdk::Symbol = iter
+                .next()
+                .ok_or(soroban_sdk::ConversionError)??
+                .try_into_val(env)
+                .map_err(|_| soroban_sdk::ConversionError)?;
+            Ok(
+                match u32::from(env.symbol_index_in_strs(discriminant.to_symbol_val(), CASES)?)
+                    as usize
+                {
+                    0 => {
+                        if iter.len() > 1usize {
+                            return Err(soroban_sdk::ConversionError);
+                        }
+                        Self::Contract(
+                            iter.next()
+                                .ok_or(soroban_sdk::ConversionError)??
+                                .try_into_val(env)?,
+                        )
+                    }
+                    1 => {
+                        if iter.len() > 1usize {
+                            return Err(soroban_sdk::ConversionError);
+                        }
+                        Self::CreateContractHostFn(
+                            iter.next()
+                                .ok_or(soroban_sdk::ConversionError)??
+                                .try_into_val(env)?,
+                        )
+                    }
+                    2 => {
+                        if iter.len() > 1usize {
+                            return Err(soroban_sdk::ConversionError);
+                        }
+                        Self::CreateContractWithCtorHostFn(
+                            iter.next()
+                                .ok_or(soroban_sdk::ConversionError)??
+                                .try_into_val(env)?,
+                        )
+                    }
+                    _ => Err(soroban_sdk::ConversionError {})?,
+                },
+            )
+        }
+    }
+    impl soroban_sdk::TryFromVal<soroban_sdk::Env, InvokerContractAuthEntry> for soroban_sdk::Val {
+        type Error = soroban_sdk::ConversionError;
+        #[inline(always)]
+        fn try_from_val(
+            env: &soroban_sdk::Env,
+            val: &InvokerContractAuthEntry,
+        ) -> Result<Self, soroban_sdk::ConversionError> {
+            use soroban_sdk::{TryFromVal, TryIntoVal};
+            match val {
+                InvokerContractAuthEntry::Contract(ref value0) => {
+                    let tup: (soroban_sdk::Val, soroban_sdk::Val) = (
+                        soroban_sdk::Symbol::try_from_val(env, &"Contract")?.to_val(),
+                        value0.try_into_val(env)?,
+                    );
+                    tup.try_into_val(env).map_err(Into::into)
+                }
+                InvokerContractAuthEntry::CreateContractHostFn(ref value0) => {
+                    let tup: (soroban_sdk::Val, soroban_sdk::Val) = (
+                        soroban_sdk::Symbol::try_from_val(env, &"CreateContractHostFn")?.to_val(),
+                        value0.try_into_val(env)?,
+                    );
+                    tup.try_into_val(env).map_err(Into::into)
+                }
+                InvokerContractAuthEntry::CreateContractWithCtorHostFn(ref value0) => {
+                    let tup: (soroban_sdk::Val, soroban_sdk::Val) = (
+                        soroban_sdk::Symbol::try_from_val(env, &"CreateContractWithCtorHostFn")?
+                            .to_val(),
+                        value0.try_into_val(env)?,
+                    );
+                    tup.try_into_val(env).map_err(Into::into)
+                }
+            }
+        }
+    }
+    impl soroban_sdk::TryFromVal<soroban_sdk::Env, &InvokerContractAuthEntry> for soroban_sdk::Val {
+        type Error = soroban_sdk::ConversionError;
+        #[inline(always)]
+        fn try_from_val(
+            env: &soroban_sdk::Env,
+            val: &&InvokerContractAuthEntry,
+        ) -> Result<Self, soroban_sdk::ConversionError> {
+            <_ as soroban_sdk::TryFromVal<soroban_sdk::Env, InvokerContractAuthEntry>>::try_from_val(
+                env, *val,
+            )
+        }
+    }
+    pub enum Executable {
+        Wasm(soroban_sdk::BytesN<32>),
+        StellarAsset,
+        Account,
+    }
+    #[automatically_derived]
+    impl ::core::fmt::Debug for Executable {
+        #[inline]
+        fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+            match self {
+                Executable::Wasm(__self_0) => {
+                    ::core::fmt::Formatter::debug_tuple_field1_finish(f, "Wasm", &__self_0)
+                }
+                Executable::StellarAsset => ::core::fmt::Formatter::write_str(f, "StellarAsset"),
+                Executable::Account => ::core::fmt::Formatter::write_str(f, "Account"),
+            }
+        }
+    }
+    #[automatically_derived]
+    impl ::core::clone::Clone for Executable {
+        #[inline]
+        fn clone(&self) -> Executable {
+            match self {
+                Executable::Wasm(__self_0) => {
+                    Executable::Wasm(::core::clone::Clone::clone(__self_0))
+                }
+                Executable::StellarAsset => Executable::StellarAsset,
+                Executable::Account => Executable::Account,
+            }
+        }
+    }
+    #[automatically_derived]
+    impl ::core::cmp::Eq for Executable {
+        #[inline]
+        #[doc(hidden)]
+        #[coverage(off)]
+        fn assert_receiver_is_total_eq(&self) -> () {
+            let _: ::core::cmp::AssertParamIsEq<soroban_sdk::BytesN<32>>;
+        }
+    }
+    #[automatically_derived]
+    impl ::core::marker::StructuralPartialEq for Executable {}
+    #[automatically_derived]
+    impl ::core::cmp::PartialEq for Executable {
+        #[inline]
+        fn eq(&self, other: &Executable) -> bool {
+            let __self_discr = ::core::intrinsics::discriminant_value(self);
+            let __arg1_discr = ::core::intrinsics::discriminant_value(other);
+            __self_discr == __arg1_discr
+                && match (self, other) {
+                    (Executable::Wasm(__self_0), Executable::Wasm(__arg1_0)) => {
+                        __self_0 == __arg1_0
+                    }
+                    _ => true,
+                }
+        }
+    }
+    #[automatically_derived]
+    impl ::core::cmp::Ord for Executable {
+        #[inline]
+        fn cmp(&self, other: &Executable) -> ::core::cmp::Ordering {
+            let __self_discr = ::core::intrinsics::discriminant_value(self);
+            let __arg1_discr = ::core::intrinsics::discriminant_value(other);
+            match ::core::cmp::Ord::cmp(&__self_discr, &__arg1_discr) {
+                ::core::cmp::Ordering::Equal => match (self, other) {
+                    (Executable::Wasm(__self_0), Executable::Wasm(__arg1_0)) => {
+                        ::core::cmp::Ord::cmp(__self_0, __arg1_0)
+                    }
+                    _ => ::core::cmp::Ordering::Equal,
+                },
+                cmp => cmp,
+            }
+        }
+    }
+    #[automatically_derived]
+    impl ::core::cmp::PartialOrd for Executable {
+        #[inline]
+        fn partial_cmp(&self, other: &Executable) -> ::core::option::Option<::core::cmp::Ordering> {
+            let __self_discr = ::core::intrinsics::discriminant_value(self);
+            let __arg1_discr = ::core::intrinsics::discriminant_value(other);
+            match (self, other) {
+                (Executable::Wasm(__self_0), Executable::Wasm(__arg1_0)) => {
+                    ::core::cmp::PartialOrd::partial_cmp(__self_0, __arg1_0)
+                }
+                _ => ::core::cmp::PartialOrd::partial_cmp(&__self_discr, &__arg1_discr),
+            }
+        }
+    }
+    impl soroban_sdk::TryFromVal<soroban_sdk::Env, soroban_sdk::Val> for Executable {
+        type Error = soroban_sdk::ConversionError;
+        #[inline(always)]
+        fn try_from_val(
+            env: &soroban_sdk::Env,
+            val: &soroban_sdk::Val,
+        ) -> Result<Self, soroban_sdk::ConversionError> {
+            use soroban_sdk::{EnvBase, TryFromVal, TryIntoVal};
+            const CASES: &'static [&'static str] = &["Wasm", "StellarAsset", "Account"];
+            let vec: soroban_sdk::Vec<soroban_sdk::Val> = val.try_into_val(env)?;
+            let mut iter = vec.try_iter();
+            let discriminant: soroban_sdk::Symbol = iter
+                .next()
+                .ok_or(soroban_sdk::ConversionError)??
+                .try_into_val(env)
+                .map_err(|_| soroban_sdk::ConversionError)?;
+            Ok(
+                match u32::from(env.symbol_index_in_strs(discriminant.to_symbol_val(), CASES)?)
+                    as usize
+                {
+                    0 => {
+                        if iter.len() > 1usize {
+                            return Err(soroban_sdk::ConversionError);
+                        }
+                        Self::Wasm(
+                            iter.next()
+                                .ok_or(soroban_sdk::ConversionError)??
+                                .try_into_val(env)?,
+                        )
+                    }
+                    1 => {
+                        if iter.len() > 0 {
+                            return Err(soroban_sdk::ConversionError);
+                        }
+                        Self::StellarAsset
+                    }
+                    2 => {
+                        if iter.len() > 0 {
+                            return Err(soroban_sdk::ConversionError);
+                        }
+                        Self::Account
+                    }
+                    _ => Err(soroban_sdk::ConversionError {})?,
+                },
+            )
+        }
+    }
+    impl soroban_sdk::TryFromVal<soroban_sdk::Env, Executable> for soroban_sdk::Val {
+        type Error = soroban_sdk::ConversionError;
+        #[inline(always)]
+        fn try_from_val(
+            env: &soroban_sdk::Env,
+            val: &Executable,
+        ) -> Result<Self, soroban_sdk::ConversionError> {
+            use soroban_sdk::{TryFromVal, TryIntoVal};
+            match val {
+                Executable::Wasm(ref value0) => {
+                    let tup: (soroban_sdk::Val, soroban_sdk::Val) = (
+                        soroban_sdk::Symbol::try_from_val(env, &"Wasm")?.to_val(),
+                        value0.try_into_val(env)?,
+                    );
+                    tup.try_into_val(env).map_err(Into::into)
+                }
+                Executable::StellarAsset => {
+                    let tup: (soroban_sdk::Val,) =
+                        (soroban_sdk::Symbol::try_from_val(env, &"StellarAsset")?.to_val(),);
+                    tup.try_into_val(env).map_err(Into::into)
+                }
+                Executable::Account => {
+                    let tup: (soroban_sdk::Val,) =
+                        (soroban_sdk::Symbol::try_from_val(env, &"Account")?.to_val(),);
+                    tup.try_into_val(env).map_err(Into::into)
+                }
+            }
+        }
+    }
+    impl soroban_sdk::TryFromVal<soroban_sdk::Env, &Executable> for soroban_sdk::Val {
+        type Error = soroban_sdk::ConversionError;
+        #[inline(always)]
+        fn try_from_val(
+            env: &soroban_sdk::Env,
+            val: &&Executable,
+        ) -> Result<Self, soroban_sdk::ConversionError> {
+            <_ as soroban_sdk::TryFromVal<soroban_sdk::Env, Executable>>::try_from_val(env, *val)
         }
     }
     pub enum EnumA {

--- a/tests-expanded/test_spec_shaking_v2_tests.rs
+++ b/tests-expanded/test_spec_shaking_v2_tests.rs
@@ -9893,7 +9893,7 @@ mod export_false_used {
     }
     #[doc(hidden)]
     #[allow(non_upper_case_globals)]
-    #[deprecated = "`export` is a no-op under `experimental_spec_shaking_v2` (specs are determined by reachability) and will be removed in a future release"]
+    #[deprecated = "`export` is a no-op under spec shaking v2 (the default; specs are determined by reachability) and will be removed in a future release"]
     const __SOROBAN_EXPORT_ARG_DEPRECATED_FOR_UsedExportFalseStruct: () = ();
     const _: () = __SOROBAN_EXPORT_ARG_DEPRECATED_FOR_UsedExportFalseStruct;
     pub static __SPEC_XDR_TYPE_USEDEXPORTFALSESTRUCT: [u8; 60usize] =
@@ -10266,7 +10266,7 @@ mod export_false_used {
     }
     #[doc(hidden)]
     #[allow(non_upper_case_globals)]
-    #[deprecated = "`export` is a no-op under `experimental_spec_shaking_v2` (specs are determined by reachability) and will be removed in a future release"]
+    #[deprecated = "`export` is a no-op under spec shaking v2 (the default; specs are determined by reachability) and will be removed in a future release"]
     const __SOROBAN_EXPORT_ARG_DEPRECATED_FOR_UsedExportFalseError: () = ();
     const _: () = __SOROBAN_EXPORT_ARG_DEPRECATED_FOR_UsedExportFalseError;
     pub static __SPEC_XDR_TYPE_USEDEXPORTFALSEERROR: [u8; 56usize] =
@@ -10435,7 +10435,7 @@ mod export_false_used {
     }
     #[doc(hidden)]
     #[allow(non_upper_case_globals)]
-    #[deprecated = "`export` is a no-op under `experimental_spec_shaking_v2` (specs are determined by reachability) and will be removed in a future release"]
+    #[deprecated = "`export` is a no-op under spec shaking v2 (the default; specs are determined by reachability) and will be removed in a future release"]
     const __SOROBAN_EXPORT_ARG_DEPRECATED_FOR_UsedExportFalseEvent: () = ();
     const _: () = __SOROBAN_EXPORT_ARG_DEPRECATED_FOR_UsedExportFalseEvent;
     pub static __SPEC_XDR_EVENT_USEDEXPORTFALSEEVENT: [u8; 120usize] =
@@ -12639,7 +12639,7 @@ const _: () = {
     }
 };
 mod wasm_imported {
-    pub const WASM: &[u8] = b"\x00asm\x01\x00\x00\x00\x01*\x07`\x02~~\x01~`\x03~~~\x01~`\x01~\x01~`\x00\x01~`\x02\x7f\x7f\x01~`\x04\x7f\x7f\x7f\x7f\x01~`\x02\x7f~\x00\x02%\x06\x01b\x01j\x00\x00\x01x\x011\x00\x00\x01v\x01g\x00\x00\x01m\x019\x00\x01\x01i\x012\x00\x02\x01i\x011\x00\x02\x03\x0b\n\x03\x04\x03\x02\x00\x05\x00\x00\x06\x06\x05\x03\x01\x00\x11\x06!\x04\x7f\x01A\x80\x80\xc0\x00\x0b\x7f\x00A\x82\x80\xc0\x00\x0b\x7f\x00A\xa0\x80\xc0\x00\x0b\x7f\x00A\xa0\x80\xc0\x00\x0b\x07\x81\x01\n\x06memory\x02\x00\tfn_enum_a\x00\x06\rfn_enum_int_a\x00\x08\nfn_error_a\x00\t\nfn_event_a\x00\n\x0bfn_struct_a\x00\x0c\x11fn_struct_tuple_a\x00\r\x01_\x03\x01\n__data_end\x03\x02\x0b__heap_base\x03\x03\n\xbd\x08\n\x8b\x02\x03\x01\x7f\x01~\x03\x7f#\x80\x80\x80\x80\x00A\x10k\"\x00$\x80\x80\x80\x80\x00B\x00!\x01A~!\x02\x03~\x02@\x02@\x02@\x02@\x02@ \x02E\r\x00A\x01!\x03 \x02A\x82\x80\xc0\x80\x00j-\x00\x00\"\x04A\xdf\x00F\r\x04 \x04APjA\xff\x01qA\nI\r\x02 \x04A\xbf\x7fjA\xff\x01qA\x1aI\r\x03\x02@ \x04A\x9f\x7fjA\xff\x01qA\x1aO\r\x00 \x04AEj!\x03\x0c\x05\x0b \x00 \x04\xadB\x08\x86B\x01\x847\x03\x00A\x80\x80\xc0\x80\x00\xadB \x86B\x04\x84B\x84\x80\x80\x80 \x10\x80\x80\x80\x80\x00!\x01\x0c\x01\x0b \x00 \x01B\x08\x86B\x0e\x84\"\x017\x02\x04\x0b \x00 \x017\x03\x00 \x00A\x01\x10\x87\x80\x80\x80\x00!\x01 \x00A\x10j$\x80\x80\x80\x80\x00 \x01\x0f\x0b \x04ARj!\x03\x0c\x01\x0b \x04AKj!\x03\x0b \x01B\x06\x86 \x03\xadB\xff\x01\x83\x84!\x01 \x02A\x01j!\x02\x0c\x00\x0b\x0b\x1a\x00 \x00\xadB \x86B\x04\x84 \x01\xadB \x86B\x04\x84\x10\x82\x80\x80\x80\x00\x0b\x08\x00B\x84\x80\x80\x800\x0b*\x00\x02@ \x00B\xff\x01\x83B\x04Q\r\x00\x00\x0bB\x83\x80\x80\x80  \x00B\x84\x80\x80\x80p\x83 \x00B\x80\x80\x80\x80\x10T\x1b\x0b\xdc\x01\x01\x02\x7f#\x80\x80\x80\x80\x00A k\"\x02$\x80\x80\x80\x80\x00\x02@ \x00B\xff\x01\x83B\xcd\x00R\r\x00 \x01B\xff\x01\x83B\xc9\x00R\r\x00 \x02 \x007\x03\x08 \x02B\x8e\xcc\xc1\xfc\xac\xdd\xab\x017\x03\x00A\x00!\x03\x03@\x02@ \x03A\x10G\r\x00A\x00!\x03\x02@\x03@ \x03A\x10F\r\x01 \x02A\x10j \x03j \x02 \x03j)\x03\x007\x03\x00 \x03A\x08j!\x03\x0c\x00\x0b\x0b \x02A\x10jA\x02\x10\x87\x80\x80\x80\x00!\x00 \x02 \x017\x03\x10 \x00A\x98\x80\xc0\x80\x00A\x01 \x02A\x10jA\x01\x10\x8b\x80\x80\x80\x00\x10\x81\x80\x80\x80\x00\x1a \x02A j$\x80\x80\x80\x80\x00B\x02\x0f\x0b \x02A\x10j \x03jB\x027\x03\x00 \x03A\x08j!\x03\x0c\x00\x0b\x0b\x00\x0b.\x00\x02@ \x01 \x03F\r\x00\x00\x0b \x00\xadB \x86B\x04\x84 \x02\xadB \x86B\x04\x84 \x01\xadB \x86B\x04\x84\x10\x83\x80\x80\x80\x00\x0by\x01\x02\x7f#\x80\x80\x80\x80\x00A\x10k\"\x02$\x80\x80\x80\x80\x00\x02@ \x00B\xff\x01\x83B\x04R\r\x00A\x01A\x02A\x00 \x01\xa7A\xff\x01q\"\x03\x1b \x03A\x01F\x1b\"\x03A\x02F\r\x00 \x02 \x03\xad7\x03\x08 \x02 \x00B\x84\x80\x80\x80p\x837\x03\x00A\x88\x80\xc0\x80\x00A\x02 \x02A\x02\x10\x8b\x80\x80\x80\x00!\x00 \x02A\x10j$\x80\x80\x80\x80\x00 \x00\x0f\x0b\x00\x0b\xb2\x01\x01\x01\x7f#\x80\x80\x80\x80\x00A k\"\x02$\x80\x80\x80\x80\x00 \x02A\x10j \x00\x10\x8e\x80\x80\x80\x00\x02@ \x02(\x02\x10A\x01F\r\x00 \x02)\x03\x18!\x00 \x02A\x10j \x01\x10\x8e\x80\x80\x80\x00 \x02(\x02\x10A\x01F\r\x00 \x02)\x03\x18!\x01 \x02A\x10j \x00\x10\x8f\x80\x80\x80\x00 \x02(\x02\x10\r\x00 \x02)\x03\x18!\x00 \x02A\x10j \x01\x10\x8f\x80\x80\x80\x00 \x02(\x02\x10A\x01F\r\x00 \x02 \x02)\x03\x187\x03\x08 \x02 \x007\x03\x00 \x02A\x02\x10\x87\x80\x80\x80\x00!\x00 \x02A j$\x80\x80\x80\x80\x00 \x00\x0f\x0b\x00\x0b]\x02\x01\x7f\x01~\x02@\x02@ \x01\xa7A\xff\x01q\"\x02A\xc1\x00F\r\x00\x02@ \x02A\x07F\r\x00B\x01!\x03B\x83\x90\x80\x80\x80\x01!\x01\x0c\x02\x0b \x01B\x08\x87!\x01B\x00!\x03\x0c\x01\x0bB\x00!\x03 \x01\x10\x84\x80\x80\x80\x00!\x01\x0b \x00 \x037\x03\x00 \x00 \x017\x03\x08\x0bF\x00\x02@\x02@ \x01B\x80\x80\x80\x80\x80\x80\x80\xc0\x00|B\xff\xff\xff\xff\xff\xff\xff\xff\x00V\r\x00 \x01B\x08\x86B\x07\x84!\x01\x0c\x01\x0b \x01\x10\x85\x80\x80\x80\x00!\x01\x0b \x00B\x007\x03\x00 \x00 \x017\x03\x08\x0b\x0b)\x01\x00A\x80\x80\xc0\x00\x0b V2f1f2\x00\x00\x02\x00\x10\x00\x02\x00\x00\x00\x04\x00\x10\x00\x02\x00\x00\x00\x04\x00\x10\x00\x02\x00\x00\x00\x00\xbf\x0e\x0econtractspecv0\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\tfn_enum_a\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x07\xd0\x00\x00\x00\x05EnumA\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\nfn_error_a\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x05input\x00\x00\x00\x00\x00\x00\x04\x00\x00\x00\x01\x00\x00\x03\xe9\x00\x00\x00\x04\x00\x00\x07\xd0\x00\x00\x00\x06ErrorA\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\nfn_event_a\x00\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x02f1\x00\x00\x00\x00\x00\x13\x00\x00\x00\x00\x00\x00\x00\x02f2\x00\x00\x00\x00\x00\x10\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x0bfn_struct_a\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x02f1\x00\x00\x00\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00\x02f2\x00\x00\x00\x00\x00\x01\x00\x00\x00\x01\x00\x00\x07\xd0\x00\x00\x00\x07StructA\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\rfn_enum_int_a\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x07\xd0\x00\x00\x00\x08EnumIntA\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x11fn_struct_tuple_a\x00\x00\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x02f1\x00\x00\x00\x00\x00\x07\x00\x00\x00\x00\x00\x00\x00\x02f2\x00\x00\x00\x00\x00\x07\x00\x00\x00\x01\x00\x00\x07\xd0\x00\x00\x00\x0cStructTupleA\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x05EnumA\x00\x00\x00\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02V1\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02V2\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02V3\x00\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x05EnumB\x00\x00\x00\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02V1\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x02V2\x00\x00\x00\x00\x00\x01\x00\x00\x00\x07\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x02V3\x00\x00\x00\x00\x00\x02\x00\x00\x00\x07\x00\x00\x00\x07\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x05EnumC\x00\x00\x00\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02V1\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x02V2\x00\x00\x00\x00\x00\x01\x00\x00\x07\xd0\x00\x00\x00\x07StructA\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x02V3\x00\x00\x00\x00\x00\x01\x00\x00\x07\xd0\x00\x00\x00\x0cStructTupleA\x00\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x06ErrorA\x00\x00\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x02E1\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x02E2\x00\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x02E3\x00\x00\x00\x00\x00\x03\x00\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x06ErrorB\x00\x00\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x02E1\x00\x00\x00\x00\x00\n\x00\x00\x00\x00\x00\x00\x00\x02E2\x00\x00\x00\x00\x00\x0b\x00\x00\x00\x00\x00\x00\x00\x02E3\x00\x00\x00\x00\x00\x0c\x00\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x06ErrorC\x00\x00\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x02E1\x00\x00\x00\x00\x00d\x00\x00\x00\x00\x00\x00\x00\x02E2\x00\x00\x00\x00\x00e\x00\x00\x00\x00\x00\x00\x00\x02E3\x00\x00\x00\x00\x00f\x00\x00\x00\x05\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x06EventA\x00\x00\x00\x00\x00\x01\x00\x00\x00\x07event_a\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x02f1\x00\x00\x00\x00\x00\x13\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x02f2\x00\x00\x00\x00\x00\x10\x00\x00\x00\x00\x00\x00\x00\x02\x00\x00\x00\x05\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x06EventB\x00\x00\x00\x00\x00\x01\x00\x00\x00\x07event_b\x00\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x02f1\x00\x00\x00\x00\x00\x13\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x02f2\x00\x00\x00\x00\x00\x13\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x02f3\x00\x00\x00\x00\x00\x0b\x00\x00\x00\x00\x00\x00\x00\x02\x00\x00\x00\x05\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x06EventC\x00\x00\x00\x00\x00\x01\x00\x00\x00\x07event_c\x00\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x02f1\x00\x00\x00\x00\x00\x11\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x02f2\x00\x00\x00\x00\x00\x07\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02f3\x00\x00\x00\x00\x00\x07\x00\x00\x00\x00\x00\x00\x00\x02\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x07StructA\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x02f1\x00\x00\x00\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00\x02f2\x00\x00\x00\x00\x00\x01\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x07StructB\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x02f1\x00\x00\x00\x00\x00\x07\x00\x00\x00\x00\x00\x00\x00\x02f2\x00\x00\x00\x00\x00\x10\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x07StructC\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x02f1\x00\x00\x00\x00\x03\xea\x00\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00\x02f2\x00\x00\x00\x00\x00\x13\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x08EnumIntA\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x02V1\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x02V2\x00\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x02V3\x00\x00\x00\x00\x00\x03\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x08EnumIntB\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x02V1\x00\x00\x00\x00\x00\n\x00\x00\x00\x00\x00\x00\x00\x02V2\x00\x00\x00\x00\x00\x14\x00\x00\x00\x00\x00\x00\x00\x02V3\x00\x00\x00\x00\x00\x1e\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x08EnumIntC\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x02V1\x00\x00\x00\x00\x00d\x00\x00\x00\x00\x00\x00\x00\x02V2\x00\x00\x00\x00\x00\xc8\x00\x00\x00\x00\x00\x00\x00\x02V3\x00\x00\x00\x00\x01,\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x0cStructTupleA\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x010\x00\x00\x00\x00\x00\x00\x07\x00\x00\x00\x00\x00\x00\x00\x011\x00\x00\x00\x00\x00\x00\x07\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x0cStructTupleB\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x010\x00\x00\x00\x00\x00\x00\n\x00\x00\x00\x00\x00\x00\x00\x011\x00\x00\x00\x00\x00\x00\n\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x0cStructTupleC\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x010\x00\x00\x00\x00\x00\x00\x13\x00\x00\x00\x00\x00\x00\x00\x011\x00\x00\x00\x00\x00\x00\x0b\x00\x1e\x11contractenvmetav0\x00\x00\x00\x00\x00\x00\x00\x1a\x00\x00\x00\x00\x00+\x0econtractmetav0\x00\x00\x00\x00\x00\x00\x00\x05rsver\x00\x00\x00\x00\x00\x00\x061.91.0\x00\x00";
+    pub const WASM: &[u8] = b"\x00asm\x01\x00\x00\x00\x01*\x07`\x02~~\x01~`\x03~~~\x01~`\x01~\x01~`\x00\x01~`\x02\x7f\x7f\x01~`\x04\x7f\x7f\x7f\x7f\x01~`\x02\x7f~\x00\x02%\x06\x01b\x01j\x00\x00\x01x\x011\x00\x00\x01v\x01g\x00\x00\x01m\x019\x00\x01\x01i\x012\x00\x02\x01i\x011\x00\x02\x03\x0b\n\x03\x04\x03\x02\x00\x05\x00\x00\x06\x06\x05\x03\x01\x00\x11\x06!\x04\x7f\x01A\x80\x80\xc0\x00\x0b\x7f\x00A\x82\x80\xc0\x00\x0b\x7f\x00A\xf4\x80\xc0\x00\x0b\x7f\x00A\x80\x81\xc0\x00\x0b\x07\x81\x01\n\x06memory\x02\x00\tfn_enum_a\x00\x06\rfn_enum_int_a\x00\x08\nfn_error_a\x00\t\nfn_event_a\x00\n\x0bfn_struct_a\x00\x0c\x11fn_struct_tuple_a\x00\r\x01_\x03\x01\n__data_end\x03\x02\x0b__heap_base\x03\x03\n\xfa\x08\n\x95\x02\x03\x01\x7f\x01~\x03\x7f#\x80\x80\x80\x80\x00A\x10k\"\x00$\x80\x80\x80\x80\x00A\x00-\x00\x82\x80\xc0\x80\x00\x1aB\x00!\x01A~!\x02\x03~\x02@\x02@\x02@\x02@\x02@ \x02E\r\x00A\x01!\x03 \x02A\x82\x80\xc0\x80\x00j-\x00\x00\"\x04A\xdf\x00F\r\x04 \x04APjA\xff\x01qA\nI\r\x02 \x04A\xbf\x7fjA\xff\x01qA\x1aI\r\x03\x02@ \x04A\x9f\x7fjA\xff\x01qA\x1aO\r\x00 \x04AEj!\x03\x0c\x05\x0b \x00 \x04\xadB\x08\x86B\x01\x847\x03\x00A\x80\x80\xc0\x80\x00\xadB \x86B\x04\x84B\x84\x80\x80\x80 \x10\x80\x80\x80\x80\x00!\x01\x0c\x01\x0b \x00 \x01B\x08\x86B\x0e\x84\"\x017\x02\x04\x0b \x00 \x017\x03\x00 \x00A\x01\x10\x87\x80\x80\x80\x00!\x01 \x00A\x10j$\x80\x80\x80\x80\x00 \x01\x0f\x0b \x04ARj!\x03\x0c\x01\x0b \x04AKj!\x03\x0b \x01B\x06\x86 \x03\xadB\xff\x01\x83\x84!\x01 \x02A\x01j!\x02\x0c\x00\x0b\x0b\x1a\x00 \x00\xadB \x86B\x04\x84 \x01\xadB \x86B\x04\x84\x10\x82\x80\x80\x80\x00\x0b\x12\x00A\x00-\x00\xba\x80\xc0\x80\x00\x1aB\x84\x80\x80\x800\x0b4\x00\x02@ \x00B\xff\x01\x83B\x04Q\r\x00\x00\x0bA\x00-\x00\x90\x80\xc0\x80\x00\x1aB\x83\x80\x80\x80  \x00B\x84\x80\x80\x80p\x83 \x00B\x80\x80\x80\x80\x10T\x1b\x0b\xe6\x01\x01\x02\x7f#\x80\x80\x80\x80\x00A k\"\x02$\x80\x80\x80\x80\x00\x02@ \x00B\xff\x01\x83B\xcd\x00R\r\x00 \x01B\xff\x01\x83B\xc9\x00R\r\x00A\x00!\x03A\x00-\x00\x9e\x80\xc0\x80\x00\x1a \x02 \x007\x03\x08 \x02B\x8e\xcc\xc1\xfc\xac\xdd\xab\x017\x03\x00\x03@\x02@ \x03A\x10G\r\x00A\x00!\x03\x02@\x03@ \x03A\x10F\r\x01 \x02A\x10j \x03j \x02 \x03j)\x03\x007\x03\x00 \x03A\x08j!\x03\x0c\x00\x0b\x0b \x02A\x10jA\x02\x10\x87\x80\x80\x80\x00!\x00 \x02 \x017\x03\x10 \x00A\xec\x80\xc0\x80\x00A\x01 \x02A\x10jA\x01\x10\x8b\x80\x80\x80\x00\x10\x81\x80\x80\x80\x00\x1a \x02A j$\x80\x80\x80\x80\x00B\x02\x0f\x0b \x02A\x10j \x03jB\x027\x03\x00 \x03A\x08j!\x03\x0c\x00\x0b\x0b\x00\x0b.\x00\x02@ \x01 \x03F\r\x00\x00\x0b \x00\xadB \x86B\x04\x84 \x02\xadB \x86B\x04\x84 \x01\xadB \x86B\x04\x84\x10\x83\x80\x80\x80\x00\x0b\x83\x01\x01\x02\x7f#\x80\x80\x80\x80\x00A\x10k\"\x02$\x80\x80\x80\x80\x00\x02@ \x00B\xff\x01\x83B\x04R\r\x00A\x01A\x02A\x00 \x01\xa7A\xff\x01q\"\x03\x1b \x03A\x01F\x1b\"\x03A\x02F\r\x00A\x00-\x00\xac\x80\xc0\x80\x00\x1a \x02 \x03\xad7\x03\x08 \x02 \x00B\x84\x80\x80\x80p\x837\x03\x00A\xdc\x80\xc0\x80\x00A\x02 \x02A\x02\x10\x8b\x80\x80\x80\x00!\x00 \x02A\x10j$\x80\x80\x80\x80\x00 \x00\x0f\x0b\x00\x0b\xbc\x01\x01\x01\x7f#\x80\x80\x80\x80\x00A k\"\x02$\x80\x80\x80\x80\x00 \x02A\x10j \x00\x10\x8e\x80\x80\x80\x00\x02@ \x02(\x02\x10A\x01F\r\x00 \x02)\x03\x18!\x00 \x02A\x10j \x01\x10\x8e\x80\x80\x80\x00 \x02(\x02\x10A\x01F\r\x00 \x02)\x03\x18!\x01A\x00-\x00\xc8\x80\xc0\x80\x00\x1a \x02A\x10j \x00\x10\x8f\x80\x80\x80\x00 \x02(\x02\x10\r\x00 \x02)\x03\x18!\x00 \x02A\x10j \x01\x10\x8f\x80\x80\x80\x00 \x02(\x02\x10A\x01F\r\x00 \x02 \x02)\x03\x187\x03\x08 \x02 \x007\x03\x00 \x02A\x02\x10\x87\x80\x80\x80\x00!\x00 \x02A j$\x80\x80\x80\x80\x00 \x00\x0f\x0b\x00\x0b]\x02\x01\x7f\x01~\x02@\x02@ \x01\xa7A\xff\x01q\"\x02A\xc1\x00F\r\x00\x02@ \x02A\x07F\r\x00B\x01!\x03B\x83\x90\x80\x80\x80\x01!\x01\x0c\x02\x0b \x01B\x08\x87!\x01B\x00!\x03\x0c\x01\x0bB\x00!\x03 \x01\x10\x84\x80\x80\x80\x00!\x01\x0b \x00 \x037\x03\x00 \x00 \x017\x03\x08\x0bF\x00\x02@\x02@ \x01B\x80\x80\x80\x80\x80\x80\x80\xc0\x00|B\xff\xff\xff\xff\xff\xff\xff\xff\x00V\r\x00 \x01B\x08\x86B\x07\x84!\x01\x0c\x01\x0b \x01\x10\x85\x80\x80\x80\x00!\x01\x0b \x00B\x007\x03\x00 \x00 \x017\x03\x08\x0b\x0b}\x01\x00A\x80\x80\xc0\x00\x0btV2SpEcV1\xa2=N\xc1p\x95\x90\xb2SpEcV1\xe9R\xa7\xe8b\x99\xa2\xc3SpEcV1K\xe6\x8ej\x19\x9en\xbdSpEcV1\xb6\x1c\xfd\xdfhY-dSpEcV1V]\x80\\~\x1a\x08/SpEcV1\xcf)\x97]S\xb2\xfd)f1f2\x00\x00V\x00\x10\x00\x02\x00\x00\x00X\x00\x10\x00\x02\x00\x00\x00X\x00\x10\x00\x02\x00\x00\x00\x00\xd3#\x0econtractspecv0\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\tfn_enum_a\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x07\xd0\x00\x00\x00\x05EnumA\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\nfn_error_a\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x05input\x00\x00\x00\x00\x00\x00\x04\x00\x00\x00\x01\x00\x00\x03\xe9\x00\x00\x00\x04\x00\x00\x07\xd0\x00\x00\x00\x06ErrorA\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\nfn_event_a\x00\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x02f1\x00\x00\x00\x00\x00\x13\x00\x00\x00\x00\x00\x00\x00\x02f2\x00\x00\x00\x00\x00\x10\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x0bfn_struct_a\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x02f1\x00\x00\x00\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00\x02f2\x00\x00\x00\x00\x00\x01\x00\x00\x00\x01\x00\x00\x07\xd0\x00\x00\x00\x07StructA\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\rfn_enum_int_a\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x07\xd0\x00\x00\x00\x08EnumIntA\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x11fn_struct_tuple_a\x00\x00\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x02f1\x00\x00\x00\x00\x00\x07\x00\x00\x00\x00\x00\x00\x00\x02f2\x00\x00\x00\x00\x00\x07\x00\x00\x00\x01\x00\x00\x07\xd0\x00\x00\x00\x0cStructTupleA\x00\x00\x00\x02\x00\x00\x00\xe3Context of a single authorized call performed by an address.\n\nCustom account contracts that implement `__check_auth` special function\nreceive a list of `Context` values corresponding to all the calls that\nneed to be authorized.\x00\x00\x00\x00\x00\x00\x00\x00\x07Context\x00\x00\x00\x00\x03\x00\x00\x00\x01\x00\x00\x00\x14Contract invocation.\x00\x00\x00\x08Contract\x00\x00\x00\x01\x00\x00\x07\xd0\x00\x00\x00\x0fContractContext\x00\x00\x00\x00\x01\x00\x00\x00=Contract that has a constructor with no arguments is created.\x00\x00\x00\x00\x00\x00\x14CreateContractHostFn\x00\x00\x00\x01\x00\x00\x07\xd0\x00\x00\x00\x1bCreateContractHostFnContext\x00\x00\x00\x00\x01\x00\x00\x00DContract that has a constructor with 1 or more arguments is created.\x00\x00\x00\x1cCreateContractWithCtorHostFn\x00\x00\x00\x01\x00\x00\x07\xd0\x00\x00\x00*CreateContractWithConstructorHostFnContext\x00\x00\x00\x00\x00\x01\x00\x00\x00\xbdAuthorization context of a single contract call.\n\nThis struct corresponds to a `require_auth_for_args` call for an address\nfrom `contract` function with `fn_name` name and `args` arguments.\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x0fContractContext\x00\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x04args\x00\x00\x03\xea\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x08contract\x00\x00\x00\x13\x00\x00\x00\x00\x00\x00\x00\x07fn_name\x00\x00\x00\x00\x11\x00\x00\x00\x02\x00\x00\x00_Contract executable used for creating a new contract and used in\n`CreateContractHostFnContext`.\x00\x00\x00\x00\x00\x00\x00\x00\x12ContractExecutable\x00\x00\x00\x00\x00\x01\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x04Wasm\x00\x00\x00\x01\x00\x00\x03\xee\x00\x00\x00 \x00\x00\x00\x01\x00\x00\x008Value of contract node in InvokerContractAuthEntry tree.\x00\x00\x00\x00\x00\x00\x00\x15SubContractInvocation\x00\x00\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x07context\x00\x00\x00\x07\xd0\x00\x00\x00\x0fContractContext\x00\x00\x00\x00\x00\x00\x00\x00\x0fsub_invocations\x00\x00\x00\x03\xea\x00\x00\x07\xd0\x00\x00\x00\x18InvokerContractAuthEntry\x00\x00\x00\x02\x00\x00\x01/A node in the tree of authorizations performed on behalf of the current\ncontract as invoker of the contracts deeper in the call stack.\n\nThis is used as an argument of `authorize_as_current_contract` host function.\n\nThis tree corresponds `require_auth[_for_args]` calls on behalf of the\ncurrent contract.\x00\x00\x00\x00\x00\x00\x00\x00\x18InvokerContractAuthEntry\x00\x00\x00\x03\x00\x00\x00\x01\x00\x00\x00\x12Invoke a contract.\x00\x00\x00\x00\x00\x08Contract\x00\x00\x00\x01\x00\x00\x07\xd0\x00\x00\x00\x15SubContractInvocation\x00\x00\x00\x00\x00\x00\x01\x00\x00\x005Create a contract passing 0 arguments to constructor.\x00\x00\x00\x00\x00\x00\x14CreateContractHostFn\x00\x00\x00\x01\x00\x00\x07\xd0\x00\x00\x00\x1bCreateContractHostFnContext\x00\x00\x00\x00\x01\x00\x00\x00=Create a contract passing 0 or more arguments to constructor.\x00\x00\x00\x00\x00\x00\x1cCreateContractWithCtorHostFn\x00\x00\x00\x01\x00\x00\x07\xd0\x00\x00\x00*CreateContractWithConstructorHostFnContext\x00\x00\x00\x00\x00\x01\x00\x00\x00vAuthorization context for `create_contract` host function that creates a\nnew contract on behalf of authorizer address.\x00\x00\x00\x00\x00\x00\x00\x00\x00\x1bCreateContractHostFnContext\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\nexecutable\x00\x00\x00\x00\x07\xd0\x00\x00\x00\x12ContractExecutable\x00\x00\x00\x00\x00\x00\x00\x00\x00\x04salt\x00\x00\x03\xee\x00\x00\x00 \x00\x00\x00\x01\x00\x00\x00\xd6Authorization context for `create_contract` host function that creates a\nnew contract on behalf of authorizer address.\nThis is the same as `CreateContractHostFnContext`, but also has\ncontract constructor arguments.\x00\x00\x00\x00\x00\x00\x00\x00\x00*CreateContractWithConstructorHostFnContext\x00\x00\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x10constructor_args\x00\x00\x03\xea\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\nexecutable\x00\x00\x00\x00\x07\xd0\x00\x00\x00\x12ContractExecutable\x00\x00\x00\x00\x00\x00\x00\x00\x00\x04salt\x00\x00\x03\xee\x00\x00\x00 \x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\nExecutable\x00\x00\x00\x00\x00\x03\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x04Wasm\x00\x00\x00\x01\x00\x00\x03\xee\x00\x00\x00 \x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x0cStellarAsset\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x07Account\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x05EnumA\x00\x00\x00\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02V1\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02V2\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02V3\x00\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x05EnumB\x00\x00\x00\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02V1\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x02V2\x00\x00\x00\x00\x00\x01\x00\x00\x00\x07\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x02V3\x00\x00\x00\x00\x00\x02\x00\x00\x00\x07\x00\x00\x00\x07\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x05EnumC\x00\x00\x00\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02V1\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x02V2\x00\x00\x00\x00\x00\x01\x00\x00\x07\xd0\x00\x00\x00\x07StructA\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x02V3\x00\x00\x00\x00\x00\x01\x00\x00\x07\xd0\x00\x00\x00\x0cStructTupleA\x00\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x06ErrorA\x00\x00\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x02E1\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x02E2\x00\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x02E3\x00\x00\x00\x00\x00\x03\x00\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x06ErrorB\x00\x00\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x02E1\x00\x00\x00\x00\x00\n\x00\x00\x00\x00\x00\x00\x00\x02E2\x00\x00\x00\x00\x00\x0b\x00\x00\x00\x00\x00\x00\x00\x02E3\x00\x00\x00\x00\x00\x0c\x00\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x06ErrorC\x00\x00\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x02E1\x00\x00\x00\x00\x00d\x00\x00\x00\x00\x00\x00\x00\x02E2\x00\x00\x00\x00\x00e\x00\x00\x00\x00\x00\x00\x00\x02E3\x00\x00\x00\x00\x00f\x00\x00\x00\x05\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x06EventA\x00\x00\x00\x00\x00\x01\x00\x00\x00\x07event_a\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x02f1\x00\x00\x00\x00\x00\x13\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x02f2\x00\x00\x00\x00\x00\x10\x00\x00\x00\x00\x00\x00\x00\x02\x00\x00\x00\x05\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x06EventB\x00\x00\x00\x00\x00\x01\x00\x00\x00\x07event_b\x00\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x02f1\x00\x00\x00\x00\x00\x13\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x02f2\x00\x00\x00\x00\x00\x13\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x02f3\x00\x00\x00\x00\x00\x0b\x00\x00\x00\x00\x00\x00\x00\x02\x00\x00\x00\x05\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x06EventC\x00\x00\x00\x00\x00\x01\x00\x00\x00\x07event_c\x00\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x02f1\x00\x00\x00\x00\x00\x11\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x02f2\x00\x00\x00\x00\x00\x07\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02f3\x00\x00\x00\x00\x00\x07\x00\x00\x00\x00\x00\x00\x00\x02\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x07StructA\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x02f1\x00\x00\x00\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00\x02f2\x00\x00\x00\x00\x00\x01\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x07StructB\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x02f1\x00\x00\x00\x00\x00\x07\x00\x00\x00\x00\x00\x00\x00\x02f2\x00\x00\x00\x00\x00\x10\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x07StructC\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x02f1\x00\x00\x00\x00\x03\xea\x00\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00\x02f2\x00\x00\x00\x00\x00\x13\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x08EnumIntA\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x02V1\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x02V2\x00\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x02V3\x00\x00\x00\x00\x00\x03\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x08EnumIntB\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x02V1\x00\x00\x00\x00\x00\n\x00\x00\x00\x00\x00\x00\x00\x02V2\x00\x00\x00\x00\x00\x14\x00\x00\x00\x00\x00\x00\x00\x02V3\x00\x00\x00\x00\x00\x1e\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x08EnumIntC\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x02V1\x00\x00\x00\x00\x00d\x00\x00\x00\x00\x00\x00\x00\x02V2\x00\x00\x00\x00\x00\xc8\x00\x00\x00\x00\x00\x00\x00\x02V3\x00\x00\x00\x00\x01,\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x0cStructTupleA\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x010\x00\x00\x00\x00\x00\x00\x07\x00\x00\x00\x00\x00\x00\x00\x011\x00\x00\x00\x00\x00\x00\x07\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x0cStructTupleB\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x010\x00\x00\x00\x00\x00\x00\n\x00\x00\x00\x00\x00\x00\x00\x011\x00\x00\x00\x00\x00\x00\n\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x0cStructTupleC\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x010\x00\x00\x00\x00\x00\x00\x13\x00\x00\x00\x00\x00\x00\x00\x011\x00\x00\x00\x00\x00\x00\x0b\x00\x1e\x11contractenvmetav0\x00\x00\x00\x00\x00\x00\x00\x1a\x00\x00\x00\x00\x00O\x0econtractmetav0\x00\x00\x00\x00\x00\x00\x00\x05rsver\x00\x00\x00\x00\x00\x00\x061.91.0\x00\x00\x00\x00\x00\x00\x00\x00\x00\x12rssdk_spec_shaking\x00\x00\x00\x00\x00\x012\x00\x00\x00";
     pub trait Contract {
         fn fn_enum_a(env: soroban_sdk::Env) -> EnumA;
         fn fn_error_a(env: soroban_sdk::Env, input: u32) -> Result<u32, ErrorA>;
@@ -13257,6 +13257,2107 @@ mod wasm_imported {
             (f1, f2)
         }
     }
+    pub struct ContractContext {
+        pub args: soroban_sdk::Vec<soroban_sdk::Val>,
+        pub contract: soroban_sdk::Address,
+        pub fn_name: soroban_sdk::Symbol,
+    }
+    #[automatically_derived]
+    impl ::core::fmt::Debug for ContractContext {
+        #[inline]
+        fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+            ::core::fmt::Formatter::debug_struct_field3_finish(
+                f,
+                "ContractContext",
+                "args",
+                &self.args,
+                "contract",
+                &self.contract,
+                "fn_name",
+                &&self.fn_name,
+            )
+        }
+    }
+    #[automatically_derived]
+    impl ::core::clone::Clone for ContractContext {
+        #[inline]
+        fn clone(&self) -> ContractContext {
+            ContractContext {
+                args: ::core::clone::Clone::clone(&self.args),
+                contract: ::core::clone::Clone::clone(&self.contract),
+                fn_name: ::core::clone::Clone::clone(&self.fn_name),
+            }
+        }
+    }
+    #[automatically_derived]
+    impl ::core::cmp::Eq for ContractContext {
+        #[inline]
+        #[doc(hidden)]
+        #[coverage(off)]
+        fn assert_receiver_is_total_eq(&self) -> () {
+            let _: ::core::cmp::AssertParamIsEq<soroban_sdk::Vec<soroban_sdk::Val>>;
+            let _: ::core::cmp::AssertParamIsEq<soroban_sdk::Address>;
+            let _: ::core::cmp::AssertParamIsEq<soroban_sdk::Symbol>;
+        }
+    }
+    #[automatically_derived]
+    impl ::core::marker::StructuralPartialEq for ContractContext {}
+    #[automatically_derived]
+    impl ::core::cmp::PartialEq for ContractContext {
+        #[inline]
+        fn eq(&self, other: &ContractContext) -> bool {
+            self.args == other.args
+                && self.contract == other.contract
+                && self.fn_name == other.fn_name
+        }
+    }
+    #[automatically_derived]
+    impl ::core::cmp::Ord for ContractContext {
+        #[inline]
+        fn cmp(&self, other: &ContractContext) -> ::core::cmp::Ordering {
+            match ::core::cmp::Ord::cmp(&self.args, &other.args) {
+                ::core::cmp::Ordering::Equal => {
+                    match ::core::cmp::Ord::cmp(&self.contract, &other.contract) {
+                        ::core::cmp::Ordering::Equal => {
+                            ::core::cmp::Ord::cmp(&self.fn_name, &other.fn_name)
+                        }
+                        cmp => cmp,
+                    }
+                }
+                cmp => cmp,
+            }
+        }
+    }
+    #[automatically_derived]
+    impl ::core::cmp::PartialOrd for ContractContext {
+        #[inline]
+        fn partial_cmp(
+            &self,
+            other: &ContractContext,
+        ) -> ::core::option::Option<::core::cmp::Ordering> {
+            match ::core::cmp::PartialOrd::partial_cmp(&self.args, &other.args) {
+                ::core::option::Option::Some(::core::cmp::Ordering::Equal) => {
+                    match ::core::cmp::PartialOrd::partial_cmp(&self.contract, &other.contract) {
+                        ::core::option::Option::Some(::core::cmp::Ordering::Equal) => {
+                            ::core::cmp::PartialOrd::partial_cmp(&self.fn_name, &other.fn_name)
+                        }
+                        cmp => cmp,
+                    }
+                }
+                cmp => cmp,
+            }
+        }
+    }
+    pub static __SPEC_XDR_TYPE_CONTRACTCONTEXT: [u8; 96usize] = ContractContext::spec_xdr();
+    impl ContractContext {
+        pub const fn spec_xdr() -> [u8; 96usize] {
+            *b"\0\0\0\x01\0\0\0\0\0\0\0\0\0\0\0\x0fContractContext\0\0\0\0\x03\0\0\0\0\0\0\0\x04args\0\0\x03\xea\0\0\0\0\0\0\0\0\0\0\0\x08contract\0\0\0\x13\0\0\0\0\0\0\0\x07fn_name\0\0\0\0\x11"
+        }
+    }
+    impl soroban_sdk::SpecShakingMarker for ContractContext {
+        #[doc(hidden)]
+        #[inline(always)]
+        fn spec_shaking_marker() {
+            <soroban_sdk::Vec<
+                soroban_sdk::Val,
+            > as soroban_sdk::SpecShakingMarker>::spec_shaking_marker();
+            <soroban_sdk::Address as soroban_sdk::SpecShakingMarker>::spec_shaking_marker();
+            <soroban_sdk::Symbol as soroban_sdk::SpecShakingMarker>::spec_shaking_marker();
+        }
+    }
+    impl soroban_sdk::TryFromVal<soroban_sdk::Env, soroban_sdk::Val> for ContractContext {
+        type Error = soroban_sdk::ConversionError;
+        fn try_from_val(
+            env: &soroban_sdk::Env,
+            val: &soroban_sdk::Val,
+        ) -> Result<Self, soroban_sdk::ConversionError> {
+            use soroban_sdk::{ConversionError, EnvBase, MapObject, TryIntoVal, Val};
+            const KEYS: [&'static str; 3usize] = ["args", "contract", "fn_name"];
+            let mut vals: [Val; 3usize] = [Val::VOID.to_val(); 3usize];
+            let map: MapObject = val.try_into().map_err(|_| ConversionError)?;
+            env.map_unpack_to_slice(map, &KEYS, &mut vals)
+                .map_err(|_| ConversionError)?;
+            Ok(Self {
+                args: vals[0]
+                    .try_into_val(env)
+                    .map_err(|_| soroban_sdk::ConversionError)?,
+                contract: vals[1]
+                    .try_into_val(env)
+                    .map_err(|_| soroban_sdk::ConversionError)?,
+                fn_name: vals[2]
+                    .try_into_val(env)
+                    .map_err(|_| soroban_sdk::ConversionError)?,
+            })
+        }
+    }
+    impl soroban_sdk::TryFromVal<soroban_sdk::Env, ContractContext> for soroban_sdk::Val {
+        type Error = soroban_sdk::ConversionError;
+        fn try_from_val(
+            env: &soroban_sdk::Env,
+            val: &ContractContext,
+        ) -> Result<Self, soroban_sdk::ConversionError> {
+            use soroban_sdk::{ConversionError, EnvBase, TryIntoVal, Val};
+            const KEYS: [&'static str; 3usize] = ["args", "contract", "fn_name"];
+            let vals: [Val; 3usize] = [
+                (&val.args).try_into_val(env).map_err(|_| ConversionError)?,
+                (&val.contract)
+                    .try_into_val(env)
+                    .map_err(|_| ConversionError)?,
+                (&val.fn_name)
+                    .try_into_val(env)
+                    .map_err(|_| ConversionError)?,
+            ];
+            Ok(env
+                .map_new_from_slices(&KEYS, &vals)
+                .map_err(|_| ConversionError)?
+                .into())
+        }
+    }
+    impl soroban_sdk::TryFromVal<soroban_sdk::Env, &ContractContext> for soroban_sdk::Val {
+        type Error = soroban_sdk::ConversionError;
+        #[inline(always)]
+        fn try_from_val(
+            env: &soroban_sdk::Env,
+            val: &&ContractContext,
+        ) -> Result<Self, soroban_sdk::ConversionError> {
+            <_ as soroban_sdk::TryFromVal<soroban_sdk::Env, ContractContext>>::try_from_val(
+                env, *val,
+            )
+        }
+    }
+    impl soroban_sdk::TryFromVal<soroban_sdk::Env, soroban_sdk::xdr::ScMap> for ContractContext {
+        type Error = soroban_sdk::xdr::Error;
+        #[inline(always)]
+        fn try_from_val(
+            env: &soroban_sdk::Env,
+            val: &soroban_sdk::xdr::ScMap,
+        ) -> Result<Self, soroban_sdk::xdr::Error> {
+            use soroban_sdk::xdr::Validate;
+            use soroban_sdk::TryIntoVal;
+            let map = val;
+            if map.len() != 3usize {
+                return Err(soroban_sdk::xdr::Error::Invalid);
+            }
+            map.validate()?;
+            Ok(Self {
+                args: {
+                    let key: soroban_sdk::xdr::ScVal = soroban_sdk::xdr::ScSymbol(
+                        "args"
+                            .try_into()
+                            .map_err(|_| soroban_sdk::xdr::Error::Invalid)?,
+                    )
+                    .into();
+                    let idx = map
+                        .binary_search_by_key(&key, |entry| entry.key.clone())
+                        .map_err(|_| soroban_sdk::xdr::Error::Invalid)?;
+                    let rv: soroban_sdk::Val = (&map[idx].val.clone())
+                        .try_into_val(env)
+                        .map_err(|_| soroban_sdk::xdr::Error::Invalid)?;
+                    rv.try_into_val(env)
+                        .map_err(|_| soroban_sdk::xdr::Error::Invalid)?
+                },
+                contract: {
+                    let key: soroban_sdk::xdr::ScVal = soroban_sdk::xdr::ScSymbol(
+                        "contract"
+                            .try_into()
+                            .map_err(|_| soroban_sdk::xdr::Error::Invalid)?,
+                    )
+                    .into();
+                    let idx = map
+                        .binary_search_by_key(&key, |entry| entry.key.clone())
+                        .map_err(|_| soroban_sdk::xdr::Error::Invalid)?;
+                    let rv: soroban_sdk::Val = (&map[idx].val.clone())
+                        .try_into_val(env)
+                        .map_err(|_| soroban_sdk::xdr::Error::Invalid)?;
+                    rv.try_into_val(env)
+                        .map_err(|_| soroban_sdk::xdr::Error::Invalid)?
+                },
+                fn_name: {
+                    let key: soroban_sdk::xdr::ScVal = soroban_sdk::xdr::ScSymbol(
+                        "fn_name"
+                            .try_into()
+                            .map_err(|_| soroban_sdk::xdr::Error::Invalid)?,
+                    )
+                    .into();
+                    let idx = map
+                        .binary_search_by_key(&key, |entry| entry.key.clone())
+                        .map_err(|_| soroban_sdk::xdr::Error::Invalid)?;
+                    let rv: soroban_sdk::Val = (&map[idx].val.clone())
+                        .try_into_val(env)
+                        .map_err(|_| soroban_sdk::xdr::Error::Invalid)?;
+                    rv.try_into_val(env)
+                        .map_err(|_| soroban_sdk::xdr::Error::Invalid)?
+                },
+            })
+        }
+    }
+    impl soroban_sdk::TryFromVal<soroban_sdk::Env, soroban_sdk::xdr::ScVal> for ContractContext {
+        type Error = soroban_sdk::xdr::Error;
+        #[inline(always)]
+        fn try_from_val(
+            env: &soroban_sdk::Env,
+            val: &soroban_sdk::xdr::ScVal,
+        ) -> Result<Self, soroban_sdk::xdr::Error> {
+            if let soroban_sdk::xdr::ScVal::Map(Some(map)) = val {
+                <_ as soroban_sdk::TryFromVal<_, _>>::try_from_val(env, map)
+            } else {
+                Err(soroban_sdk::xdr::Error::Invalid)
+            }
+        }
+    }
+    impl TryFrom<&ContractContext> for soroban_sdk::xdr::ScMap {
+        type Error = soroban_sdk::xdr::Error;
+        #[inline(always)]
+        fn try_from(val: &ContractContext) -> Result<Self, soroban_sdk::xdr::Error> {
+            extern crate alloc;
+            use soroban_sdk::TryFromVal;
+            soroban_sdk::xdr::ScMap::sorted_from(<[_]>::into_vec(::alloc::boxed::box_new([
+                soroban_sdk::xdr::ScMapEntry {
+                    key: soroban_sdk::xdr::ScSymbol(
+                        "args"
+                            .try_into()
+                            .map_err(|_| soroban_sdk::xdr::Error::Invalid)?,
+                    )
+                    .into(),
+                    val: (&val.args)
+                        .try_into()
+                        .map_err(|_| soroban_sdk::xdr::Error::Invalid)?,
+                },
+                soroban_sdk::xdr::ScMapEntry {
+                    key: soroban_sdk::xdr::ScSymbol(
+                        "contract"
+                            .try_into()
+                            .map_err(|_| soroban_sdk::xdr::Error::Invalid)?,
+                    )
+                    .into(),
+                    val: (&val.contract)
+                        .try_into()
+                        .map_err(|_| soroban_sdk::xdr::Error::Invalid)?,
+                },
+                soroban_sdk::xdr::ScMapEntry {
+                    key: soroban_sdk::xdr::ScSymbol(
+                        "fn_name"
+                            .try_into()
+                            .map_err(|_| soroban_sdk::xdr::Error::Invalid)?,
+                    )
+                    .into(),
+                    val: (&val.fn_name)
+                        .try_into()
+                        .map_err(|_| soroban_sdk::xdr::Error::Invalid)?,
+                },
+            ])))
+        }
+    }
+    impl TryFrom<ContractContext> for soroban_sdk::xdr::ScMap {
+        type Error = soroban_sdk::xdr::Error;
+        #[inline(always)]
+        fn try_from(val: ContractContext) -> Result<Self, soroban_sdk::xdr::Error> {
+            (&val).try_into()
+        }
+    }
+    impl TryFrom<&ContractContext> for soroban_sdk::xdr::ScVal {
+        type Error = soroban_sdk::xdr::Error;
+        #[inline(always)]
+        fn try_from(val: &ContractContext) -> Result<Self, soroban_sdk::xdr::Error> {
+            Ok(soroban_sdk::xdr::ScVal::Map(Some(val.try_into()?)))
+        }
+    }
+    impl TryFrom<ContractContext> for soroban_sdk::xdr::ScVal {
+        type Error = soroban_sdk::xdr::Error;
+        #[inline(always)]
+        fn try_from(val: ContractContext) -> Result<Self, soroban_sdk::xdr::Error> {
+            (&val).try_into()
+        }
+    }
+    const _: () = {
+        use soroban_sdk::testutils::arbitrary::arbitrary;
+        use soroban_sdk::testutils::arbitrary::std;
+        pub struct ArbitraryContractContext {
+            args: <soroban_sdk::Vec<
+                soroban_sdk::Val,
+            > as soroban_sdk::testutils::arbitrary::SorobanArbitrary>::Prototype,
+            contract: <soroban_sdk::Address as soroban_sdk::testutils::arbitrary::SorobanArbitrary>::Prototype,
+            fn_name: <soroban_sdk::Symbol as soroban_sdk::testutils::arbitrary::SorobanArbitrary>::Prototype,
+        }
+        #[automatically_derived]
+        impl ::core::fmt::Debug for ArbitraryContractContext {
+            #[inline]
+            fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+                ::core::fmt::Formatter::debug_struct_field3_finish(
+                    f,
+                    "ArbitraryContractContext",
+                    "args",
+                    &self.args,
+                    "contract",
+                    &self.contract,
+                    "fn_name",
+                    &&self.fn_name,
+                )
+            }
+        }
+        #[automatically_derived]
+        impl ::core::clone::Clone for ArbitraryContractContext {
+            #[inline]
+            fn clone(&self) -> ArbitraryContractContext {
+                ArbitraryContractContext {
+                    args: ::core::clone::Clone::clone(&self.args),
+                    contract: ::core::clone::Clone::clone(&self.contract),
+                    fn_name: ::core::clone::Clone::clone(&self.fn_name),
+                }
+            }
+        }
+        #[automatically_derived]
+        impl ::core::cmp::Eq for ArbitraryContractContext {
+            #[inline]
+            #[doc(hidden)]
+            #[coverage(off)]
+            fn assert_receiver_is_total_eq(&self) -> () {
+                let _: ::core::cmp::AssertParamIsEq<
+                    <soroban_sdk::Vec<
+                        soroban_sdk::Val,
+                    > as soroban_sdk::testutils::arbitrary::SorobanArbitrary>::Prototype,
+                >;
+                let _: ::core::cmp::AssertParamIsEq<
+                    <soroban_sdk::Address as soroban_sdk::testutils::arbitrary::SorobanArbitrary>::Prototype,
+                >;
+                let _: ::core::cmp::AssertParamIsEq<
+                    <soroban_sdk::Symbol as soroban_sdk::testutils::arbitrary::SorobanArbitrary>::Prototype,
+                >;
+            }
+        }
+        #[automatically_derived]
+        impl ::core::marker::StructuralPartialEq for ArbitraryContractContext {}
+        #[automatically_derived]
+        impl ::core::cmp::PartialEq for ArbitraryContractContext {
+            #[inline]
+            fn eq(&self, other: &ArbitraryContractContext) -> bool {
+                self.args == other.args
+                    && self.contract == other.contract
+                    && self.fn_name == other.fn_name
+            }
+        }
+        #[automatically_derived]
+        impl ::core::cmp::Ord for ArbitraryContractContext {
+            #[inline]
+            fn cmp(&self, other: &ArbitraryContractContext) -> ::core::cmp::Ordering {
+                match ::core::cmp::Ord::cmp(&self.args, &other.args) {
+                    ::core::cmp::Ordering::Equal => {
+                        match ::core::cmp::Ord::cmp(&self.contract, &other.contract) {
+                            ::core::cmp::Ordering::Equal => {
+                                ::core::cmp::Ord::cmp(&self.fn_name, &other.fn_name)
+                            }
+                            cmp => cmp,
+                        }
+                    }
+                    cmp => cmp,
+                }
+            }
+        }
+        #[automatically_derived]
+        impl ::core::cmp::PartialOrd for ArbitraryContractContext {
+            #[inline]
+            fn partial_cmp(
+                &self,
+                other: &ArbitraryContractContext,
+            ) -> ::core::option::Option<::core::cmp::Ordering> {
+                match ::core::cmp::PartialOrd::partial_cmp(&self.args, &other.args) {
+                    ::core::option::Option::Some(::core::cmp::Ordering::Equal) => {
+                        match ::core::cmp::PartialOrd::partial_cmp(&self.contract, &other.contract)
+                        {
+                            ::core::option::Option::Some(::core::cmp::Ordering::Equal) => {
+                                ::core::cmp::PartialOrd::partial_cmp(&self.fn_name, &other.fn_name)
+                            }
+                            cmp => cmp,
+                        }
+                    }
+                    cmp => cmp,
+                }
+            }
+        }
+        const _: () = {
+            #[allow(non_upper_case_globals)]
+            const RECURSIVE_COUNT_ArbitraryContractContext: ::std::thread::LocalKey<
+                std::cell::Cell<u32>,
+            > = {
+                #[inline]
+                fn __init() -> std::cell::Cell<u32> {
+                    std::cell::Cell::new(0)
+                }
+                unsafe {
+                    ::std::thread::LocalKey::new(
+                        const {
+                            if ::std::mem::needs_drop::<std::cell::Cell<u32>>() {
+                                |init| {
+                                    #[thread_local]
+                                    static VAL: ::std::thread::local_impl::LazyStorage<
+                                        std::cell::Cell<u32>,
+                                        (),
+                                    > = ::std::thread::local_impl::LazyStorage::new();
+                                    VAL.get_or_init(init, __init)
+                                }
+                            } else {
+                                |init| {
+                                    #[thread_local]
+                                    static VAL: ::std::thread::local_impl::LazyStorage<
+                                        std::cell::Cell<u32>,
+                                        !,
+                                    > = ::std::thread::local_impl::LazyStorage::new();
+                                    VAL.get_or_init(init, __init)
+                                }
+                            }
+                        },
+                    )
+                }
+            };
+            #[automatically_derived]
+            impl<'arbitrary> arbitrary::Arbitrary<'arbitrary> for ArbitraryContractContext {
+                fn arbitrary(
+                    u: &mut arbitrary::Unstructured<'arbitrary>,
+                ) -> arbitrary::Result<Self> {
+                    let guard_against_recursion = u.is_empty();
+                    if guard_against_recursion {
+                        RECURSIVE_COUNT_ArbitraryContractContext.with(|count| {
+                            if count.get() > 0 {
+                                return Err(arbitrary::Error::NotEnoughData);
+                            }
+                            count.set(count.get() + 1);
+                            Ok(())
+                        })?;
+                    }
+                    let result = (|| {
+                        Ok(ArbitraryContractContext {
+                            args: arbitrary::Arbitrary::arbitrary(u)?,
+                            contract: arbitrary::Arbitrary::arbitrary(u)?,
+                            fn_name: arbitrary::Arbitrary::arbitrary(u)?,
+                        })
+                    })();
+                    if guard_against_recursion {
+                        RECURSIVE_COUNT_ArbitraryContractContext.with(|count| {
+                            count.set(count.get() - 1);
+                        });
+                    }
+                    result
+                }
+                fn arbitrary_take_rest(
+                    mut u: arbitrary::Unstructured<'arbitrary>,
+                ) -> arbitrary::Result<Self> {
+                    let guard_against_recursion = u.is_empty();
+                    if guard_against_recursion {
+                        RECURSIVE_COUNT_ArbitraryContractContext.with(|count| {
+                            if count.get() > 0 {
+                                return Err(arbitrary::Error::NotEnoughData);
+                            }
+                            count.set(count.get() + 1);
+                            Ok(())
+                        })?;
+                    }
+                    let result = (|| {
+                        Ok(ArbitraryContractContext {
+                            args: arbitrary::Arbitrary::arbitrary(&mut u)?,
+                            contract: arbitrary::Arbitrary::arbitrary(&mut u)?,
+                            fn_name: arbitrary::Arbitrary::arbitrary_take_rest(u)?,
+                        })
+                    })();
+                    if guard_against_recursion {
+                        RECURSIVE_COUNT_ArbitraryContractContext.with(|count| {
+                            count.set(count.get() - 1);
+                        });
+                    }
+                    result
+                }
+                #[inline]
+                fn size_hint(depth: usize) -> (usize, Option<usize>) {
+                    arbitrary::size_hint::recursion_guard(depth, |depth| {
+                        arbitrary::size_hint::and_all(
+                            &[
+                                <<soroban_sdk::Vec<
+                                    soroban_sdk::Val,
+                                > as soroban_sdk::testutils::arbitrary::SorobanArbitrary>::Prototype as arbitrary::Arbitrary>::size_hint(
+                                    depth,
+                                ),
+                                <<soroban_sdk::Address as soroban_sdk::testutils::arbitrary::SorobanArbitrary>::Prototype as arbitrary::Arbitrary>::size_hint(
+                                    depth,
+                                ),
+                                <<soroban_sdk::Symbol as soroban_sdk::testutils::arbitrary::SorobanArbitrary>::Prototype as arbitrary::Arbitrary>::size_hint(
+                                    depth,
+                                ),
+                            ],
+                        )
+                    })
+                }
+            }
+        };
+        impl soroban_sdk::testutils::arbitrary::SorobanArbitrary for ContractContext {
+            type Prototype = ArbitraryContractContext;
+        }
+        impl soroban_sdk::TryFromVal<soroban_sdk::Env, ArbitraryContractContext> for ContractContext {
+            type Error = soroban_sdk::ConversionError;
+            fn try_from_val(
+                env: &soroban_sdk::Env,
+                v: &ArbitraryContractContext,
+            ) -> std::result::Result<Self, Self::Error> {
+                Ok(ContractContext {
+                    args: soroban_sdk::IntoVal::into_val(&v.args, env),
+                    contract: soroban_sdk::IntoVal::into_val(&v.contract, env),
+                    fn_name: soroban_sdk::IntoVal::into_val(&v.fn_name, env),
+                })
+            }
+        }
+    };
+    pub struct SubContractInvocation {
+        pub context: ContractContext,
+        pub sub_invocations: soroban_sdk::Vec<InvokerContractAuthEntry>,
+    }
+    #[automatically_derived]
+    impl ::core::fmt::Debug for SubContractInvocation {
+        #[inline]
+        fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+            ::core::fmt::Formatter::debug_struct_field2_finish(
+                f,
+                "SubContractInvocation",
+                "context",
+                &self.context,
+                "sub_invocations",
+                &&self.sub_invocations,
+            )
+        }
+    }
+    #[automatically_derived]
+    impl ::core::clone::Clone for SubContractInvocation {
+        #[inline]
+        fn clone(&self) -> SubContractInvocation {
+            SubContractInvocation {
+                context: ::core::clone::Clone::clone(&self.context),
+                sub_invocations: ::core::clone::Clone::clone(&self.sub_invocations),
+            }
+        }
+    }
+    #[automatically_derived]
+    impl ::core::cmp::Eq for SubContractInvocation {
+        #[inline]
+        #[doc(hidden)]
+        #[coverage(off)]
+        fn assert_receiver_is_total_eq(&self) -> () {
+            let _: ::core::cmp::AssertParamIsEq<ContractContext>;
+            let _: ::core::cmp::AssertParamIsEq<soroban_sdk::Vec<InvokerContractAuthEntry>>;
+        }
+    }
+    #[automatically_derived]
+    impl ::core::marker::StructuralPartialEq for SubContractInvocation {}
+    #[automatically_derived]
+    impl ::core::cmp::PartialEq for SubContractInvocation {
+        #[inline]
+        fn eq(&self, other: &SubContractInvocation) -> bool {
+            self.context == other.context && self.sub_invocations == other.sub_invocations
+        }
+    }
+    #[automatically_derived]
+    impl ::core::cmp::Ord for SubContractInvocation {
+        #[inline]
+        fn cmp(&self, other: &SubContractInvocation) -> ::core::cmp::Ordering {
+            match ::core::cmp::Ord::cmp(&self.context, &other.context) {
+                ::core::cmp::Ordering::Equal => {
+                    ::core::cmp::Ord::cmp(&self.sub_invocations, &other.sub_invocations)
+                }
+                cmp => cmp,
+            }
+        }
+    }
+    #[automatically_derived]
+    impl ::core::cmp::PartialOrd for SubContractInvocation {
+        #[inline]
+        fn partial_cmp(
+            &self,
+            other: &SubContractInvocation,
+        ) -> ::core::option::Option<::core::cmp::Ordering> {
+            match ::core::cmp::PartialOrd::partial_cmp(&self.context, &other.context) {
+                ::core::option::Option::Some(::core::cmp::Ordering::Equal) => {
+                    ::core::cmp::PartialOrd::partial_cmp(
+                        &self.sub_invocations,
+                        &other.sub_invocations,
+                    )
+                }
+                cmp => cmp,
+            }
+        }
+    }
+    pub static __SPEC_XDR_TYPE_SUBCONTRACTINVOCATION: [u8; 144usize] =
+        SubContractInvocation::spec_xdr();
+    impl SubContractInvocation {
+        pub const fn spec_xdr() -> [u8; 144usize] {
+            *b"\0\0\0\x01\0\0\0\0\0\0\0\0\0\0\0\x15SubContractInvocation\0\0\0\0\0\0\x02\0\0\0\0\0\0\0\x07context\0\0\0\x07\xd0\0\0\0\x0fContractContext\0\0\0\0\0\0\0\0\x0fsub_invocations\0\0\0\x03\xea\0\0\x07\xd0\0\0\0\x18InvokerContractAuthEntry"
+        }
+    }
+    impl soroban_sdk::SpecShakingMarker for SubContractInvocation {
+        #[doc(hidden)]
+        #[inline(always)]
+        fn spec_shaking_marker() {
+            <ContractContext as soroban_sdk::SpecShakingMarker>::spec_shaking_marker();
+            <soroban_sdk::Vec<
+                InvokerContractAuthEntry,
+            > as soroban_sdk::SpecShakingMarker>::spec_shaking_marker();
+        }
+    }
+    impl soroban_sdk::TryFromVal<soroban_sdk::Env, soroban_sdk::Val> for SubContractInvocation {
+        type Error = soroban_sdk::ConversionError;
+        fn try_from_val(
+            env: &soroban_sdk::Env,
+            val: &soroban_sdk::Val,
+        ) -> Result<Self, soroban_sdk::ConversionError> {
+            use soroban_sdk::{ConversionError, EnvBase, MapObject, TryIntoVal, Val};
+            const KEYS: [&'static str; 2usize] = ["context", "sub_invocations"];
+            let mut vals: [Val; 2usize] = [Val::VOID.to_val(); 2usize];
+            let map: MapObject = val.try_into().map_err(|_| ConversionError)?;
+            env.map_unpack_to_slice(map, &KEYS, &mut vals)
+                .map_err(|_| ConversionError)?;
+            Ok(Self {
+                context: vals[0]
+                    .try_into_val(env)
+                    .map_err(|_| soroban_sdk::ConversionError)?,
+                sub_invocations: vals[1]
+                    .try_into_val(env)
+                    .map_err(|_| soroban_sdk::ConversionError)?,
+            })
+        }
+    }
+    impl soroban_sdk::TryFromVal<soroban_sdk::Env, SubContractInvocation> for soroban_sdk::Val {
+        type Error = soroban_sdk::ConversionError;
+        fn try_from_val(
+            env: &soroban_sdk::Env,
+            val: &SubContractInvocation,
+        ) -> Result<Self, soroban_sdk::ConversionError> {
+            use soroban_sdk::{ConversionError, EnvBase, TryIntoVal, Val};
+            const KEYS: [&'static str; 2usize] = ["context", "sub_invocations"];
+            let vals: [Val; 2usize] = [
+                (&val.context)
+                    .try_into_val(env)
+                    .map_err(|_| ConversionError)?,
+                (&val.sub_invocations)
+                    .try_into_val(env)
+                    .map_err(|_| ConversionError)?,
+            ];
+            Ok(env
+                .map_new_from_slices(&KEYS, &vals)
+                .map_err(|_| ConversionError)?
+                .into())
+        }
+    }
+    impl soroban_sdk::TryFromVal<soroban_sdk::Env, &SubContractInvocation> for soroban_sdk::Val {
+        type Error = soroban_sdk::ConversionError;
+        #[inline(always)]
+        fn try_from_val(
+            env: &soroban_sdk::Env,
+            val: &&SubContractInvocation,
+        ) -> Result<Self, soroban_sdk::ConversionError> {
+            <_ as soroban_sdk::TryFromVal<soroban_sdk::Env, SubContractInvocation>>::try_from_val(
+                env, *val,
+            )
+        }
+    }
+    impl soroban_sdk::TryFromVal<soroban_sdk::Env, soroban_sdk::xdr::ScMap> for SubContractInvocation {
+        type Error = soroban_sdk::xdr::Error;
+        #[inline(always)]
+        fn try_from_val(
+            env: &soroban_sdk::Env,
+            val: &soroban_sdk::xdr::ScMap,
+        ) -> Result<Self, soroban_sdk::xdr::Error> {
+            use soroban_sdk::xdr::Validate;
+            use soroban_sdk::TryIntoVal;
+            let map = val;
+            if map.len() != 2usize {
+                return Err(soroban_sdk::xdr::Error::Invalid);
+            }
+            map.validate()?;
+            Ok(Self {
+                context: {
+                    let key: soroban_sdk::xdr::ScVal = soroban_sdk::xdr::ScSymbol(
+                        "context"
+                            .try_into()
+                            .map_err(|_| soroban_sdk::xdr::Error::Invalid)?,
+                    )
+                    .into();
+                    let idx = map
+                        .binary_search_by_key(&key, |entry| entry.key.clone())
+                        .map_err(|_| soroban_sdk::xdr::Error::Invalid)?;
+                    let rv: soroban_sdk::Val = (&map[idx].val.clone())
+                        .try_into_val(env)
+                        .map_err(|_| soroban_sdk::xdr::Error::Invalid)?;
+                    rv.try_into_val(env)
+                        .map_err(|_| soroban_sdk::xdr::Error::Invalid)?
+                },
+                sub_invocations: {
+                    let key: soroban_sdk::xdr::ScVal = soroban_sdk::xdr::ScSymbol(
+                        "sub_invocations"
+                            .try_into()
+                            .map_err(|_| soroban_sdk::xdr::Error::Invalid)?,
+                    )
+                    .into();
+                    let idx = map
+                        .binary_search_by_key(&key, |entry| entry.key.clone())
+                        .map_err(|_| soroban_sdk::xdr::Error::Invalid)?;
+                    let rv: soroban_sdk::Val = (&map[idx].val.clone())
+                        .try_into_val(env)
+                        .map_err(|_| soroban_sdk::xdr::Error::Invalid)?;
+                    rv.try_into_val(env)
+                        .map_err(|_| soroban_sdk::xdr::Error::Invalid)?
+                },
+            })
+        }
+    }
+    impl soroban_sdk::TryFromVal<soroban_sdk::Env, soroban_sdk::xdr::ScVal> for SubContractInvocation {
+        type Error = soroban_sdk::xdr::Error;
+        #[inline(always)]
+        fn try_from_val(
+            env: &soroban_sdk::Env,
+            val: &soroban_sdk::xdr::ScVal,
+        ) -> Result<Self, soroban_sdk::xdr::Error> {
+            if let soroban_sdk::xdr::ScVal::Map(Some(map)) = val {
+                <_ as soroban_sdk::TryFromVal<_, _>>::try_from_val(env, map)
+            } else {
+                Err(soroban_sdk::xdr::Error::Invalid)
+            }
+        }
+    }
+    impl TryFrom<&SubContractInvocation> for soroban_sdk::xdr::ScMap {
+        type Error = soroban_sdk::xdr::Error;
+        #[inline(always)]
+        fn try_from(val: &SubContractInvocation) -> Result<Self, soroban_sdk::xdr::Error> {
+            extern crate alloc;
+            use soroban_sdk::TryFromVal;
+            soroban_sdk::xdr::ScMap::sorted_from(<[_]>::into_vec(::alloc::boxed::box_new([
+                soroban_sdk::xdr::ScMapEntry {
+                    key: soroban_sdk::xdr::ScSymbol(
+                        "context"
+                            .try_into()
+                            .map_err(|_| soroban_sdk::xdr::Error::Invalid)?,
+                    )
+                    .into(),
+                    val: (&val.context)
+                        .try_into()
+                        .map_err(|_| soroban_sdk::xdr::Error::Invalid)?,
+                },
+                soroban_sdk::xdr::ScMapEntry {
+                    key: soroban_sdk::xdr::ScSymbol(
+                        "sub_invocations"
+                            .try_into()
+                            .map_err(|_| soroban_sdk::xdr::Error::Invalid)?,
+                    )
+                    .into(),
+                    val: (&val.sub_invocations)
+                        .try_into()
+                        .map_err(|_| soroban_sdk::xdr::Error::Invalid)?,
+                },
+            ])))
+        }
+    }
+    impl TryFrom<SubContractInvocation> for soroban_sdk::xdr::ScMap {
+        type Error = soroban_sdk::xdr::Error;
+        #[inline(always)]
+        fn try_from(val: SubContractInvocation) -> Result<Self, soroban_sdk::xdr::Error> {
+            (&val).try_into()
+        }
+    }
+    impl TryFrom<&SubContractInvocation> for soroban_sdk::xdr::ScVal {
+        type Error = soroban_sdk::xdr::Error;
+        #[inline(always)]
+        fn try_from(val: &SubContractInvocation) -> Result<Self, soroban_sdk::xdr::Error> {
+            Ok(soroban_sdk::xdr::ScVal::Map(Some(val.try_into()?)))
+        }
+    }
+    impl TryFrom<SubContractInvocation> for soroban_sdk::xdr::ScVal {
+        type Error = soroban_sdk::xdr::Error;
+        #[inline(always)]
+        fn try_from(val: SubContractInvocation) -> Result<Self, soroban_sdk::xdr::Error> {
+            (&val).try_into()
+        }
+    }
+    const _: () = {
+        use soroban_sdk::testutils::arbitrary::arbitrary;
+        use soroban_sdk::testutils::arbitrary::std;
+        pub struct ArbitrarySubContractInvocation {
+            context: <ContractContext as soroban_sdk::testutils::arbitrary::SorobanArbitrary>::Prototype,
+            sub_invocations: <soroban_sdk::Vec<
+                InvokerContractAuthEntry,
+            > as soroban_sdk::testutils::arbitrary::SorobanArbitrary>::Prototype,
+        }
+        #[automatically_derived]
+        impl ::core::fmt::Debug for ArbitrarySubContractInvocation {
+            #[inline]
+            fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+                ::core::fmt::Formatter::debug_struct_field2_finish(
+                    f,
+                    "ArbitrarySubContractInvocation",
+                    "context",
+                    &self.context,
+                    "sub_invocations",
+                    &&self.sub_invocations,
+                )
+            }
+        }
+        #[automatically_derived]
+        impl ::core::clone::Clone for ArbitrarySubContractInvocation {
+            #[inline]
+            fn clone(&self) -> ArbitrarySubContractInvocation {
+                ArbitrarySubContractInvocation {
+                    context: ::core::clone::Clone::clone(&self.context),
+                    sub_invocations: ::core::clone::Clone::clone(&self.sub_invocations),
+                }
+            }
+        }
+        #[automatically_derived]
+        impl ::core::cmp::Eq for ArbitrarySubContractInvocation {
+            #[inline]
+            #[doc(hidden)]
+            #[coverage(off)]
+            fn assert_receiver_is_total_eq(&self) -> () {
+                let _: ::core::cmp::AssertParamIsEq<
+                    <ContractContext as soroban_sdk::testutils::arbitrary::SorobanArbitrary>::Prototype,
+                >;
+                let _: ::core::cmp::AssertParamIsEq<
+                    <soroban_sdk::Vec<
+                        InvokerContractAuthEntry,
+                    > as soroban_sdk::testutils::arbitrary::SorobanArbitrary>::Prototype,
+                >;
+            }
+        }
+        #[automatically_derived]
+        impl ::core::marker::StructuralPartialEq for ArbitrarySubContractInvocation {}
+        #[automatically_derived]
+        impl ::core::cmp::PartialEq for ArbitrarySubContractInvocation {
+            #[inline]
+            fn eq(&self, other: &ArbitrarySubContractInvocation) -> bool {
+                self.context == other.context && self.sub_invocations == other.sub_invocations
+            }
+        }
+        #[automatically_derived]
+        impl ::core::cmp::Ord for ArbitrarySubContractInvocation {
+            #[inline]
+            fn cmp(&self, other: &ArbitrarySubContractInvocation) -> ::core::cmp::Ordering {
+                match ::core::cmp::Ord::cmp(&self.context, &other.context) {
+                    ::core::cmp::Ordering::Equal => {
+                        ::core::cmp::Ord::cmp(&self.sub_invocations, &other.sub_invocations)
+                    }
+                    cmp => cmp,
+                }
+            }
+        }
+        #[automatically_derived]
+        impl ::core::cmp::PartialOrd for ArbitrarySubContractInvocation {
+            #[inline]
+            fn partial_cmp(
+                &self,
+                other: &ArbitrarySubContractInvocation,
+            ) -> ::core::option::Option<::core::cmp::Ordering> {
+                match ::core::cmp::PartialOrd::partial_cmp(&self.context, &other.context) {
+                    ::core::option::Option::Some(::core::cmp::Ordering::Equal) => {
+                        ::core::cmp::PartialOrd::partial_cmp(
+                            &self.sub_invocations,
+                            &other.sub_invocations,
+                        )
+                    }
+                    cmp => cmp,
+                }
+            }
+        }
+        const _: () = {
+            #[allow(non_upper_case_globals)]
+            const RECURSIVE_COUNT_ArbitrarySubContractInvocation: ::std::thread::LocalKey<
+                std::cell::Cell<u32>,
+            > = {
+                #[inline]
+                fn __init() -> std::cell::Cell<u32> {
+                    std::cell::Cell::new(0)
+                }
+                unsafe {
+                    ::std::thread::LocalKey::new(
+                        const {
+                            if ::std::mem::needs_drop::<std::cell::Cell<u32>>() {
+                                |init| {
+                                    #[thread_local]
+                                    static VAL: ::std::thread::local_impl::LazyStorage<
+                                        std::cell::Cell<u32>,
+                                        (),
+                                    > = ::std::thread::local_impl::LazyStorage::new();
+                                    VAL.get_or_init(init, __init)
+                                }
+                            } else {
+                                |init| {
+                                    #[thread_local]
+                                    static VAL: ::std::thread::local_impl::LazyStorage<
+                                        std::cell::Cell<u32>,
+                                        !,
+                                    > = ::std::thread::local_impl::LazyStorage::new();
+                                    VAL.get_or_init(init, __init)
+                                }
+                            }
+                        },
+                    )
+                }
+            };
+            #[automatically_derived]
+            impl<'arbitrary> arbitrary::Arbitrary<'arbitrary> for ArbitrarySubContractInvocation {
+                fn arbitrary(
+                    u: &mut arbitrary::Unstructured<'arbitrary>,
+                ) -> arbitrary::Result<Self> {
+                    let guard_against_recursion = u.is_empty();
+                    if guard_against_recursion {
+                        RECURSIVE_COUNT_ArbitrarySubContractInvocation.with(|count| {
+                            if count.get() > 0 {
+                                return Err(arbitrary::Error::NotEnoughData);
+                            }
+                            count.set(count.get() + 1);
+                            Ok(())
+                        })?;
+                    }
+                    let result = (|| {
+                        Ok(ArbitrarySubContractInvocation {
+                            context: arbitrary::Arbitrary::arbitrary(u)?,
+                            sub_invocations: arbitrary::Arbitrary::arbitrary(u)?,
+                        })
+                    })();
+                    if guard_against_recursion {
+                        RECURSIVE_COUNT_ArbitrarySubContractInvocation.with(|count| {
+                            count.set(count.get() - 1);
+                        });
+                    }
+                    result
+                }
+                fn arbitrary_take_rest(
+                    mut u: arbitrary::Unstructured<'arbitrary>,
+                ) -> arbitrary::Result<Self> {
+                    let guard_against_recursion = u.is_empty();
+                    if guard_against_recursion {
+                        RECURSIVE_COUNT_ArbitrarySubContractInvocation.with(|count| {
+                            if count.get() > 0 {
+                                return Err(arbitrary::Error::NotEnoughData);
+                            }
+                            count.set(count.get() + 1);
+                            Ok(())
+                        })?;
+                    }
+                    let result = (|| {
+                        Ok(ArbitrarySubContractInvocation {
+                            context: arbitrary::Arbitrary::arbitrary(&mut u)?,
+                            sub_invocations: arbitrary::Arbitrary::arbitrary_take_rest(u)?,
+                        })
+                    })();
+                    if guard_against_recursion {
+                        RECURSIVE_COUNT_ArbitrarySubContractInvocation.with(|count| {
+                            count.set(count.get() - 1);
+                        });
+                    }
+                    result
+                }
+                #[inline]
+                fn size_hint(depth: usize) -> (usize, Option<usize>) {
+                    arbitrary::size_hint::recursion_guard(depth, |depth| {
+                        arbitrary::size_hint::and_all(
+                            &[
+                                <<ContractContext as soroban_sdk::testutils::arbitrary::SorobanArbitrary>::Prototype as arbitrary::Arbitrary>::size_hint(
+                                    depth,
+                                ),
+                                <<soroban_sdk::Vec<
+                                    InvokerContractAuthEntry,
+                                > as soroban_sdk::testutils::arbitrary::SorobanArbitrary>::Prototype as arbitrary::Arbitrary>::size_hint(
+                                    depth,
+                                ),
+                            ],
+                        )
+                    })
+                }
+            }
+        };
+        impl soroban_sdk::testutils::arbitrary::SorobanArbitrary for SubContractInvocation {
+            type Prototype = ArbitrarySubContractInvocation;
+        }
+        impl soroban_sdk::TryFromVal<soroban_sdk::Env, ArbitrarySubContractInvocation>
+            for SubContractInvocation
+        {
+            type Error = soroban_sdk::ConversionError;
+            fn try_from_val(
+                env: &soroban_sdk::Env,
+                v: &ArbitrarySubContractInvocation,
+            ) -> std::result::Result<Self, Self::Error> {
+                Ok(SubContractInvocation {
+                    context: soroban_sdk::IntoVal::into_val(&v.context, env),
+                    sub_invocations: soroban_sdk::IntoVal::into_val(&v.sub_invocations, env),
+                })
+            }
+        }
+    };
+    pub struct CreateContractHostFnContext {
+        pub executable: ContractExecutable,
+        pub salt: soroban_sdk::BytesN<32>,
+    }
+    #[automatically_derived]
+    impl ::core::fmt::Debug for CreateContractHostFnContext {
+        #[inline]
+        fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+            ::core::fmt::Formatter::debug_struct_field2_finish(
+                f,
+                "CreateContractHostFnContext",
+                "executable",
+                &self.executable,
+                "salt",
+                &&self.salt,
+            )
+        }
+    }
+    #[automatically_derived]
+    impl ::core::clone::Clone for CreateContractHostFnContext {
+        #[inline]
+        fn clone(&self) -> CreateContractHostFnContext {
+            CreateContractHostFnContext {
+                executable: ::core::clone::Clone::clone(&self.executable),
+                salt: ::core::clone::Clone::clone(&self.salt),
+            }
+        }
+    }
+    #[automatically_derived]
+    impl ::core::cmp::Eq for CreateContractHostFnContext {
+        #[inline]
+        #[doc(hidden)]
+        #[coverage(off)]
+        fn assert_receiver_is_total_eq(&self) -> () {
+            let _: ::core::cmp::AssertParamIsEq<ContractExecutable>;
+            let _: ::core::cmp::AssertParamIsEq<soroban_sdk::BytesN<32>>;
+        }
+    }
+    #[automatically_derived]
+    impl ::core::marker::StructuralPartialEq for CreateContractHostFnContext {}
+    #[automatically_derived]
+    impl ::core::cmp::PartialEq for CreateContractHostFnContext {
+        #[inline]
+        fn eq(&self, other: &CreateContractHostFnContext) -> bool {
+            self.executable == other.executable && self.salt == other.salt
+        }
+    }
+    #[automatically_derived]
+    impl ::core::cmp::Ord for CreateContractHostFnContext {
+        #[inline]
+        fn cmp(&self, other: &CreateContractHostFnContext) -> ::core::cmp::Ordering {
+            match ::core::cmp::Ord::cmp(&self.executable, &other.executable) {
+                ::core::cmp::Ordering::Equal => ::core::cmp::Ord::cmp(&self.salt, &other.salt),
+                cmp => cmp,
+            }
+        }
+    }
+    #[automatically_derived]
+    impl ::core::cmp::PartialOrd for CreateContractHostFnContext {
+        #[inline]
+        fn partial_cmp(
+            &self,
+            other: &CreateContractHostFnContext,
+        ) -> ::core::option::Option<::core::cmp::Ordering> {
+            match ::core::cmp::PartialOrd::partial_cmp(&self.executable, &other.executable) {
+                ::core::option::Option::Some(::core::cmp::Ordering::Equal) => {
+                    ::core::cmp::PartialOrd::partial_cmp(&self.salt, &other.salt)
+                }
+                cmp => cmp,
+            }
+        }
+    }
+    pub static __SPEC_XDR_TYPE_CREATECONTRACTHOSTFNCONTEXT: [u8; 116usize] =
+        CreateContractHostFnContext::spec_xdr();
+    impl CreateContractHostFnContext {
+        pub const fn spec_xdr() -> [u8; 116usize] {
+            *b"\0\0\0\x01\0\0\0\0\0\0\0\0\0\0\0\x1bCreateContractHostFnContext\0\0\0\0\x02\0\0\0\0\0\0\0\nexecutable\0\0\0\0\x07\xd0\0\0\0\x12ContractExecutable\0\0\0\0\0\0\0\0\0\x04salt\0\0\x03\xee\0\0\0 "
+        }
+    }
+    impl soroban_sdk::SpecShakingMarker for CreateContractHostFnContext {
+        #[doc(hidden)]
+        #[inline(always)]
+        fn spec_shaking_marker() {
+            <ContractExecutable as soroban_sdk::SpecShakingMarker>::spec_shaking_marker();
+            <soroban_sdk::BytesN<32> as soroban_sdk::SpecShakingMarker>::spec_shaking_marker();
+        }
+    }
+    impl soroban_sdk::TryFromVal<soroban_sdk::Env, soroban_sdk::Val> for CreateContractHostFnContext {
+        type Error = soroban_sdk::ConversionError;
+        fn try_from_val(
+            env: &soroban_sdk::Env,
+            val: &soroban_sdk::Val,
+        ) -> Result<Self, soroban_sdk::ConversionError> {
+            use soroban_sdk::{ConversionError, EnvBase, MapObject, TryIntoVal, Val};
+            const KEYS: [&'static str; 2usize] = ["executable", "salt"];
+            let mut vals: [Val; 2usize] = [Val::VOID.to_val(); 2usize];
+            let map: MapObject = val.try_into().map_err(|_| ConversionError)?;
+            env.map_unpack_to_slice(map, &KEYS, &mut vals)
+                .map_err(|_| ConversionError)?;
+            Ok(Self {
+                executable: vals[0]
+                    .try_into_val(env)
+                    .map_err(|_| soroban_sdk::ConversionError)?,
+                salt: vals[1]
+                    .try_into_val(env)
+                    .map_err(|_| soroban_sdk::ConversionError)?,
+            })
+        }
+    }
+    impl soroban_sdk::TryFromVal<soroban_sdk::Env, CreateContractHostFnContext> for soroban_sdk::Val {
+        type Error = soroban_sdk::ConversionError;
+        fn try_from_val(
+            env: &soroban_sdk::Env,
+            val: &CreateContractHostFnContext,
+        ) -> Result<Self, soroban_sdk::ConversionError> {
+            use soroban_sdk::{ConversionError, EnvBase, TryIntoVal, Val};
+            const KEYS: [&'static str; 2usize] = ["executable", "salt"];
+            let vals: [Val; 2usize] = [
+                (&val.executable)
+                    .try_into_val(env)
+                    .map_err(|_| ConversionError)?,
+                (&val.salt).try_into_val(env).map_err(|_| ConversionError)?,
+            ];
+            Ok(env
+                .map_new_from_slices(&KEYS, &vals)
+                .map_err(|_| ConversionError)?
+                .into())
+        }
+    }
+    impl soroban_sdk::TryFromVal<soroban_sdk::Env, &CreateContractHostFnContext> for soroban_sdk::Val {
+        type Error = soroban_sdk::ConversionError;
+        #[inline(always)]
+        fn try_from_val(
+            env: &soroban_sdk::Env,
+            val: &&CreateContractHostFnContext,
+        ) -> Result<Self, soroban_sdk::ConversionError> {
+            <_ as soroban_sdk::TryFromVal<
+                soroban_sdk::Env,
+                CreateContractHostFnContext,
+            >>::try_from_val(env, *val)
+        }
+    }
+    impl soroban_sdk::TryFromVal<soroban_sdk::Env, soroban_sdk::xdr::ScMap>
+        for CreateContractHostFnContext
+    {
+        type Error = soroban_sdk::xdr::Error;
+        #[inline(always)]
+        fn try_from_val(
+            env: &soroban_sdk::Env,
+            val: &soroban_sdk::xdr::ScMap,
+        ) -> Result<Self, soroban_sdk::xdr::Error> {
+            use soroban_sdk::xdr::Validate;
+            use soroban_sdk::TryIntoVal;
+            let map = val;
+            if map.len() != 2usize {
+                return Err(soroban_sdk::xdr::Error::Invalid);
+            }
+            map.validate()?;
+            Ok(Self {
+                executable: {
+                    let key: soroban_sdk::xdr::ScVal = soroban_sdk::xdr::ScSymbol(
+                        "executable"
+                            .try_into()
+                            .map_err(|_| soroban_sdk::xdr::Error::Invalid)?,
+                    )
+                    .into();
+                    let idx = map
+                        .binary_search_by_key(&key, |entry| entry.key.clone())
+                        .map_err(|_| soroban_sdk::xdr::Error::Invalid)?;
+                    let rv: soroban_sdk::Val = (&map[idx].val.clone())
+                        .try_into_val(env)
+                        .map_err(|_| soroban_sdk::xdr::Error::Invalid)?;
+                    rv.try_into_val(env)
+                        .map_err(|_| soroban_sdk::xdr::Error::Invalid)?
+                },
+                salt: {
+                    let key: soroban_sdk::xdr::ScVal = soroban_sdk::xdr::ScSymbol(
+                        "salt"
+                            .try_into()
+                            .map_err(|_| soroban_sdk::xdr::Error::Invalid)?,
+                    )
+                    .into();
+                    let idx = map
+                        .binary_search_by_key(&key, |entry| entry.key.clone())
+                        .map_err(|_| soroban_sdk::xdr::Error::Invalid)?;
+                    let rv: soroban_sdk::Val = (&map[idx].val.clone())
+                        .try_into_val(env)
+                        .map_err(|_| soroban_sdk::xdr::Error::Invalid)?;
+                    rv.try_into_val(env)
+                        .map_err(|_| soroban_sdk::xdr::Error::Invalid)?
+                },
+            })
+        }
+    }
+    impl soroban_sdk::TryFromVal<soroban_sdk::Env, soroban_sdk::xdr::ScVal>
+        for CreateContractHostFnContext
+    {
+        type Error = soroban_sdk::xdr::Error;
+        #[inline(always)]
+        fn try_from_val(
+            env: &soroban_sdk::Env,
+            val: &soroban_sdk::xdr::ScVal,
+        ) -> Result<Self, soroban_sdk::xdr::Error> {
+            if let soroban_sdk::xdr::ScVal::Map(Some(map)) = val {
+                <_ as soroban_sdk::TryFromVal<_, _>>::try_from_val(env, map)
+            } else {
+                Err(soroban_sdk::xdr::Error::Invalid)
+            }
+        }
+    }
+    impl TryFrom<&CreateContractHostFnContext> for soroban_sdk::xdr::ScMap {
+        type Error = soroban_sdk::xdr::Error;
+        #[inline(always)]
+        fn try_from(val: &CreateContractHostFnContext) -> Result<Self, soroban_sdk::xdr::Error> {
+            extern crate alloc;
+            use soroban_sdk::TryFromVal;
+            soroban_sdk::xdr::ScMap::sorted_from(<[_]>::into_vec(::alloc::boxed::box_new([
+                soroban_sdk::xdr::ScMapEntry {
+                    key: soroban_sdk::xdr::ScSymbol(
+                        "executable"
+                            .try_into()
+                            .map_err(|_| soroban_sdk::xdr::Error::Invalid)?,
+                    )
+                    .into(),
+                    val: (&val.executable)
+                        .try_into()
+                        .map_err(|_| soroban_sdk::xdr::Error::Invalid)?,
+                },
+                soroban_sdk::xdr::ScMapEntry {
+                    key: soroban_sdk::xdr::ScSymbol(
+                        "salt"
+                            .try_into()
+                            .map_err(|_| soroban_sdk::xdr::Error::Invalid)?,
+                    )
+                    .into(),
+                    val: (&val.salt)
+                        .try_into()
+                        .map_err(|_| soroban_sdk::xdr::Error::Invalid)?,
+                },
+            ])))
+        }
+    }
+    impl TryFrom<CreateContractHostFnContext> for soroban_sdk::xdr::ScMap {
+        type Error = soroban_sdk::xdr::Error;
+        #[inline(always)]
+        fn try_from(val: CreateContractHostFnContext) -> Result<Self, soroban_sdk::xdr::Error> {
+            (&val).try_into()
+        }
+    }
+    impl TryFrom<&CreateContractHostFnContext> for soroban_sdk::xdr::ScVal {
+        type Error = soroban_sdk::xdr::Error;
+        #[inline(always)]
+        fn try_from(val: &CreateContractHostFnContext) -> Result<Self, soroban_sdk::xdr::Error> {
+            Ok(soroban_sdk::xdr::ScVal::Map(Some(val.try_into()?)))
+        }
+    }
+    impl TryFrom<CreateContractHostFnContext> for soroban_sdk::xdr::ScVal {
+        type Error = soroban_sdk::xdr::Error;
+        #[inline(always)]
+        fn try_from(val: CreateContractHostFnContext) -> Result<Self, soroban_sdk::xdr::Error> {
+            (&val).try_into()
+        }
+    }
+    const _: () = {
+        use soroban_sdk::testutils::arbitrary::arbitrary;
+        use soroban_sdk::testutils::arbitrary::std;
+        pub struct ArbitraryCreateContractHostFnContext {
+            executable: <ContractExecutable as soroban_sdk::testutils::arbitrary::SorobanArbitrary>::Prototype,
+            salt: <soroban_sdk::BytesN<
+                32,
+            > as soroban_sdk::testutils::arbitrary::SorobanArbitrary>::Prototype,
+        }
+        #[automatically_derived]
+        impl ::core::fmt::Debug for ArbitraryCreateContractHostFnContext {
+            #[inline]
+            fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+                ::core::fmt::Formatter::debug_struct_field2_finish(
+                    f,
+                    "ArbitraryCreateContractHostFnContext",
+                    "executable",
+                    &self.executable,
+                    "salt",
+                    &&self.salt,
+                )
+            }
+        }
+        #[automatically_derived]
+        impl ::core::clone::Clone for ArbitraryCreateContractHostFnContext {
+            #[inline]
+            fn clone(&self) -> ArbitraryCreateContractHostFnContext {
+                ArbitraryCreateContractHostFnContext {
+                    executable: ::core::clone::Clone::clone(&self.executable),
+                    salt: ::core::clone::Clone::clone(&self.salt),
+                }
+            }
+        }
+        #[automatically_derived]
+        impl ::core::cmp::Eq for ArbitraryCreateContractHostFnContext {
+            #[inline]
+            #[doc(hidden)]
+            #[coverage(off)]
+            fn assert_receiver_is_total_eq(&self) -> () {
+                let _: ::core::cmp::AssertParamIsEq<
+                    <ContractExecutable as soroban_sdk::testutils::arbitrary::SorobanArbitrary>::Prototype,
+                >;
+                let _: ::core::cmp::AssertParamIsEq<
+                    <soroban_sdk::BytesN<
+                        32,
+                    > as soroban_sdk::testutils::arbitrary::SorobanArbitrary>::Prototype,
+                >;
+            }
+        }
+        #[automatically_derived]
+        impl ::core::marker::StructuralPartialEq for ArbitraryCreateContractHostFnContext {}
+        #[automatically_derived]
+        impl ::core::cmp::PartialEq for ArbitraryCreateContractHostFnContext {
+            #[inline]
+            fn eq(&self, other: &ArbitraryCreateContractHostFnContext) -> bool {
+                self.executable == other.executable && self.salt == other.salt
+            }
+        }
+        #[automatically_derived]
+        impl ::core::cmp::Ord for ArbitraryCreateContractHostFnContext {
+            #[inline]
+            fn cmp(&self, other: &ArbitraryCreateContractHostFnContext) -> ::core::cmp::Ordering {
+                match ::core::cmp::Ord::cmp(&self.executable, &other.executable) {
+                    ::core::cmp::Ordering::Equal => ::core::cmp::Ord::cmp(&self.salt, &other.salt),
+                    cmp => cmp,
+                }
+            }
+        }
+        #[automatically_derived]
+        impl ::core::cmp::PartialOrd for ArbitraryCreateContractHostFnContext {
+            #[inline]
+            fn partial_cmp(
+                &self,
+                other: &ArbitraryCreateContractHostFnContext,
+            ) -> ::core::option::Option<::core::cmp::Ordering> {
+                match ::core::cmp::PartialOrd::partial_cmp(&self.executable, &other.executable) {
+                    ::core::option::Option::Some(::core::cmp::Ordering::Equal) => {
+                        ::core::cmp::PartialOrd::partial_cmp(&self.salt, &other.salt)
+                    }
+                    cmp => cmp,
+                }
+            }
+        }
+        const _: () = {
+            #[allow(non_upper_case_globals)]
+            const RECURSIVE_COUNT_ArbitraryCreateContractHostFnContext: ::std::thread::LocalKey<
+                std::cell::Cell<u32>,
+            > = {
+                #[inline]
+                fn __init() -> std::cell::Cell<u32> {
+                    std::cell::Cell::new(0)
+                }
+                unsafe {
+                    ::std::thread::LocalKey::new(
+                        const {
+                            if ::std::mem::needs_drop::<std::cell::Cell<u32>>() {
+                                |init| {
+                                    #[thread_local]
+                                    static VAL: ::std::thread::local_impl::LazyStorage<
+                                        std::cell::Cell<u32>,
+                                        (),
+                                    > = ::std::thread::local_impl::LazyStorage::new();
+                                    VAL.get_or_init(init, __init)
+                                }
+                            } else {
+                                |init| {
+                                    #[thread_local]
+                                    static VAL: ::std::thread::local_impl::LazyStorage<
+                                        std::cell::Cell<u32>,
+                                        !,
+                                    > = ::std::thread::local_impl::LazyStorage::new();
+                                    VAL.get_or_init(init, __init)
+                                }
+                            }
+                        },
+                    )
+                }
+            };
+            #[automatically_derived]
+            impl<'arbitrary> arbitrary::Arbitrary<'arbitrary> for ArbitraryCreateContractHostFnContext {
+                fn arbitrary(
+                    u: &mut arbitrary::Unstructured<'arbitrary>,
+                ) -> arbitrary::Result<Self> {
+                    let guard_against_recursion = u.is_empty();
+                    if guard_against_recursion {
+                        RECURSIVE_COUNT_ArbitraryCreateContractHostFnContext.with(|count| {
+                            if count.get() > 0 {
+                                return Err(arbitrary::Error::NotEnoughData);
+                            }
+                            count.set(count.get() + 1);
+                            Ok(())
+                        })?;
+                    }
+                    let result = (|| {
+                        Ok(ArbitraryCreateContractHostFnContext {
+                            executable: arbitrary::Arbitrary::arbitrary(u)?,
+                            salt: arbitrary::Arbitrary::arbitrary(u)?,
+                        })
+                    })();
+                    if guard_against_recursion {
+                        RECURSIVE_COUNT_ArbitraryCreateContractHostFnContext.with(|count| {
+                            count.set(count.get() - 1);
+                        });
+                    }
+                    result
+                }
+                fn arbitrary_take_rest(
+                    mut u: arbitrary::Unstructured<'arbitrary>,
+                ) -> arbitrary::Result<Self> {
+                    let guard_against_recursion = u.is_empty();
+                    if guard_against_recursion {
+                        RECURSIVE_COUNT_ArbitraryCreateContractHostFnContext.with(|count| {
+                            if count.get() > 0 {
+                                return Err(arbitrary::Error::NotEnoughData);
+                            }
+                            count.set(count.get() + 1);
+                            Ok(())
+                        })?;
+                    }
+                    let result = (|| {
+                        Ok(ArbitraryCreateContractHostFnContext {
+                            executable: arbitrary::Arbitrary::arbitrary(&mut u)?,
+                            salt: arbitrary::Arbitrary::arbitrary_take_rest(u)?,
+                        })
+                    })();
+                    if guard_against_recursion {
+                        RECURSIVE_COUNT_ArbitraryCreateContractHostFnContext.with(|count| {
+                            count.set(count.get() - 1);
+                        });
+                    }
+                    result
+                }
+                #[inline]
+                fn size_hint(depth: usize) -> (usize, Option<usize>) {
+                    arbitrary::size_hint::recursion_guard(depth, |depth| {
+                        arbitrary::size_hint::and_all(
+                            &[
+                                <<ContractExecutable as soroban_sdk::testutils::arbitrary::SorobanArbitrary>::Prototype as arbitrary::Arbitrary>::size_hint(
+                                    depth,
+                                ),
+                                <<soroban_sdk::BytesN<
+                                    32,
+                                > as soroban_sdk::testutils::arbitrary::SorobanArbitrary>::Prototype as arbitrary::Arbitrary>::size_hint(
+                                    depth,
+                                ),
+                            ],
+                        )
+                    })
+                }
+            }
+        };
+        impl soroban_sdk::testutils::arbitrary::SorobanArbitrary for CreateContractHostFnContext {
+            type Prototype = ArbitraryCreateContractHostFnContext;
+        }
+        impl soroban_sdk::TryFromVal<soroban_sdk::Env, ArbitraryCreateContractHostFnContext>
+            for CreateContractHostFnContext
+        {
+            type Error = soroban_sdk::ConversionError;
+            fn try_from_val(
+                env: &soroban_sdk::Env,
+                v: &ArbitraryCreateContractHostFnContext,
+            ) -> std::result::Result<Self, Self::Error> {
+                Ok(CreateContractHostFnContext {
+                    executable: soroban_sdk::IntoVal::into_val(&v.executable, env),
+                    salt: soroban_sdk::IntoVal::into_val(&v.salt, env),
+                })
+            }
+        }
+    };
+    pub struct CreateContractWithConstructorHostFnContext {
+        pub constructor_args: soroban_sdk::Vec<soroban_sdk::Val>,
+        pub executable: ContractExecutable,
+        pub salt: soroban_sdk::BytesN<32>,
+    }
+    #[automatically_derived]
+    impl ::core::fmt::Debug for CreateContractWithConstructorHostFnContext {
+        #[inline]
+        fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+            ::core::fmt::Formatter::debug_struct_field3_finish(
+                f,
+                "CreateContractWithConstructorHostFnContext",
+                "constructor_args",
+                &self.constructor_args,
+                "executable",
+                &self.executable,
+                "salt",
+                &&self.salt,
+            )
+        }
+    }
+    #[automatically_derived]
+    impl ::core::clone::Clone for CreateContractWithConstructorHostFnContext {
+        #[inline]
+        fn clone(&self) -> CreateContractWithConstructorHostFnContext {
+            CreateContractWithConstructorHostFnContext {
+                constructor_args: ::core::clone::Clone::clone(&self.constructor_args),
+                executable: ::core::clone::Clone::clone(&self.executable),
+                salt: ::core::clone::Clone::clone(&self.salt),
+            }
+        }
+    }
+    #[automatically_derived]
+    impl ::core::cmp::Eq for CreateContractWithConstructorHostFnContext {
+        #[inline]
+        #[doc(hidden)]
+        #[coverage(off)]
+        fn assert_receiver_is_total_eq(&self) -> () {
+            let _: ::core::cmp::AssertParamIsEq<soroban_sdk::Vec<soroban_sdk::Val>>;
+            let _: ::core::cmp::AssertParamIsEq<ContractExecutable>;
+            let _: ::core::cmp::AssertParamIsEq<soroban_sdk::BytesN<32>>;
+        }
+    }
+    #[automatically_derived]
+    impl ::core::marker::StructuralPartialEq for CreateContractWithConstructorHostFnContext {}
+    #[automatically_derived]
+    impl ::core::cmp::PartialEq for CreateContractWithConstructorHostFnContext {
+        #[inline]
+        fn eq(&self, other: &CreateContractWithConstructorHostFnContext) -> bool {
+            self.constructor_args == other.constructor_args
+                && self.executable == other.executable
+                && self.salt == other.salt
+        }
+    }
+    #[automatically_derived]
+    impl ::core::cmp::Ord for CreateContractWithConstructorHostFnContext {
+        #[inline]
+        fn cmp(&self, other: &CreateContractWithConstructorHostFnContext) -> ::core::cmp::Ordering {
+            match ::core::cmp::Ord::cmp(&self.constructor_args, &other.constructor_args) {
+                ::core::cmp::Ordering::Equal => {
+                    match ::core::cmp::Ord::cmp(&self.executable, &other.executable) {
+                        ::core::cmp::Ordering::Equal => {
+                            ::core::cmp::Ord::cmp(&self.salt, &other.salt)
+                        }
+                        cmp => cmp,
+                    }
+                }
+                cmp => cmp,
+            }
+        }
+    }
+    #[automatically_derived]
+    impl ::core::cmp::PartialOrd for CreateContractWithConstructorHostFnContext {
+        #[inline]
+        fn partial_cmp(
+            &self,
+            other: &CreateContractWithConstructorHostFnContext,
+        ) -> ::core::option::Option<::core::cmp::Ordering> {
+            match ::core::cmp::PartialOrd::partial_cmp(
+                &self.constructor_args,
+                &other.constructor_args,
+            ) {
+                ::core::option::Option::Some(::core::cmp::Ordering::Equal) => {
+                    match ::core::cmp::PartialOrd::partial_cmp(&self.executable, &other.executable)
+                    {
+                        ::core::option::Option::Some(::core::cmp::Ordering::Equal) => {
+                            ::core::cmp::PartialOrd::partial_cmp(&self.salt, &other.salt)
+                        }
+                        cmp => cmp,
+                    }
+                }
+                cmp => cmp,
+            }
+        }
+    }
+    pub static __SPEC_XDR_TYPE_CREATECONTRACTWITHCONSTRUCTORHOSTFNCONTEXT: [u8; 164usize] =
+        CreateContractWithConstructorHostFnContext::spec_xdr();
+    impl CreateContractWithConstructorHostFnContext {
+        pub const fn spec_xdr() -> [u8; 164usize] {
+            *b"\0\0\0\x01\0\0\0\0\0\0\0\0\0\0\0*CreateContractWithConstructorHostFnContext\0\0\0\0\0\x03\0\0\0\0\0\0\0\x10constructor_args\0\0\x03\xea\0\0\0\0\0\0\0\0\0\0\0\nexecutable\0\0\0\0\x07\xd0\0\0\0\x12ContractExecutable\0\0\0\0\0\0\0\0\0\x04salt\0\0\x03\xee\0\0\0 "
+        }
+    }
+    impl soroban_sdk::SpecShakingMarker for CreateContractWithConstructorHostFnContext {
+        #[doc(hidden)]
+        #[inline(always)]
+        fn spec_shaking_marker() {
+            <soroban_sdk::Vec<
+                soroban_sdk::Val,
+            > as soroban_sdk::SpecShakingMarker>::spec_shaking_marker();
+            <ContractExecutable as soroban_sdk::SpecShakingMarker>::spec_shaking_marker();
+            <soroban_sdk::BytesN<32> as soroban_sdk::SpecShakingMarker>::spec_shaking_marker();
+        }
+    }
+    impl soroban_sdk::TryFromVal<soroban_sdk::Env, soroban_sdk::Val>
+        for CreateContractWithConstructorHostFnContext
+    {
+        type Error = soroban_sdk::ConversionError;
+        fn try_from_val(
+            env: &soroban_sdk::Env,
+            val: &soroban_sdk::Val,
+        ) -> Result<Self, soroban_sdk::ConversionError> {
+            use soroban_sdk::{ConversionError, EnvBase, MapObject, TryIntoVal, Val};
+            const KEYS: [&'static str; 3usize] = ["constructor_args", "executable", "salt"];
+            let mut vals: [Val; 3usize] = [Val::VOID.to_val(); 3usize];
+            let map: MapObject = val.try_into().map_err(|_| ConversionError)?;
+            env.map_unpack_to_slice(map, &KEYS, &mut vals)
+                .map_err(|_| ConversionError)?;
+            Ok(Self {
+                constructor_args: vals[0]
+                    .try_into_val(env)
+                    .map_err(|_| soroban_sdk::ConversionError)?,
+                executable: vals[1]
+                    .try_into_val(env)
+                    .map_err(|_| soroban_sdk::ConversionError)?,
+                salt: vals[2]
+                    .try_into_val(env)
+                    .map_err(|_| soroban_sdk::ConversionError)?,
+            })
+        }
+    }
+    impl soroban_sdk::TryFromVal<soroban_sdk::Env, CreateContractWithConstructorHostFnContext>
+        for soroban_sdk::Val
+    {
+        type Error = soroban_sdk::ConversionError;
+        fn try_from_val(
+            env: &soroban_sdk::Env,
+            val: &CreateContractWithConstructorHostFnContext,
+        ) -> Result<Self, soroban_sdk::ConversionError> {
+            use soroban_sdk::{ConversionError, EnvBase, TryIntoVal, Val};
+            const KEYS: [&'static str; 3usize] = ["constructor_args", "executable", "salt"];
+            let vals: [Val; 3usize] = [
+                (&val.constructor_args)
+                    .try_into_val(env)
+                    .map_err(|_| ConversionError)?,
+                (&val.executable)
+                    .try_into_val(env)
+                    .map_err(|_| ConversionError)?,
+                (&val.salt).try_into_val(env).map_err(|_| ConversionError)?,
+            ];
+            Ok(env
+                .map_new_from_slices(&KEYS, &vals)
+                .map_err(|_| ConversionError)?
+                .into())
+        }
+    }
+    impl soroban_sdk::TryFromVal<soroban_sdk::Env, &CreateContractWithConstructorHostFnContext>
+        for soroban_sdk::Val
+    {
+        type Error = soroban_sdk::ConversionError;
+        #[inline(always)]
+        fn try_from_val(
+            env: &soroban_sdk::Env,
+            val: &&CreateContractWithConstructorHostFnContext,
+        ) -> Result<Self, soroban_sdk::ConversionError> {
+            <_ as soroban_sdk::TryFromVal<
+                soroban_sdk::Env,
+                CreateContractWithConstructorHostFnContext,
+            >>::try_from_val(env, *val)
+        }
+    }
+    impl soroban_sdk::TryFromVal<soroban_sdk::Env, soroban_sdk::xdr::ScMap>
+        for CreateContractWithConstructorHostFnContext
+    {
+        type Error = soroban_sdk::xdr::Error;
+        #[inline(always)]
+        fn try_from_val(
+            env: &soroban_sdk::Env,
+            val: &soroban_sdk::xdr::ScMap,
+        ) -> Result<Self, soroban_sdk::xdr::Error> {
+            use soroban_sdk::xdr::Validate;
+            use soroban_sdk::TryIntoVal;
+            let map = val;
+            if map.len() != 3usize {
+                return Err(soroban_sdk::xdr::Error::Invalid);
+            }
+            map.validate()?;
+            Ok(Self {
+                constructor_args: {
+                    let key: soroban_sdk::xdr::ScVal = soroban_sdk::xdr::ScSymbol(
+                        "constructor_args"
+                            .try_into()
+                            .map_err(|_| soroban_sdk::xdr::Error::Invalid)?,
+                    )
+                    .into();
+                    let idx = map
+                        .binary_search_by_key(&key, |entry| entry.key.clone())
+                        .map_err(|_| soroban_sdk::xdr::Error::Invalid)?;
+                    let rv: soroban_sdk::Val = (&map[idx].val.clone())
+                        .try_into_val(env)
+                        .map_err(|_| soroban_sdk::xdr::Error::Invalid)?;
+                    rv.try_into_val(env)
+                        .map_err(|_| soroban_sdk::xdr::Error::Invalid)?
+                },
+                executable: {
+                    let key: soroban_sdk::xdr::ScVal = soroban_sdk::xdr::ScSymbol(
+                        "executable"
+                            .try_into()
+                            .map_err(|_| soroban_sdk::xdr::Error::Invalid)?,
+                    )
+                    .into();
+                    let idx = map
+                        .binary_search_by_key(&key, |entry| entry.key.clone())
+                        .map_err(|_| soroban_sdk::xdr::Error::Invalid)?;
+                    let rv: soroban_sdk::Val = (&map[idx].val.clone())
+                        .try_into_val(env)
+                        .map_err(|_| soroban_sdk::xdr::Error::Invalid)?;
+                    rv.try_into_val(env)
+                        .map_err(|_| soroban_sdk::xdr::Error::Invalid)?
+                },
+                salt: {
+                    let key: soroban_sdk::xdr::ScVal = soroban_sdk::xdr::ScSymbol(
+                        "salt"
+                            .try_into()
+                            .map_err(|_| soroban_sdk::xdr::Error::Invalid)?,
+                    )
+                    .into();
+                    let idx = map
+                        .binary_search_by_key(&key, |entry| entry.key.clone())
+                        .map_err(|_| soroban_sdk::xdr::Error::Invalid)?;
+                    let rv: soroban_sdk::Val = (&map[idx].val.clone())
+                        .try_into_val(env)
+                        .map_err(|_| soroban_sdk::xdr::Error::Invalid)?;
+                    rv.try_into_val(env)
+                        .map_err(|_| soroban_sdk::xdr::Error::Invalid)?
+                },
+            })
+        }
+    }
+    impl soroban_sdk::TryFromVal<soroban_sdk::Env, soroban_sdk::xdr::ScVal>
+        for CreateContractWithConstructorHostFnContext
+    {
+        type Error = soroban_sdk::xdr::Error;
+        #[inline(always)]
+        fn try_from_val(
+            env: &soroban_sdk::Env,
+            val: &soroban_sdk::xdr::ScVal,
+        ) -> Result<Self, soroban_sdk::xdr::Error> {
+            if let soroban_sdk::xdr::ScVal::Map(Some(map)) = val {
+                <_ as soroban_sdk::TryFromVal<_, _>>::try_from_val(env, map)
+            } else {
+                Err(soroban_sdk::xdr::Error::Invalid)
+            }
+        }
+    }
+    impl TryFrom<&CreateContractWithConstructorHostFnContext> for soroban_sdk::xdr::ScMap {
+        type Error = soroban_sdk::xdr::Error;
+        #[inline(always)]
+        fn try_from(
+            val: &CreateContractWithConstructorHostFnContext,
+        ) -> Result<Self, soroban_sdk::xdr::Error> {
+            extern crate alloc;
+            use soroban_sdk::TryFromVal;
+            soroban_sdk::xdr::ScMap::sorted_from(<[_]>::into_vec(::alloc::boxed::box_new([
+                soroban_sdk::xdr::ScMapEntry {
+                    key: soroban_sdk::xdr::ScSymbol(
+                        "constructor_args"
+                            .try_into()
+                            .map_err(|_| soroban_sdk::xdr::Error::Invalid)?,
+                    )
+                    .into(),
+                    val: (&val.constructor_args)
+                        .try_into()
+                        .map_err(|_| soroban_sdk::xdr::Error::Invalid)?,
+                },
+                soroban_sdk::xdr::ScMapEntry {
+                    key: soroban_sdk::xdr::ScSymbol(
+                        "executable"
+                            .try_into()
+                            .map_err(|_| soroban_sdk::xdr::Error::Invalid)?,
+                    )
+                    .into(),
+                    val: (&val.executable)
+                        .try_into()
+                        .map_err(|_| soroban_sdk::xdr::Error::Invalid)?,
+                },
+                soroban_sdk::xdr::ScMapEntry {
+                    key: soroban_sdk::xdr::ScSymbol(
+                        "salt"
+                            .try_into()
+                            .map_err(|_| soroban_sdk::xdr::Error::Invalid)?,
+                    )
+                    .into(),
+                    val: (&val.salt)
+                        .try_into()
+                        .map_err(|_| soroban_sdk::xdr::Error::Invalid)?,
+                },
+            ])))
+        }
+    }
+    impl TryFrom<CreateContractWithConstructorHostFnContext> for soroban_sdk::xdr::ScMap {
+        type Error = soroban_sdk::xdr::Error;
+        #[inline(always)]
+        fn try_from(
+            val: CreateContractWithConstructorHostFnContext,
+        ) -> Result<Self, soroban_sdk::xdr::Error> {
+            (&val).try_into()
+        }
+    }
+    impl TryFrom<&CreateContractWithConstructorHostFnContext> for soroban_sdk::xdr::ScVal {
+        type Error = soroban_sdk::xdr::Error;
+        #[inline(always)]
+        fn try_from(
+            val: &CreateContractWithConstructorHostFnContext,
+        ) -> Result<Self, soroban_sdk::xdr::Error> {
+            Ok(soroban_sdk::xdr::ScVal::Map(Some(val.try_into()?)))
+        }
+    }
+    impl TryFrom<CreateContractWithConstructorHostFnContext> for soroban_sdk::xdr::ScVal {
+        type Error = soroban_sdk::xdr::Error;
+        #[inline(always)]
+        fn try_from(
+            val: CreateContractWithConstructorHostFnContext,
+        ) -> Result<Self, soroban_sdk::xdr::Error> {
+            (&val).try_into()
+        }
+    }
+    const _: () = {
+        use soroban_sdk::testutils::arbitrary::arbitrary;
+        use soroban_sdk::testutils::arbitrary::std;
+        pub struct ArbitraryCreateContractWithConstructorHostFnContext {
+            constructor_args: <soroban_sdk::Vec<
+                soroban_sdk::Val,
+            > as soroban_sdk::testutils::arbitrary::SorobanArbitrary>::Prototype,
+            executable: <ContractExecutable as soroban_sdk::testutils::arbitrary::SorobanArbitrary>::Prototype,
+            salt: <soroban_sdk::BytesN<
+                32,
+            > as soroban_sdk::testutils::arbitrary::SorobanArbitrary>::Prototype,
+        }
+        #[automatically_derived]
+        impl ::core::fmt::Debug for ArbitraryCreateContractWithConstructorHostFnContext {
+            #[inline]
+            fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+                ::core::fmt::Formatter::debug_struct_field3_finish(
+                    f,
+                    "ArbitraryCreateContractWithConstructorHostFnContext",
+                    "constructor_args",
+                    &self.constructor_args,
+                    "executable",
+                    &self.executable,
+                    "salt",
+                    &&self.salt,
+                )
+            }
+        }
+        #[automatically_derived]
+        impl ::core::clone::Clone for ArbitraryCreateContractWithConstructorHostFnContext {
+            #[inline]
+            fn clone(&self) -> ArbitraryCreateContractWithConstructorHostFnContext {
+                ArbitraryCreateContractWithConstructorHostFnContext {
+                    constructor_args: ::core::clone::Clone::clone(&self.constructor_args),
+                    executable: ::core::clone::Clone::clone(&self.executable),
+                    salt: ::core::clone::Clone::clone(&self.salt),
+                }
+            }
+        }
+        #[automatically_derived]
+        impl ::core::cmp::Eq for ArbitraryCreateContractWithConstructorHostFnContext {
+            #[inline]
+            #[doc(hidden)]
+            #[coverage(off)]
+            fn assert_receiver_is_total_eq(&self) -> () {
+                let _: ::core::cmp::AssertParamIsEq<
+                    <soroban_sdk::Vec<
+                        soroban_sdk::Val,
+                    > as soroban_sdk::testutils::arbitrary::SorobanArbitrary>::Prototype,
+                >;
+                let _: ::core::cmp::AssertParamIsEq<
+                    <ContractExecutable as soroban_sdk::testutils::arbitrary::SorobanArbitrary>::Prototype,
+                >;
+                let _: ::core::cmp::AssertParamIsEq<
+                    <soroban_sdk::BytesN<
+                        32,
+                    > as soroban_sdk::testutils::arbitrary::SorobanArbitrary>::Prototype,
+                >;
+            }
+        }
+        #[automatically_derived]
+        impl ::core::marker::StructuralPartialEq for ArbitraryCreateContractWithConstructorHostFnContext {}
+        #[automatically_derived]
+        impl ::core::cmp::PartialEq for ArbitraryCreateContractWithConstructorHostFnContext {
+            #[inline]
+            fn eq(&self, other: &ArbitraryCreateContractWithConstructorHostFnContext) -> bool {
+                self.constructor_args == other.constructor_args
+                    && self.executable == other.executable
+                    && self.salt == other.salt
+            }
+        }
+        #[automatically_derived]
+        impl ::core::cmp::Ord for ArbitraryCreateContractWithConstructorHostFnContext {
+            #[inline]
+            fn cmp(
+                &self,
+                other: &ArbitraryCreateContractWithConstructorHostFnContext,
+            ) -> ::core::cmp::Ordering {
+                match ::core::cmp::Ord::cmp(&self.constructor_args, &other.constructor_args) {
+                    ::core::cmp::Ordering::Equal => {
+                        match ::core::cmp::Ord::cmp(&self.executable, &other.executable) {
+                            ::core::cmp::Ordering::Equal => {
+                                ::core::cmp::Ord::cmp(&self.salt, &other.salt)
+                            }
+                            cmp => cmp,
+                        }
+                    }
+                    cmp => cmp,
+                }
+            }
+        }
+        #[automatically_derived]
+        impl ::core::cmp::PartialOrd for ArbitraryCreateContractWithConstructorHostFnContext {
+            #[inline]
+            fn partial_cmp(
+                &self,
+                other: &ArbitraryCreateContractWithConstructorHostFnContext,
+            ) -> ::core::option::Option<::core::cmp::Ordering> {
+                match ::core::cmp::PartialOrd::partial_cmp(
+                    &self.constructor_args,
+                    &other.constructor_args,
+                ) {
+                    ::core::option::Option::Some(::core::cmp::Ordering::Equal) => {
+                        match ::core::cmp::PartialOrd::partial_cmp(
+                            &self.executable,
+                            &other.executable,
+                        ) {
+                            ::core::option::Option::Some(::core::cmp::Ordering::Equal) => {
+                                ::core::cmp::PartialOrd::partial_cmp(&self.salt, &other.salt)
+                            }
+                            cmp => cmp,
+                        }
+                    }
+                    cmp => cmp,
+                }
+            }
+        }
+        const _: () = {
+            #[allow(non_upper_case_globals)]
+            const RECURSIVE_COUNT_ArbitraryCreateContractWithConstructorHostFnContext:
+                ::std::thread::LocalKey<std::cell::Cell<u32>> = {
+                #[inline]
+                fn __init() -> std::cell::Cell<u32> {
+                    std::cell::Cell::new(0)
+                }
+                unsafe {
+                    ::std::thread::LocalKey::new(
+                        const {
+                            if ::std::mem::needs_drop::<std::cell::Cell<u32>>() {
+                                |init| {
+                                    #[thread_local]
+                                    static VAL: ::std::thread::local_impl::LazyStorage<
+                                        std::cell::Cell<u32>,
+                                        (),
+                                    > = ::std::thread::local_impl::LazyStorage::new();
+                                    VAL.get_or_init(init, __init)
+                                }
+                            } else {
+                                |init| {
+                                    #[thread_local]
+                                    static VAL: ::std::thread::local_impl::LazyStorage<
+                                        std::cell::Cell<u32>,
+                                        !,
+                                    > = ::std::thread::local_impl::LazyStorage::new();
+                                    VAL.get_or_init(init, __init)
+                                }
+                            }
+                        },
+                    )
+                }
+            };
+            #[automatically_derived]
+            impl<'arbitrary> arbitrary::Arbitrary<'arbitrary>
+                for ArbitraryCreateContractWithConstructorHostFnContext
+            {
+                fn arbitrary(
+                    u: &mut arbitrary::Unstructured<'arbitrary>,
+                ) -> arbitrary::Result<Self> {
+                    let guard_against_recursion = u.is_empty();
+                    if guard_against_recursion {
+                        RECURSIVE_COUNT_ArbitraryCreateContractWithConstructorHostFnContext.with(
+                            |count| {
+                                if count.get() > 0 {
+                                    return Err(arbitrary::Error::NotEnoughData);
+                                }
+                                count.set(count.get() + 1);
+                                Ok(())
+                            },
+                        )?;
+                    }
+                    let result = (|| {
+                        Ok(ArbitraryCreateContractWithConstructorHostFnContext {
+                            constructor_args: arbitrary::Arbitrary::arbitrary(u)?,
+                            executable: arbitrary::Arbitrary::arbitrary(u)?,
+                            salt: arbitrary::Arbitrary::arbitrary(u)?,
+                        })
+                    })();
+                    if guard_against_recursion {
+                        RECURSIVE_COUNT_ArbitraryCreateContractWithConstructorHostFnContext.with(
+                            |count| {
+                                count.set(count.get() - 1);
+                            },
+                        );
+                    }
+                    result
+                }
+                fn arbitrary_take_rest(
+                    mut u: arbitrary::Unstructured<'arbitrary>,
+                ) -> arbitrary::Result<Self> {
+                    let guard_against_recursion = u.is_empty();
+                    if guard_against_recursion {
+                        RECURSIVE_COUNT_ArbitraryCreateContractWithConstructorHostFnContext.with(
+                            |count| {
+                                if count.get() > 0 {
+                                    return Err(arbitrary::Error::NotEnoughData);
+                                }
+                                count.set(count.get() + 1);
+                                Ok(())
+                            },
+                        )?;
+                    }
+                    let result = (|| {
+                        Ok(ArbitraryCreateContractWithConstructorHostFnContext {
+                            constructor_args: arbitrary::Arbitrary::arbitrary(&mut u)?,
+                            executable: arbitrary::Arbitrary::arbitrary(&mut u)?,
+                            salt: arbitrary::Arbitrary::arbitrary_take_rest(u)?,
+                        })
+                    })();
+                    if guard_against_recursion {
+                        RECURSIVE_COUNT_ArbitraryCreateContractWithConstructorHostFnContext.with(
+                            |count| {
+                                count.set(count.get() - 1);
+                            },
+                        );
+                    }
+                    result
+                }
+                #[inline]
+                fn size_hint(depth: usize) -> (usize, Option<usize>) {
+                    arbitrary::size_hint::recursion_guard(depth, |depth| {
+                        arbitrary::size_hint::and_all(
+                            &[
+                                <<soroban_sdk::Vec<
+                                    soroban_sdk::Val,
+                                > as soroban_sdk::testutils::arbitrary::SorobanArbitrary>::Prototype as arbitrary::Arbitrary>::size_hint(
+                                    depth,
+                                ),
+                                <<ContractExecutable as soroban_sdk::testutils::arbitrary::SorobanArbitrary>::Prototype as arbitrary::Arbitrary>::size_hint(
+                                    depth,
+                                ),
+                                <<soroban_sdk::BytesN<
+                                    32,
+                                > as soroban_sdk::testutils::arbitrary::SorobanArbitrary>::Prototype as arbitrary::Arbitrary>::size_hint(
+                                    depth,
+                                ),
+                            ],
+                        )
+                    })
+                }
+            }
+        };
+        impl soroban_sdk::testutils::arbitrary::SorobanArbitrary
+            for CreateContractWithConstructorHostFnContext
+        {
+            type Prototype = ArbitraryCreateContractWithConstructorHostFnContext;
+        }
+        impl
+            soroban_sdk::TryFromVal<
+                soroban_sdk::Env,
+                ArbitraryCreateContractWithConstructorHostFnContext,
+            > for CreateContractWithConstructorHostFnContext
+        {
+            type Error = soroban_sdk::ConversionError;
+            fn try_from_val(
+                env: &soroban_sdk::Env,
+                v: &ArbitraryCreateContractWithConstructorHostFnContext,
+            ) -> std::result::Result<Self, Self::Error> {
+                Ok(CreateContractWithConstructorHostFnContext {
+                    constructor_args: soroban_sdk::IntoVal::into_val(&v.constructor_args, env),
+                    executable: soroban_sdk::IntoVal::into_val(&v.executable, env),
+                    salt: soroban_sdk::IntoVal::into_val(&v.salt, env),
+                })
+            }
+        }
+    };
     pub struct StructA {
         pub f1: u32,
         pub f2: bool,
@@ -15796,6 +17897,2527 @@ mod wasm_imported {
                     soroban_sdk::IntoVal::into_val(&v.0, env),
                     soroban_sdk::IntoVal::into_val(&v.1, env),
                 ))
+            }
+        }
+    };
+    pub enum Context {
+        Contract(ContractContext),
+        CreateContractHostFn(CreateContractHostFnContext),
+        CreateContractWithCtorHostFn(CreateContractWithConstructorHostFnContext),
+    }
+    #[automatically_derived]
+    impl ::core::fmt::Debug for Context {
+        #[inline]
+        fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+            match self {
+                Context::Contract(__self_0) => {
+                    ::core::fmt::Formatter::debug_tuple_field1_finish(f, "Contract", &__self_0)
+                }
+                Context::CreateContractHostFn(__self_0) => {
+                    ::core::fmt::Formatter::debug_tuple_field1_finish(
+                        f,
+                        "CreateContractHostFn",
+                        &__self_0,
+                    )
+                }
+                Context::CreateContractWithCtorHostFn(__self_0) => {
+                    ::core::fmt::Formatter::debug_tuple_field1_finish(
+                        f,
+                        "CreateContractWithCtorHostFn",
+                        &__self_0,
+                    )
+                }
+            }
+        }
+    }
+    #[automatically_derived]
+    impl ::core::clone::Clone for Context {
+        #[inline]
+        fn clone(&self) -> Context {
+            match self {
+                Context::Contract(__self_0) => {
+                    Context::Contract(::core::clone::Clone::clone(__self_0))
+                }
+                Context::CreateContractHostFn(__self_0) => {
+                    Context::CreateContractHostFn(::core::clone::Clone::clone(__self_0))
+                }
+                Context::CreateContractWithCtorHostFn(__self_0) => {
+                    Context::CreateContractWithCtorHostFn(::core::clone::Clone::clone(__self_0))
+                }
+            }
+        }
+    }
+    #[automatically_derived]
+    impl ::core::cmp::Eq for Context {
+        #[inline]
+        #[doc(hidden)]
+        #[coverage(off)]
+        fn assert_receiver_is_total_eq(&self) -> () {
+            let _: ::core::cmp::AssertParamIsEq<ContractContext>;
+            let _: ::core::cmp::AssertParamIsEq<CreateContractHostFnContext>;
+            let _: ::core::cmp::AssertParamIsEq<CreateContractWithConstructorHostFnContext>;
+        }
+    }
+    #[automatically_derived]
+    impl ::core::marker::StructuralPartialEq for Context {}
+    #[automatically_derived]
+    impl ::core::cmp::PartialEq for Context {
+        #[inline]
+        fn eq(&self, other: &Context) -> bool {
+            let __self_discr = ::core::intrinsics::discriminant_value(self);
+            let __arg1_discr = ::core::intrinsics::discriminant_value(other);
+            __self_discr == __arg1_discr
+                && match (self, other) {
+                    (Context::Contract(__self_0), Context::Contract(__arg1_0)) => {
+                        __self_0 == __arg1_0
+                    }
+                    (
+                        Context::CreateContractHostFn(__self_0),
+                        Context::CreateContractHostFn(__arg1_0),
+                    ) => __self_0 == __arg1_0,
+                    (
+                        Context::CreateContractWithCtorHostFn(__self_0),
+                        Context::CreateContractWithCtorHostFn(__arg1_0),
+                    ) => __self_0 == __arg1_0,
+                    _ => unsafe { ::core::intrinsics::unreachable() },
+                }
+        }
+    }
+    #[automatically_derived]
+    impl ::core::cmp::Ord for Context {
+        #[inline]
+        fn cmp(&self, other: &Context) -> ::core::cmp::Ordering {
+            let __self_discr = ::core::intrinsics::discriminant_value(self);
+            let __arg1_discr = ::core::intrinsics::discriminant_value(other);
+            match ::core::cmp::Ord::cmp(&__self_discr, &__arg1_discr) {
+                ::core::cmp::Ordering::Equal => match (self, other) {
+                    (Context::Contract(__self_0), Context::Contract(__arg1_0)) => {
+                        ::core::cmp::Ord::cmp(__self_0, __arg1_0)
+                    }
+                    (
+                        Context::CreateContractHostFn(__self_0),
+                        Context::CreateContractHostFn(__arg1_0),
+                    ) => ::core::cmp::Ord::cmp(__self_0, __arg1_0),
+                    (
+                        Context::CreateContractWithCtorHostFn(__self_0),
+                        Context::CreateContractWithCtorHostFn(__arg1_0),
+                    ) => ::core::cmp::Ord::cmp(__self_0, __arg1_0),
+                    _ => unsafe { ::core::intrinsics::unreachable() },
+                },
+                cmp => cmp,
+            }
+        }
+    }
+    #[automatically_derived]
+    impl ::core::cmp::PartialOrd for Context {
+        #[inline]
+        fn partial_cmp(&self, other: &Context) -> ::core::option::Option<::core::cmp::Ordering> {
+            let __self_discr = ::core::intrinsics::discriminant_value(self);
+            let __arg1_discr = ::core::intrinsics::discriminant_value(other);
+            match (self, other) {
+                (Context::Contract(__self_0), Context::Contract(__arg1_0)) => {
+                    ::core::cmp::PartialOrd::partial_cmp(__self_0, __arg1_0)
+                }
+                (
+                    Context::CreateContractHostFn(__self_0),
+                    Context::CreateContractHostFn(__arg1_0),
+                ) => ::core::cmp::PartialOrd::partial_cmp(__self_0, __arg1_0),
+                (
+                    Context::CreateContractWithCtorHostFn(__self_0),
+                    Context::CreateContractWithCtorHostFn(__arg1_0),
+                ) => ::core::cmp::PartialOrd::partial_cmp(__self_0, __arg1_0),
+                _ => ::core::cmp::PartialOrd::partial_cmp(&__self_discr, &__arg1_discr),
+            }
+        }
+    }
+    pub static __SPEC_XDR_TYPE_CONTEXT: [u8; 244usize] = Context::spec_xdr();
+    impl Context {
+        pub const fn spec_xdr() -> [u8; 244usize] {
+            *b"\0\0\0\x02\0\0\0\0\0\0\0\0\0\0\0\x07Context\0\0\0\0\x03\0\0\0\x01\0\0\0\0\0\0\0\x08Contract\0\0\0\x01\0\0\x07\xd0\0\0\0\x0fContractContext\0\0\0\0\x01\0\0\0\0\0\0\0\x14CreateContractHostFn\0\0\0\x01\0\0\x07\xd0\0\0\0\x1bCreateContractHostFnContext\0\0\0\0\x01\0\0\0\0\0\0\0\x1cCreateContractWithCtorHostFn\0\0\0\x01\0\0\x07\xd0\0\0\0*CreateContractWithConstructorHostFnContext\0\0"
+        }
+    }
+    impl soroban_sdk::SpecShakingMarker for Context {
+        #[doc(hidden)]
+        #[inline(always)]
+        fn spec_shaking_marker() {
+            <ContractContext as soroban_sdk::SpecShakingMarker>::spec_shaking_marker();
+            <CreateContractHostFnContext as soroban_sdk::SpecShakingMarker>::spec_shaking_marker();
+            <CreateContractWithConstructorHostFnContext as soroban_sdk::SpecShakingMarker>::spec_shaking_marker();
+        }
+    }
+    impl soroban_sdk::TryFromVal<soroban_sdk::Env, soroban_sdk::Val> for Context {
+        type Error = soroban_sdk::ConversionError;
+        #[inline(always)]
+        fn try_from_val(
+            env: &soroban_sdk::Env,
+            val: &soroban_sdk::Val,
+        ) -> Result<Self, soroban_sdk::ConversionError> {
+            use soroban_sdk::{EnvBase, TryFromVal, TryIntoVal};
+            const CASES: &'static [&'static str] = &[
+                "Contract",
+                "CreateContractHostFn",
+                "CreateContractWithCtorHostFn",
+            ];
+            let vec: soroban_sdk::Vec<soroban_sdk::Val> = val.try_into_val(env)?;
+            let mut iter = vec.try_iter();
+            let discriminant: soroban_sdk::Symbol = iter
+                .next()
+                .ok_or(soroban_sdk::ConversionError)??
+                .try_into_val(env)
+                .map_err(|_| soroban_sdk::ConversionError)?;
+            Ok(
+                match u32::from(env.symbol_index_in_strs(discriminant.to_symbol_val(), CASES)?)
+                    as usize
+                {
+                    0 => {
+                        if iter.len() > 1usize {
+                            return Err(soroban_sdk::ConversionError);
+                        }
+                        Self::Contract(
+                            iter.next()
+                                .ok_or(soroban_sdk::ConversionError)??
+                                .try_into_val(env)?,
+                        )
+                    }
+                    1 => {
+                        if iter.len() > 1usize {
+                            return Err(soroban_sdk::ConversionError);
+                        }
+                        Self::CreateContractHostFn(
+                            iter.next()
+                                .ok_or(soroban_sdk::ConversionError)??
+                                .try_into_val(env)?,
+                        )
+                    }
+                    2 => {
+                        if iter.len() > 1usize {
+                            return Err(soroban_sdk::ConversionError);
+                        }
+                        Self::CreateContractWithCtorHostFn(
+                            iter.next()
+                                .ok_or(soroban_sdk::ConversionError)??
+                                .try_into_val(env)?,
+                        )
+                    }
+                    _ => Err(soroban_sdk::ConversionError {})?,
+                },
+            )
+        }
+    }
+    impl soroban_sdk::TryFromVal<soroban_sdk::Env, Context> for soroban_sdk::Val {
+        type Error = soroban_sdk::ConversionError;
+        #[inline(always)]
+        fn try_from_val(
+            env: &soroban_sdk::Env,
+            val: &Context,
+        ) -> Result<Self, soroban_sdk::ConversionError> {
+            use soroban_sdk::{TryFromVal, TryIntoVal};
+            match val {
+                Context::Contract(ref value0) => {
+                    let tup: (soroban_sdk::Val, soroban_sdk::Val) = (
+                        soroban_sdk::Symbol::try_from_val(env, &"Contract")?.to_val(),
+                        value0.try_into_val(env)?,
+                    );
+                    tup.try_into_val(env).map_err(Into::into)
+                }
+                Context::CreateContractHostFn(ref value0) => {
+                    let tup: (soroban_sdk::Val, soroban_sdk::Val) = (
+                        soroban_sdk::Symbol::try_from_val(env, &"CreateContractHostFn")?.to_val(),
+                        value0.try_into_val(env)?,
+                    );
+                    tup.try_into_val(env).map_err(Into::into)
+                }
+                Context::CreateContractWithCtorHostFn(ref value0) => {
+                    let tup: (soroban_sdk::Val, soroban_sdk::Val) = (
+                        soroban_sdk::Symbol::try_from_val(env, &"CreateContractWithCtorHostFn")?
+                            .to_val(),
+                        value0.try_into_val(env)?,
+                    );
+                    tup.try_into_val(env).map_err(Into::into)
+                }
+            }
+        }
+    }
+    impl soroban_sdk::TryFromVal<soroban_sdk::Env, &Context> for soroban_sdk::Val {
+        type Error = soroban_sdk::ConversionError;
+        #[inline(always)]
+        fn try_from_val(
+            env: &soroban_sdk::Env,
+            val: &&Context,
+        ) -> Result<Self, soroban_sdk::ConversionError> {
+            <_ as soroban_sdk::TryFromVal<soroban_sdk::Env, Context>>::try_from_val(env, *val)
+        }
+    }
+    impl soroban_sdk::TryFromVal<soroban_sdk::Env, soroban_sdk::xdr::ScVec> for Context {
+        type Error = soroban_sdk::xdr::Error;
+        #[inline(always)]
+        fn try_from_val(
+            env: &soroban_sdk::Env,
+            val: &soroban_sdk::xdr::ScVec,
+        ) -> Result<Self, soroban_sdk::xdr::Error> {
+            use soroban_sdk::xdr::Validate;
+            use soroban_sdk::TryIntoVal;
+            let vec = val;
+            let mut iter = vec.iter();
+            let discriminant: soroban_sdk::xdr::ScSymbol = iter
+                .next()
+                .ok_or(soroban_sdk::xdr::Error::Invalid)?
+                .clone()
+                .try_into()
+                .map_err(|_| soroban_sdk::xdr::Error::Invalid)?;
+            let discriminant_name: &str = &discriminant.to_utf8_string()?;
+            Ok(match discriminant_name {
+                "Contract" => {
+                    if iter.len() > 1usize {
+                        return Err(soroban_sdk::xdr::Error::Invalid);
+                    }
+                    let rv0: soroban_sdk::Val = iter
+                        .next()
+                        .ok_or(soroban_sdk::xdr::Error::Invalid)?
+                        .try_into_val(env)
+                        .map_err(|_| soroban_sdk::xdr::Error::Invalid)?;
+                    Self::Contract(
+                        rv0.try_into_val(env)
+                            .map_err(|_| soroban_sdk::xdr::Error::Invalid)?,
+                    )
+                }
+                "CreateContractHostFn" => {
+                    if iter.len() > 1usize {
+                        return Err(soroban_sdk::xdr::Error::Invalid);
+                    }
+                    let rv0: soroban_sdk::Val = iter
+                        .next()
+                        .ok_or(soroban_sdk::xdr::Error::Invalid)?
+                        .try_into_val(env)
+                        .map_err(|_| soroban_sdk::xdr::Error::Invalid)?;
+                    Self::CreateContractHostFn(
+                        rv0.try_into_val(env)
+                            .map_err(|_| soroban_sdk::xdr::Error::Invalid)?,
+                    )
+                }
+                "CreateContractWithCtorHostFn" => {
+                    if iter.len() > 1usize {
+                        return Err(soroban_sdk::xdr::Error::Invalid);
+                    }
+                    let rv0: soroban_sdk::Val = iter
+                        .next()
+                        .ok_or(soroban_sdk::xdr::Error::Invalid)?
+                        .try_into_val(env)
+                        .map_err(|_| soroban_sdk::xdr::Error::Invalid)?;
+                    Self::CreateContractWithCtorHostFn(
+                        rv0.try_into_val(env)
+                            .map_err(|_| soroban_sdk::xdr::Error::Invalid)?,
+                    )
+                }
+                _ => Err(soroban_sdk::xdr::Error::Invalid)?,
+            })
+        }
+    }
+    impl soroban_sdk::TryFromVal<soroban_sdk::Env, soroban_sdk::xdr::ScVal> for Context {
+        type Error = soroban_sdk::xdr::Error;
+        #[inline(always)]
+        fn try_from_val(
+            env: &soroban_sdk::Env,
+            val: &soroban_sdk::xdr::ScVal,
+        ) -> Result<Self, soroban_sdk::xdr::Error> {
+            if let soroban_sdk::xdr::ScVal::Vec(Some(vec)) = val {
+                <_ as soroban_sdk::TryFromVal<_, _>>::try_from_val(env, vec)
+            } else {
+                Err(soroban_sdk::xdr::Error::Invalid)
+            }
+        }
+    }
+    impl TryFrom<&Context> for soroban_sdk::xdr::ScVec {
+        type Error = soroban_sdk::xdr::Error;
+        #[inline(always)]
+        fn try_from(val: &Context) -> Result<Self, soroban_sdk::xdr::Error> {
+            extern crate alloc;
+            Ok(match val {
+                Context::Contract(value0) => (
+                    soroban_sdk::xdr::ScSymbol(
+                        "Contract"
+                            .try_into()
+                            .map_err(|_| soroban_sdk::xdr::Error::Invalid)?,
+                    ),
+                    value0,
+                )
+                    .try_into()
+                    .map_err(|_| soroban_sdk::xdr::Error::Invalid)?,
+                Context::CreateContractHostFn(value0) => (
+                    soroban_sdk::xdr::ScSymbol(
+                        "CreateContractHostFn"
+                            .try_into()
+                            .map_err(|_| soroban_sdk::xdr::Error::Invalid)?,
+                    ),
+                    value0,
+                )
+                    .try_into()
+                    .map_err(|_| soroban_sdk::xdr::Error::Invalid)?,
+                Context::CreateContractWithCtorHostFn(value0) => (
+                    soroban_sdk::xdr::ScSymbol(
+                        "CreateContractWithCtorHostFn"
+                            .try_into()
+                            .map_err(|_| soroban_sdk::xdr::Error::Invalid)?,
+                    ),
+                    value0,
+                )
+                    .try_into()
+                    .map_err(|_| soroban_sdk::xdr::Error::Invalid)?,
+            })
+        }
+    }
+    impl TryFrom<Context> for soroban_sdk::xdr::ScVec {
+        type Error = soroban_sdk::xdr::Error;
+        #[inline(always)]
+        fn try_from(val: Context) -> Result<Self, soroban_sdk::xdr::Error> {
+            (&val).try_into()
+        }
+    }
+    impl TryFrom<&Context> for soroban_sdk::xdr::ScVal {
+        type Error = soroban_sdk::xdr::Error;
+        #[inline(always)]
+        fn try_from(val: &Context) -> Result<Self, soroban_sdk::xdr::Error> {
+            Ok(soroban_sdk::xdr::ScVal::Vec(Some(val.try_into()?)))
+        }
+    }
+    impl TryFrom<Context> for soroban_sdk::xdr::ScVal {
+        type Error = soroban_sdk::xdr::Error;
+        #[inline(always)]
+        fn try_from(val: Context) -> Result<Self, soroban_sdk::xdr::Error> {
+            (&val).try_into()
+        }
+    }
+    const _: () = {
+        use soroban_sdk::testutils::arbitrary::arbitrary;
+        use soroban_sdk::testutils::arbitrary::std;
+        pub enum ArbitraryContext {
+            Contract(
+                <ContractContext as soroban_sdk::testutils::arbitrary::SorobanArbitrary>::Prototype,
+            ),
+            CreateContractHostFn(
+                <CreateContractHostFnContext as soroban_sdk::testutils::arbitrary::SorobanArbitrary>::Prototype,
+            ),
+            CreateContractWithCtorHostFn(
+                <CreateContractWithConstructorHostFnContext as soroban_sdk::testutils::arbitrary::SorobanArbitrary>::Prototype,
+            ),
+        }
+        #[automatically_derived]
+        impl ::core::fmt::Debug for ArbitraryContext {
+            #[inline]
+            fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+                match self {
+                    ArbitraryContext::Contract(__self_0) => {
+                        ::core::fmt::Formatter::debug_tuple_field1_finish(f, "Contract", &__self_0)
+                    }
+                    ArbitraryContext::CreateContractHostFn(__self_0) => {
+                        ::core::fmt::Formatter::debug_tuple_field1_finish(
+                            f,
+                            "CreateContractHostFn",
+                            &__self_0,
+                        )
+                    }
+                    ArbitraryContext::CreateContractWithCtorHostFn(__self_0) => {
+                        ::core::fmt::Formatter::debug_tuple_field1_finish(
+                            f,
+                            "CreateContractWithCtorHostFn",
+                            &__self_0,
+                        )
+                    }
+                }
+            }
+        }
+        #[automatically_derived]
+        impl ::core::clone::Clone for ArbitraryContext {
+            #[inline]
+            fn clone(&self) -> ArbitraryContext {
+                match self {
+                    ArbitraryContext::Contract(__self_0) => {
+                        ArbitraryContext::Contract(::core::clone::Clone::clone(__self_0))
+                    }
+                    ArbitraryContext::CreateContractHostFn(__self_0) => {
+                        ArbitraryContext::CreateContractHostFn(::core::clone::Clone::clone(
+                            __self_0,
+                        ))
+                    }
+                    ArbitraryContext::CreateContractWithCtorHostFn(__self_0) => {
+                        ArbitraryContext::CreateContractWithCtorHostFn(::core::clone::Clone::clone(
+                            __self_0,
+                        ))
+                    }
+                }
+            }
+        }
+        #[automatically_derived]
+        impl ::core::cmp::Eq for ArbitraryContext {
+            #[inline]
+            #[doc(hidden)]
+            #[coverage(off)]
+            fn assert_receiver_is_total_eq(&self) -> () {
+                let _: ::core::cmp::AssertParamIsEq<
+                    <ContractContext as soroban_sdk::testutils::arbitrary::SorobanArbitrary>::Prototype,
+                >;
+                let _: ::core::cmp::AssertParamIsEq<
+                    <CreateContractHostFnContext as soroban_sdk::testutils::arbitrary::SorobanArbitrary>::Prototype,
+                >;
+                let _: ::core::cmp::AssertParamIsEq<
+                    <CreateContractWithConstructorHostFnContext as soroban_sdk::testutils::arbitrary::SorobanArbitrary>::Prototype,
+                >;
+            }
+        }
+        #[automatically_derived]
+        impl ::core::marker::StructuralPartialEq for ArbitraryContext {}
+        #[automatically_derived]
+        impl ::core::cmp::PartialEq for ArbitraryContext {
+            #[inline]
+            fn eq(&self, other: &ArbitraryContext) -> bool {
+                let __self_discr = ::core::intrinsics::discriminant_value(self);
+                let __arg1_discr = ::core::intrinsics::discriminant_value(other);
+                __self_discr == __arg1_discr
+                    && match (self, other) {
+                        (
+                            ArbitraryContext::Contract(__self_0),
+                            ArbitraryContext::Contract(__arg1_0),
+                        ) => __self_0 == __arg1_0,
+                        (
+                            ArbitraryContext::CreateContractHostFn(__self_0),
+                            ArbitraryContext::CreateContractHostFn(__arg1_0),
+                        ) => __self_0 == __arg1_0,
+                        (
+                            ArbitraryContext::CreateContractWithCtorHostFn(__self_0),
+                            ArbitraryContext::CreateContractWithCtorHostFn(__arg1_0),
+                        ) => __self_0 == __arg1_0,
+                        _ => unsafe { ::core::intrinsics::unreachable() },
+                    }
+            }
+        }
+        #[automatically_derived]
+        impl ::core::cmp::Ord for ArbitraryContext {
+            #[inline]
+            fn cmp(&self, other: &ArbitraryContext) -> ::core::cmp::Ordering {
+                let __self_discr = ::core::intrinsics::discriminant_value(self);
+                let __arg1_discr = ::core::intrinsics::discriminant_value(other);
+                match ::core::cmp::Ord::cmp(&__self_discr, &__arg1_discr) {
+                    ::core::cmp::Ordering::Equal => match (self, other) {
+                        (
+                            ArbitraryContext::Contract(__self_0),
+                            ArbitraryContext::Contract(__arg1_0),
+                        ) => ::core::cmp::Ord::cmp(__self_0, __arg1_0),
+                        (
+                            ArbitraryContext::CreateContractHostFn(__self_0),
+                            ArbitraryContext::CreateContractHostFn(__arg1_0),
+                        ) => ::core::cmp::Ord::cmp(__self_0, __arg1_0),
+                        (
+                            ArbitraryContext::CreateContractWithCtorHostFn(__self_0),
+                            ArbitraryContext::CreateContractWithCtorHostFn(__arg1_0),
+                        ) => ::core::cmp::Ord::cmp(__self_0, __arg1_0),
+                        _ => unsafe { ::core::intrinsics::unreachable() },
+                    },
+                    cmp => cmp,
+                }
+            }
+        }
+        #[automatically_derived]
+        impl ::core::cmp::PartialOrd for ArbitraryContext {
+            #[inline]
+            fn partial_cmp(
+                &self,
+                other: &ArbitraryContext,
+            ) -> ::core::option::Option<::core::cmp::Ordering> {
+                let __self_discr = ::core::intrinsics::discriminant_value(self);
+                let __arg1_discr = ::core::intrinsics::discriminant_value(other);
+                match (self, other) {
+                    (
+                        ArbitraryContext::Contract(__self_0),
+                        ArbitraryContext::Contract(__arg1_0),
+                    ) => ::core::cmp::PartialOrd::partial_cmp(__self_0, __arg1_0),
+                    (
+                        ArbitraryContext::CreateContractHostFn(__self_0),
+                        ArbitraryContext::CreateContractHostFn(__arg1_0),
+                    ) => ::core::cmp::PartialOrd::partial_cmp(__self_0, __arg1_0),
+                    (
+                        ArbitraryContext::CreateContractWithCtorHostFn(__self_0),
+                        ArbitraryContext::CreateContractWithCtorHostFn(__arg1_0),
+                    ) => ::core::cmp::PartialOrd::partial_cmp(__self_0, __arg1_0),
+                    _ => ::core::cmp::PartialOrd::partial_cmp(&__self_discr, &__arg1_discr),
+                }
+            }
+        }
+        const _: () = {
+            #[allow(non_upper_case_globals)]
+            const RECURSIVE_COUNT_ArbitraryContext: ::std::thread::LocalKey<std::cell::Cell<u32>> = {
+                #[inline]
+                fn __init() -> std::cell::Cell<u32> {
+                    std::cell::Cell::new(0)
+                }
+                unsafe {
+                    ::std::thread::LocalKey::new(
+                        const {
+                            if ::std::mem::needs_drop::<std::cell::Cell<u32>>() {
+                                |init| {
+                                    #[thread_local]
+                                    static VAL: ::std::thread::local_impl::LazyStorage<
+                                        std::cell::Cell<u32>,
+                                        (),
+                                    > = ::std::thread::local_impl::LazyStorage::new();
+                                    VAL.get_or_init(init, __init)
+                                }
+                            } else {
+                                |init| {
+                                    #[thread_local]
+                                    static VAL: ::std::thread::local_impl::LazyStorage<
+                                        std::cell::Cell<u32>,
+                                        !,
+                                    > = ::std::thread::local_impl::LazyStorage::new();
+                                    VAL.get_or_init(init, __init)
+                                }
+                            }
+                        },
+                    )
+                }
+            };
+            #[automatically_derived]
+            impl<'arbitrary> arbitrary::Arbitrary<'arbitrary> for ArbitraryContext {
+                fn arbitrary(
+                    u: &mut arbitrary::Unstructured<'arbitrary>,
+                ) -> arbitrary::Result<Self> {
+                    let guard_against_recursion = u.is_empty();
+                    if guard_against_recursion {
+                        RECURSIVE_COUNT_ArbitraryContext.with(|count| {
+                            if count.get() > 0 {
+                                return Err(arbitrary::Error::NotEnoughData);
+                            }
+                            count.set(count.get() + 1);
+                            Ok(())
+                        })?;
+                    }
+                    let result = (|| {
+                        Ok(
+                            match (u64::from(<u32 as arbitrary::Arbitrary>::arbitrary(u)?) * 3u64)
+                                >> 32
+                            {
+                                0u64 => {
+                                    ArbitraryContext::Contract(arbitrary::Arbitrary::arbitrary(u)?)
+                                }
+                                1u64 => ArbitraryContext::CreateContractHostFn(
+                                    arbitrary::Arbitrary::arbitrary(u)?,
+                                ),
+                                2u64 => ArbitraryContext::CreateContractWithCtorHostFn(
+                                    arbitrary::Arbitrary::arbitrary(u)?,
+                                ),
+                                _ => ::core::panicking::panic(
+                                    "internal error: entered unreachable code",
+                                ),
+                            },
+                        )
+                    })();
+                    if guard_against_recursion {
+                        RECURSIVE_COUNT_ArbitraryContext.with(|count| {
+                            count.set(count.get() - 1);
+                        });
+                    }
+                    result
+                }
+                fn arbitrary_take_rest(
+                    mut u: arbitrary::Unstructured<'arbitrary>,
+                ) -> arbitrary::Result<Self> {
+                    let guard_against_recursion = u.is_empty();
+                    if guard_against_recursion {
+                        RECURSIVE_COUNT_ArbitraryContext.with(|count| {
+                            if count.get() > 0 {
+                                return Err(arbitrary::Error::NotEnoughData);
+                            }
+                            count.set(count.get() + 1);
+                            Ok(())
+                        })?;
+                    }
+                    let result = (|| {
+                        Ok(
+                            match (u64::from(<u32 as arbitrary::Arbitrary>::arbitrary(&mut u)?)
+                                * 3u64)
+                                >> 32
+                            {
+                                0u64 => ArbitraryContext::Contract(
+                                    arbitrary::Arbitrary::arbitrary_take_rest(u)?,
+                                ),
+                                1u64 => ArbitraryContext::CreateContractHostFn(
+                                    arbitrary::Arbitrary::arbitrary_take_rest(u)?,
+                                ),
+                                2u64 => ArbitraryContext::CreateContractWithCtorHostFn(
+                                    arbitrary::Arbitrary::arbitrary_take_rest(u)?,
+                                ),
+                                _ => ::core::panicking::panic(
+                                    "internal error: entered unreachable code",
+                                ),
+                            },
+                        )
+                    })();
+                    if guard_against_recursion {
+                        RECURSIVE_COUNT_ArbitraryContext.with(|count| {
+                            count.set(count.get() - 1);
+                        });
+                    }
+                    result
+                }
+                #[inline]
+                fn size_hint(depth: usize) -> (usize, Option<usize>) {
+                    arbitrary::size_hint::and(
+                        <u32 as arbitrary::Arbitrary>::size_hint(depth),
+                        arbitrary::size_hint::recursion_guard(depth, |depth| {
+                            arbitrary::size_hint::or_all(
+                                    &[
+                                        arbitrary::size_hint::and_all(
+                                            &[
+                                                <<ContractContext as soroban_sdk::testutils::arbitrary::SorobanArbitrary>::Prototype as arbitrary::Arbitrary>::size_hint(
+                                                    depth,
+                                                ),
+                                            ],
+                                        ),
+                                        arbitrary::size_hint::and_all(
+                                            &[
+                                                <<CreateContractHostFnContext as soroban_sdk::testutils::arbitrary::SorobanArbitrary>::Prototype as arbitrary::Arbitrary>::size_hint(
+                                                    depth,
+                                                ),
+                                            ],
+                                        ),
+                                        arbitrary::size_hint::and_all(
+                                            &[
+                                                <<CreateContractWithConstructorHostFnContext as soroban_sdk::testutils::arbitrary::SorobanArbitrary>::Prototype as arbitrary::Arbitrary>::size_hint(
+                                                    depth,
+                                                ),
+                                            ],
+                                        ),
+                                    ],
+                                )
+                        }),
+                    )
+                }
+            }
+        };
+        impl soroban_sdk::testutils::arbitrary::SorobanArbitrary for Context {
+            type Prototype = ArbitraryContext;
+        }
+        impl soroban_sdk::TryFromVal<soroban_sdk::Env, ArbitraryContext> for Context {
+            type Error = soroban_sdk::ConversionError;
+            fn try_from_val(
+                env: &soroban_sdk::Env,
+                v: &ArbitraryContext,
+            ) -> std::result::Result<Self, Self::Error> {
+                Ok(match v {
+                    ArbitraryContext::Contract(field_0) => {
+                        Context::Contract(soroban_sdk::IntoVal::into_val(field_0, env))
+                    }
+                    ArbitraryContext::CreateContractHostFn(field_0) => {
+                        Context::CreateContractHostFn(soroban_sdk::IntoVal::into_val(field_0, env))
+                    }
+                    ArbitraryContext::CreateContractWithCtorHostFn(field_0) => {
+                        Context::CreateContractWithCtorHostFn(soroban_sdk::IntoVal::into_val(
+                            field_0, env,
+                        ))
+                    }
+                })
+            }
+        }
+    };
+    pub enum ContractExecutable {
+        Wasm(soroban_sdk::BytesN<32>),
+    }
+    #[automatically_derived]
+    impl ::core::fmt::Debug for ContractExecutable {
+        #[inline]
+        fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+            match self {
+                ContractExecutable::Wasm(__self_0) => {
+                    ::core::fmt::Formatter::debug_tuple_field1_finish(f, "Wasm", &__self_0)
+                }
+            }
+        }
+    }
+    #[automatically_derived]
+    impl ::core::clone::Clone for ContractExecutable {
+        #[inline]
+        fn clone(&self) -> ContractExecutable {
+            match self {
+                ContractExecutable::Wasm(__self_0) => {
+                    ContractExecutable::Wasm(::core::clone::Clone::clone(__self_0))
+                }
+            }
+        }
+    }
+    #[automatically_derived]
+    impl ::core::cmp::Eq for ContractExecutable {
+        #[inline]
+        #[doc(hidden)]
+        #[coverage(off)]
+        fn assert_receiver_is_total_eq(&self) -> () {
+            let _: ::core::cmp::AssertParamIsEq<soroban_sdk::BytesN<32>>;
+        }
+    }
+    #[automatically_derived]
+    impl ::core::marker::StructuralPartialEq for ContractExecutable {}
+    #[automatically_derived]
+    impl ::core::cmp::PartialEq for ContractExecutable {
+        #[inline]
+        fn eq(&self, other: &ContractExecutable) -> bool {
+            match (self, other) {
+                (ContractExecutable::Wasm(__self_0), ContractExecutable::Wasm(__arg1_0)) => {
+                    __self_0 == __arg1_0
+                }
+            }
+        }
+    }
+    #[automatically_derived]
+    impl ::core::cmp::Ord for ContractExecutable {
+        #[inline]
+        fn cmp(&self, other: &ContractExecutable) -> ::core::cmp::Ordering {
+            match (self, other) {
+                (ContractExecutable::Wasm(__self_0), ContractExecutable::Wasm(__arg1_0)) => {
+                    ::core::cmp::Ord::cmp(__self_0, __arg1_0)
+                }
+            }
+        }
+    }
+    #[automatically_derived]
+    impl ::core::cmp::PartialOrd for ContractExecutable {
+        #[inline]
+        fn partial_cmp(
+            &self,
+            other: &ContractExecutable,
+        ) -> ::core::option::Option<::core::cmp::Ordering> {
+            match (self, other) {
+                (ContractExecutable::Wasm(__self_0), ContractExecutable::Wasm(__arg1_0)) => {
+                    ::core::cmp::PartialOrd::partial_cmp(__self_0, __arg1_0)
+                }
+            }
+        }
+    }
+    pub static __SPEC_XDR_TYPE_CONTRACTEXECUTABLE: [u8; 68usize] = ContractExecutable::spec_xdr();
+    impl ContractExecutable {
+        pub const fn spec_xdr() -> [u8; 68usize] {
+            *b"\0\0\0\x02\0\0\0\0\0\0\0\0\0\0\0\x12ContractExecutable\0\0\0\0\0\x01\0\0\0\x01\0\0\0\0\0\0\0\x04Wasm\0\0\0\x01\0\0\x03\xee\0\0\0 "
+        }
+    }
+    impl soroban_sdk::SpecShakingMarker for ContractExecutable {
+        #[doc(hidden)]
+        #[inline(always)]
+        fn spec_shaking_marker() {
+            <soroban_sdk::BytesN<32> as soroban_sdk::SpecShakingMarker>::spec_shaking_marker();
+        }
+    }
+    impl soroban_sdk::TryFromVal<soroban_sdk::Env, soroban_sdk::Val> for ContractExecutable {
+        type Error = soroban_sdk::ConversionError;
+        #[inline(always)]
+        fn try_from_val(
+            env: &soroban_sdk::Env,
+            val: &soroban_sdk::Val,
+        ) -> Result<Self, soroban_sdk::ConversionError> {
+            use soroban_sdk::{EnvBase, TryFromVal, TryIntoVal};
+            const CASES: &'static [&'static str] = &["Wasm"];
+            let vec: soroban_sdk::Vec<soroban_sdk::Val> = val.try_into_val(env)?;
+            let mut iter = vec.try_iter();
+            let discriminant: soroban_sdk::Symbol = iter
+                .next()
+                .ok_or(soroban_sdk::ConversionError)??
+                .try_into_val(env)
+                .map_err(|_| soroban_sdk::ConversionError)?;
+            Ok(
+                match u32::from(env.symbol_index_in_strs(discriminant.to_symbol_val(), CASES)?)
+                    as usize
+                {
+                    0 => {
+                        if iter.len() > 1usize {
+                            return Err(soroban_sdk::ConversionError);
+                        }
+                        Self::Wasm(
+                            iter.next()
+                                .ok_or(soroban_sdk::ConversionError)??
+                                .try_into_val(env)?,
+                        )
+                    }
+                    _ => Err(soroban_sdk::ConversionError {})?,
+                },
+            )
+        }
+    }
+    impl soroban_sdk::TryFromVal<soroban_sdk::Env, ContractExecutable> for soroban_sdk::Val {
+        type Error = soroban_sdk::ConversionError;
+        #[inline(always)]
+        fn try_from_val(
+            env: &soroban_sdk::Env,
+            val: &ContractExecutable,
+        ) -> Result<Self, soroban_sdk::ConversionError> {
+            use soroban_sdk::{TryFromVal, TryIntoVal};
+            match val {
+                ContractExecutable::Wasm(ref value0) => {
+                    let tup: (soroban_sdk::Val, soroban_sdk::Val) = (
+                        soroban_sdk::Symbol::try_from_val(env, &"Wasm")?.to_val(),
+                        value0.try_into_val(env)?,
+                    );
+                    tup.try_into_val(env).map_err(Into::into)
+                }
+            }
+        }
+    }
+    impl soroban_sdk::TryFromVal<soroban_sdk::Env, &ContractExecutable> for soroban_sdk::Val {
+        type Error = soroban_sdk::ConversionError;
+        #[inline(always)]
+        fn try_from_val(
+            env: &soroban_sdk::Env,
+            val: &&ContractExecutable,
+        ) -> Result<Self, soroban_sdk::ConversionError> {
+            <_ as soroban_sdk::TryFromVal<soroban_sdk::Env, ContractExecutable>>::try_from_val(
+                env, *val,
+            )
+        }
+    }
+    impl soroban_sdk::TryFromVal<soroban_sdk::Env, soroban_sdk::xdr::ScVec> for ContractExecutable {
+        type Error = soroban_sdk::xdr::Error;
+        #[inline(always)]
+        fn try_from_val(
+            env: &soroban_sdk::Env,
+            val: &soroban_sdk::xdr::ScVec,
+        ) -> Result<Self, soroban_sdk::xdr::Error> {
+            use soroban_sdk::xdr::Validate;
+            use soroban_sdk::TryIntoVal;
+            let vec = val;
+            let mut iter = vec.iter();
+            let discriminant: soroban_sdk::xdr::ScSymbol = iter
+                .next()
+                .ok_or(soroban_sdk::xdr::Error::Invalid)?
+                .clone()
+                .try_into()
+                .map_err(|_| soroban_sdk::xdr::Error::Invalid)?;
+            let discriminant_name: &str = &discriminant.to_utf8_string()?;
+            Ok(match discriminant_name {
+                "Wasm" => {
+                    if iter.len() > 1usize {
+                        return Err(soroban_sdk::xdr::Error::Invalid);
+                    }
+                    let rv0: soroban_sdk::Val = iter
+                        .next()
+                        .ok_or(soroban_sdk::xdr::Error::Invalid)?
+                        .try_into_val(env)
+                        .map_err(|_| soroban_sdk::xdr::Error::Invalid)?;
+                    Self::Wasm(
+                        rv0.try_into_val(env)
+                            .map_err(|_| soroban_sdk::xdr::Error::Invalid)?,
+                    )
+                }
+                _ => Err(soroban_sdk::xdr::Error::Invalid)?,
+            })
+        }
+    }
+    impl soroban_sdk::TryFromVal<soroban_sdk::Env, soroban_sdk::xdr::ScVal> for ContractExecutable {
+        type Error = soroban_sdk::xdr::Error;
+        #[inline(always)]
+        fn try_from_val(
+            env: &soroban_sdk::Env,
+            val: &soroban_sdk::xdr::ScVal,
+        ) -> Result<Self, soroban_sdk::xdr::Error> {
+            if let soroban_sdk::xdr::ScVal::Vec(Some(vec)) = val {
+                <_ as soroban_sdk::TryFromVal<_, _>>::try_from_val(env, vec)
+            } else {
+                Err(soroban_sdk::xdr::Error::Invalid)
+            }
+        }
+    }
+    impl TryFrom<&ContractExecutable> for soroban_sdk::xdr::ScVec {
+        type Error = soroban_sdk::xdr::Error;
+        #[inline(always)]
+        fn try_from(val: &ContractExecutable) -> Result<Self, soroban_sdk::xdr::Error> {
+            extern crate alloc;
+            Ok(match val {
+                ContractExecutable::Wasm(value0) => (
+                    soroban_sdk::xdr::ScSymbol(
+                        "Wasm"
+                            .try_into()
+                            .map_err(|_| soroban_sdk::xdr::Error::Invalid)?,
+                    ),
+                    value0,
+                )
+                    .try_into()
+                    .map_err(|_| soroban_sdk::xdr::Error::Invalid)?,
+            })
+        }
+    }
+    impl TryFrom<ContractExecutable> for soroban_sdk::xdr::ScVec {
+        type Error = soroban_sdk::xdr::Error;
+        #[inline(always)]
+        fn try_from(val: ContractExecutable) -> Result<Self, soroban_sdk::xdr::Error> {
+            (&val).try_into()
+        }
+    }
+    impl TryFrom<&ContractExecutable> for soroban_sdk::xdr::ScVal {
+        type Error = soroban_sdk::xdr::Error;
+        #[inline(always)]
+        fn try_from(val: &ContractExecutable) -> Result<Self, soroban_sdk::xdr::Error> {
+            Ok(soroban_sdk::xdr::ScVal::Vec(Some(val.try_into()?)))
+        }
+    }
+    impl TryFrom<ContractExecutable> for soroban_sdk::xdr::ScVal {
+        type Error = soroban_sdk::xdr::Error;
+        #[inline(always)]
+        fn try_from(val: ContractExecutable) -> Result<Self, soroban_sdk::xdr::Error> {
+            (&val).try_into()
+        }
+    }
+    const _: () = {
+        use soroban_sdk::testutils::arbitrary::arbitrary;
+        use soroban_sdk::testutils::arbitrary::std;
+        pub enum ArbitraryContractExecutable {
+            Wasm(
+                <soroban_sdk::BytesN<
+                    32,
+                > as soroban_sdk::testutils::arbitrary::SorobanArbitrary>::Prototype,
+            ),
+        }
+        #[automatically_derived]
+        impl ::core::fmt::Debug for ArbitraryContractExecutable {
+            #[inline]
+            fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+                match self {
+                    ArbitraryContractExecutable::Wasm(__self_0) => {
+                        ::core::fmt::Formatter::debug_tuple_field1_finish(f, "Wasm", &__self_0)
+                    }
+                }
+            }
+        }
+        #[automatically_derived]
+        impl ::core::clone::Clone for ArbitraryContractExecutable {
+            #[inline]
+            fn clone(&self) -> ArbitraryContractExecutable {
+                match self {
+                    ArbitraryContractExecutable::Wasm(__self_0) => {
+                        ArbitraryContractExecutable::Wasm(::core::clone::Clone::clone(__self_0))
+                    }
+                }
+            }
+        }
+        #[automatically_derived]
+        impl ::core::cmp::Eq for ArbitraryContractExecutable {
+            #[inline]
+            #[doc(hidden)]
+            #[coverage(off)]
+            fn assert_receiver_is_total_eq(&self) -> () {
+                let _: ::core::cmp::AssertParamIsEq<
+                    <soroban_sdk::BytesN<
+                        32,
+                    > as soroban_sdk::testutils::arbitrary::SorobanArbitrary>::Prototype,
+                >;
+            }
+        }
+        #[automatically_derived]
+        impl ::core::marker::StructuralPartialEq for ArbitraryContractExecutable {}
+        #[automatically_derived]
+        impl ::core::cmp::PartialEq for ArbitraryContractExecutable {
+            #[inline]
+            fn eq(&self, other: &ArbitraryContractExecutable) -> bool {
+                match (self, other) {
+                    (
+                        ArbitraryContractExecutable::Wasm(__self_0),
+                        ArbitraryContractExecutable::Wasm(__arg1_0),
+                    ) => __self_0 == __arg1_0,
+                }
+            }
+        }
+        #[automatically_derived]
+        impl ::core::cmp::Ord for ArbitraryContractExecutable {
+            #[inline]
+            fn cmp(&self, other: &ArbitraryContractExecutable) -> ::core::cmp::Ordering {
+                match (self, other) {
+                    (
+                        ArbitraryContractExecutable::Wasm(__self_0),
+                        ArbitraryContractExecutable::Wasm(__arg1_0),
+                    ) => ::core::cmp::Ord::cmp(__self_0, __arg1_0),
+                }
+            }
+        }
+        #[automatically_derived]
+        impl ::core::cmp::PartialOrd for ArbitraryContractExecutable {
+            #[inline]
+            fn partial_cmp(
+                &self,
+                other: &ArbitraryContractExecutable,
+            ) -> ::core::option::Option<::core::cmp::Ordering> {
+                match (self, other) {
+                    (
+                        ArbitraryContractExecutable::Wasm(__self_0),
+                        ArbitraryContractExecutable::Wasm(__arg1_0),
+                    ) => ::core::cmp::PartialOrd::partial_cmp(__self_0, __arg1_0),
+                }
+            }
+        }
+        const _: () = {
+            #[allow(non_upper_case_globals)]
+            const RECURSIVE_COUNT_ArbitraryContractExecutable: ::std::thread::LocalKey<
+                std::cell::Cell<u32>,
+            > = {
+                #[inline]
+                fn __init() -> std::cell::Cell<u32> {
+                    std::cell::Cell::new(0)
+                }
+                unsafe {
+                    ::std::thread::LocalKey::new(
+                        const {
+                            if ::std::mem::needs_drop::<std::cell::Cell<u32>>() {
+                                |init| {
+                                    #[thread_local]
+                                    static VAL: ::std::thread::local_impl::LazyStorage<
+                                        std::cell::Cell<u32>,
+                                        (),
+                                    > = ::std::thread::local_impl::LazyStorage::new();
+                                    VAL.get_or_init(init, __init)
+                                }
+                            } else {
+                                |init| {
+                                    #[thread_local]
+                                    static VAL: ::std::thread::local_impl::LazyStorage<
+                                        std::cell::Cell<u32>,
+                                        !,
+                                    > = ::std::thread::local_impl::LazyStorage::new();
+                                    VAL.get_or_init(init, __init)
+                                }
+                            }
+                        },
+                    )
+                }
+            };
+            #[automatically_derived]
+            impl<'arbitrary> arbitrary::Arbitrary<'arbitrary> for ArbitraryContractExecutable {
+                fn arbitrary(
+                    u: &mut arbitrary::Unstructured<'arbitrary>,
+                ) -> arbitrary::Result<Self> {
+                    let guard_against_recursion = u.is_empty();
+                    if guard_against_recursion {
+                        RECURSIVE_COUNT_ArbitraryContractExecutable.with(|count| {
+                            if count.get() > 0 {
+                                return Err(arbitrary::Error::NotEnoughData);
+                            }
+                            count.set(count.get() + 1);
+                            Ok(())
+                        })?;
+                    }
+                    let result = (|| {
+                        Ok(
+                            match (u64::from(<u32 as arbitrary::Arbitrary>::arbitrary(u)?) * 1u64)
+                                >> 32
+                            {
+                                0u64 => ArbitraryContractExecutable::Wasm(
+                                    arbitrary::Arbitrary::arbitrary(u)?,
+                                ),
+                                _ => ::core::panicking::panic(
+                                    "internal error: entered unreachable code",
+                                ),
+                            },
+                        )
+                    })();
+                    if guard_against_recursion {
+                        RECURSIVE_COUNT_ArbitraryContractExecutable.with(|count| {
+                            count.set(count.get() - 1);
+                        });
+                    }
+                    result
+                }
+                fn arbitrary_take_rest(
+                    mut u: arbitrary::Unstructured<'arbitrary>,
+                ) -> arbitrary::Result<Self> {
+                    let guard_against_recursion = u.is_empty();
+                    if guard_against_recursion {
+                        RECURSIVE_COUNT_ArbitraryContractExecutable.with(|count| {
+                            if count.get() > 0 {
+                                return Err(arbitrary::Error::NotEnoughData);
+                            }
+                            count.set(count.get() + 1);
+                            Ok(())
+                        })?;
+                    }
+                    let result = (|| {
+                        Ok(
+                            match (u64::from(<u32 as arbitrary::Arbitrary>::arbitrary(&mut u)?)
+                                * 1u64)
+                                >> 32
+                            {
+                                0u64 => ArbitraryContractExecutable::Wasm(
+                                    arbitrary::Arbitrary::arbitrary_take_rest(u)?,
+                                ),
+                                _ => ::core::panicking::panic(
+                                    "internal error: entered unreachable code",
+                                ),
+                            },
+                        )
+                    })();
+                    if guard_against_recursion {
+                        RECURSIVE_COUNT_ArbitraryContractExecutable.with(|count| {
+                            count.set(count.get() - 1);
+                        });
+                    }
+                    result
+                }
+                #[inline]
+                fn size_hint(depth: usize) -> (usize, Option<usize>) {
+                    arbitrary::size_hint::and(
+                        <u32 as arbitrary::Arbitrary>::size_hint(depth),
+                        arbitrary::size_hint::recursion_guard(depth, |depth| {
+                            arbitrary::size_hint::or_all(
+                                    &[
+                                        arbitrary::size_hint::and_all(
+                                            &[
+                                                <<soroban_sdk::BytesN<
+                                                    32,
+                                                > as soroban_sdk::testutils::arbitrary::SorobanArbitrary>::Prototype as arbitrary::Arbitrary>::size_hint(
+                                                    depth,
+                                                ),
+                                            ],
+                                        ),
+                                    ],
+                                )
+                        }),
+                    )
+                }
+            }
+        };
+        impl soroban_sdk::testutils::arbitrary::SorobanArbitrary for ContractExecutable {
+            type Prototype = ArbitraryContractExecutable;
+        }
+        impl soroban_sdk::TryFromVal<soroban_sdk::Env, ArbitraryContractExecutable> for ContractExecutable {
+            type Error = soroban_sdk::ConversionError;
+            fn try_from_val(
+                env: &soroban_sdk::Env,
+                v: &ArbitraryContractExecutable,
+            ) -> std::result::Result<Self, Self::Error> {
+                Ok(match v {
+                    ArbitraryContractExecutable::Wasm(field_0) => {
+                        ContractExecutable::Wasm(soroban_sdk::IntoVal::into_val(field_0, env))
+                    }
+                })
+            }
+        }
+    };
+    pub enum InvokerContractAuthEntry {
+        Contract(SubContractInvocation),
+        CreateContractHostFn(CreateContractHostFnContext),
+        CreateContractWithCtorHostFn(CreateContractWithConstructorHostFnContext),
+    }
+    #[automatically_derived]
+    impl ::core::fmt::Debug for InvokerContractAuthEntry {
+        #[inline]
+        fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+            match self {
+                InvokerContractAuthEntry::Contract(__self_0) => {
+                    ::core::fmt::Formatter::debug_tuple_field1_finish(f, "Contract", &__self_0)
+                }
+                InvokerContractAuthEntry::CreateContractHostFn(__self_0) => {
+                    ::core::fmt::Formatter::debug_tuple_field1_finish(
+                        f,
+                        "CreateContractHostFn",
+                        &__self_0,
+                    )
+                }
+                InvokerContractAuthEntry::CreateContractWithCtorHostFn(__self_0) => {
+                    ::core::fmt::Formatter::debug_tuple_field1_finish(
+                        f,
+                        "CreateContractWithCtorHostFn",
+                        &__self_0,
+                    )
+                }
+            }
+        }
+    }
+    #[automatically_derived]
+    impl ::core::clone::Clone for InvokerContractAuthEntry {
+        #[inline]
+        fn clone(&self) -> InvokerContractAuthEntry {
+            match self {
+                InvokerContractAuthEntry::Contract(__self_0) => {
+                    InvokerContractAuthEntry::Contract(::core::clone::Clone::clone(__self_0))
+                }
+                InvokerContractAuthEntry::CreateContractHostFn(__self_0) => {
+                    InvokerContractAuthEntry::CreateContractHostFn(::core::clone::Clone::clone(
+                        __self_0,
+                    ))
+                }
+                InvokerContractAuthEntry::CreateContractWithCtorHostFn(__self_0) => {
+                    InvokerContractAuthEntry::CreateContractWithCtorHostFn(
+                        ::core::clone::Clone::clone(__self_0),
+                    )
+                }
+            }
+        }
+    }
+    #[automatically_derived]
+    impl ::core::cmp::Eq for InvokerContractAuthEntry {
+        #[inline]
+        #[doc(hidden)]
+        #[coverage(off)]
+        fn assert_receiver_is_total_eq(&self) -> () {
+            let _: ::core::cmp::AssertParamIsEq<SubContractInvocation>;
+            let _: ::core::cmp::AssertParamIsEq<CreateContractHostFnContext>;
+            let _: ::core::cmp::AssertParamIsEq<CreateContractWithConstructorHostFnContext>;
+        }
+    }
+    #[automatically_derived]
+    impl ::core::marker::StructuralPartialEq for InvokerContractAuthEntry {}
+    #[automatically_derived]
+    impl ::core::cmp::PartialEq for InvokerContractAuthEntry {
+        #[inline]
+        fn eq(&self, other: &InvokerContractAuthEntry) -> bool {
+            let __self_discr = ::core::intrinsics::discriminant_value(self);
+            let __arg1_discr = ::core::intrinsics::discriminant_value(other);
+            __self_discr == __arg1_discr
+                && match (self, other) {
+                    (
+                        InvokerContractAuthEntry::Contract(__self_0),
+                        InvokerContractAuthEntry::Contract(__arg1_0),
+                    ) => __self_0 == __arg1_0,
+                    (
+                        InvokerContractAuthEntry::CreateContractHostFn(__self_0),
+                        InvokerContractAuthEntry::CreateContractHostFn(__arg1_0),
+                    ) => __self_0 == __arg1_0,
+                    (
+                        InvokerContractAuthEntry::CreateContractWithCtorHostFn(__self_0),
+                        InvokerContractAuthEntry::CreateContractWithCtorHostFn(__arg1_0),
+                    ) => __self_0 == __arg1_0,
+                    _ => unsafe { ::core::intrinsics::unreachable() },
+                }
+        }
+    }
+    #[automatically_derived]
+    impl ::core::cmp::Ord for InvokerContractAuthEntry {
+        #[inline]
+        fn cmp(&self, other: &InvokerContractAuthEntry) -> ::core::cmp::Ordering {
+            let __self_discr = ::core::intrinsics::discriminant_value(self);
+            let __arg1_discr = ::core::intrinsics::discriminant_value(other);
+            match ::core::cmp::Ord::cmp(&__self_discr, &__arg1_discr) {
+                ::core::cmp::Ordering::Equal => match (self, other) {
+                    (
+                        InvokerContractAuthEntry::Contract(__self_0),
+                        InvokerContractAuthEntry::Contract(__arg1_0),
+                    ) => ::core::cmp::Ord::cmp(__self_0, __arg1_0),
+                    (
+                        InvokerContractAuthEntry::CreateContractHostFn(__self_0),
+                        InvokerContractAuthEntry::CreateContractHostFn(__arg1_0),
+                    ) => ::core::cmp::Ord::cmp(__self_0, __arg1_0),
+                    (
+                        InvokerContractAuthEntry::CreateContractWithCtorHostFn(__self_0),
+                        InvokerContractAuthEntry::CreateContractWithCtorHostFn(__arg1_0),
+                    ) => ::core::cmp::Ord::cmp(__self_0, __arg1_0),
+                    _ => unsafe { ::core::intrinsics::unreachable() },
+                },
+                cmp => cmp,
+            }
+        }
+    }
+    #[automatically_derived]
+    impl ::core::cmp::PartialOrd for InvokerContractAuthEntry {
+        #[inline]
+        fn partial_cmp(
+            &self,
+            other: &InvokerContractAuthEntry,
+        ) -> ::core::option::Option<::core::cmp::Ordering> {
+            let __self_discr = ::core::intrinsics::discriminant_value(self);
+            let __arg1_discr = ::core::intrinsics::discriminant_value(other);
+            match (self, other) {
+                (
+                    InvokerContractAuthEntry::Contract(__self_0),
+                    InvokerContractAuthEntry::Contract(__arg1_0),
+                ) => ::core::cmp::PartialOrd::partial_cmp(__self_0, __arg1_0),
+                (
+                    InvokerContractAuthEntry::CreateContractHostFn(__self_0),
+                    InvokerContractAuthEntry::CreateContractHostFn(__arg1_0),
+                ) => ::core::cmp::PartialOrd::partial_cmp(__self_0, __arg1_0),
+                (
+                    InvokerContractAuthEntry::CreateContractWithCtorHostFn(__self_0),
+                    InvokerContractAuthEntry::CreateContractWithCtorHostFn(__arg1_0),
+                ) => ::core::cmp::PartialOrd::partial_cmp(__self_0, __arg1_0),
+                _ => ::core::cmp::PartialOrd::partial_cmp(&__self_discr, &__arg1_discr),
+            }
+        }
+    }
+    pub static __SPEC_XDR_TYPE_INVOKERCONTRACTAUTHENTRY: [u8; 268usize] =
+        InvokerContractAuthEntry::spec_xdr();
+    impl InvokerContractAuthEntry {
+        pub const fn spec_xdr() -> [u8; 268usize] {
+            *b"\0\0\0\x02\0\0\0\0\0\0\0\0\0\0\0\x18InvokerContractAuthEntry\0\0\0\x03\0\0\0\x01\0\0\0\0\0\0\0\x08Contract\0\0\0\x01\0\0\x07\xd0\0\0\0\x15SubContractInvocation\0\0\0\0\0\0\x01\0\0\0\0\0\0\0\x14CreateContractHostFn\0\0\0\x01\0\0\x07\xd0\0\0\0\x1bCreateContractHostFnContext\0\0\0\0\x01\0\0\0\0\0\0\0\x1cCreateContractWithCtorHostFn\0\0\0\x01\0\0\x07\xd0\0\0\0*CreateContractWithConstructorHostFnContext\0\0"
+        }
+    }
+    impl soroban_sdk::SpecShakingMarker for InvokerContractAuthEntry {
+        #[doc(hidden)]
+        #[inline(always)]
+        fn spec_shaking_marker() {
+            <SubContractInvocation as soroban_sdk::SpecShakingMarker>::spec_shaking_marker();
+            <CreateContractHostFnContext as soroban_sdk::SpecShakingMarker>::spec_shaking_marker();
+            <CreateContractWithConstructorHostFnContext as soroban_sdk::SpecShakingMarker>::spec_shaking_marker();
+        }
+    }
+    impl soroban_sdk::TryFromVal<soroban_sdk::Env, soroban_sdk::Val> for InvokerContractAuthEntry {
+        type Error = soroban_sdk::ConversionError;
+        #[inline(always)]
+        fn try_from_val(
+            env: &soroban_sdk::Env,
+            val: &soroban_sdk::Val,
+        ) -> Result<Self, soroban_sdk::ConversionError> {
+            use soroban_sdk::{EnvBase, TryFromVal, TryIntoVal};
+            const CASES: &'static [&'static str] = &[
+                "Contract",
+                "CreateContractHostFn",
+                "CreateContractWithCtorHostFn",
+            ];
+            let vec: soroban_sdk::Vec<soroban_sdk::Val> = val.try_into_val(env)?;
+            let mut iter = vec.try_iter();
+            let discriminant: soroban_sdk::Symbol = iter
+                .next()
+                .ok_or(soroban_sdk::ConversionError)??
+                .try_into_val(env)
+                .map_err(|_| soroban_sdk::ConversionError)?;
+            Ok(
+                match u32::from(env.symbol_index_in_strs(discriminant.to_symbol_val(), CASES)?)
+                    as usize
+                {
+                    0 => {
+                        if iter.len() > 1usize {
+                            return Err(soroban_sdk::ConversionError);
+                        }
+                        Self::Contract(
+                            iter.next()
+                                .ok_or(soroban_sdk::ConversionError)??
+                                .try_into_val(env)?,
+                        )
+                    }
+                    1 => {
+                        if iter.len() > 1usize {
+                            return Err(soroban_sdk::ConversionError);
+                        }
+                        Self::CreateContractHostFn(
+                            iter.next()
+                                .ok_or(soroban_sdk::ConversionError)??
+                                .try_into_val(env)?,
+                        )
+                    }
+                    2 => {
+                        if iter.len() > 1usize {
+                            return Err(soroban_sdk::ConversionError);
+                        }
+                        Self::CreateContractWithCtorHostFn(
+                            iter.next()
+                                .ok_or(soroban_sdk::ConversionError)??
+                                .try_into_val(env)?,
+                        )
+                    }
+                    _ => Err(soroban_sdk::ConversionError {})?,
+                },
+            )
+        }
+    }
+    impl soroban_sdk::TryFromVal<soroban_sdk::Env, InvokerContractAuthEntry> for soroban_sdk::Val {
+        type Error = soroban_sdk::ConversionError;
+        #[inline(always)]
+        fn try_from_val(
+            env: &soroban_sdk::Env,
+            val: &InvokerContractAuthEntry,
+        ) -> Result<Self, soroban_sdk::ConversionError> {
+            use soroban_sdk::{TryFromVal, TryIntoVal};
+            match val {
+                InvokerContractAuthEntry::Contract(ref value0) => {
+                    let tup: (soroban_sdk::Val, soroban_sdk::Val) = (
+                        soroban_sdk::Symbol::try_from_val(env, &"Contract")?.to_val(),
+                        value0.try_into_val(env)?,
+                    );
+                    tup.try_into_val(env).map_err(Into::into)
+                }
+                InvokerContractAuthEntry::CreateContractHostFn(ref value0) => {
+                    let tup: (soroban_sdk::Val, soroban_sdk::Val) = (
+                        soroban_sdk::Symbol::try_from_val(env, &"CreateContractHostFn")?.to_val(),
+                        value0.try_into_val(env)?,
+                    );
+                    tup.try_into_val(env).map_err(Into::into)
+                }
+                InvokerContractAuthEntry::CreateContractWithCtorHostFn(ref value0) => {
+                    let tup: (soroban_sdk::Val, soroban_sdk::Val) = (
+                        soroban_sdk::Symbol::try_from_val(env, &"CreateContractWithCtorHostFn")?
+                            .to_val(),
+                        value0.try_into_val(env)?,
+                    );
+                    tup.try_into_val(env).map_err(Into::into)
+                }
+            }
+        }
+    }
+    impl soroban_sdk::TryFromVal<soroban_sdk::Env, &InvokerContractAuthEntry> for soroban_sdk::Val {
+        type Error = soroban_sdk::ConversionError;
+        #[inline(always)]
+        fn try_from_val(
+            env: &soroban_sdk::Env,
+            val: &&InvokerContractAuthEntry,
+        ) -> Result<Self, soroban_sdk::ConversionError> {
+            <_ as soroban_sdk::TryFromVal<soroban_sdk::Env, InvokerContractAuthEntry>>::try_from_val(
+                env, *val,
+            )
+        }
+    }
+    impl soroban_sdk::TryFromVal<soroban_sdk::Env, soroban_sdk::xdr::ScVec>
+        for InvokerContractAuthEntry
+    {
+        type Error = soroban_sdk::xdr::Error;
+        #[inline(always)]
+        fn try_from_val(
+            env: &soroban_sdk::Env,
+            val: &soroban_sdk::xdr::ScVec,
+        ) -> Result<Self, soroban_sdk::xdr::Error> {
+            use soroban_sdk::xdr::Validate;
+            use soroban_sdk::TryIntoVal;
+            let vec = val;
+            let mut iter = vec.iter();
+            let discriminant: soroban_sdk::xdr::ScSymbol = iter
+                .next()
+                .ok_or(soroban_sdk::xdr::Error::Invalid)?
+                .clone()
+                .try_into()
+                .map_err(|_| soroban_sdk::xdr::Error::Invalid)?;
+            let discriminant_name: &str = &discriminant.to_utf8_string()?;
+            Ok(match discriminant_name {
+                "Contract" => {
+                    if iter.len() > 1usize {
+                        return Err(soroban_sdk::xdr::Error::Invalid);
+                    }
+                    let rv0: soroban_sdk::Val = iter
+                        .next()
+                        .ok_or(soroban_sdk::xdr::Error::Invalid)?
+                        .try_into_val(env)
+                        .map_err(|_| soroban_sdk::xdr::Error::Invalid)?;
+                    Self::Contract(
+                        rv0.try_into_val(env)
+                            .map_err(|_| soroban_sdk::xdr::Error::Invalid)?,
+                    )
+                }
+                "CreateContractHostFn" => {
+                    if iter.len() > 1usize {
+                        return Err(soroban_sdk::xdr::Error::Invalid);
+                    }
+                    let rv0: soroban_sdk::Val = iter
+                        .next()
+                        .ok_or(soroban_sdk::xdr::Error::Invalid)?
+                        .try_into_val(env)
+                        .map_err(|_| soroban_sdk::xdr::Error::Invalid)?;
+                    Self::CreateContractHostFn(
+                        rv0.try_into_val(env)
+                            .map_err(|_| soroban_sdk::xdr::Error::Invalid)?,
+                    )
+                }
+                "CreateContractWithCtorHostFn" => {
+                    if iter.len() > 1usize {
+                        return Err(soroban_sdk::xdr::Error::Invalid);
+                    }
+                    let rv0: soroban_sdk::Val = iter
+                        .next()
+                        .ok_or(soroban_sdk::xdr::Error::Invalid)?
+                        .try_into_val(env)
+                        .map_err(|_| soroban_sdk::xdr::Error::Invalid)?;
+                    Self::CreateContractWithCtorHostFn(
+                        rv0.try_into_val(env)
+                            .map_err(|_| soroban_sdk::xdr::Error::Invalid)?,
+                    )
+                }
+                _ => Err(soroban_sdk::xdr::Error::Invalid)?,
+            })
+        }
+    }
+    impl soroban_sdk::TryFromVal<soroban_sdk::Env, soroban_sdk::xdr::ScVal>
+        for InvokerContractAuthEntry
+    {
+        type Error = soroban_sdk::xdr::Error;
+        #[inline(always)]
+        fn try_from_val(
+            env: &soroban_sdk::Env,
+            val: &soroban_sdk::xdr::ScVal,
+        ) -> Result<Self, soroban_sdk::xdr::Error> {
+            if let soroban_sdk::xdr::ScVal::Vec(Some(vec)) = val {
+                <_ as soroban_sdk::TryFromVal<_, _>>::try_from_val(env, vec)
+            } else {
+                Err(soroban_sdk::xdr::Error::Invalid)
+            }
+        }
+    }
+    impl TryFrom<&InvokerContractAuthEntry> for soroban_sdk::xdr::ScVec {
+        type Error = soroban_sdk::xdr::Error;
+        #[inline(always)]
+        fn try_from(val: &InvokerContractAuthEntry) -> Result<Self, soroban_sdk::xdr::Error> {
+            extern crate alloc;
+            Ok(match val {
+                InvokerContractAuthEntry::Contract(value0) => (
+                    soroban_sdk::xdr::ScSymbol(
+                        "Contract"
+                            .try_into()
+                            .map_err(|_| soroban_sdk::xdr::Error::Invalid)?,
+                    ),
+                    value0,
+                )
+                    .try_into()
+                    .map_err(|_| soroban_sdk::xdr::Error::Invalid)?,
+                InvokerContractAuthEntry::CreateContractHostFn(value0) => (
+                    soroban_sdk::xdr::ScSymbol(
+                        "CreateContractHostFn"
+                            .try_into()
+                            .map_err(|_| soroban_sdk::xdr::Error::Invalid)?,
+                    ),
+                    value0,
+                )
+                    .try_into()
+                    .map_err(|_| soroban_sdk::xdr::Error::Invalid)?,
+                InvokerContractAuthEntry::CreateContractWithCtorHostFn(value0) => (
+                    soroban_sdk::xdr::ScSymbol(
+                        "CreateContractWithCtorHostFn"
+                            .try_into()
+                            .map_err(|_| soroban_sdk::xdr::Error::Invalid)?,
+                    ),
+                    value0,
+                )
+                    .try_into()
+                    .map_err(|_| soroban_sdk::xdr::Error::Invalid)?,
+            })
+        }
+    }
+    impl TryFrom<InvokerContractAuthEntry> for soroban_sdk::xdr::ScVec {
+        type Error = soroban_sdk::xdr::Error;
+        #[inline(always)]
+        fn try_from(val: InvokerContractAuthEntry) -> Result<Self, soroban_sdk::xdr::Error> {
+            (&val).try_into()
+        }
+    }
+    impl TryFrom<&InvokerContractAuthEntry> for soroban_sdk::xdr::ScVal {
+        type Error = soroban_sdk::xdr::Error;
+        #[inline(always)]
+        fn try_from(val: &InvokerContractAuthEntry) -> Result<Self, soroban_sdk::xdr::Error> {
+            Ok(soroban_sdk::xdr::ScVal::Vec(Some(val.try_into()?)))
+        }
+    }
+    impl TryFrom<InvokerContractAuthEntry> for soroban_sdk::xdr::ScVal {
+        type Error = soroban_sdk::xdr::Error;
+        #[inline(always)]
+        fn try_from(val: InvokerContractAuthEntry) -> Result<Self, soroban_sdk::xdr::Error> {
+            (&val).try_into()
+        }
+    }
+    const _: () = {
+        use soroban_sdk::testutils::arbitrary::arbitrary;
+        use soroban_sdk::testutils::arbitrary::std;
+        pub enum ArbitraryInvokerContractAuthEntry {
+            Contract(
+                <SubContractInvocation as soroban_sdk::testutils::arbitrary::SorobanArbitrary>::Prototype,
+            ),
+            CreateContractHostFn(
+                <CreateContractHostFnContext as soroban_sdk::testutils::arbitrary::SorobanArbitrary>::Prototype,
+            ),
+            CreateContractWithCtorHostFn(
+                <CreateContractWithConstructorHostFnContext as soroban_sdk::testutils::arbitrary::SorobanArbitrary>::Prototype,
+            ),
+        }
+        #[automatically_derived]
+        impl ::core::fmt::Debug for ArbitraryInvokerContractAuthEntry {
+            #[inline]
+            fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+                match self {
+                    ArbitraryInvokerContractAuthEntry::Contract(__self_0) => {
+                        ::core::fmt::Formatter::debug_tuple_field1_finish(f, "Contract", &__self_0)
+                    }
+                    ArbitraryInvokerContractAuthEntry::CreateContractHostFn(__self_0) => {
+                        ::core::fmt::Formatter::debug_tuple_field1_finish(
+                            f,
+                            "CreateContractHostFn",
+                            &__self_0,
+                        )
+                    }
+                    ArbitraryInvokerContractAuthEntry::CreateContractWithCtorHostFn(__self_0) => {
+                        ::core::fmt::Formatter::debug_tuple_field1_finish(
+                            f,
+                            "CreateContractWithCtorHostFn",
+                            &__self_0,
+                        )
+                    }
+                }
+            }
+        }
+        #[automatically_derived]
+        impl ::core::clone::Clone for ArbitraryInvokerContractAuthEntry {
+            #[inline]
+            fn clone(&self) -> ArbitraryInvokerContractAuthEntry {
+                match self {
+                    ArbitraryInvokerContractAuthEntry::Contract(__self_0) => {
+                        ArbitraryInvokerContractAuthEntry::Contract(::core::clone::Clone::clone(
+                            __self_0,
+                        ))
+                    }
+                    ArbitraryInvokerContractAuthEntry::CreateContractHostFn(__self_0) => {
+                        ArbitraryInvokerContractAuthEntry::CreateContractHostFn(
+                            ::core::clone::Clone::clone(__self_0),
+                        )
+                    }
+                    ArbitraryInvokerContractAuthEntry::CreateContractWithCtorHostFn(__self_0) => {
+                        ArbitraryInvokerContractAuthEntry::CreateContractWithCtorHostFn(
+                            ::core::clone::Clone::clone(__self_0),
+                        )
+                    }
+                }
+            }
+        }
+        #[automatically_derived]
+        impl ::core::cmp::Eq for ArbitraryInvokerContractAuthEntry {
+            #[inline]
+            #[doc(hidden)]
+            #[coverage(off)]
+            fn assert_receiver_is_total_eq(&self) -> () {
+                let _: ::core::cmp::AssertParamIsEq<
+                    <SubContractInvocation as soroban_sdk::testutils::arbitrary::SorobanArbitrary>::Prototype,
+                >;
+                let _: ::core::cmp::AssertParamIsEq<
+                    <CreateContractHostFnContext as soroban_sdk::testutils::arbitrary::SorobanArbitrary>::Prototype,
+                >;
+                let _: ::core::cmp::AssertParamIsEq<
+                    <CreateContractWithConstructorHostFnContext as soroban_sdk::testutils::arbitrary::SorobanArbitrary>::Prototype,
+                >;
+            }
+        }
+        #[automatically_derived]
+        impl ::core::marker::StructuralPartialEq for ArbitraryInvokerContractAuthEntry {}
+        #[automatically_derived]
+        impl ::core::cmp::PartialEq for ArbitraryInvokerContractAuthEntry {
+            #[inline]
+            fn eq(&self, other: &ArbitraryInvokerContractAuthEntry) -> bool {
+                let __self_discr = ::core::intrinsics::discriminant_value(self);
+                let __arg1_discr = ::core::intrinsics::discriminant_value(other);
+                __self_discr == __arg1_discr
+                    && match (self, other) {
+                        (
+                            ArbitraryInvokerContractAuthEntry::Contract(__self_0),
+                            ArbitraryInvokerContractAuthEntry::Contract(__arg1_0),
+                        ) => __self_0 == __arg1_0,
+                        (
+                            ArbitraryInvokerContractAuthEntry::CreateContractHostFn(__self_0),
+                            ArbitraryInvokerContractAuthEntry::CreateContractHostFn(__arg1_0),
+                        ) => __self_0 == __arg1_0,
+                        (
+                            ArbitraryInvokerContractAuthEntry::CreateContractWithCtorHostFn(
+                                __self_0,
+                            ),
+                            ArbitraryInvokerContractAuthEntry::CreateContractWithCtorHostFn(
+                                __arg1_0,
+                            ),
+                        ) => __self_0 == __arg1_0,
+                        _ => unsafe { ::core::intrinsics::unreachable() },
+                    }
+            }
+        }
+        #[automatically_derived]
+        impl ::core::cmp::Ord for ArbitraryInvokerContractAuthEntry {
+            #[inline]
+            fn cmp(&self, other: &ArbitraryInvokerContractAuthEntry) -> ::core::cmp::Ordering {
+                let __self_discr = ::core::intrinsics::discriminant_value(self);
+                let __arg1_discr = ::core::intrinsics::discriminant_value(other);
+                match ::core::cmp::Ord::cmp(&__self_discr, &__arg1_discr) {
+                    ::core::cmp::Ordering::Equal => match (self, other) {
+                        (
+                            ArbitraryInvokerContractAuthEntry::Contract(__self_0),
+                            ArbitraryInvokerContractAuthEntry::Contract(__arg1_0),
+                        ) => ::core::cmp::Ord::cmp(__self_0, __arg1_0),
+                        (
+                            ArbitraryInvokerContractAuthEntry::CreateContractHostFn(__self_0),
+                            ArbitraryInvokerContractAuthEntry::CreateContractHostFn(__arg1_0),
+                        ) => ::core::cmp::Ord::cmp(__self_0, __arg1_0),
+                        (
+                            ArbitraryInvokerContractAuthEntry::CreateContractWithCtorHostFn(
+                                __self_0,
+                            ),
+                            ArbitraryInvokerContractAuthEntry::CreateContractWithCtorHostFn(
+                                __arg1_0,
+                            ),
+                        ) => ::core::cmp::Ord::cmp(__self_0, __arg1_0),
+                        _ => unsafe { ::core::intrinsics::unreachable() },
+                    },
+                    cmp => cmp,
+                }
+            }
+        }
+        #[automatically_derived]
+        impl ::core::cmp::PartialOrd for ArbitraryInvokerContractAuthEntry {
+            #[inline]
+            fn partial_cmp(
+                &self,
+                other: &ArbitraryInvokerContractAuthEntry,
+            ) -> ::core::option::Option<::core::cmp::Ordering> {
+                let __self_discr = ::core::intrinsics::discriminant_value(self);
+                let __arg1_discr = ::core::intrinsics::discriminant_value(other);
+                match (self, other) {
+                    (
+                        ArbitraryInvokerContractAuthEntry::Contract(__self_0),
+                        ArbitraryInvokerContractAuthEntry::Contract(__arg1_0),
+                    ) => ::core::cmp::PartialOrd::partial_cmp(__self_0, __arg1_0),
+                    (
+                        ArbitraryInvokerContractAuthEntry::CreateContractHostFn(__self_0),
+                        ArbitraryInvokerContractAuthEntry::CreateContractHostFn(__arg1_0),
+                    ) => ::core::cmp::PartialOrd::partial_cmp(__self_0, __arg1_0),
+                    (
+                        ArbitraryInvokerContractAuthEntry::CreateContractWithCtorHostFn(__self_0),
+                        ArbitraryInvokerContractAuthEntry::CreateContractWithCtorHostFn(__arg1_0),
+                    ) => ::core::cmp::PartialOrd::partial_cmp(__self_0, __arg1_0),
+                    _ => ::core::cmp::PartialOrd::partial_cmp(&__self_discr, &__arg1_discr),
+                }
+            }
+        }
+        const _: () = {
+            #[allow(non_upper_case_globals)]
+            const RECURSIVE_COUNT_ArbitraryInvokerContractAuthEntry: ::std::thread::LocalKey<
+                std::cell::Cell<u32>,
+            > = {
+                #[inline]
+                fn __init() -> std::cell::Cell<u32> {
+                    std::cell::Cell::new(0)
+                }
+                unsafe {
+                    ::std::thread::LocalKey::new(
+                        const {
+                            if ::std::mem::needs_drop::<std::cell::Cell<u32>>() {
+                                |init| {
+                                    #[thread_local]
+                                    static VAL: ::std::thread::local_impl::LazyStorage<
+                                        std::cell::Cell<u32>,
+                                        (),
+                                    > = ::std::thread::local_impl::LazyStorage::new();
+                                    VAL.get_or_init(init, __init)
+                                }
+                            } else {
+                                |init| {
+                                    #[thread_local]
+                                    static VAL: ::std::thread::local_impl::LazyStorage<
+                                        std::cell::Cell<u32>,
+                                        !,
+                                    > = ::std::thread::local_impl::LazyStorage::new();
+                                    VAL.get_or_init(init, __init)
+                                }
+                            }
+                        },
+                    )
+                }
+            };
+            #[automatically_derived]
+            impl<'arbitrary> arbitrary::Arbitrary<'arbitrary> for ArbitraryInvokerContractAuthEntry {
+                fn arbitrary(
+                    u: &mut arbitrary::Unstructured<'arbitrary>,
+                ) -> arbitrary::Result<Self> {
+                    let guard_against_recursion = u.is_empty();
+                    if guard_against_recursion {
+                        RECURSIVE_COUNT_ArbitraryInvokerContractAuthEntry.with(|count| {
+                            if count.get() > 0 {
+                                return Err(arbitrary::Error::NotEnoughData);
+                            }
+                            count.set(count.get() + 1);
+                            Ok(())
+                        })?;
+                    }
+                    let result = (|| {
+                        Ok(
+                            match (u64::from(<u32 as arbitrary::Arbitrary>::arbitrary(u)?) * 3u64)
+                                >> 32
+                            {
+                                0u64 => ArbitraryInvokerContractAuthEntry::Contract(
+                                    arbitrary::Arbitrary::arbitrary(u)?,
+                                ),
+                                1u64 => ArbitraryInvokerContractAuthEntry::CreateContractHostFn(
+                                    arbitrary::Arbitrary::arbitrary(u)?,
+                                ),
+                                2u64 => {
+                                    ArbitraryInvokerContractAuthEntry::CreateContractWithCtorHostFn(
+                                        arbitrary::Arbitrary::arbitrary(u)?,
+                                    )
+                                }
+                                _ => ::core::panicking::panic(
+                                    "internal error: entered unreachable code",
+                                ),
+                            },
+                        )
+                    })();
+                    if guard_against_recursion {
+                        RECURSIVE_COUNT_ArbitraryInvokerContractAuthEntry.with(|count| {
+                            count.set(count.get() - 1);
+                        });
+                    }
+                    result
+                }
+                fn arbitrary_take_rest(
+                    mut u: arbitrary::Unstructured<'arbitrary>,
+                ) -> arbitrary::Result<Self> {
+                    let guard_against_recursion = u.is_empty();
+                    if guard_against_recursion {
+                        RECURSIVE_COUNT_ArbitraryInvokerContractAuthEntry.with(|count| {
+                            if count.get() > 0 {
+                                return Err(arbitrary::Error::NotEnoughData);
+                            }
+                            count.set(count.get() + 1);
+                            Ok(())
+                        })?;
+                    }
+                    let result = (|| {
+                        Ok(
+                            match (u64::from(<u32 as arbitrary::Arbitrary>::arbitrary(&mut u)?)
+                                * 3u64)
+                                >> 32
+                            {
+                                0u64 => ArbitraryInvokerContractAuthEntry::Contract(
+                                    arbitrary::Arbitrary::arbitrary_take_rest(u)?,
+                                ),
+                                1u64 => ArbitraryInvokerContractAuthEntry::CreateContractHostFn(
+                                    arbitrary::Arbitrary::arbitrary_take_rest(u)?,
+                                ),
+                                2u64 => {
+                                    ArbitraryInvokerContractAuthEntry::CreateContractWithCtorHostFn(
+                                        arbitrary::Arbitrary::arbitrary_take_rest(u)?,
+                                    )
+                                }
+                                _ => ::core::panicking::panic(
+                                    "internal error: entered unreachable code",
+                                ),
+                            },
+                        )
+                    })();
+                    if guard_against_recursion {
+                        RECURSIVE_COUNT_ArbitraryInvokerContractAuthEntry.with(|count| {
+                            count.set(count.get() - 1);
+                        });
+                    }
+                    result
+                }
+                #[inline]
+                fn size_hint(depth: usize) -> (usize, Option<usize>) {
+                    arbitrary::size_hint::and(
+                        <u32 as arbitrary::Arbitrary>::size_hint(depth),
+                        arbitrary::size_hint::recursion_guard(depth, |depth| {
+                            arbitrary::size_hint::or_all(
+                                    &[
+                                        arbitrary::size_hint::and_all(
+                                            &[
+                                                <<SubContractInvocation as soroban_sdk::testutils::arbitrary::SorobanArbitrary>::Prototype as arbitrary::Arbitrary>::size_hint(
+                                                    depth,
+                                                ),
+                                            ],
+                                        ),
+                                        arbitrary::size_hint::and_all(
+                                            &[
+                                                <<CreateContractHostFnContext as soroban_sdk::testutils::arbitrary::SorobanArbitrary>::Prototype as arbitrary::Arbitrary>::size_hint(
+                                                    depth,
+                                                ),
+                                            ],
+                                        ),
+                                        arbitrary::size_hint::and_all(
+                                            &[
+                                                <<CreateContractWithConstructorHostFnContext as soroban_sdk::testutils::arbitrary::SorobanArbitrary>::Prototype as arbitrary::Arbitrary>::size_hint(
+                                                    depth,
+                                                ),
+                                            ],
+                                        ),
+                                    ],
+                                )
+                        }),
+                    )
+                }
+            }
+        };
+        impl soroban_sdk::testutils::arbitrary::SorobanArbitrary for InvokerContractAuthEntry {
+            type Prototype = ArbitraryInvokerContractAuthEntry;
+        }
+        impl soroban_sdk::TryFromVal<soroban_sdk::Env, ArbitraryInvokerContractAuthEntry>
+            for InvokerContractAuthEntry
+        {
+            type Error = soroban_sdk::ConversionError;
+            fn try_from_val(
+                env: &soroban_sdk::Env,
+                v: &ArbitraryInvokerContractAuthEntry,
+            ) -> std::result::Result<Self, Self::Error> {
+                Ok(match v {
+                    ArbitraryInvokerContractAuthEntry::Contract(field_0) => {
+                        InvokerContractAuthEntry::Contract(soroban_sdk::IntoVal::into_val(
+                            field_0, env,
+                        ))
+                    }
+                    ArbitraryInvokerContractAuthEntry::CreateContractHostFn(field_0) => {
+                        InvokerContractAuthEntry::CreateContractHostFn(
+                            soroban_sdk::IntoVal::into_val(field_0, env),
+                        )
+                    }
+                    ArbitraryInvokerContractAuthEntry::CreateContractWithCtorHostFn(field_0) => {
+                        InvokerContractAuthEntry::CreateContractWithCtorHostFn(
+                            soroban_sdk::IntoVal::into_val(field_0, env),
+                        )
+                    }
+                })
+            }
+        }
+    };
+    pub enum Executable {
+        Wasm(soroban_sdk::BytesN<32>),
+        StellarAsset,
+        Account,
+    }
+    #[automatically_derived]
+    impl ::core::fmt::Debug for Executable {
+        #[inline]
+        fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+            match self {
+                Executable::Wasm(__self_0) => {
+                    ::core::fmt::Formatter::debug_tuple_field1_finish(f, "Wasm", &__self_0)
+                }
+                Executable::StellarAsset => ::core::fmt::Formatter::write_str(f, "StellarAsset"),
+                Executable::Account => ::core::fmt::Formatter::write_str(f, "Account"),
+            }
+        }
+    }
+    #[automatically_derived]
+    impl ::core::clone::Clone for Executable {
+        #[inline]
+        fn clone(&self) -> Executable {
+            match self {
+                Executable::Wasm(__self_0) => {
+                    Executable::Wasm(::core::clone::Clone::clone(__self_0))
+                }
+                Executable::StellarAsset => Executable::StellarAsset,
+                Executable::Account => Executable::Account,
+            }
+        }
+    }
+    #[automatically_derived]
+    impl ::core::cmp::Eq for Executable {
+        #[inline]
+        #[doc(hidden)]
+        #[coverage(off)]
+        fn assert_receiver_is_total_eq(&self) -> () {
+            let _: ::core::cmp::AssertParamIsEq<soroban_sdk::BytesN<32>>;
+        }
+    }
+    #[automatically_derived]
+    impl ::core::marker::StructuralPartialEq for Executable {}
+    #[automatically_derived]
+    impl ::core::cmp::PartialEq for Executable {
+        #[inline]
+        fn eq(&self, other: &Executable) -> bool {
+            let __self_discr = ::core::intrinsics::discriminant_value(self);
+            let __arg1_discr = ::core::intrinsics::discriminant_value(other);
+            __self_discr == __arg1_discr
+                && match (self, other) {
+                    (Executable::Wasm(__self_0), Executable::Wasm(__arg1_0)) => {
+                        __self_0 == __arg1_0
+                    }
+                    _ => true,
+                }
+        }
+    }
+    #[automatically_derived]
+    impl ::core::cmp::Ord for Executable {
+        #[inline]
+        fn cmp(&self, other: &Executable) -> ::core::cmp::Ordering {
+            let __self_discr = ::core::intrinsics::discriminant_value(self);
+            let __arg1_discr = ::core::intrinsics::discriminant_value(other);
+            match ::core::cmp::Ord::cmp(&__self_discr, &__arg1_discr) {
+                ::core::cmp::Ordering::Equal => match (self, other) {
+                    (Executable::Wasm(__self_0), Executable::Wasm(__arg1_0)) => {
+                        ::core::cmp::Ord::cmp(__self_0, __arg1_0)
+                    }
+                    _ => ::core::cmp::Ordering::Equal,
+                },
+                cmp => cmp,
+            }
+        }
+    }
+    #[automatically_derived]
+    impl ::core::cmp::PartialOrd for Executable {
+        #[inline]
+        fn partial_cmp(&self, other: &Executable) -> ::core::option::Option<::core::cmp::Ordering> {
+            let __self_discr = ::core::intrinsics::discriminant_value(self);
+            let __arg1_discr = ::core::intrinsics::discriminant_value(other);
+            match (self, other) {
+                (Executable::Wasm(__self_0), Executable::Wasm(__arg1_0)) => {
+                    ::core::cmp::PartialOrd::partial_cmp(__self_0, __arg1_0)
+                }
+                _ => ::core::cmp::PartialOrd::partial_cmp(&__self_discr, &__arg1_discr),
+            }
+        }
+    }
+    pub static __SPEC_XDR_TYPE_EXECUTABLE: [u8; 104usize] = Executable::spec_xdr();
+    impl Executable {
+        pub const fn spec_xdr() -> [u8; 104usize] {
+            *b"\0\0\0\x02\0\0\0\0\0\0\0\0\0\0\0\nExecutable\0\0\0\0\0\x03\0\0\0\x01\0\0\0\0\0\0\0\x04Wasm\0\0\0\x01\0\0\x03\xee\0\0\0 \0\0\0\0\0\0\0\0\0\0\0\x0cStellarAsset\0\0\0\0\0\0\0\0\0\0\0\x07Account\0"
+        }
+    }
+    impl soroban_sdk::SpecShakingMarker for Executable {
+        #[doc(hidden)]
+        #[inline(always)]
+        fn spec_shaking_marker() {
+            <soroban_sdk::BytesN<32> as soroban_sdk::SpecShakingMarker>::spec_shaking_marker();
+        }
+    }
+    impl soroban_sdk::TryFromVal<soroban_sdk::Env, soroban_sdk::Val> for Executable {
+        type Error = soroban_sdk::ConversionError;
+        #[inline(always)]
+        fn try_from_val(
+            env: &soroban_sdk::Env,
+            val: &soroban_sdk::Val,
+        ) -> Result<Self, soroban_sdk::ConversionError> {
+            use soroban_sdk::{EnvBase, TryFromVal, TryIntoVal};
+            const CASES: &'static [&'static str] = &["Wasm", "StellarAsset", "Account"];
+            let vec: soroban_sdk::Vec<soroban_sdk::Val> = val.try_into_val(env)?;
+            let mut iter = vec.try_iter();
+            let discriminant: soroban_sdk::Symbol = iter
+                .next()
+                .ok_or(soroban_sdk::ConversionError)??
+                .try_into_val(env)
+                .map_err(|_| soroban_sdk::ConversionError)?;
+            Ok(
+                match u32::from(env.symbol_index_in_strs(discriminant.to_symbol_val(), CASES)?)
+                    as usize
+                {
+                    0 => {
+                        if iter.len() > 1usize {
+                            return Err(soroban_sdk::ConversionError);
+                        }
+                        Self::Wasm(
+                            iter.next()
+                                .ok_or(soroban_sdk::ConversionError)??
+                                .try_into_val(env)?,
+                        )
+                    }
+                    1 => {
+                        if iter.len() > 0 {
+                            return Err(soroban_sdk::ConversionError);
+                        }
+                        Self::StellarAsset
+                    }
+                    2 => {
+                        if iter.len() > 0 {
+                            return Err(soroban_sdk::ConversionError);
+                        }
+                        Self::Account
+                    }
+                    _ => Err(soroban_sdk::ConversionError {})?,
+                },
+            )
+        }
+    }
+    impl soroban_sdk::TryFromVal<soroban_sdk::Env, Executable> for soroban_sdk::Val {
+        type Error = soroban_sdk::ConversionError;
+        #[inline(always)]
+        fn try_from_val(
+            env: &soroban_sdk::Env,
+            val: &Executable,
+        ) -> Result<Self, soroban_sdk::ConversionError> {
+            use soroban_sdk::{TryFromVal, TryIntoVal};
+            match val {
+                Executable::Wasm(ref value0) => {
+                    let tup: (soroban_sdk::Val, soroban_sdk::Val) = (
+                        soroban_sdk::Symbol::try_from_val(env, &"Wasm")?.to_val(),
+                        value0.try_into_val(env)?,
+                    );
+                    tup.try_into_val(env).map_err(Into::into)
+                }
+                Executable::StellarAsset => {
+                    let tup: (soroban_sdk::Val,) =
+                        (soroban_sdk::Symbol::try_from_val(env, &"StellarAsset")?.to_val(),);
+                    tup.try_into_val(env).map_err(Into::into)
+                }
+                Executable::Account => {
+                    let tup: (soroban_sdk::Val,) =
+                        (soroban_sdk::Symbol::try_from_val(env, &"Account")?.to_val(),);
+                    tup.try_into_val(env).map_err(Into::into)
+                }
+            }
+        }
+    }
+    impl soroban_sdk::TryFromVal<soroban_sdk::Env, &Executable> for soroban_sdk::Val {
+        type Error = soroban_sdk::ConversionError;
+        #[inline(always)]
+        fn try_from_val(
+            env: &soroban_sdk::Env,
+            val: &&Executable,
+        ) -> Result<Self, soroban_sdk::ConversionError> {
+            <_ as soroban_sdk::TryFromVal<soroban_sdk::Env, Executable>>::try_from_val(env, *val)
+        }
+    }
+    impl soroban_sdk::TryFromVal<soroban_sdk::Env, soroban_sdk::xdr::ScVec> for Executable {
+        type Error = soroban_sdk::xdr::Error;
+        #[inline(always)]
+        fn try_from_val(
+            env: &soroban_sdk::Env,
+            val: &soroban_sdk::xdr::ScVec,
+        ) -> Result<Self, soroban_sdk::xdr::Error> {
+            use soroban_sdk::xdr::Validate;
+            use soroban_sdk::TryIntoVal;
+            let vec = val;
+            let mut iter = vec.iter();
+            let discriminant: soroban_sdk::xdr::ScSymbol = iter
+                .next()
+                .ok_or(soroban_sdk::xdr::Error::Invalid)?
+                .clone()
+                .try_into()
+                .map_err(|_| soroban_sdk::xdr::Error::Invalid)?;
+            let discriminant_name: &str = &discriminant.to_utf8_string()?;
+            Ok(match discriminant_name {
+                "Wasm" => {
+                    if iter.len() > 1usize {
+                        return Err(soroban_sdk::xdr::Error::Invalid);
+                    }
+                    let rv0: soroban_sdk::Val = iter
+                        .next()
+                        .ok_or(soroban_sdk::xdr::Error::Invalid)?
+                        .try_into_val(env)
+                        .map_err(|_| soroban_sdk::xdr::Error::Invalid)?;
+                    Self::Wasm(
+                        rv0.try_into_val(env)
+                            .map_err(|_| soroban_sdk::xdr::Error::Invalid)?,
+                    )
+                }
+                "StellarAsset" => {
+                    if iter.len() > 0 {
+                        return Err(soroban_sdk::xdr::Error::Invalid);
+                    }
+                    Self::StellarAsset
+                }
+                "Account" => {
+                    if iter.len() > 0 {
+                        return Err(soroban_sdk::xdr::Error::Invalid);
+                    }
+                    Self::Account
+                }
+                _ => Err(soroban_sdk::xdr::Error::Invalid)?,
+            })
+        }
+    }
+    impl soroban_sdk::TryFromVal<soroban_sdk::Env, soroban_sdk::xdr::ScVal> for Executable {
+        type Error = soroban_sdk::xdr::Error;
+        #[inline(always)]
+        fn try_from_val(
+            env: &soroban_sdk::Env,
+            val: &soroban_sdk::xdr::ScVal,
+        ) -> Result<Self, soroban_sdk::xdr::Error> {
+            if let soroban_sdk::xdr::ScVal::Vec(Some(vec)) = val {
+                <_ as soroban_sdk::TryFromVal<_, _>>::try_from_val(env, vec)
+            } else {
+                Err(soroban_sdk::xdr::Error::Invalid)
+            }
+        }
+    }
+    impl TryFrom<&Executable> for soroban_sdk::xdr::ScVec {
+        type Error = soroban_sdk::xdr::Error;
+        #[inline(always)]
+        fn try_from(val: &Executable) -> Result<Self, soroban_sdk::xdr::Error> {
+            extern crate alloc;
+            Ok(match val {
+                Executable::Wasm(value0) => (
+                    soroban_sdk::xdr::ScSymbol(
+                        "Wasm"
+                            .try_into()
+                            .map_err(|_| soroban_sdk::xdr::Error::Invalid)?,
+                    ),
+                    value0,
+                )
+                    .try_into()
+                    .map_err(|_| soroban_sdk::xdr::Error::Invalid)?,
+                Executable::StellarAsset => {
+                    let symbol = soroban_sdk::xdr::ScSymbol(
+                        "StellarAsset"
+                            .try_into()
+                            .map_err(|_| soroban_sdk::xdr::Error::Invalid)?,
+                    );
+                    let val = soroban_sdk::xdr::ScVal::Symbol(symbol);
+                    (val,)
+                        .try_into()
+                        .map_err(|_| soroban_sdk::xdr::Error::Invalid)?
+                }
+                Executable::Account => {
+                    let symbol = soroban_sdk::xdr::ScSymbol(
+                        "Account"
+                            .try_into()
+                            .map_err(|_| soroban_sdk::xdr::Error::Invalid)?,
+                    );
+                    let val = soroban_sdk::xdr::ScVal::Symbol(symbol);
+                    (val,)
+                        .try_into()
+                        .map_err(|_| soroban_sdk::xdr::Error::Invalid)?
+                }
+            })
+        }
+    }
+    impl TryFrom<Executable> for soroban_sdk::xdr::ScVec {
+        type Error = soroban_sdk::xdr::Error;
+        #[inline(always)]
+        fn try_from(val: Executable) -> Result<Self, soroban_sdk::xdr::Error> {
+            (&val).try_into()
+        }
+    }
+    impl TryFrom<&Executable> for soroban_sdk::xdr::ScVal {
+        type Error = soroban_sdk::xdr::Error;
+        #[inline(always)]
+        fn try_from(val: &Executable) -> Result<Self, soroban_sdk::xdr::Error> {
+            Ok(soroban_sdk::xdr::ScVal::Vec(Some(val.try_into()?)))
+        }
+    }
+    impl TryFrom<Executable> for soroban_sdk::xdr::ScVal {
+        type Error = soroban_sdk::xdr::Error;
+        #[inline(always)]
+        fn try_from(val: Executable) -> Result<Self, soroban_sdk::xdr::Error> {
+            (&val).try_into()
+        }
+    }
+    const _: () = {
+        use soroban_sdk::testutils::arbitrary::arbitrary;
+        use soroban_sdk::testutils::arbitrary::std;
+        pub enum ArbitraryExecutable {
+            Wasm(
+                <soroban_sdk::BytesN<
+                    32,
+                > as soroban_sdk::testutils::arbitrary::SorobanArbitrary>::Prototype,
+            ),
+            StellarAsset,
+            Account,
+        }
+        #[automatically_derived]
+        impl ::core::fmt::Debug for ArbitraryExecutable {
+            #[inline]
+            fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+                match self {
+                    ArbitraryExecutable::Wasm(__self_0) => {
+                        ::core::fmt::Formatter::debug_tuple_field1_finish(f, "Wasm", &__self_0)
+                    }
+                    ArbitraryExecutable::StellarAsset => {
+                        ::core::fmt::Formatter::write_str(f, "StellarAsset")
+                    }
+                    ArbitraryExecutable::Account => ::core::fmt::Formatter::write_str(f, "Account"),
+                }
+            }
+        }
+        #[automatically_derived]
+        impl ::core::clone::Clone for ArbitraryExecutable {
+            #[inline]
+            fn clone(&self) -> ArbitraryExecutable {
+                match self {
+                    ArbitraryExecutable::Wasm(__self_0) => {
+                        ArbitraryExecutable::Wasm(::core::clone::Clone::clone(__self_0))
+                    }
+                    ArbitraryExecutable::StellarAsset => ArbitraryExecutable::StellarAsset,
+                    ArbitraryExecutable::Account => ArbitraryExecutable::Account,
+                }
+            }
+        }
+        #[automatically_derived]
+        impl ::core::cmp::Eq for ArbitraryExecutable {
+            #[inline]
+            #[doc(hidden)]
+            #[coverage(off)]
+            fn assert_receiver_is_total_eq(&self) -> () {
+                let _: ::core::cmp::AssertParamIsEq<
+                    <soroban_sdk::BytesN<
+                        32,
+                    > as soroban_sdk::testutils::arbitrary::SorobanArbitrary>::Prototype,
+                >;
+            }
+        }
+        #[automatically_derived]
+        impl ::core::marker::StructuralPartialEq for ArbitraryExecutable {}
+        #[automatically_derived]
+        impl ::core::cmp::PartialEq for ArbitraryExecutable {
+            #[inline]
+            fn eq(&self, other: &ArbitraryExecutable) -> bool {
+                let __self_discr = ::core::intrinsics::discriminant_value(self);
+                let __arg1_discr = ::core::intrinsics::discriminant_value(other);
+                __self_discr == __arg1_discr
+                    && match (self, other) {
+                        (
+                            ArbitraryExecutable::Wasm(__self_0),
+                            ArbitraryExecutable::Wasm(__arg1_0),
+                        ) => __self_0 == __arg1_0,
+                        _ => true,
+                    }
+            }
+        }
+        #[automatically_derived]
+        impl ::core::cmp::Ord for ArbitraryExecutable {
+            #[inline]
+            fn cmp(&self, other: &ArbitraryExecutable) -> ::core::cmp::Ordering {
+                let __self_discr = ::core::intrinsics::discriminant_value(self);
+                let __arg1_discr = ::core::intrinsics::discriminant_value(other);
+                match ::core::cmp::Ord::cmp(&__self_discr, &__arg1_discr) {
+                    ::core::cmp::Ordering::Equal => match (self, other) {
+                        (
+                            ArbitraryExecutable::Wasm(__self_0),
+                            ArbitraryExecutable::Wasm(__arg1_0),
+                        ) => ::core::cmp::Ord::cmp(__self_0, __arg1_0),
+                        _ => ::core::cmp::Ordering::Equal,
+                    },
+                    cmp => cmp,
+                }
+            }
+        }
+        #[automatically_derived]
+        impl ::core::cmp::PartialOrd for ArbitraryExecutable {
+            #[inline]
+            fn partial_cmp(
+                &self,
+                other: &ArbitraryExecutable,
+            ) -> ::core::option::Option<::core::cmp::Ordering> {
+                let __self_discr = ::core::intrinsics::discriminant_value(self);
+                let __arg1_discr = ::core::intrinsics::discriminant_value(other);
+                match (self, other) {
+                    (ArbitraryExecutable::Wasm(__self_0), ArbitraryExecutable::Wasm(__arg1_0)) => {
+                        ::core::cmp::PartialOrd::partial_cmp(__self_0, __arg1_0)
+                    }
+                    _ => ::core::cmp::PartialOrd::partial_cmp(&__self_discr, &__arg1_discr),
+                }
+            }
+        }
+        const _: () = {
+            #[allow(non_upper_case_globals)]
+            const RECURSIVE_COUNT_ArbitraryExecutable: ::std::thread::LocalKey<
+                std::cell::Cell<u32>,
+            > = {
+                #[inline]
+                fn __init() -> std::cell::Cell<u32> {
+                    std::cell::Cell::new(0)
+                }
+                unsafe {
+                    ::std::thread::LocalKey::new(
+                        const {
+                            if ::std::mem::needs_drop::<std::cell::Cell<u32>>() {
+                                |init| {
+                                    #[thread_local]
+                                    static VAL: ::std::thread::local_impl::LazyStorage<
+                                        std::cell::Cell<u32>,
+                                        (),
+                                    > = ::std::thread::local_impl::LazyStorage::new();
+                                    VAL.get_or_init(init, __init)
+                                }
+                            } else {
+                                |init| {
+                                    #[thread_local]
+                                    static VAL: ::std::thread::local_impl::LazyStorage<
+                                        std::cell::Cell<u32>,
+                                        !,
+                                    > = ::std::thread::local_impl::LazyStorage::new();
+                                    VAL.get_or_init(init, __init)
+                                }
+                            }
+                        },
+                    )
+                }
+            };
+            #[automatically_derived]
+            impl<'arbitrary> arbitrary::Arbitrary<'arbitrary> for ArbitraryExecutable {
+                fn arbitrary(
+                    u: &mut arbitrary::Unstructured<'arbitrary>,
+                ) -> arbitrary::Result<Self> {
+                    let guard_against_recursion = u.is_empty();
+                    if guard_against_recursion {
+                        RECURSIVE_COUNT_ArbitraryExecutable.with(|count| {
+                            if count.get() > 0 {
+                                return Err(arbitrary::Error::NotEnoughData);
+                            }
+                            count.set(count.get() + 1);
+                            Ok(())
+                        })?;
+                    }
+                    let result = (|| {
+                        Ok(
+                            match (u64::from(<u32 as arbitrary::Arbitrary>::arbitrary(u)?) * 3u64)
+                                >> 32
+                            {
+                                0u64 => {
+                                    ArbitraryExecutable::Wasm(arbitrary::Arbitrary::arbitrary(u)?)
+                                }
+                                1u64 => ArbitraryExecutable::StellarAsset,
+                                2u64 => ArbitraryExecutable::Account,
+                                _ => ::core::panicking::panic(
+                                    "internal error: entered unreachable code",
+                                ),
+                            },
+                        )
+                    })();
+                    if guard_against_recursion {
+                        RECURSIVE_COUNT_ArbitraryExecutable.with(|count| {
+                            count.set(count.get() - 1);
+                        });
+                    }
+                    result
+                }
+                fn arbitrary_take_rest(
+                    mut u: arbitrary::Unstructured<'arbitrary>,
+                ) -> arbitrary::Result<Self> {
+                    let guard_against_recursion = u.is_empty();
+                    if guard_against_recursion {
+                        RECURSIVE_COUNT_ArbitraryExecutable.with(|count| {
+                            if count.get() > 0 {
+                                return Err(arbitrary::Error::NotEnoughData);
+                            }
+                            count.set(count.get() + 1);
+                            Ok(())
+                        })?;
+                    }
+                    let result = (|| {
+                        Ok(
+                            match (u64::from(<u32 as arbitrary::Arbitrary>::arbitrary(&mut u)?)
+                                * 3u64)
+                                >> 32
+                            {
+                                0u64 => ArbitraryExecutable::Wasm(
+                                    arbitrary::Arbitrary::arbitrary_take_rest(u)?,
+                                ),
+                                1u64 => ArbitraryExecutable::StellarAsset,
+                                2u64 => ArbitraryExecutable::Account,
+                                _ => ::core::panicking::panic(
+                                    "internal error: entered unreachable code",
+                                ),
+                            },
+                        )
+                    })();
+                    if guard_against_recursion {
+                        RECURSIVE_COUNT_ArbitraryExecutable.with(|count| {
+                            count.set(count.get() - 1);
+                        });
+                    }
+                    result
+                }
+                #[inline]
+                fn size_hint(depth: usize) -> (usize, Option<usize>) {
+                    arbitrary::size_hint::and(
+                        <u32 as arbitrary::Arbitrary>::size_hint(depth),
+                        arbitrary::size_hint::recursion_guard(depth, |depth| {
+                            arbitrary::size_hint::or_all(
+                                    &[
+                                        arbitrary::size_hint::and_all(
+                                            &[
+                                                <<soroban_sdk::BytesN<
+                                                    32,
+                                                > as soroban_sdk::testutils::arbitrary::SorobanArbitrary>::Prototype as arbitrary::Arbitrary>::size_hint(
+                                                    depth,
+                                                ),
+                                            ],
+                                        ),
+                                        arbitrary::size_hint::and_all(&[]),
+                                        arbitrary::size_hint::and_all(&[]),
+                                    ],
+                                )
+                        }),
+                    )
+                }
+            }
+        };
+        impl soroban_sdk::testutils::arbitrary::SorobanArbitrary for Executable {
+            type Prototype = ArbitraryExecutable;
+        }
+        impl soroban_sdk::TryFromVal<soroban_sdk::Env, ArbitraryExecutable> for Executable {
+            type Error = soroban_sdk::ConversionError;
+            fn try_from_val(
+                env: &soroban_sdk::Env,
+                v: &ArbitraryExecutable,
+            ) -> std::result::Result<Self, Self::Error> {
+                Ok(match v {
+                    ArbitraryExecutable::Wasm(field_0) => {
+                        Executable::Wasm(soroban_sdk::IntoVal::into_val(field_0, env))
+                    }
+                    ArbitraryExecutable::StellarAsset => Executable::StellarAsset,
+                    ArbitraryExecutable::Account => Executable::Account,
+                })
             }
         }
     };
@@ -26616,7 +31238,7 @@ mod test {
     use soroban_sdk::xdr::ScSpecEntry;
     use std::collections::HashSet;
     use std::vec::Vec;
-    const WASM: &[u8] = b"\x00asm\x01\x00\x00\x00\x01^\x10`\x02~~\x01~`\x01~\x01~`\x03~~~\x01~`\x04~~~~\x01~`\x00\x00`\x00\x01~`\x02\x7f\x7f\x01~`\x04\x7f\x7f\x7f\x7f\x01~`\x01~\x00`\x02\x7f\x7f\x00`\x03~\x7f\x7f\x01~`\x02\x7f\x7f\x01\x7f`\x02\x7f~\x00`\x05~\x7f\x7f\x7f\x7f\x00`\x03\x7f\x7f\x7f\x00`\x01\x7f\x01~\x02I\x0c\x01x\x011\x00\x00\x01v\x013\x00\x01\x01i\x012\x00\x01\x01v\x01h\x00\x02\x01v\x01g\x00\x00\x01m\x01a\x00\x03\x01b\x01m\x00\x02\x01b\x01j\x00\x00\x01v\x011\x00\x00\x01b\x018\x00\x01\x01x\x015\x00\x01\x01m\x019\x00\x02\x0398\x04\x04\x04\x04\x04\x04\x04\x04\x04\x04\x04\x05\x06\x00\x07\x05\x00\x05\x05\x05\x05\x05\x01\x08\x01\x05\x01\t\n\x0b\x0c\x05\x01\r\x01\x0c\x01\x01\x01\x05\x01\x01\x01\x00\x01\x05\x05\x0e\x0f\x01\x05\x01\x01\x01\x04\x04\x04\x05\x01p\x01\x0c\x0c\x05\x03\x01\x00\x11\x06!\x04\x7f\x01A\x80\x80\xc0\x00\x0b\x7f\x00A\x96\x89\xc0\x00\x0b\x7f\x00A\xe4\x8a\xc0\x00\x0b\x7f\x00A\xf0\x8a\xc0\x00\x0b\x07\xd8\x04\"\x06memory\x02\x00\x11publish_data_type\x00\x17\x1apublish_export_false_event\x00\x1b\x13publish_nested_data\x00\x1d\x14publish_nested_topic\x00\x1e\x11publish_ref_event\x00\x1f\x0epublish_simple\x00 \x12publish_topic_type\x00!\x11with_assert_error\x00\"\x12with_auth_contexts\x00$\nwith_error\x00%\x0fwith_executable\x00&\x17with_export_false_error\x00+\x18with_export_false_struct\x00,\x11with_invoker_auth\x00.\x0fwith_lib_struct\x000\x08with_map\x001\x0cwith_non_pub\x002\x12with_non_pub_error\x003\x0bwith_option\x004\x10with_panic_error\x005\x14with_panic_raw_error\x006\nwith_param\x007\x0ewith_recursion\x008\x0bwith_result\x009\x0bwith_return\x00:\nwith_tuple\x00=\x11with_tuple_return\x00>\x08with_vec\x00?\x0fwith_vec_nested\x00@\x12with_wasm_imported\x00A\x01_\x03\x01\n__data_end\x03\x02\x0b__heap_base\x03\x03\t\x11\x01\x00A\x01\x0b\x0b\x0f\x11\x13\x12\x0e\r\x14\x15\x16\x0c\x10\n\xc128\x0c\x00A\x00-\x00\x9c\x80\xc0\x80\x00\x1a\x0b\x16\x00A\x00-\x00\xfe\x80\xc0\x80\x00\x1aA\x00-\x00\xd4\x80\xc0\x80\x00\x1a\x0b\x0c\x00A\x00-\x00\x8c\x81\xc0\x80\x00\x1a\x0bJ\x01\x01\x7f#\x80\x80\x80\x80\x00!\x00A\x00-\x00\x94\x84\xc0\x80\x00\x1a \x00A\x10k\"\x00A\x81\x80\x80\x80\x006\x02\x0c \x00(\x02\x0c\x1aA\x00-\x00\xd2\x81\xc0\x80\x00\x1aA\x00-\x00\xe0\x81\xc0\x80\x00\x1aA\x00-\x00\xee\x81\xc0\x80\x00\x1a\x0b6\x01\x01\x7f#\x80\x80\x80\x80\x00!\x00A\x00-\x00\xec\x82\xc0\x80\x00\x1a \x00A\x10k\"\x00A\x82\x80\x80\x80\x006\x02\x0c \x00(\x02\x0c\x1aA\x00-\x00\xfa\x82\xc0\x80\x00\x1a\x0b\x0c\x00A\x00-\x00\xb2\x83\xc0\x80\x00\x1a\x0b\x86\x01\x01\x01\x7f#\x80\x80\x80\x80\x00A\x10k\"\x00A\x83\x80\x80\x80\x006\x02\x0c \x00(\x02\x0c\x1aA\x00-\x00\x88\x89\xc0\x80\x00\x1a \x00A\x84\x80\x80\x80\x006\x02\x04 \x00(\x02\x04\x1aA\x00-\x00\xb4\x88\xc0\x80\x00\x1aA\x00-\x00\xa6\x88\xc0\x80\x00\x1aA\x00-\x00\xd0\x88\xc0\x80\x00\x1a \x00A\x83\x80\x80\x80\x006\x02\x08 \x00(\x02\x08\x1aA\x00-\x00\xa6\x88\xc0\x80\x00\x1aA\x00-\x00\xde\x88\xc0\x80\x00\x1aA\x00-\x00\xc2\x88\xc0\x80\x00\x1a\x0b\x02\x00\x0bk\x01\x01\x7f#\x80\x80\x80\x80\x00A\x10k\"\x00A\x83\x80\x80\x80\x006\x02\x0c \x00(\x02\x0c\x1aA\x00-\x00\x88\x89\xc0\x80\x00\x1aA\x00-\x00\xa6\x88\xc0\x80\x00\x1aA\x00-\x00\xd0\x88\xc0\x80\x00\x1a \x00A\x83\x80\x80\x80\x006\x02\x08 \x00(\x02\x08\x1aA\x00-\x00\xa6\x88\xc0\x80\x00\x1aA\x00-\x00\xde\x88\xc0\x80\x00\x1aA\x00-\x00\xec\x88\xc0\x80\x00\x1a\x0b\x0c\x00A\x00-\x00\xa2\x84\xc0\x80\x00\x1a\x0b\x0c\x00A\x00-\x00\xb0\x84\xc0\x80\x00\x1a\x0b\xae\x01\x02\x01\x7f\x01~#\x80\x80\x80\x80\x00A k\"\x00$\x80\x80\x80\x80\x00A\x80\x87\xc0\x80\x00A\x06\x10\x98\x80\x80\x80\x00!\x01A\x00-\x00\xa8\x81\xc0\x80\x00\x1aA\x00-\x00\x88\x83\xc0\x80\x00\x1aA\xbc\x87\xc0\x80\x00A\x19\x10\x98\x80\x80\x80\x00 \x01\x10\x99\x80\x80\x80\x00!\x01 \x00B\x84\x80\x80\x80 7\x03\x18 \x00B\x84\x80\x80\x80\x107\x03\x10 \x00A\xd8\x86\xc0\x80\x00A\x02 \x00A\x10jA\x02\x10\x9a\x80\x80\x80\x007\x03\x08 \x01A\xa0\x87\xc0\x80\x00A\x01 \x00A\x08jA\x01\x10\x9a\x80\x80\x80\x00\x10\x80\x80\x80\x80\x00\x1a \x00A j$\x80\x80\x80\x80\x00B\x02\x0bE\x02\x01\x7f\x01~#\x80\x80\x80\x80\x00A\x10k\"\x02$\x80\x80\x80\x80\x00 \x02 \x00 \x01\x10\xbb\x80\x80\x80\x00\x02@ \x02(\x02\x00A\x01G\r\x00\x00\x0b \x02)\x03\x08!\x03 \x02A\x10j$\x80\x80\x80\x80\x00 \x03\x0b\x92\x01\x01\x02\x7f#\x80\x80\x80\x80\x00A k\"\x02$\x80\x80\x80\x80\x00 \x02 \x017\x03\x08 \x02 \x007\x03\x00A\x00!\x03\x03~\x02@ \x03A\x10G\r\x00A\x00!\x03\x02@\x03@ \x03A\x10F\r\x01 \x02A\x10j \x03j \x02 \x03j)\x03\x007\x03\x00 \x03A\x08j!\x03\x0c\x00\x0b\x0b \x02A\x10j\x10\xbc\x80\x80\x80\x00!\x01 \x02A j$\x80\x80\x80\x80\x00 \x01\x0f\x0b \x02A\x10j \x03jB\x027\x03\x00 \x03A\x08j!\x03\x0c\x00\x0b\x0b.\x00\x02@ \x01 \x03F\r\x00\x00\x0b \x00\xadB \x86B\x04\x84 \x02\xadB \x86B\x04\x84 \x01\xadB \x86B\x04\x84\x10\x8b\x80\x80\x80\x00\x0b\x83\x01\x02\x01\x7f\x01~#\x80\x80\x80\x80\x00A\x10k\"\x00$\x80\x80\x80\x80\x00A\x86\x87\xc0\x80\x00A\x02\x10\x98\x80\x80\x80\x00!\x01A\x00-\x00\xf8\x83\xc0\x80\x00\x1aA\xdc\x84\xc0\x80\x00A\x17\x10\x98\x80\x80\x80\x00 \x01\x10\x99\x80\x80\x80\x00!\x01 \x00B\x01B\x00\x10\x9c\x80\x80\x80\x007\x03\x08 \x01A\xd4\x84\xc0\x80\x00A\x01 \x00A\x08jA\x01\x10\x9a\x80\x80\x80\x00\x10\x80\x80\x80\x80\x00\x1a \x00A\x10j$\x80\x80\x80\x80\x00B\x02\x0b\n\x00 \x00B\x08\x86B\x0b\x84\x0b\xc5\x01\x02\x01\x7f\x01~#\x80\x80\x80\x80\x00A\x10k\"\x00$\x80\x80\x80\x80\x00A\xad\x85\xc0\x80\x00A\x06\x10\x98\x80\x80\x80\x00!\x01A\x00-\x00\xfc\x81\xc0\x80\x00\x1aA\x00-\x00\x8a\x82\xc0\x80\x00\x1aA\x00-\x00\xce\x83\xc0\x80\x00\x1aA\xef\x87\xc0\x80\x00A\x1b\x10\x98\x80\x80\x80\x00 \x01\x10\x99\x80\x80\x80\x00!\x01 \x00B\x84\x80\x80\x80\xa0\x057\x03\x08 \x00A\xf8\x84\xc0\x80\x00A\x01 \x00A\x08jA\x01\x10\x9a\x80\x80\x80\x007\x03\x00 \x00A\xf0\x86\xc0\x80\x00A\x01 \x00A\x01\x10\x9a\x80\x80\x80\x007\x03\x08 \x01A\xa0\x87\xc0\x80\x00A\x01 \x00A\x08jA\x01\x10\x9a\x80\x80\x80\x00\x10\x80\x80\x80\x80\x00\x1a \x00A\x10j$\x80\x80\x80\x80\x00B\x02\x0b\xc2\x01\x02\x01\x7f\x01~#\x80\x80\x80\x80\x00A\x10k\"\x00$\x80\x80\x80\x80\x00A\x00-\x00\xd0\x82\xc0\x80\x00\x1aA\x00-\x00\xde\x82\xc0\x80\x00\x1aA\x00-\x00\xdc\x83\xc0\x80\x00\x1aA\x8a\x88\xc0\x80\x00A\x1c\x10\x98\x80\x80\x80\x00!\x01 \x00B\x84\x80\x80\x80\xa0\x057\x03\x08 \x00A\xf8\x84\xc0\x80\x00A\x01 \x00A\x08jA\x01\x10\x9a\x80\x80\x80\x007\x03\x00 \x01A\xf0\x86\xc0\x80\x00A\x01 \x00A\x01\x10\x9a\x80\x80\x80\x00\x10\x99\x80\x80\x80\x00!\x01 \x00B\xe4\x00B\x00\x10\x9c\x80\x80\x80\x007\x03\x08 \x01A\xd4\x84\xc0\x80\x00A\x01 \x00A\x08jA\x01\x10\x9a\x80\x80\x80\x00\x10\x80\x80\x80\x80\x00\x1a \x00A\x10j$\x80\x80\x80\x80\x00B\x02\x0b\xc7\x01\x02\x01\x7f\x01~#\x80\x80\x80\x80\x00A\x10k\"\x00$\x80\x80\x80\x80\x00 \x00A\x85\x80\x80\x80\x006\x02\x08 \x00(\x02\x08\x1a \x00A\x86\x80\x80\x80\x006\x02\x08 \x00(\x02\x08\x1aA\x00-\x00\xb6\x81\xc0\x80\x00\x1aA\xa8\x87\xc0\x80\x00A\x14\x10\x98\x80\x80\x80\x00B\x84\x80\x80\x80\x10\x10\x99\x80\x80\x80\x00!\x01 \x00B\x84\x80\x80\x80\xb0\x0c7\x03\x08 \x00A\xf8\x84\xc0\x80\x00A\x01 \x00A\x08jA\x01\x10\x9a\x80\x80\x80\x007\x03\x00 \x00A\xcc\x86\xc0\x80\x00A\x01 \x00A\x01\x10\x9a\x80\x80\x80\x007\x03\x08 \x01A\xa0\x87\xc0\x80\x00A\x01 \x00A\x08jA\x01\x10\x9a\x80\x80\x80\x00\x10\x80\x80\x80\x80\x00\x1a \x00A\x10j$\x80\x80\x80\x80\x00B\x02\x0b\x84\x01\x02\x01\x7f\x01~#\x80\x80\x80\x80\x00A\x10k\"\x00$\x80\x80\x80\x80\x00A\xf8\x86\xc0\x80\x00A\x08\x10\x98\x80\x80\x80\x00!\x01A\x00-\x00\xaa\x80\xc0\x80\x00\x1aA\x88\x87\xc0\x80\x00A\x11\x10\x98\x80\x80\x80\x00 \x01\x10\x99\x80\x80\x80\x00!\x01 \x00B\xe4\x00B\x00\x10\x9c\x80\x80\x80\x007\x03\x08 \x01A\xd4\x84\xc0\x80\x00A\x01 \x00A\x08jA\x01\x10\x9a\x80\x80\x80\x00\x10\x80\x80\x80\x80\x00\x1a \x00A\x10j$\x80\x80\x80\x80\x00B\x02\x0b\x82\x01\x02\x01\x7f\x01~#\x80\x80\x80\x80\x00A\x10k\"\x00$\x80\x80\x80\x80\x00A\x00-\x00\x98\x82\xc0\x80\x00\x1aA\x00-\x00\x96\x83\xc0\x80\x00\x1aA\xd5\x87\xc0\x80\x00A\x1a\x10\x98\x80\x80\x80\x00B\x84\x80\x80\x80\x10\x10\x99\x80\x80\x80\x00!\x01 \x00B\xe4\x00B\x00\x10\x9c\x80\x80\x80\x007\x03\x08 \x01A\xd4\x84\xc0\x80\x00A\x01 \x00A\x08jA\x01\x10\x9a\x80\x80\x80\x00\x10\x80\x80\x80\x80\x00\x1a \x00A\x10j$\x80\x80\x80\x80\x00B\x02\x0bJ\x01\x01\x7f\x02@\x02@A\x01A\x02A\x00 \x00\xa7A\xff\x01q\"\x01\x1b \x01A\x01F\x1b\"\x01A\x02F\r\x00 \x01A\x01qE\r\x01B\x02\x0f\x0b\x00\x0bA\x00-\x00\xc2\x82\xc0\x80\x00\x1aB\x83\x80\x80\x80\x10\x10\xa3\x80\x80\x80\x00\x00\x0b\x0b\x00 \x00\x10\x8a\x80\x80\x80\x00\x1a\x0b0\x01\x01\x7f#\x80\x80\x80\x80\x00A\x10k\"\x01A\x87\x80\x80\x80\x006\x02\x0c \x01(\x02\x0c\x1a\x02@ \x00B\xff\x01\x83B\xcb\x00Q\r\x00\x00\x0bB\x02\x0b\x13\x00A\x00-\x00\x80\x80\xc0\x80\x00\x1aB\x84\x80\x80\x80\xa0\x05\x0b\xc0\x02\x03\x01\x7f\x01~\x01\x7f#\x80\x80\x80\x80\x00A k\"\x01$\x80\x80\x80\x80\x00A\x00-\x00\xfa\x88\xc0\x80\x00\x1a\x02@ \x00B\xff\x01\x83B\xcb\x00R\r\x00 \x00\x10\x81\x80\x80\x80\x00!\x02 \x01A\x006\x02\x08 \x01 \x007\x03\x00 \x01 \x02B \x88>\x02\x0c \x01A\x10j \x01\x10\xa7\x80\x80\x80\x00 \x01)\x03\x10\"\x00B\x02Q\r\x00 \x00\xa7A\x01q\r\x00\x02@ \x01)\x03\x18\"\x00\xa7A\xff\x01q\"\x03A\xca\x00F\r\x00 \x03A\x0eG\r\x01\x0b\x02@\x02@\x02@\x02@ \x00A\x94\x85\xc0\x80\x00A\x03\x10\xa8\x80\x80\x80\x00B \x88\xa7\x0e\x03\x01\x02\x00\x04\x0b \x01(\x02\x08 \x01(\x02\x0c\x10\xa9\x80\x80\x80\x00\r\x03\x0c\x02\x0b \x01(\x02\x08 \x01(\x02\x0c\x10\xa9\x80\x80\x80\x00A\x01K\r\x02 \x01A\x10j \x01\x10\xa7\x80\x80\x80\x00 \x01)\x03\x10\"\x00B\x02Q\r\x02 \x00\xa7A\x01q\r\x02 \x01A\x10j \x01)\x03\x18\x10\xaa\x80\x80\x80\x00 \x01(\x02\x10A\x01G\r\x01\x0c\x02\x0b \x01(\x02\x08 \x01(\x02\x0c\x10\xa9\x80\x80\x80\x00\r\x01\x0b \x01A j$\x80\x80\x80\x80\x00B\x02\x0f\x0b\x00\x0bJ\x02\x01~\x01\x7fB\x02!\x02\x02@ \x01(\x02\x08\"\x03 \x01(\x02\x0cO\r\x00 \x00 \x01)\x03\x00 \x03\xadB \x86B\x04\x84\x10\x88\x80\x80\x80\x007\x03\x08 \x01 \x03A\x01j6\x02\x08B\x00!\x02\x0b \x00 \x027\x03\x00\x0b\x1c\x00 \x00 \x01\xadB \x86B\x04\x84 \x02\xadB \x86B\x04\x84\x10\x86\x80\x80\x80\x00\x0b\x19\x00\x02@ \x01 \x00I\r\x00 \x01 \x00k\x0f\x0b\x10\xc3\x80\x80\x80\x00\x00\x0bB\x01\x01~B\x01!\x02\x02@ \x01B\xff\x01\x83B\xc8\x00R\r\x00 \x01\x10\x89\x80\x80\x80\x00B\x80\x80\x80\x80p\x83B\x80\x80\x80\x80\x80\x04R\r\x00 \x00 \x017\x03\x08B\x00!\x02\x0b \x00 \x027\x03\x00\x0b\x12\x00A\x00-\x00\xea\x83\xc0\x80\x00\x1aB\x84\x80\x80\x80\x10\x0bg\x01\x01\x7f#\x80\x80\x80\x80\x00A\x10k\"\x01$\x80\x80\x80\x80\x00A\x00-\x00\x86\x84\xc0\x80\x00\x1a \x01B\x027\x03\x08\x02@\x02@ \x00B\xff\x01\x83B\xcc\x00R\r\x00 \x00A\xf8\x84\xc0\x80\x00A\x01 \x01A\x08jA\x01\x10\xad\x80\x80\x80\x00 \x011\x00\x08B\x04Q\r\x01\x0b\x00\x0b \x01A\x10j$\x80\x80\x80\x80\x00B\x02\x0b1\x00\x02@ \x02 \x04F\r\x00\x00\x0b \x00 \x01\xadB \x86B\x04\x84 \x03\xadB \x86B\x04\x84 \x02\xadB \x86B\x04\x84\x10\x85\x80\x80\x80\x00\x1a\x0b\xd3\x07\x03\x01\x7f\x01~\x01\x7f#\x80\x80\x80\x80\x00A\xc0\x00k\"\x01$\x80\x80\x80\x80\x00 \x01A\x83\x80\x80\x80\x006\x02\x18 \x01(\x02\x18\x1aA\x00-\x00\x88\x89\xc0\x80\x00\x1a \x01A\x84\x80\x80\x80\x006\x02\x18 \x01(\x02\x18\x1aA\x00-\x00\xb4\x88\xc0\x80\x00\x1aA\x00-\x00\xa6\x88\xc0\x80\x00\x1aA\x00-\x00\xd0\x88\xc0\x80\x00\x1a \x01A\x83\x80\x80\x80\x006\x02\x18 \x01(\x02\x18\x1aA\x00-\x00\xa6\x88\xc0\x80\x00\x1aA\x00-\x00\xde\x88\xc0\x80\x00\x1aA\x00-\x00\xc2\x88\xc0\x80\x00\x1a\x02@\x02@ \x00B\xff\x01\x83B\xcb\x00R\r\x00 \x00\x10\x81\x80\x80\x80\x00!\x02 \x01A\x006\x02\x10 \x01 \x007\x03\x08 \x01 \x02B \x88>\x02\x14 \x01A\x18j \x01A\x08j\x10\xa7\x80\x80\x80\x00 \x01)\x03\x18\"\x00B\x02Q\r\x00 \x00\xa7A\x01q\r\x00\x02@ \x01)\x03 \"\x00\xa7A\xff\x01q\"\x03A\xca\x00F\r\x00 \x03A\x0eG\r\x01\x0b\x02@\x02@\x02@ \x00A\xb0\x86\xc0\x80\x00A\x03\x10\xa8\x80\x80\x80\x00B \x88\xa7\x0e\x03\x00\x01\x02\x03\x0b \x01(\x02\x10 \x01(\x02\x14\x10\xa9\x80\x80\x80\x00A\x01K\r\x02 \x01A\x18j \x01A\x08j\x10\xa7\x80\x80\x80\x00 \x01)\x03\x18\"\x00B\x02Q\r\x02 \x00\xa7A\x01q\r\x02 \x01)\x03 !\x00A\x00!\x03\x02@\x03@ \x03A\x10F\r\x01 \x01A0j \x03jB\x027\x03\x00 \x03A\x08j!\x03\x0c\x00\x0b\x0b \x00B\xff\x01\x83B\xcc\x00R\r\x02 \x00A\xe8\x89\xc0\x80\x00A\x02 \x01A0jA\x02\x10\xad\x80\x80\x80\x00 \x01)\x030!\x00A\x00!\x03\x02@\x03@ \x03A\x18F\r\x01 \x01A\x18j \x03jB\x027\x03\x00 \x03A\x08j!\x03\x0c\x00\x0b\x0b \x00B\xff\x01\x83B\xcc\x00R\r\x02 \x00A\xac\x89\xc0\x80\x00A\x03 \x01A\x18jA\x03\x10\xad\x80\x80\x80\x00 \x011\x00\x18B\xcb\x00R\r\x02 \x011\x00 B\xcd\x00R\r\x02\x02@ \x01-\x00(\"\x03A\x0eF\r\x00 \x03A\xca\x00G\r\x03\x0b \x011\x008B\xcb\x00R\r\x02\x0c\x03\x0b \x01(\x02\x10 \x01(\x02\x14\x10\xa9\x80\x80\x80\x00A\x01K\r\x01 \x01A\x18j \x01A\x08j\x10\xa7\x80\x80\x80\x00 \x01)\x03\x18\"\x00B\x02Q\r\x01 \x00\xa7A\x01q\r\x01 \x01)\x03 !\x00A\x00!\x03\x02@\x03@ \x03A\x10F\r\x01 \x01A0j \x03jB\x027\x03\x00 \x03A\x08j!\x03\x0c\x00\x0b\x0b \x00B\xff\x01\x83B\xcc\x00R\r\x01 \x00A\x88\x8a\xc0\x80\x00A\x02 \x01A0jA\x02\x10\xad\x80\x80\x80\x00 \x01A\x18j \x01)\x030\x10\xaf\x80\x80\x80\x00 \x01(\x02\x18\r\x01 \x01A\x18j \x01)\x038\x10\xaa\x80\x80\x80\x00 \x01(\x02\x18A\x01G\r\x02\x0c\x01\x0b \x01(\x02\x10 \x01(\x02\x14\x10\xa9\x80\x80\x80\x00A\x01K\r\x00 \x01A\x18j \x01A\x08j\x10\xa7\x80\x80\x80\x00 \x01)\x03\x18\"\x00B\x02Q\r\x00 \x00\xa7A\x01q\r\x00 \x01)\x03 !\x00A\x00!\x03\x02@\x03@ \x03A\x18F\r\x01 \x01A\x18j \x03jB\x027\x03\x00 \x03A\x08j!\x03\x0c\x00\x0b\x0b \x00B\xff\x01\x83B\xcc\x00R\r\x00 \x00A\xa8\x8a\xc0\x80\x00A\x03 \x01A\x18jA\x03\x10\xad\x80\x80\x80\x00 \x011\x00\x18B\xcb\x00R\r\x00 \x01A0j \x01)\x03 \x10\xaf\x80\x80\x80\x00 \x01(\x020\r\x00 \x01A0j \x01)\x03(\x10\xaa\x80\x80\x80\x00 \x01(\x020A\x01G\r\x01\x0b\x00\x0b \x01A\xc0\x00j$\x80\x80\x80\x80\x00B\x02\x0b\xb3\x02\x03\x01\x7f\x01~\x01\x7f#\x80\x80\x80\x80\x00A k\"\x02$\x80\x80\x80\x80\x00\x02@\x02@ \x01B\xff\x01\x83B\xcb\x00Q\r\x00 \x00B\x017\x03\x00\x0c\x01\x0b \x01\x10\x81\x80\x80\x80\x00!\x03 \x02A\x006\x02\x08 \x02 \x017\x03\x00 \x02 \x03B \x88>\x02\x0c \x02A\x10j \x02\x10\xa7\x80\x80\x80\x00\x02@ \x02)\x03\x10\"\x01B\x02Q\r\x00 \x01\xa7A\x01q\r\x00\x02@ \x02)\x03\x18\"\x01\xa7A\xff\x01q\"\x04A\xca\x00F\r\x00 \x04A\x0eG\r\x01\x0b\x02@ \x01A\xc8\x89\xc0\x80\x00A\x01\x10\xa8\x80\x80\x80\x00B\xff\xff\xff\xff\x0fV\r\x00 \x02(\x02\x08 \x02(\x02\x0c\x10\xa9\x80\x80\x80\x00A\x01K\r\x00 \x02A\x10j \x02\x10\xa7\x80\x80\x80\x00 \x02)\x03\x10\"\x01B\x02Q\r\x00 \x01\xa7A\x01q\r\x00 \x02A\x10j \x02)\x03\x18\x10\xaa\x80\x80\x80\x00 \x02(\x02\x10\r\x00 \x02)\x03\x18!\x01 \x00B\x007\x03\x00 \x00 \x017\x03\x08\x0c\x02\x0b \x00B\x017\x03\x00\x0c\x01\x0b \x00B\x017\x03\x00\x0b \x02A j$\x80\x80\x80\x80\x00\x0b\x9e\x01\x01\x02\x7f#\x80\x80\x80\x80\x00A\x10k\"\x01$\x80\x80\x80\x80\x00 \x01A\x83\x80\x80\x80\x006\x02\x00 \x01(\x02\x00\x1aA\x00!\x02A\x00-\x00\xc0\x8a\xc0\x80\x00\x1a\x02@\x03@ \x02A\x10F\r\x01 \x01 \x02jB\x027\x03\x00 \x02A\x08j!\x02\x0c\x00\x0b\x0b\x02@\x02@ \x00B\xff\x01\x83B\xcc\x00R\r\x00 \x00A\xd4\x8a\xc0\x80\x00A\x02 \x01A\x02\x10\xad\x80\x80\x80\x00 \x011\x00\x00B\xcb\x00R\r\x00 \x011\x00\x08B\xcd\x00Q\r\x01\x0b\x00\x0b \x01A\x10j$\x80\x80\x80\x80\x00B\x02\x0bA\x01\x01\x7f#\x80\x80\x80\x80\x00A\x10k\"\x01A\x88\x80\x80\x80\x006\x02\x0c \x01(\x02\x0c\x1a \x01A\x89\x80\x80\x80\x006\x02\x08 \x01(\x02\x08\x1a\x02@ \x00B\xff\x01\x83B\xcc\x00Q\r\x00\x00\x0bB\x02\x0bg\x01\x01\x7f#\x80\x80\x80\x80\x00A\x10k\"\x01$\x80\x80\x80\x80\x00A\x00-\x00\xe2\x80\xc0\x80\x00\x1a \x01B\x027\x03\x08\x02@\x02@ \x00B\xff\x01\x83B\xcc\x00R\r\x00 \x00A\xf8\x84\xc0\x80\x00A\x01 \x01A\x08jA\x01\x10\xad\x80\x80\x80\x00 \x011\x00\x08B\x04Q\r\x01\x0b\x00\x0b \x01A\x10j$\x80\x80\x80\x80\x00B\x02\x0b\x12\x00A\x00-\x00\xb8\x80\xc0\x80\x00\x1aB\x84\x80\x80\x80\x10\x0br\x01\x01\x7f#\x80\x80\x80\x80\x00A\x10k\"\x01$\x80\x80\x80\x80\x00A\x00-\x00\xc4\x81\xc0\x80\x00\x1a\x02@ \x00B\x02Q\r\x00 \x01B\x027\x03\x08\x02@ \x00B\xff\x01\x83B\xcc\x00R\r\x00 \x00A\xc8\x85\xc0\x80\x00A\x01 \x01A\x08jA\x01\x10\xad\x80\x80\x80\x00 \x01)\x03\x08B\xff\x01\x83B\x04Q\r\x01\x0b\x00\x0b \x01A\x10j$\x80\x80\x80\x80\x00B\x02\x0bI\x01\x01\x7f\x02@\x02@A\x01A\x02A\x00 \x00\xa7A\xff\x01q\"\x01\x1b \x01A\x01F\x1b\"\x01A\x02F\r\x00 \x01A\x01q\r\x01B\x02\x0f\x0b\x00\x0bA\x00-\x00\xb4\x82\xc0\x80\x00\x1aB\x83\x80\x80\x80\x10\x10\xa3\x80\x80\x80\x00\x00\x0b@\x01\x01\x7f\x02@\x02@A\x01A\x02A\x00 \x00\xa7A\xff\x01q\"\x01\x1b \x01A\x01F\x1b\"\x01A\x02F\r\x00 \x01A\x01q\r\x01B\x02\x0f\x0b\x00\x0bB\x83\x80\x80\x80\xf0\x00\x10\xa3\x80\x80\x80\x00\x00\x0b\x8a\x02\x01\x02\x7f#\x80\x80\x80\x80\x00A k\"\x02$\x80\x80\x80\x80\x00A\x00!\x03A\x00-\x00\xa6\x82\xc0\x80\x00\x1aA\x00-\x00\xc6\x80\xc0\x80\x00\x1a\x02@\x03@ \x03A\x10F\r\x01 \x02A\x08j \x03jB\x027\x03\x00 \x03A\x08j!\x03\x0c\x00\x0b\x0b\x02@\x02@ \x00B\xff\x01\x83B\xcc\x00R\r\x00 \x00A\xb4\x85\xc0\x80\x00A\x02 \x02A\x08jA\x02\x10\xad\x80\x80\x80\x00 \x021\x00\x08B\x04R\r\x00 \x02B\x027\x03\x18 \x02)\x03\x10\"\x00B\xff\x01\x83B\xcc\x00R\r\x00 \x00A\xf8\x84\xc0\x80\x00A\x01 \x02A\x18jA\x01\x10\xad\x80\x80\x80\x00\x02@ \x02)\x03\x18\"\x00\xa7A\xff\x01q\"\x03A\x07F\r\x00 \x03A\xc1\x00G\r\x01 \x00\x10\x82\x80\x80\x80\x00\x1a\x0bA\x00-\x00\xf0\x80\xc0\x80\x00\x1a \x01B\xff\x01\x83B\x04R\r\x00 \x01B \x88\xa7A}jA}K\r\x01\x0b\x00\x0b \x02A j$\x80\x80\x80\x80\x00B\x02\x0b\x90\x04\x03\x01\x7f\x01~\x01\x7f#\x80\x80\x80\x80\x00A0k\"\x01$\x80\x80\x80\x80\x00A\x00-\x00\x94\x84\xc0\x80\x00\x1a \x01A\x81\x80\x80\x80\x006\x02  \x01(\x02 \x1aA\x00-\x00\xd2\x81\xc0\x80\x00\x1aA\x00-\x00\xe0\x81\xc0\x80\x00\x1aA\x00-\x00\xee\x81\xc0\x80\x00\x1a \x01B\x027\x03\x08\x02@ \x00B\xff\x01\x83B\xcc\x00R\r\x00 \x00A\xf8\x84\xc0\x80\x00A\x01 \x01A\x08jA\x01\x10\xad\x80\x80\x80\x00 \x01)\x03\x08\"\x00B\xff\x01\x83B\xcb\x00R\r\x00 \x00\x10\x81\x80\x80\x80\x00!\x02 \x01A\x006\x02\x18 \x01 \x007\x03\x10 \x01 \x02B \x88>\x02\x1c \x01A j \x01A\x10j\x10\xa7\x80\x80\x80\x00 \x01)\x03 \"\x00B\x02Q\r\x00 \x00\xa7A\x01q\r\x00\x02@ \x01)\x03(\"\x00\xa7A\xff\x01q\"\x03A\xca\x00F\r\x00 \x03A\x0eG\r\x01\x0b\x02@\x02@\x02@ \x00A\xe8\x85\xc0\x80\x00A\x02\x10\xa8\x80\x80\x80\x00B \x88\xa7\x0e\x02\x01\x00\x03\x0b \x01(\x02\x18 \x01(\x02\x1c\x10\xa9\x80\x80\x80\x00A\x01K\r\x02 \x01A j \x01A\x10j\x10\xa7\x80\x80\x80\x00 \x01)\x03 \"\x00B\x02Q\r\x02 \x00\xa7A\x01q\r\x02 \x01)\x03(!\x00 \x01B\x027\x03  \x00B\xff\x01\x83B\xcc\x00R\r\x02 \x00A\xf8\x84\xc0\x80\x00A\x01 \x01A jA\x01\x10\xad\x80\x80\x80\x00 \x011\x00 B\xcb\x00Q\r\x01\x0c\x02\x0b \x01(\x02\x18 \x01(\x02\x1c\x10\xa9\x80\x80\x80\x00A\x01K\r\x01 \x01A j \x01A\x10j\x10\xa7\x80\x80\x80\x00 \x01)\x03 \"\x00B\x02Q\r\x01 \x00\xa7A\x01q\r\x01 \x01)\x03(!\x00 \x01B\x027\x03  \x00B\xff\x01\x83B\xcc\x00R\r\x01 \x00A\xf8\x84\xc0\x80\x00A\x01 \x01A jA\x01\x10\xad\x80\x80\x80\x00 \x011\x00 B\x04R\r\x01\x0b \x01A0j$\x80\x80\x80\x80\x00B\x02\x0f\x0b\x00\x0bZ\x02\x01\x7f\x01~#\x80\x80\x80\x80\x00A\x10k\"\x00$\x80\x80\x80\x80\x00A\x00-\x00\xbe\x84\xc0\x80\x00\x1aA\x00-\x00\x80\x80\xc0\x80\x00\x1a \x00B\x84\x80\x80\x80\x107\x03\x08A\xc8\x85\xc0\x80\x00A\x01 \x00A\x08jA\x01\x10\x9a\x80\x80\x80\x00!\x01 \x00A\x10j$\x80\x80\x80\x80\x00 \x01\x0bo\x02\x01\x7f\x01~#\x80\x80\x80\x80\x00A\x10k\"\x00$\x80\x80\x80\x80\x00A\x00-\x00\x8e\x80\xc0\x80\x00\x1a \x00A\xc8\x86\xc0\x80\x00A\x01\x10\xbb\x80\x80\x80\x00\x02@ \x00(\x02\x00A\x01G\r\x00\x00\x0b \x00)\x03\x08!\x01 \x00B\x84\x80\x80\x80\x107\x03\x08 \x00 \x017\x03\x00 \x00\x10\xbc\x80\x80\x80\x00!\x01 \x00A\x10j$\x80\x80\x80\x80\x00 \x01\x0b\xdb\x01\x02\x01~\x04\x7f\x02@\x02@ \x02A\tK\r\x00B\x00!\x03 \x02!\x04 \x01!\x05\x03@\x02@ \x04\r\x00 \x03B\x08\x86B\x0e\x84!\x03\x0c\x03\x0bA\x01!\x06\x02@ \x05-\x00\x00\"\x07A\xdf\x00F\r\x00\x02@\x02@ \x07APjA\xff\x01qA\nI\r\x00 \x07A\xbf\x7fjA\xff\x01qA\x1aI\r\x01 \x07A\x9f\x7fjA\xff\x01qA\x1aO\r\x04 \x07AEj!\x06\x0c\x02\x0b \x07ARj!\x06\x0c\x01\x0b \x07AKj!\x06\x0b \x03B\x06\x86 \x06\xadB\xff\x01\x83\x84!\x03 \x04A\x7fj!\x04 \x05A\x01j!\x05\x0c\x00\x0b\x0b \x01\xadB \x86B\x04\x84 \x02\xadB \x86B\x04\x84\x10\x87\x80\x80\x80\x00!\x03\x0b \x00B\x007\x03\x00 \x00 \x037\x03\x08\x0b\x17\x00 \x00\xadB \x86B\x04\x84B\x84\x80\x80\x80 \x10\x84\x80\x80\x80\x00\x0b\xc4\x01\x01\x02\x7f#\x80\x80\x80\x80\x00A k\"\x01$\x80\x80\x80\x80\x00A\x00!\x02A\x00-\x00\x9a\x81\xc0\x80\x00\x1a\x02@\x02@ \x00B\xff\x01\x83B\xcb\x00R\r\x00\x02@\x03@ \x02A\x10F\r\x01 \x01A\x08j \x02jB\x027\x03\x00 \x02A\x08j!\x02\x0c\x00\x0b\x0b \x00 \x01A\x08j\xadB \x86B\x04\x84B\x84\x80\x80\x80 \x10\x83\x80\x80\x80\x00\x1a \x01B\x027\x03\x18 \x01)\x03\x08\"\x00B\xff\x01\x83B\xcc\x00R\r\x00 \x00A\xf8\x84\xc0\x80\x00A\x01 \x01A\x18jA\x01\x10\xad\x80\x80\x80\x00 \x011\x00\x18B\x04R\r\x00 \x011\x00\x10B\x04Q\r\x01\x0b\x00\x0b \x01A j$\x80\x80\x80\x80\x00B\x02\x0bo\x02\x01\x7f\x01~#\x80\x80\x80\x80\x00A k\"\x00$\x80\x80\x80\x80\x00A\x00-\x00\xa4\x83\xc0\x80\x00\x1a \x00B\x84\x80\x80\x80\x107\x03\x18A\xf8\x84\xc0\x80\x00A\x01 \x00A\x18jA\x01\x10\x9a\x80\x80\x80\x00!\x01 \x00B\x84\x80\x80\x80 7\x03\x10 \x00 \x017\x03\x08 \x00A\x08j\x10\xbc\x80\x80\x80\x00!\x01 \x00A j$\x80\x80\x80\x80\x00 \x01\x0b0\x01\x01\x7f#\x80\x80\x80\x80\x00A\x10k\"\x01A\x8a\x80\x80\x80\x006\x02\x0c \x01(\x02\x0c\x1a\x02@ \x00B\xff\x01\x83B\xcb\x00Q\r\x00\x00\x0bB\x02\x0b0\x01\x01\x7f#\x80\x80\x80\x80\x00A\x10k\"\x01A\x8b\x80\x80\x80\x006\x02\x0c \x01(\x02\x0c\x1a\x02@ \x00B\xff\x01\x83B\xcb\x00Q\r\x00\x00\x0bB\x02\x0b\x8d\x01\x01\x02\x7f#\x80\x80\x80\x80\x00A\x10k\"\x01$\x80\x80\x80\x80\x00A\x00!\x02A\x00-\x00\xc0\x83\xc0\x80\x00\x1a\x02@\x03@ \x02A\x10F\r\x01 \x01 \x02jB\x027\x03\x00 \x02A\x08j!\x02\x0c\x00\x0b\x0b\x02@\x02@ \x00B\xff\x01\x83B\xcc\x00R\r\x00 \x00A\xd4\x8a\xc0\x80\x00A\x02 \x01A\x02\x10\xad\x80\x80\x80\x00 \x011\x00\x00B\x04R\r\x00 \x01)\x03\x08B\xfe\x01\x83P\r\x01\x0b\x00\x0b \x01A\x10j$\x80\x80\x80\x80\x00B\x02\x0b\x03\x00\x00\x0b\t\x00\x10\xc2\x80\x80\x80\x00\x00\x0b\x0b\xee\n\x01\x00A\x80\x80\xc0\x00\x0b\xe4\nSpEcV1Hh\xdc\xaaa\x8d\xf7\rSpEcV1\xe7\xcf\x9b1n\x15\x13\xfeSpEcV1\xe2\x01y\xc9\x9a\xf8\xedtSpEcV1v1\x0eP\xa9C\xc7*SpEcV1\xa9<\xd8+\xb7\xa7\r\x17SpEcV1X\x03\xf6t\xc7\xd0\x01\"SpEcV1\'\xbd_A\r\x9a\x89\x02SpEcV1p\x8c\x0fN!\x082\xd8SpEcV1\xc2\xf4N\xbf\xebqvpSpEcV1K\xdf\'8m/\xe8\x1dSpEcV1@\xb9LO\xf9\xd1\xe8\xe2SpEcV1\xde\x1dMa\x01\xec\xb0ASpEcV1\xc2 \x1b\xdc\xc8gxZSpEcV1[Q+\xe9\xde\xd5\xf2>SpEcV1\xb3/\x97\xd5\x06\xbd3BSpEcV1?\xd9\xb3q\xdep>\xf3SpEcV1*\\\x9c\xf4e\xaa\x1e]SpEcV1u2\x0b\x97\xae\xcd\x86\xbfSpEcV1\x0c\xf0\xf6w\xfd\x1a\x1b\x94SpEcV1\'\xf2\xa2\xb9\xd0)\xc0uSpEcV1\xf5\xd4\x9b\xa3\xccI\x13\xf7SpEcV1\x84\x08Y\xae\xa0\xf128SpEcV1\r\xb76\xae\x93D\xef\x1aSpEcV1\x8b\x89\x1f#\xbd\x157\xf4SpEcV16\x83?\xf0\xcdW\xb1/SpEcV1\x94\xc7w/_\xebXcSpEcV1\xb4\xabN]\xe3\xeaA\xd6SpEcV1\x13?J\x12d\xden|SpEcV1q\xa3z;6\xa6R\x01SpEcV1q^\xe2&\x9di\x9d\x0eSpEcV1Y\xa66\xb3\xecxE\x13SpEcV1\xcf@%X\xde+J@SpEcV1\xb6\x1c\xfd\xdfhY-dSpEcV1 \xfbl\x04B\x82\xc0\xb4SpEcV1\xe3\xf2\x9b5%a\xfb\xd6SpEcV1\r\xd6\r \xfc\xdb\xea\xf3SpEcV1\x9a\x14*\xbc\x82a\x08XSpEcV1\x7f\xc5\xceo\xc3ST\x08SpEcV1\xe6Q\xd5T\x13\x8a\xb7lSpEcV1[\xf4R\xdf\xdd\xb4\xb0\xbcSpEcV1\xaaX8\xde\xef\xbb6%SpEcV1k\xe4zxB\xd1+\x02amount\x00\x00L\x02\x10\x00\x06\x00\x00\x00used_export_false_eventval\x00\x00s\x02\x10\x00\x03\x00\x00\x00StellarAssetAccount\x00\xc4\x04\x10\x00\x04\x00\x00\x00\x80\x02\x10\x00\x0c\x00\x00\x00\x8c\x02\x10\x00\x07\x00\x00\x00anested\x00\xac\x02\x10\x00\x01\x00\x00\x00\xad\x02\x10\x00\x06\x00\x00\x00data\xc4\x02\x10\x00\x04\x00\x00\x00NotRecursiveRecursive\x00\x00\x00\xd0\x02\x10\x00\x0c\x00\x00\x00\xdc\x02\x10\x00\t\x00\x00\x00ContractCreateContractHostFnCreateContractWithCtorHostFn\xf8\x02\x10\x00\x08\x00\x00\x00\x00\x03\x10\x00\x14\x00\x00\x00\x14\x03\x10\x00\x1c\x00\x00\x00A\x00\x00\x00\xad\x02\x10\x00\x06\x00\x00\x00xy\x00\x00T\x03\x10\x00\x01\x00\x00\x00U\x03\x10\x00\x01\x00\x00\x00inner\x00\x00\x00h\x03\x10\x00\x05\x00\x00\x00transfercoordsefused_event_simplepayload\x99\x03\x10\x00\x07\x00\x00\x00used_event_with_refsused_event_with_data_typeused_event_with_topic_typeused_event_with_nested_dataused_event_with_nested_topicSpEcV1\xb6\xb1Hy\xda\xca\xaf\xccSpEcV1\x9e)H\x8e\xf0\x01{{SpEcV1ULqD\xd3\xfa:\x1fSpEcV1\x15\xe5\x1a,\xc0\xc7\xef\xd4SpEcV1s\x94\x0c\x1926\x1d\x90SpEcV1\xa3J\xcf\xf7D\x93\x0bBSpEcV1L|{\r\xf4\xf2\x1a\xa8SpEcV1\xf1\xf9\x90\x07E*e\xfdargscontractfn_name\x00\x00\x00\x96\x04\x10\x00\x04\x00\x00\x00\x9a\x04\x10\x00\x08\x00\x00\x00\xa2\x04\x10\x00\x07\x00\x00\x00Wasm\xc4\x04\x10\x00\x04\x00\x00\x00contextsub_invocations\x00\x00\xd0\x04\x10\x00\x07\x00\x00\x00\xd7\x04\x10\x00\x0f\x00\x00\x00executablesalt\x00\x00\xf8\x04\x10\x00\n\x00\x00\x00\x02\x05\x10\x00\x04\x00\x00\x00constructor_args\x18\x05\x10\x00\x10\x00\x00\x00\xf8\x04\x10\x00\n\x00\x00\x00\x02\x05\x10\x00\x04\x00\x00\x00SpEcV1\xa3\x16\n\x8f\xc9\x92\xd2\x11f1f2\x00\x00N\x05\x10\x00\x02\x00\x00\x00P\x05\x10\x00\x02\x00\x00\x00\x00\xb7Y\x0econtractspecv0\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x05EnumA\x00\x00\x00\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02V1\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02V2\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02V3\x00\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x05EnumB\x00\x00\x00\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02V1\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x02V2\x00\x00\x00\x00\x00\x01\x00\x00\x00\x07\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x02V3\x00\x00\x00\x00\x00\x02\x00\x00\x00\x07\x00\x00\x00\x07\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x05EnumC\x00\x00\x00\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02V1\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x02V2\x00\x00\x00\x00\x00\x01\x00\x00\x07\xd0\x00\x00\x00\x07StructA\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x02V3\x00\x00\x00\x00\x00\x01\x00\x00\x07\xd0\x00\x00\x00\x0cStructTupleA\x00\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x06ErrorA\x00\x00\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x02E1\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x02E2\x00\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x02E3\x00\x00\x00\x00\x00\x03\x00\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x06ErrorB\x00\x00\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x02E1\x00\x00\x00\x00\x00\n\x00\x00\x00\x00\x00\x00\x00\x02E2\x00\x00\x00\x00\x00\x0b\x00\x00\x00\x00\x00\x00\x00\x02E3\x00\x00\x00\x00\x00\x0c\x00\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x06ErrorC\x00\x00\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x02E1\x00\x00\x00\x00\x00d\x00\x00\x00\x00\x00\x00\x00\x02E2\x00\x00\x00\x00\x00e\x00\x00\x00\x00\x00\x00\x00\x02E3\x00\x00\x00\x00\x00f\x00\x00\x00\x05\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x06EventA\x00\x00\x00\x00\x00\x01\x00\x00\x00\x07event_a\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x02f1\x00\x00\x00\x00\x00\x13\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x02f2\x00\x00\x00\x00\x00\x10\x00\x00\x00\x00\x00\x00\x00\x02\x00\x00\x00\x05\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x06EventB\x00\x00\x00\x00\x00\x01\x00\x00\x00\x07event_b\x00\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x02f1\x00\x00\x00\x00\x00\x13\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x02f2\x00\x00\x00\x00\x00\x13\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x02f3\x00\x00\x00\x00\x00\x0b\x00\x00\x00\x00\x00\x00\x00\x02\x00\x00\x00\x05\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x06EventC\x00\x00\x00\x00\x00\x01\x00\x00\x00\x07event_c\x00\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x02f1\x00\x00\x00\x00\x00\x11\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x02f2\x00\x00\x00\x00\x00\x07\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02f3\x00\x00\x00\x00\x00\x07\x00\x00\x00\x00\x00\x00\x00\x02\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x07StructA\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x02f1\x00\x00\x00\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00\x02f2\x00\x00\x00\x00\x00\x01\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x07StructB\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x02f1\x00\x00\x00\x00\x00\x07\x00\x00\x00\x00\x00\x00\x00\x02f2\x00\x00\x00\x00\x00\x10\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x07StructC\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x02f1\x00\x00\x00\x00\x03\xea\x00\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00\x02f2\x00\x00\x00\x00\x00\x13\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x08EnumIntA\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x02V1\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x02V2\x00\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x02V3\x00\x00\x00\x00\x00\x03\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x08EnumIntB\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x02V1\x00\x00\x00\x00\x00\n\x00\x00\x00\x00\x00\x00\x00\x02V2\x00\x00\x00\x00\x00\x14\x00\x00\x00\x00\x00\x00\x00\x02V3\x00\x00\x00\x00\x00\x1e\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x08EnumIntC\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x02V1\x00\x00\x00\x00\x00d\x00\x00\x00\x00\x00\x00\x00\x02V2\x00\x00\x00\x00\x00\xc8\x00\x00\x00\x00\x00\x00\x00\x02V3\x00\x00\x00\x00\x01,\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x0cStructTupleA\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x010\x00\x00\x00\x00\x00\x00\x07\x00\x00\x00\x00\x00\x00\x00\x011\x00\x00\x00\x00\x00\x00\x07\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x0cStructTupleB\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x010\x00\x00\x00\x00\x00\x00\n\x00\x00\x00\x00\x00\x00\x00\x011\x00\x00\x00\x00\x00\x00\n\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x0cStructTupleC\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x010\x00\x00\x00\x00\x00\x00\x13\x00\x00\x00\x00\x00\x00\x00\x011\x00\x00\x00\x00\x00\x00\x0b\x00\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x14UsedExportFalseError\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x04Fail\x00\x00\x00\x01\x00\x00\x00\x05\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x14UsedExportFalseEvent\x00\x00\x00\x01\x00\x00\x00\x17used_export_false_event\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x04kind\x00\x00\x00\x11\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x06amount\x00\x00\x00\x00\x00\x0b\x00\x00\x00\x00\x00\x00\x00\x02\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x15UsedExportFalseStruct\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x03val\x00\x00\x00\x00\x04\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x08UsedLeaf\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x03val\x00\x00\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x08with_map\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x01m\x00\x00\x00\x00\x00\x03\xec\x00\x00\x07\xd0\x00\x00\x00\nUsedMapKey\x00\x00\x00\x00\x07\xd0\x00\x00\x00\nUsedMapVal\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x08with_vec\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x01v\x00\x00\x00\x00\x00\x03\xea\x00\x00\x07\xd0\x00\x00\x00\x0eUsedVecElement\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\nUnusedEnum\x00\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01A\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x01B\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x07\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\nUsedMapKey\x00\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x02K1\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x02K2\x00\x00\x00\x00\x00\x02\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\nUsedMapVal\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x01v\x00\x00\x00\x00\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\nwith_error\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x03\xe9\x00\x00\x00\x04\x00\x00\x07\xd0\x00\x00\x00\rUsedErrorEnum\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\nwith_param\x00\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x01s\x00\x00\x00\x00\x00\x07\xd0\x00\x00\x00\x0fUsedParamStruct\x00\x00\x00\x00\x00\x00\x00\x00\x02ie\x00\x00\x00\x00\x07\xd0\x00\x00\x00\x10UsedParamIntEnum\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\nwith_tuple\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x01t\x00\x00\x00\x00\x00\x03\xed\x00\x00\x00\x02\x00\x00\x07\xd0\x00\x00\x00\x10UsedTupleElement\x00\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00\x05\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x0bUnusedEvent\x00\x00\x00\x00\x01\x00\x00\x00\x0cunused_event\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x04kind\x00\x00\x00\x11\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x04data\x00\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00\x02\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x0cUnusedStruct\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x01x\x00\x00\x00\x00\x00\x00\x04\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x0cUsedResultOk\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x04data\x00\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x0bwith_option\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x01o\x00\x00\x00\x00\x00\x03\xe8\x00\x00\x07\xd0\x00\x00\x00\x11UsedOptionElement\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x0bwith_result\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x03\xe9\x00\x00\x07\xd0\x00\x00\x00\x0cUsedResultOk\x00\x00\x07\xd0\x00\x00\x00\rUsedErrorEnum\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x0bwith_return\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x07\xd0\x00\x00\x00\x0eUsedReturnEnum\x00\x00\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\rUnusedIntEnum\x00\x00\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x02U1\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x02U2\x00\x00\x00\x00\x00\x02\x00\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\rUsedErrorEnum\x00\x00\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x08NotFound\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x07Invalid\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x0cwith_non_pub\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x01s\x00\x00\x00\x00\x00\x07\xd0\x00\x00\x00\x10UsedNonPubStruct\x00\x00\x00\x00\x00\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x0eUnusedPubError\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x04Nope\x00\x00\x00\x01\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x0eUsedReturnEnum\x00\x00\x00\x00\x00\x02\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x01A\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x04\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x01B\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x07\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x0eUsedVecElement\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x04data\x00\x00\x00\x04\x00\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x0fUsedNonPubError\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x04Fail\x00\x00\x00\x01\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x0fUsedParamStruct\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x01a\x00\x00\x00\x00\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00\x06nested\x00\x00\x00\x00\x07\xd0\x00\x00\x00\x12UsedNestedInStruct\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x0fUsedRefDataType\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x06nested\x00\x00\x00\x00\x07\xd0\x00\x00\x00\x10UsedRefDataInner\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x0epublish_simple\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x0ewith_recursion\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x01r\x00\x00\x00\x00\x00\x07\xd0\x00\x00\x00\x11UsedRecursiveRoot\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x05\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x0fUsedEventSimple\x00\x00\x00\x00\x01\x00\x00\x00\x11used_event_simple\x00\x00\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x04kind\x00\x00\x00\x11\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x06amount\x00\x00\x00\x00\x00\x0b\x00\x00\x00\x00\x00\x00\x00\x02\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x10UsedNonPubStruct\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x03val\x00\x00\x00\x00\x04\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x10UsedParamIntEnum\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x01X\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x01Y\x00\x00\x00\x00\x00\x00\x02\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x10UsedRefDataInner\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x03val\x00\x00\x00\x00\x04\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x10UsedRefTopicType\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x04Send\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x04Recv\x00\x00\x00\x02\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x10UsedTupleElement\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x03val\x00\x00\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x0fwith_executable\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x01e\x00\x00\x00\x00\x00\x07\xd0\x00\x00\x00\nExecutable\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x0fwith_lib_struct\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x01s\x00\x00\x00\x00\x00\x07\xd0\x00\x00\x00\x07StructC\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x0fwith_vec_nested\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x01v\x00\x00\x00\x00\x00\x03\xea\x00\x00\x07\xd0\x00\x00\x00\x14UsedVecElementNested\x00\x00\x00\x00\x00\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x11UnusedNonPubError\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x03Bad\x00\x00\x00\x00\x01\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x11UsedEventDataType\x00\x00\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x01x\x00\x00\x00\x00\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00\x01y\x00\x00\x00\x00\x00\x00\x04\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x11UsedOptionElement\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x04data\x00\x00\x00\x04\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x11UsedRecursiveLeaf\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x03val\x00\x00\x00\x03\xea\x00\x00\x07\xd0\x00\x00\x00\x11UsedRecursiveRoot\x00\x00\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x11UsedRecursiveNode\x00\x00\x00\x00\x00\x00\x02\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x0cNotRecursive\x00\x00\x00\x01\x00\x00\x07\xd0\x00\x00\x00\x08UsedLeaf\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\tRecursive\x00\x00\x00\x00\x00\x00\x01\x00\x00\x07\xd0\x00\x00\x00\x11UsedRecursiveLeaf\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x11UsedRecursiveRoot\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x03val\x00\x00\x00\x07\xd0\x00\x00\x00\x11UsedRecursiveNode\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x10with_panic_error\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x04fail\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x05\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x11UsedEventWithRefs\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x14used_event_with_refs\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x04kind\x00\x00\x07\xd0\x00\x00\x00\x10UsedRefTopicType\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x07payload\x00\x00\x00\x07\xd0\x00\x00\x00\x0fUsedRefDataType\x00\x00\x00\x00\x00\x00\x00\x00\x02\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x12UnusedNonPubStruct\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x01x\x00\x00\x00\x00\x00\x00\x04\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x12UsedEventDataInner\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x03val\x00\x00\x00\x00\x04\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x12UsedEventDataOuter\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x05inner\x00\x00\x00\x00\x00\x07\xd0\x00\x00\x00\x12UsedEventDataInner\x00\x00\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x12UsedEventTopicType\x00\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x08Transfer\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x04Mint\x00\x00\x00\x02\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x12UsedNestedInStruct\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x03val\x00\x00\x00\x00\x07\x00\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x12UsedPanicErrorEnum\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x04Boom\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x11publish_data_type\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x11publish_ref_event\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x11with_assert_error\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x02ok\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x11with_invoker_auth\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x01i\x00\x00\x00\x00\x00\x07\xd0\x00\x00\x00\x18InvokerContractAuthEntry\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x11with_tuple_return\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x03\xed\x00\x00\x00\x02\x00\x00\x07\xd0\x00\x00\x00\x16UsedTupleReturnElement\x00\x00\x00\x00\x00\x04\x00\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x13UsedAssertErrorEnum\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x03Bad\x00\x00\x00\x00\x01\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x13UsedEventTopicInner\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x03val\x00\x00\x00\x00\x04\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x13UsedEventTopicOuter\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x05inner\x00\x00\x00\x00\x00\x07\xd0\x00\x00\x00\x13UsedEventTopicInner\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x13UsedVecInnerElement\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x03val\x00\x00\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x12publish_topic_type\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x12with_auth_contexts\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x01c\x00\x00\x00\x00\x00\x03\xea\x00\x00\x07\xd0\x00\x00\x00\x07Context\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x12with_non_pub_error\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x03\xe9\x00\x00\x00\x04\x00\x00\x07\xd0\x00\x00\x00\x0fUsedNonPubError\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x12with_wasm_imported\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x01s\x00\x00\x00\x00\x00\x07\xd0\x00\x00\x00\x07StructA\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x14UsedVecElementNested\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x05inner\x00\x00\x00\x00\x00\x07\xd0\x00\x00\x00\x13UsedVecInnerElement\x00\x00\x00\x00\x00\x00\x00\x00\x03val\x00\x00\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00\tvec_inner\x00\x00\x00\x00\x00\x03\xea\x00\x00\x07\xd0\x00\x00\x00\x16UsedVecInnerVecElement\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x13publish_nested_data\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x14publish_nested_topic\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x14with_panic_raw_error\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x04fail\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x05\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x15UsedEventWithDataType\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x19used_event_with_data_type\x00\x00\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x04kind\x00\x00\x00\x11\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x07payload\x00\x00\x00\x07\xd0\x00\x00\x00\x11UsedEventDataType\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x16UsedTupleReturnElement\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x03val\x00\x00\x00\x00\x04\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x16UsedVecInnerVecElement\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x03val\x00\x00\x00\x00\x04\x00\x00\x00\x05\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x16UsedEventWithTopicType\x00\x00\x00\x00\x00\x01\x00\x00\x00\x1aused_event_with_topic_type\x00\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x04kind\x00\x00\x07\xd0\x00\x00\x00\x12UsedEventTopicType\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x06amount\x00\x00\x00\x00\x00\x0b\x00\x00\x00\x00\x00\x00\x00\x02\x00\x00\x00\x05\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x17UsedEventWithNestedData\x00\x00\x00\x00\x01\x00\x00\x00\x1bused_event_with_nested_data\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x04kind\x00\x00\x00\x11\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x07payload\x00\x00\x00\x07\xd0\x00\x00\x00\x12UsedEventDataOuter\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x18UnusedNonContractFnParam\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x01x\x00\x00\x00\x00\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x17with_export_false_error\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x03\xe9\x00\x00\x00\x04\x00\x00\x07\xd0\x00\x00\x00\x14UsedExportFalseError\x00\x00\x00\x05\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x18UsedEventWithNestedTopic\x00\x00\x00\x01\x00\x00\x00\x1cused_event_with_nested_topic\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x04info\x00\x00\x07\xd0\x00\x00\x00\x13UsedEventTopicOuter\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x06amount\x00\x00\x00\x00\x00\x0b\x00\x00\x00\x00\x00\x00\x00\x02\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x19UnusedNonContractFnReturn\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x01x\x00\x00\x00\x00\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x18with_export_false_struct\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x01s\x00\x00\x00\x00\x00\x07\xd0\x00\x00\x00\x15UsedExportFalseStruct\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x1apublish_export_false_event\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02\x00\x00\x00\xe3Context of a single authorized call performed by an address.\n\nCustom account contracts that implement `__check_auth` special function\nreceive a list of `Context` values corresponding to all the calls that\nneed to be authorized.\x00\x00\x00\x00\x00\x00\x00\x00\x07Context\x00\x00\x00\x00\x03\x00\x00\x00\x01\x00\x00\x00\x14Contract invocation.\x00\x00\x00\x08Contract\x00\x00\x00\x01\x00\x00\x07\xd0\x00\x00\x00\x0fContractContext\x00\x00\x00\x00\x01\x00\x00\x00=Contract that has a constructor with no arguments is created.\x00\x00\x00\x00\x00\x00\x14CreateContractHostFn\x00\x00\x00\x01\x00\x00\x07\xd0\x00\x00\x00\x1bCreateContractHostFnContext\x00\x00\x00\x00\x01\x00\x00\x00DContract that has a constructor with 1 or more arguments is created.\x00\x00\x00\x1cCreateContractWithCtorHostFn\x00\x00\x00\x01\x00\x00\x07\xd0\x00\x00\x00*CreateContractWithConstructorHostFnContext\x00\x00\x00\x00\x00\x01\x00\x00\x00\xbdAuthorization context of a single contract call.\n\nThis struct corresponds to a `require_auth_for_args` call for an address\nfrom `contract` function with `fn_name` name and `args` arguments.\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x0fContractContext\x00\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x04args\x00\x00\x03\xea\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x08contract\x00\x00\x00\x13\x00\x00\x00\x00\x00\x00\x00\x07fn_name\x00\x00\x00\x00\x11\x00\x00\x00\x02\x00\x00\x00_Contract executable used for creating a new contract and used in\n`CreateContractHostFnContext`.\x00\x00\x00\x00\x00\x00\x00\x00\x12ContractExecutable\x00\x00\x00\x00\x00\x01\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x04Wasm\x00\x00\x00\x01\x00\x00\x03\xee\x00\x00\x00 \x00\x00\x00\x01\x00\x00\x008Value of contract node in InvokerContractAuthEntry tree.\x00\x00\x00\x00\x00\x00\x00\x15SubContractInvocation\x00\x00\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x07context\x00\x00\x00\x07\xd0\x00\x00\x00\x0fContractContext\x00\x00\x00\x00\x00\x00\x00\x00\x0fsub_invocations\x00\x00\x00\x03\xea\x00\x00\x07\xd0\x00\x00\x00\x18InvokerContractAuthEntry\x00\x00\x00\x02\x00\x00\x01/A node in the tree of authorizations performed on behalf of the current\ncontract as invoker of the contracts deeper in the call stack.\n\nThis is used as an argument of `authorize_as_current_contract` host function.\n\nThis tree corresponds `require_auth[_for_args]` calls on behalf of the\ncurrent contract.\x00\x00\x00\x00\x00\x00\x00\x00\x18InvokerContractAuthEntry\x00\x00\x00\x03\x00\x00\x00\x01\x00\x00\x00\x12Invoke a contract.\x00\x00\x00\x00\x00\x08Contract\x00\x00\x00\x01\x00\x00\x07\xd0\x00\x00\x00\x15SubContractInvocation\x00\x00\x00\x00\x00\x00\x01\x00\x00\x005Create a contract passing 0 arguments to constructor.\x00\x00\x00\x00\x00\x00\x14CreateContractHostFn\x00\x00\x00\x01\x00\x00\x07\xd0\x00\x00\x00\x1bCreateContractHostFnContext\x00\x00\x00\x00\x01\x00\x00\x00=Create a contract passing 0 or more arguments to constructor.\x00\x00\x00\x00\x00\x00\x1cCreateContractWithCtorHostFn\x00\x00\x00\x01\x00\x00\x07\xd0\x00\x00\x00*CreateContractWithConstructorHostFnContext\x00\x00\x00\x00\x00\x01\x00\x00\x00vAuthorization context for `create_contract` host function that creates a\nnew contract on behalf of authorizer address.\x00\x00\x00\x00\x00\x00\x00\x00\x00\x1bCreateContractHostFnContext\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\nexecutable\x00\x00\x00\x00\x07\xd0\x00\x00\x00\x12ContractExecutable\x00\x00\x00\x00\x00\x00\x00\x00\x00\x04salt\x00\x00\x03\xee\x00\x00\x00 \x00\x00\x00\x01\x00\x00\x00\xd6Authorization context for `create_contract` host function that creates a\nnew contract on behalf of authorizer address.\nThis is the same as `CreateContractHostFnContext`, but also has\ncontract constructor arguments.\x00\x00\x00\x00\x00\x00\x00\x00\x00*CreateContractWithConstructorHostFnContext\x00\x00\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x10constructor_args\x00\x00\x03\xea\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\nexecutable\x00\x00\x00\x00\x07\xd0\x00\x00\x00\x12ContractExecutable\x00\x00\x00\x00\x00\x00\x00\x00\x00\x04salt\x00\x00\x03\xee\x00\x00\x00 \x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\nExecutable\x00\x00\x00\x00\x00\x03\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x04Wasm\x00\x00\x00\x01\x00\x00\x03\xee\x00\x00\x00 \x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x0cStellarAsset\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x07Account\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x05EnumA\x00\x00\x00\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02V1\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02V2\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02V3\x00\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x05EnumB\x00\x00\x00\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02V1\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x02V2\x00\x00\x00\x00\x00\x01\x00\x00\x00\x07\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x02V3\x00\x00\x00\x00\x00\x02\x00\x00\x00\x07\x00\x00\x00\x07\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x05EnumC\x00\x00\x00\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02V1\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x02V2\x00\x00\x00\x00\x00\x01\x00\x00\x07\xd0\x00\x00\x00\x07StructA\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x02V3\x00\x00\x00\x00\x00\x01\x00\x00\x07\xd0\x00\x00\x00\x0cStructTupleA\x00\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x06ErrorA\x00\x00\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x02E1\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x02E2\x00\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x02E3\x00\x00\x00\x00\x00\x03\x00\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x06ErrorB\x00\x00\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x02E1\x00\x00\x00\x00\x00\n\x00\x00\x00\x00\x00\x00\x00\x02E2\x00\x00\x00\x00\x00\x0b\x00\x00\x00\x00\x00\x00\x00\x02E3\x00\x00\x00\x00\x00\x0c\x00\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x06ErrorC\x00\x00\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x02E1\x00\x00\x00\x00\x00d\x00\x00\x00\x00\x00\x00\x00\x02E2\x00\x00\x00\x00\x00e\x00\x00\x00\x00\x00\x00\x00\x02E3\x00\x00\x00\x00\x00f\x00\x00\x00\x05\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x06EventA\x00\x00\x00\x00\x00\x01\x00\x00\x00\x07event_a\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x02f1\x00\x00\x00\x00\x00\x13\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x02f2\x00\x00\x00\x00\x00\x10\x00\x00\x00\x00\x00\x00\x00\x02\x00\x00\x00\x05\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x06EventB\x00\x00\x00\x00\x00\x01\x00\x00\x00\x07event_b\x00\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x02f1\x00\x00\x00\x00\x00\x13\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x02f2\x00\x00\x00\x00\x00\x13\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x02f3\x00\x00\x00\x00\x00\x0b\x00\x00\x00\x00\x00\x00\x00\x02\x00\x00\x00\x05\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x06EventC\x00\x00\x00\x00\x00\x01\x00\x00\x00\x07event_c\x00\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x02f1\x00\x00\x00\x00\x00\x11\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x02f2\x00\x00\x00\x00\x00\x07\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02f3\x00\x00\x00\x00\x00\x07\x00\x00\x00\x00\x00\x00\x00\x02\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x07StructA\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x02f1\x00\x00\x00\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00\x02f2\x00\x00\x00\x00\x00\x01\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x07StructB\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x02f1\x00\x00\x00\x00\x00\x07\x00\x00\x00\x00\x00\x00\x00\x02f2\x00\x00\x00\x00\x00\x10\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x07StructC\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x02f1\x00\x00\x00\x00\x03\xea\x00\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00\x02f2\x00\x00\x00\x00\x00\x13\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x08EnumIntA\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x02V1\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x02V2\x00\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x02V3\x00\x00\x00\x00\x00\x03\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x08EnumIntB\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x02V1\x00\x00\x00\x00\x00\n\x00\x00\x00\x00\x00\x00\x00\x02V2\x00\x00\x00\x00\x00\x14\x00\x00\x00\x00\x00\x00\x00\x02V3\x00\x00\x00\x00\x00\x1e\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x08EnumIntC\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x02V1\x00\x00\x00\x00\x00d\x00\x00\x00\x00\x00\x00\x00\x02V2\x00\x00\x00\x00\x00\xc8\x00\x00\x00\x00\x00\x00\x00\x02V3\x00\x00\x00\x00\x01,\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x0cStructTupleA\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x010\x00\x00\x00\x00\x00\x00\x07\x00\x00\x00\x00\x00\x00\x00\x011\x00\x00\x00\x00\x00\x00\x07\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x0cStructTupleB\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x010\x00\x00\x00\x00\x00\x00\n\x00\x00\x00\x00\x00\x00\x00\x011\x00\x00\x00\x00\x00\x00\n\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x0cStructTupleC\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x010\x00\x00\x00\x00\x00\x00\x13\x00\x00\x00\x00\x00\x00\x00\x011\x00\x00\x00\x00\x00\x00\x0b\x00\x1e\x11contractenvmetav0\x00\x00\x00\x00\x00\x00\x00\x1a\x00\x00\x00\x00\x00O\x0econtractmetav0\x00\x00\x00\x00\x00\x00\x00\x05rsver\x00\x00\x00\x00\x00\x00\x061.91.0\x00\x00\x00\x00\x00\x00\x00\x00\x00\x12rssdk_spec_shaking\x00\x00\x00\x00\x00\x012\x00\x00\x00";
+    const WASM: &[u8] = b"\x00asm\x01\x00\x00\x00\x01^\x10`\x02~~\x01~`\x01~\x01~`\x03~~~\x01~`\x04~~~~\x01~`\x00\x00`\x00\x01~`\x02\x7f\x7f\x01~`\x04\x7f\x7f\x7f\x7f\x01~`\x01~\x00`\x02\x7f\x7f\x00`\x03~\x7f\x7f\x01~`\x02\x7f\x7f\x01\x7f`\x02\x7f~\x00`\x05~\x7f\x7f\x7f\x7f\x00`\x03\x7f\x7f\x7f\x00`\x01\x7f\x01~\x02I\x0c\x01x\x011\x00\x00\x01v\x013\x00\x01\x01i\x012\x00\x01\x01v\x01h\x00\x02\x01v\x01g\x00\x00\x01m\x01a\x00\x03\x01b\x01m\x00\x02\x01b\x01j\x00\x00\x01v\x011\x00\x00\x01b\x018\x00\x01\x01x\x015\x00\x01\x01m\x019\x00\x02\x0398\x04\x04\x04\x04\x04\x04\x04\x04\x04\x04\x04\x05\x06\x00\x07\x05\x00\x05\x05\x05\x05\x05\x01\x08\x01\x05\x01\t\n\x0b\x0c\x05\x01\r\x01\x0c\x01\x01\x01\x05\x01\x01\x01\x00\x01\x05\x05\x0e\x0f\x01\x05\x01\x01\x01\x04\x04\x04\x05\x01p\x01\x0c\x0c\x05\x03\x01\x00\x11\x06!\x04\x7f\x01A\x80\x80\xc0\x00\x0b\x7f\x00A\x96\x89\xc0\x00\x0b\x7f\x00A\xe4\x8a\xc0\x00\x0b\x7f\x00A\xf0\x8a\xc0\x00\x0b\x07\xd8\x04\"\x06memory\x02\x00\x11publish_data_type\x00\x17\x1apublish_export_false_event\x00\x1b\x13publish_nested_data\x00\x1d\x14publish_nested_topic\x00\x1e\x11publish_ref_event\x00\x1f\x0epublish_simple\x00 \x12publish_topic_type\x00!\x11with_assert_error\x00\"\x12with_auth_contexts\x00$\nwith_error\x00%\x0fwith_executable\x00&\x17with_export_false_error\x00+\x18with_export_false_struct\x00,\x11with_invoker_auth\x00.\x0fwith_lib_struct\x000\x08with_map\x001\x0cwith_non_pub\x002\x12with_non_pub_error\x003\x0bwith_option\x004\x10with_panic_error\x005\x14with_panic_raw_error\x006\nwith_param\x007\x0ewith_recursion\x008\x0bwith_result\x009\x0bwith_return\x00:\nwith_tuple\x00=\x11with_tuple_return\x00>\x08with_vec\x00?\x0fwith_vec_nested\x00@\x12with_wasm_imported\x00A\x01_\x03\x01\n__data_end\x03\x02\x0b__heap_base\x03\x03\t\x11\x01\x00A\x01\x0b\x0b\x0f\x11\x13\x12\x0e\r\x14\x15\x16\x0c\x10\n\xc128\x0c\x00A\x00-\x00\x9c\x80\xc0\x80\x00\x1a\x0b\x16\x00A\x00-\x00\xfe\x80\xc0\x80\x00\x1aA\x00-\x00\xd4\x80\xc0\x80\x00\x1a\x0b\x0c\x00A\x00-\x00\x8c\x81\xc0\x80\x00\x1a\x0bJ\x01\x01\x7f#\x80\x80\x80\x80\x00!\x00A\x00-\x00\x94\x84\xc0\x80\x00\x1a \x00A\x10k\"\x00A\x81\x80\x80\x80\x006\x02\x0c \x00(\x02\x0c\x1aA\x00-\x00\xd2\x81\xc0\x80\x00\x1aA\x00-\x00\xe0\x81\xc0\x80\x00\x1aA\x00-\x00\xee\x81\xc0\x80\x00\x1a\x0b6\x01\x01\x7f#\x80\x80\x80\x80\x00!\x00A\x00-\x00\xec\x82\xc0\x80\x00\x1a \x00A\x10k\"\x00A\x82\x80\x80\x80\x006\x02\x0c \x00(\x02\x0c\x1aA\x00-\x00\xfa\x82\xc0\x80\x00\x1a\x0b\x0c\x00A\x00-\x00\xb2\x83\xc0\x80\x00\x1a\x0b\x86\x01\x01\x01\x7f#\x80\x80\x80\x80\x00A\x10k\"\x00A\x83\x80\x80\x80\x006\x02\x0c \x00(\x02\x0c\x1aA\x00-\x00\x88\x89\xc0\x80\x00\x1a \x00A\x84\x80\x80\x80\x006\x02\x08 \x00(\x02\x08\x1aA\x00-\x00\xb4\x88\xc0\x80\x00\x1aA\x00-\x00\xa6\x88\xc0\x80\x00\x1aA\x00-\x00\xd0\x88\xc0\x80\x00\x1a \x00A\x83\x80\x80\x80\x006\x02\x04 \x00(\x02\x04\x1aA\x00-\x00\xa6\x88\xc0\x80\x00\x1aA\x00-\x00\xde\x88\xc0\x80\x00\x1aA\x00-\x00\xc2\x88\xc0\x80\x00\x1a\x0b\x02\x00\x0bk\x01\x01\x7f#\x80\x80\x80\x80\x00A\x10k\"\x00A\x83\x80\x80\x80\x006\x02\x0c \x00(\x02\x0c\x1aA\x00-\x00\x88\x89\xc0\x80\x00\x1aA\x00-\x00\xa6\x88\xc0\x80\x00\x1aA\x00-\x00\xd0\x88\xc0\x80\x00\x1a \x00A\x83\x80\x80\x80\x006\x02\x08 \x00(\x02\x08\x1aA\x00-\x00\xa6\x88\xc0\x80\x00\x1aA\x00-\x00\xde\x88\xc0\x80\x00\x1aA\x00-\x00\xec\x88\xc0\x80\x00\x1a\x0b\x0c\x00A\x00-\x00\xa2\x84\xc0\x80\x00\x1a\x0b\x0c\x00A\x00-\x00\xb0\x84\xc0\x80\x00\x1a\x0b\xae\x01\x02\x01\x7f\x01~#\x80\x80\x80\x80\x00A k\"\x00$\x80\x80\x80\x80\x00A\x80\x87\xc0\x80\x00A\x06\x10\x98\x80\x80\x80\x00!\x01A\x00-\x00\xa8\x81\xc0\x80\x00\x1aA\x00-\x00\x88\x83\xc0\x80\x00\x1aA\xbc\x87\xc0\x80\x00A\x19\x10\x98\x80\x80\x80\x00 \x01\x10\x99\x80\x80\x80\x00!\x01 \x00B\x84\x80\x80\x80 7\x03\x18 \x00B\x84\x80\x80\x80\x107\x03\x10 \x00A\xd8\x86\xc0\x80\x00A\x02 \x00A\x10jA\x02\x10\x9a\x80\x80\x80\x007\x03\x08 \x01A\xa0\x87\xc0\x80\x00A\x01 \x00A\x08jA\x01\x10\x9a\x80\x80\x80\x00\x10\x80\x80\x80\x80\x00\x1a \x00A j$\x80\x80\x80\x80\x00B\x02\x0bE\x02\x01\x7f\x01~#\x80\x80\x80\x80\x00A\x10k\"\x02$\x80\x80\x80\x80\x00 \x02 \x00 \x01\x10\xbb\x80\x80\x80\x00\x02@ \x02(\x02\x00A\x01G\r\x00\x00\x0b \x02)\x03\x08!\x03 \x02A\x10j$\x80\x80\x80\x80\x00 \x03\x0b\x92\x01\x01\x02\x7f#\x80\x80\x80\x80\x00A k\"\x02$\x80\x80\x80\x80\x00 \x02 \x017\x03\x08 \x02 \x007\x03\x00A\x00!\x03\x03~\x02@ \x03A\x10G\r\x00A\x00!\x03\x02@\x03@ \x03A\x10F\r\x01 \x02A\x10j \x03j \x02 \x03j)\x03\x007\x03\x00 \x03A\x08j!\x03\x0c\x00\x0b\x0b \x02A\x10j\x10\xbc\x80\x80\x80\x00!\x01 \x02A j$\x80\x80\x80\x80\x00 \x01\x0f\x0b \x02A\x10j \x03jB\x027\x03\x00 \x03A\x08j!\x03\x0c\x00\x0b\x0b.\x00\x02@ \x01 \x03F\r\x00\x00\x0b \x00\xadB \x86B\x04\x84 \x02\xadB \x86B\x04\x84 \x01\xadB \x86B\x04\x84\x10\x8b\x80\x80\x80\x00\x0b\x83\x01\x02\x01\x7f\x01~#\x80\x80\x80\x80\x00A\x10k\"\x00$\x80\x80\x80\x80\x00A\x86\x87\xc0\x80\x00A\x02\x10\x98\x80\x80\x80\x00!\x01A\x00-\x00\xf8\x83\xc0\x80\x00\x1aA\xdc\x84\xc0\x80\x00A\x17\x10\x98\x80\x80\x80\x00 \x01\x10\x99\x80\x80\x80\x00!\x01 \x00B\x01B\x00\x10\x9c\x80\x80\x80\x007\x03\x08 \x01A\xd4\x84\xc0\x80\x00A\x01 \x00A\x08jA\x01\x10\x9a\x80\x80\x80\x00\x10\x80\x80\x80\x80\x00\x1a \x00A\x10j$\x80\x80\x80\x80\x00B\x02\x0b\n\x00 \x00B\x08\x86B\x0b\x84\x0b\xc5\x01\x02\x01\x7f\x01~#\x80\x80\x80\x80\x00A\x10k\"\x00$\x80\x80\x80\x80\x00A\xad\x85\xc0\x80\x00A\x06\x10\x98\x80\x80\x80\x00!\x01A\x00-\x00\xfc\x81\xc0\x80\x00\x1aA\x00-\x00\x8a\x82\xc0\x80\x00\x1aA\x00-\x00\xce\x83\xc0\x80\x00\x1aA\xef\x87\xc0\x80\x00A\x1b\x10\x98\x80\x80\x80\x00 \x01\x10\x99\x80\x80\x80\x00!\x01 \x00B\x84\x80\x80\x80\xa0\x057\x03\x08 \x00A\xf8\x84\xc0\x80\x00A\x01 \x00A\x08jA\x01\x10\x9a\x80\x80\x80\x007\x03\x00 \x00A\xf0\x86\xc0\x80\x00A\x01 \x00A\x01\x10\x9a\x80\x80\x80\x007\x03\x08 \x01A\xa0\x87\xc0\x80\x00A\x01 \x00A\x08jA\x01\x10\x9a\x80\x80\x80\x00\x10\x80\x80\x80\x80\x00\x1a \x00A\x10j$\x80\x80\x80\x80\x00B\x02\x0b\xc2\x01\x02\x01\x7f\x01~#\x80\x80\x80\x80\x00A\x10k\"\x00$\x80\x80\x80\x80\x00A\x00-\x00\xd0\x82\xc0\x80\x00\x1aA\x00-\x00\xde\x82\xc0\x80\x00\x1aA\x00-\x00\xdc\x83\xc0\x80\x00\x1aA\x8a\x88\xc0\x80\x00A\x1c\x10\x98\x80\x80\x80\x00!\x01 \x00B\x84\x80\x80\x80\xa0\x057\x03\x08 \x00A\xf8\x84\xc0\x80\x00A\x01 \x00A\x08jA\x01\x10\x9a\x80\x80\x80\x007\x03\x00 \x01A\xf0\x86\xc0\x80\x00A\x01 \x00A\x01\x10\x9a\x80\x80\x80\x00\x10\x99\x80\x80\x80\x00!\x01 \x00B\xe4\x00B\x00\x10\x9c\x80\x80\x80\x007\x03\x08 \x01A\xd4\x84\xc0\x80\x00A\x01 \x00A\x08jA\x01\x10\x9a\x80\x80\x80\x00\x10\x80\x80\x80\x80\x00\x1a \x00A\x10j$\x80\x80\x80\x80\x00B\x02\x0b\xc7\x01\x02\x01\x7f\x01~#\x80\x80\x80\x80\x00A\x10k\"\x00$\x80\x80\x80\x80\x00 \x00A\x85\x80\x80\x80\x006\x02\x08 \x00(\x02\x08\x1a \x00A\x86\x80\x80\x80\x006\x02\x08 \x00(\x02\x08\x1aA\x00-\x00\xb6\x81\xc0\x80\x00\x1aA\xa8\x87\xc0\x80\x00A\x14\x10\x98\x80\x80\x80\x00B\x84\x80\x80\x80\x10\x10\x99\x80\x80\x80\x00!\x01 \x00B\x84\x80\x80\x80\xb0\x0c7\x03\x08 \x00A\xf8\x84\xc0\x80\x00A\x01 \x00A\x08jA\x01\x10\x9a\x80\x80\x80\x007\x03\x00 \x00A\xcc\x86\xc0\x80\x00A\x01 \x00A\x01\x10\x9a\x80\x80\x80\x007\x03\x08 \x01A\xa0\x87\xc0\x80\x00A\x01 \x00A\x08jA\x01\x10\x9a\x80\x80\x80\x00\x10\x80\x80\x80\x80\x00\x1a \x00A\x10j$\x80\x80\x80\x80\x00B\x02\x0b\x84\x01\x02\x01\x7f\x01~#\x80\x80\x80\x80\x00A\x10k\"\x00$\x80\x80\x80\x80\x00A\xf8\x86\xc0\x80\x00A\x08\x10\x98\x80\x80\x80\x00!\x01A\x00-\x00\xaa\x80\xc0\x80\x00\x1aA\x88\x87\xc0\x80\x00A\x11\x10\x98\x80\x80\x80\x00 \x01\x10\x99\x80\x80\x80\x00!\x01 \x00B\xe4\x00B\x00\x10\x9c\x80\x80\x80\x007\x03\x08 \x01A\xd4\x84\xc0\x80\x00A\x01 \x00A\x08jA\x01\x10\x9a\x80\x80\x80\x00\x10\x80\x80\x80\x80\x00\x1a \x00A\x10j$\x80\x80\x80\x80\x00B\x02\x0b\x82\x01\x02\x01\x7f\x01~#\x80\x80\x80\x80\x00A\x10k\"\x00$\x80\x80\x80\x80\x00A\x00-\x00\x98\x82\xc0\x80\x00\x1aA\x00-\x00\x96\x83\xc0\x80\x00\x1aA\xd5\x87\xc0\x80\x00A\x1a\x10\x98\x80\x80\x80\x00B\x84\x80\x80\x80\x10\x10\x99\x80\x80\x80\x00!\x01 \x00B\xe4\x00B\x00\x10\x9c\x80\x80\x80\x007\x03\x08 \x01A\xd4\x84\xc0\x80\x00A\x01 \x00A\x08jA\x01\x10\x9a\x80\x80\x80\x00\x10\x80\x80\x80\x80\x00\x1a \x00A\x10j$\x80\x80\x80\x80\x00B\x02\x0bJ\x01\x01\x7f\x02@\x02@A\x01A\x02A\x00 \x00\xa7A\xff\x01q\"\x01\x1b \x01A\x01F\x1b\"\x01A\x02F\r\x00 \x01A\x01qE\r\x01B\x02\x0f\x0b\x00\x0bA\x00-\x00\xc2\x82\xc0\x80\x00\x1aB\x83\x80\x80\x80\x10\x10\xa3\x80\x80\x80\x00\x00\x0b\x0b\x00 \x00\x10\x8a\x80\x80\x80\x00\x1a\x0b0\x01\x01\x7f#\x80\x80\x80\x80\x00A\x10k\"\x01A\x87\x80\x80\x80\x006\x02\x0c \x01(\x02\x0c\x1a\x02@ \x00B\xff\x01\x83B\xcb\x00Q\r\x00\x00\x0bB\x02\x0b\x13\x00A\x00-\x00\x80\x80\xc0\x80\x00\x1aB\x84\x80\x80\x80\xa0\x05\x0b\xc0\x02\x03\x01\x7f\x01~\x01\x7f#\x80\x80\x80\x80\x00A k\"\x01$\x80\x80\x80\x80\x00A\x00-\x00\xfa\x88\xc0\x80\x00\x1a\x02@ \x00B\xff\x01\x83B\xcb\x00R\r\x00 \x00\x10\x81\x80\x80\x80\x00!\x02 \x01A\x006\x02\x08 \x01 \x007\x03\x00 \x01 \x02B \x88>\x02\x0c \x01A\x10j \x01\x10\xa7\x80\x80\x80\x00 \x01)\x03\x10\"\x00B\x02Q\r\x00 \x00\xa7A\x01q\r\x00\x02@ \x01)\x03\x18\"\x00\xa7A\xff\x01q\"\x03A\xca\x00F\r\x00 \x03A\x0eG\r\x01\x0b\x02@\x02@\x02@\x02@ \x00A\x94\x85\xc0\x80\x00A\x03\x10\xa8\x80\x80\x80\x00B \x88\xa7\x0e\x03\x01\x02\x00\x04\x0b \x01(\x02\x08 \x01(\x02\x0c\x10\xa9\x80\x80\x80\x00\r\x03\x0c\x02\x0b \x01(\x02\x08 \x01(\x02\x0c\x10\xa9\x80\x80\x80\x00A\x01K\r\x02 \x01A\x10j \x01\x10\xa7\x80\x80\x80\x00 \x01)\x03\x10\"\x00B\x02Q\r\x02 \x00\xa7A\x01q\r\x02 \x01A\x10j \x01)\x03\x18\x10\xaa\x80\x80\x80\x00 \x01(\x02\x10A\x01G\r\x01\x0c\x02\x0b \x01(\x02\x08 \x01(\x02\x0c\x10\xa9\x80\x80\x80\x00\r\x01\x0b \x01A j$\x80\x80\x80\x80\x00B\x02\x0f\x0b\x00\x0bJ\x02\x01~\x01\x7fB\x02!\x02\x02@ \x01(\x02\x08\"\x03 \x01(\x02\x0cO\r\x00 \x00 \x01)\x03\x00 \x03\xadB \x86B\x04\x84\x10\x88\x80\x80\x80\x007\x03\x08 \x01 \x03A\x01j6\x02\x08B\x00!\x02\x0b \x00 \x027\x03\x00\x0b\x1c\x00 \x00 \x01\xadB \x86B\x04\x84 \x02\xadB \x86B\x04\x84\x10\x86\x80\x80\x80\x00\x0b\x19\x00\x02@ \x01 \x00I\r\x00 \x01 \x00k\x0f\x0b\x10\xc3\x80\x80\x80\x00\x00\x0bB\x01\x01~B\x01!\x02\x02@ \x01B\xff\x01\x83B\xc8\x00R\r\x00 \x01\x10\x89\x80\x80\x80\x00B\x80\x80\x80\x80p\x83B\x80\x80\x80\x80\x80\x04R\r\x00 \x00 \x017\x03\x08B\x00!\x02\x0b \x00 \x027\x03\x00\x0b\x12\x00A\x00-\x00\xea\x83\xc0\x80\x00\x1aB\x84\x80\x80\x80\x10\x0bg\x01\x01\x7f#\x80\x80\x80\x80\x00A\x10k\"\x01$\x80\x80\x80\x80\x00A\x00-\x00\x86\x84\xc0\x80\x00\x1a \x01B\x027\x03\x08\x02@\x02@ \x00B\xff\x01\x83B\xcc\x00R\r\x00 \x00A\xf8\x84\xc0\x80\x00A\x01 \x01A\x08jA\x01\x10\xad\x80\x80\x80\x00 \x011\x00\x08B\x04Q\r\x01\x0b\x00\x0b \x01A\x10j$\x80\x80\x80\x80\x00B\x02\x0b1\x00\x02@ \x02 \x04F\r\x00\x00\x0b \x00 \x01\xadB \x86B\x04\x84 \x03\xadB \x86B\x04\x84 \x02\xadB \x86B\x04\x84\x10\x85\x80\x80\x80\x00\x1a\x0b\xd3\x07\x03\x01\x7f\x01~\x01\x7f#\x80\x80\x80\x80\x00A\xc0\x00k\"\x01$\x80\x80\x80\x80\x00 \x01A\x83\x80\x80\x80\x006\x02\x18 \x01(\x02\x18\x1aA\x00-\x00\x88\x89\xc0\x80\x00\x1a \x01A\x84\x80\x80\x80\x006\x02\x18 \x01(\x02\x18\x1aA\x00-\x00\xb4\x88\xc0\x80\x00\x1aA\x00-\x00\xa6\x88\xc0\x80\x00\x1aA\x00-\x00\xd0\x88\xc0\x80\x00\x1a \x01A\x83\x80\x80\x80\x006\x02\x18 \x01(\x02\x18\x1aA\x00-\x00\xa6\x88\xc0\x80\x00\x1aA\x00-\x00\xde\x88\xc0\x80\x00\x1aA\x00-\x00\xc2\x88\xc0\x80\x00\x1a\x02@\x02@ \x00B\xff\x01\x83B\xcb\x00R\r\x00 \x00\x10\x81\x80\x80\x80\x00!\x02 \x01A\x006\x02\x10 \x01 \x007\x03\x08 \x01 \x02B \x88>\x02\x14 \x01A\x18j \x01A\x08j\x10\xa7\x80\x80\x80\x00 \x01)\x03\x18\"\x00B\x02Q\r\x00 \x00\xa7A\x01q\r\x00\x02@ \x01)\x03 \"\x00\xa7A\xff\x01q\"\x03A\xca\x00F\r\x00 \x03A\x0eG\r\x01\x0b\x02@\x02@\x02@ \x00A\xb0\x86\xc0\x80\x00A\x03\x10\xa8\x80\x80\x80\x00B \x88\xa7\x0e\x03\x00\x01\x02\x03\x0b \x01(\x02\x10 \x01(\x02\x14\x10\xa9\x80\x80\x80\x00A\x01K\r\x02 \x01A\x18j \x01A\x08j\x10\xa7\x80\x80\x80\x00 \x01)\x03\x18\"\x00B\x02Q\r\x02 \x00\xa7A\x01q\r\x02 \x01)\x03 !\x00A\x00!\x03\x02@\x03@ \x03A\x10F\r\x01 \x01A0j \x03jB\x027\x03\x00 \x03A\x08j!\x03\x0c\x00\x0b\x0b \x00B\xff\x01\x83B\xcc\x00R\r\x02 \x00A\xe8\x89\xc0\x80\x00A\x02 \x01A0jA\x02\x10\xad\x80\x80\x80\x00 \x01)\x030!\x00A\x00!\x03\x02@\x03@ \x03A\x18F\r\x01 \x01A\x18j \x03jB\x027\x03\x00 \x03A\x08j!\x03\x0c\x00\x0b\x0b \x00B\xff\x01\x83B\xcc\x00R\r\x02 \x00A\xac\x89\xc0\x80\x00A\x03 \x01A\x18jA\x03\x10\xad\x80\x80\x80\x00 \x011\x00\x18B\xcb\x00R\r\x02 \x011\x00 B\xcd\x00R\r\x02\x02@ \x01-\x00(\"\x03A\x0eF\r\x00 \x03A\xca\x00G\r\x03\x0b \x011\x008B\xcb\x00R\r\x02\x0c\x03\x0b \x01(\x02\x10 \x01(\x02\x14\x10\xa9\x80\x80\x80\x00A\x01K\r\x01 \x01A\x18j \x01A\x08j\x10\xa7\x80\x80\x80\x00 \x01)\x03\x18\"\x00B\x02Q\r\x01 \x00\xa7A\x01q\r\x01 \x01)\x03 !\x00A\x00!\x03\x02@\x03@ \x03A\x10F\r\x01 \x01A0j \x03jB\x027\x03\x00 \x03A\x08j!\x03\x0c\x00\x0b\x0b \x00B\xff\x01\x83B\xcc\x00R\r\x01 \x00A\x88\x8a\xc0\x80\x00A\x02 \x01A0jA\x02\x10\xad\x80\x80\x80\x00 \x01A\x18j \x01)\x030\x10\xaf\x80\x80\x80\x00 \x01(\x02\x18\r\x01 \x01A\x18j \x01)\x038\x10\xaa\x80\x80\x80\x00 \x01(\x02\x18A\x01G\r\x02\x0c\x01\x0b \x01(\x02\x10 \x01(\x02\x14\x10\xa9\x80\x80\x80\x00A\x01K\r\x00 \x01A\x18j \x01A\x08j\x10\xa7\x80\x80\x80\x00 \x01)\x03\x18\"\x00B\x02Q\r\x00 \x00\xa7A\x01q\r\x00 \x01)\x03 !\x00A\x00!\x03\x02@\x03@ \x03A\x18F\r\x01 \x01A\x18j \x03jB\x027\x03\x00 \x03A\x08j!\x03\x0c\x00\x0b\x0b \x00B\xff\x01\x83B\xcc\x00R\r\x00 \x00A\xa8\x8a\xc0\x80\x00A\x03 \x01A\x18jA\x03\x10\xad\x80\x80\x80\x00 \x011\x00\x18B\xcb\x00R\r\x00 \x01A0j \x01)\x03 \x10\xaf\x80\x80\x80\x00 \x01(\x020\r\x00 \x01A0j \x01)\x03(\x10\xaa\x80\x80\x80\x00 \x01(\x020A\x01G\r\x01\x0b\x00\x0b \x01A\xc0\x00j$\x80\x80\x80\x80\x00B\x02\x0b\xb3\x02\x03\x01\x7f\x01~\x01\x7f#\x80\x80\x80\x80\x00A k\"\x02$\x80\x80\x80\x80\x00\x02@\x02@ \x01B\xff\x01\x83B\xcb\x00Q\r\x00 \x00B\x017\x03\x00\x0c\x01\x0b \x01\x10\x81\x80\x80\x80\x00!\x03 \x02A\x006\x02\x08 \x02 \x017\x03\x00 \x02 \x03B \x88>\x02\x0c \x02A\x10j \x02\x10\xa7\x80\x80\x80\x00\x02@ \x02)\x03\x10\"\x01B\x02Q\r\x00 \x01\xa7A\x01q\r\x00\x02@ \x02)\x03\x18\"\x01\xa7A\xff\x01q\"\x04A\xca\x00F\r\x00 \x04A\x0eG\r\x01\x0b\x02@ \x01A\xc8\x89\xc0\x80\x00A\x01\x10\xa8\x80\x80\x80\x00B\xff\xff\xff\xff\x0fV\r\x00 \x02(\x02\x08 \x02(\x02\x0c\x10\xa9\x80\x80\x80\x00A\x01K\r\x00 \x02A\x10j \x02\x10\xa7\x80\x80\x80\x00 \x02)\x03\x10\"\x01B\x02Q\r\x00 \x01\xa7A\x01q\r\x00 \x02A\x10j \x02)\x03\x18\x10\xaa\x80\x80\x80\x00 \x02(\x02\x10\r\x00 \x02)\x03\x18!\x01 \x00B\x007\x03\x00 \x00 \x017\x03\x08\x0c\x02\x0b \x00B\x017\x03\x00\x0c\x01\x0b \x00B\x017\x03\x00\x0b \x02A j$\x80\x80\x80\x80\x00\x0b\x9e\x01\x01\x02\x7f#\x80\x80\x80\x80\x00A\x10k\"\x01$\x80\x80\x80\x80\x00 \x01A\x83\x80\x80\x80\x006\x02\x00 \x01(\x02\x00\x1aA\x00!\x02A\x00-\x00\xc0\x8a\xc0\x80\x00\x1a\x02@\x03@ \x02A\x10F\r\x01 \x01 \x02jB\x027\x03\x00 \x02A\x08j!\x02\x0c\x00\x0b\x0b\x02@\x02@ \x00B\xff\x01\x83B\xcc\x00R\r\x00 \x00A\xd4\x8a\xc0\x80\x00A\x02 \x01A\x02\x10\xad\x80\x80\x80\x00 \x011\x00\x00B\xcb\x00R\r\x00 \x011\x00\x08B\xcd\x00Q\r\x01\x0b\x00\x0b \x01A\x10j$\x80\x80\x80\x80\x00B\x02\x0bA\x01\x01\x7f#\x80\x80\x80\x80\x00A\x10k\"\x01A\x88\x80\x80\x80\x006\x02\x0c \x01(\x02\x0c\x1a \x01A\x89\x80\x80\x80\x006\x02\x08 \x01(\x02\x08\x1a\x02@ \x00B\xff\x01\x83B\xcc\x00Q\r\x00\x00\x0bB\x02\x0bg\x01\x01\x7f#\x80\x80\x80\x80\x00A\x10k\"\x01$\x80\x80\x80\x80\x00A\x00-\x00\xe2\x80\xc0\x80\x00\x1a \x01B\x027\x03\x08\x02@\x02@ \x00B\xff\x01\x83B\xcc\x00R\r\x00 \x00A\xf8\x84\xc0\x80\x00A\x01 \x01A\x08jA\x01\x10\xad\x80\x80\x80\x00 \x011\x00\x08B\x04Q\r\x01\x0b\x00\x0b \x01A\x10j$\x80\x80\x80\x80\x00B\x02\x0b\x12\x00A\x00-\x00\xb8\x80\xc0\x80\x00\x1aB\x84\x80\x80\x80\x10\x0br\x01\x01\x7f#\x80\x80\x80\x80\x00A\x10k\"\x01$\x80\x80\x80\x80\x00A\x00-\x00\xc4\x81\xc0\x80\x00\x1a\x02@ \x00B\x02Q\r\x00 \x01B\x027\x03\x08\x02@ \x00B\xff\x01\x83B\xcc\x00R\r\x00 \x00A\xc8\x85\xc0\x80\x00A\x01 \x01A\x08jA\x01\x10\xad\x80\x80\x80\x00 \x01)\x03\x08B\xff\x01\x83B\x04Q\r\x01\x0b\x00\x0b \x01A\x10j$\x80\x80\x80\x80\x00B\x02\x0bI\x01\x01\x7f\x02@\x02@A\x01A\x02A\x00 \x00\xa7A\xff\x01q\"\x01\x1b \x01A\x01F\x1b\"\x01A\x02F\r\x00 \x01A\x01q\r\x01B\x02\x0f\x0b\x00\x0bA\x00-\x00\xb4\x82\xc0\x80\x00\x1aB\x83\x80\x80\x80\x10\x10\xa3\x80\x80\x80\x00\x00\x0b@\x01\x01\x7f\x02@\x02@A\x01A\x02A\x00 \x00\xa7A\xff\x01q\"\x01\x1b \x01A\x01F\x1b\"\x01A\x02F\r\x00 \x01A\x01q\r\x01B\x02\x0f\x0b\x00\x0bB\x83\x80\x80\x80\xf0\x00\x10\xa3\x80\x80\x80\x00\x00\x0b\x8a\x02\x01\x02\x7f#\x80\x80\x80\x80\x00A k\"\x02$\x80\x80\x80\x80\x00A\x00!\x03A\x00-\x00\xa6\x82\xc0\x80\x00\x1aA\x00-\x00\xc6\x80\xc0\x80\x00\x1a\x02@\x03@ \x03A\x10F\r\x01 \x02A\x08j \x03jB\x027\x03\x00 \x03A\x08j!\x03\x0c\x00\x0b\x0b\x02@\x02@ \x00B\xff\x01\x83B\xcc\x00R\r\x00 \x00A\xb4\x85\xc0\x80\x00A\x02 \x02A\x08jA\x02\x10\xad\x80\x80\x80\x00 \x021\x00\x08B\x04R\r\x00 \x02B\x027\x03\x18 \x02)\x03\x10\"\x00B\xff\x01\x83B\xcc\x00R\r\x00 \x00A\xf8\x84\xc0\x80\x00A\x01 \x02A\x18jA\x01\x10\xad\x80\x80\x80\x00\x02@ \x02)\x03\x18\"\x00\xa7A\xff\x01q\"\x03A\x07F\r\x00 \x03A\xc1\x00G\r\x01 \x00\x10\x82\x80\x80\x80\x00\x1a\x0bA\x00-\x00\xf0\x80\xc0\x80\x00\x1a \x01B\xff\x01\x83B\x04R\r\x00 \x01B \x88\xa7A}jA}K\r\x01\x0b\x00\x0b \x02A j$\x80\x80\x80\x80\x00B\x02\x0b\x90\x04\x03\x01\x7f\x01~\x01\x7f#\x80\x80\x80\x80\x00A0k\"\x01$\x80\x80\x80\x80\x00A\x00-\x00\x94\x84\xc0\x80\x00\x1a \x01A\x81\x80\x80\x80\x006\x02  \x01(\x02 \x1aA\x00-\x00\xd2\x81\xc0\x80\x00\x1aA\x00-\x00\xe0\x81\xc0\x80\x00\x1aA\x00-\x00\xee\x81\xc0\x80\x00\x1a \x01B\x027\x03\x08\x02@ \x00B\xff\x01\x83B\xcc\x00R\r\x00 \x00A\xf8\x84\xc0\x80\x00A\x01 \x01A\x08jA\x01\x10\xad\x80\x80\x80\x00 \x01)\x03\x08\"\x00B\xff\x01\x83B\xcb\x00R\r\x00 \x00\x10\x81\x80\x80\x80\x00!\x02 \x01A\x006\x02\x18 \x01 \x007\x03\x10 \x01 \x02B \x88>\x02\x1c \x01A j \x01A\x10j\x10\xa7\x80\x80\x80\x00 \x01)\x03 \"\x00B\x02Q\r\x00 \x00\xa7A\x01q\r\x00\x02@ \x01)\x03(\"\x00\xa7A\xff\x01q\"\x03A\xca\x00F\r\x00 \x03A\x0eG\r\x01\x0b\x02@\x02@\x02@ \x00A\xe8\x85\xc0\x80\x00A\x02\x10\xa8\x80\x80\x80\x00B \x88\xa7\x0e\x02\x01\x00\x03\x0b \x01(\x02\x18 \x01(\x02\x1c\x10\xa9\x80\x80\x80\x00A\x01K\r\x02 \x01A j \x01A\x10j\x10\xa7\x80\x80\x80\x00 \x01)\x03 \"\x00B\x02Q\r\x02 \x00\xa7A\x01q\r\x02 \x01)\x03(!\x00 \x01B\x027\x03  \x00B\xff\x01\x83B\xcc\x00R\r\x02 \x00A\xf8\x84\xc0\x80\x00A\x01 \x01A jA\x01\x10\xad\x80\x80\x80\x00 \x011\x00 B\xcb\x00Q\r\x01\x0c\x02\x0b \x01(\x02\x18 \x01(\x02\x1c\x10\xa9\x80\x80\x80\x00A\x01K\r\x01 \x01A j \x01A\x10j\x10\xa7\x80\x80\x80\x00 \x01)\x03 \"\x00B\x02Q\r\x01 \x00\xa7A\x01q\r\x01 \x01)\x03(!\x00 \x01B\x027\x03  \x00B\xff\x01\x83B\xcc\x00R\r\x01 \x00A\xf8\x84\xc0\x80\x00A\x01 \x01A jA\x01\x10\xad\x80\x80\x80\x00 \x011\x00 B\x04R\r\x01\x0b \x01A0j$\x80\x80\x80\x80\x00B\x02\x0f\x0b\x00\x0bZ\x02\x01\x7f\x01~#\x80\x80\x80\x80\x00A\x10k\"\x00$\x80\x80\x80\x80\x00A\x00-\x00\xbe\x84\xc0\x80\x00\x1aA\x00-\x00\x80\x80\xc0\x80\x00\x1a \x00B\x84\x80\x80\x80\x107\x03\x08A\xc8\x85\xc0\x80\x00A\x01 \x00A\x08jA\x01\x10\x9a\x80\x80\x80\x00!\x01 \x00A\x10j$\x80\x80\x80\x80\x00 \x01\x0bo\x02\x01\x7f\x01~#\x80\x80\x80\x80\x00A\x10k\"\x00$\x80\x80\x80\x80\x00A\x00-\x00\x8e\x80\xc0\x80\x00\x1a \x00A\xc8\x86\xc0\x80\x00A\x01\x10\xbb\x80\x80\x80\x00\x02@ \x00(\x02\x00A\x01G\r\x00\x00\x0b \x00)\x03\x08!\x01 \x00B\x84\x80\x80\x80\x107\x03\x08 \x00 \x017\x03\x00 \x00\x10\xbc\x80\x80\x80\x00!\x01 \x00A\x10j$\x80\x80\x80\x80\x00 \x01\x0b\xdb\x01\x02\x01~\x04\x7f\x02@\x02@ \x02A\tK\r\x00B\x00!\x03 \x02!\x04 \x01!\x05\x03@\x02@ \x04\r\x00 \x03B\x08\x86B\x0e\x84!\x03\x0c\x03\x0bA\x01!\x06\x02@ \x05-\x00\x00\"\x07A\xdf\x00F\r\x00\x02@\x02@ \x07APjA\xff\x01qA\nI\r\x00 \x07A\xbf\x7fjA\xff\x01qA\x1aI\r\x01 \x07A\x9f\x7fjA\xff\x01qA\x1aO\r\x04 \x07AEj!\x06\x0c\x02\x0b \x07ARj!\x06\x0c\x01\x0b \x07AKj!\x06\x0b \x03B\x06\x86 \x06\xadB\xff\x01\x83\x84!\x03 \x04A\x7fj!\x04 \x05A\x01j!\x05\x0c\x00\x0b\x0b \x01\xadB \x86B\x04\x84 \x02\xadB \x86B\x04\x84\x10\x87\x80\x80\x80\x00!\x03\x0b \x00B\x007\x03\x00 \x00 \x037\x03\x08\x0b\x17\x00 \x00\xadB \x86B\x04\x84B\x84\x80\x80\x80 \x10\x84\x80\x80\x80\x00\x0b\xc4\x01\x01\x02\x7f#\x80\x80\x80\x80\x00A k\"\x01$\x80\x80\x80\x80\x00A\x00!\x02A\x00-\x00\x9a\x81\xc0\x80\x00\x1a\x02@\x02@ \x00B\xff\x01\x83B\xcb\x00R\r\x00\x02@\x03@ \x02A\x10F\r\x01 \x01A\x08j \x02jB\x027\x03\x00 \x02A\x08j!\x02\x0c\x00\x0b\x0b \x00 \x01A\x08j\xadB \x86B\x04\x84B\x84\x80\x80\x80 \x10\x83\x80\x80\x80\x00\x1a \x01B\x027\x03\x18 \x01)\x03\x08\"\x00B\xff\x01\x83B\xcc\x00R\r\x00 \x00A\xf8\x84\xc0\x80\x00A\x01 \x01A\x18jA\x01\x10\xad\x80\x80\x80\x00 \x011\x00\x18B\x04R\r\x00 \x011\x00\x10B\x04Q\r\x01\x0b\x00\x0b \x01A j$\x80\x80\x80\x80\x00B\x02\x0bo\x02\x01\x7f\x01~#\x80\x80\x80\x80\x00A k\"\x00$\x80\x80\x80\x80\x00A\x00-\x00\xa4\x83\xc0\x80\x00\x1a \x00B\x84\x80\x80\x80\x107\x03\x18A\xf8\x84\xc0\x80\x00A\x01 \x00A\x18jA\x01\x10\x9a\x80\x80\x80\x00!\x01 \x00B\x84\x80\x80\x80 7\x03\x10 \x00 \x017\x03\x08 \x00A\x08j\x10\xbc\x80\x80\x80\x00!\x01 \x00A j$\x80\x80\x80\x80\x00 \x01\x0b0\x01\x01\x7f#\x80\x80\x80\x80\x00A\x10k\"\x01A\x8a\x80\x80\x80\x006\x02\x0c \x01(\x02\x0c\x1a\x02@ \x00B\xff\x01\x83B\xcb\x00Q\r\x00\x00\x0bB\x02\x0b0\x01\x01\x7f#\x80\x80\x80\x80\x00A\x10k\"\x01A\x8b\x80\x80\x80\x006\x02\x0c \x01(\x02\x0c\x1a\x02@ \x00B\xff\x01\x83B\xcb\x00Q\r\x00\x00\x0bB\x02\x0b\x8d\x01\x01\x02\x7f#\x80\x80\x80\x80\x00A\x10k\"\x01$\x80\x80\x80\x80\x00A\x00!\x02A\x00-\x00\xc0\x83\xc0\x80\x00\x1a\x02@\x03@ \x02A\x10F\r\x01 \x01 \x02jB\x027\x03\x00 \x02A\x08j!\x02\x0c\x00\x0b\x0b\x02@\x02@ \x00B\xff\x01\x83B\xcc\x00R\r\x00 \x00A\xd4\x8a\xc0\x80\x00A\x02 \x01A\x02\x10\xad\x80\x80\x80\x00 \x011\x00\x00B\x04R\r\x00 \x01)\x03\x08B\xfe\x01\x83P\r\x01\x0b\x00\x0b \x01A\x10j$\x80\x80\x80\x80\x00B\x02\x0b\x03\x00\x00\x0b\t\x00\x10\xc2\x80\x80\x80\x00\x00\x0b\x0b\xee\n\x01\x00A\x80\x80\xc0\x00\x0b\xe4\nSpEcV1Hh\xdc\xaaa\x8d\xf7\rSpEcV1\xe7\xcf\x9b1n\x15\x13\xfeSpEcV1\xe2\x01y\xc9\x9a\xf8\xedtSpEcV1v1\x0eP\xa9C\xc7*SpEcV1\xa9<\xd8+\xb7\xa7\r\x17SpEcV1X\x03\xf6t\xc7\xd0\x01\"SpEcV1\'\xbd_A\r\x9a\x89\x02SpEcV1p\x8c\x0fN!\x082\xd8SpEcV1\xc2\xf4N\xbf\xebqvpSpEcV1K\xdf\'8m/\xe8\x1dSpEcV1@\xb9LO\xf9\xd1\xe8\xe2SpEcV1\xde\x1dMa\x01\xec\xb0ASpEcV1\xc2 \x1b\xdc\xc8gxZSpEcV1[Q+\xe9\xde\xd5\xf2>SpEcV1\xb3/\x97\xd5\x06\xbd3BSpEcV1?\xd9\xb3q\xdep>\xf3SpEcV1*\\\x9c\xf4e\xaa\x1e]SpEcV1u2\x0b\x97\xae\xcd\x86\xbfSpEcV1\x0c\xf0\xf6w\xfd\x1a\x1b\x94SpEcV1\'\xf2\xa2\xb9\xd0)\xc0uSpEcV1\xf5\xd4\x9b\xa3\xccI\x13\xf7SpEcV1\x84\x08Y\xae\xa0\xf128SpEcV1\r\xb76\xae\x93D\xef\x1aSpEcV1\x8b\x89\x1f#\xbd\x157\xf4SpEcV16\x83?\xf0\xcdW\xb1/SpEcV1\x94\xc7w/_\xebXcSpEcV1\xb4\xabN]\xe3\xeaA\xd6SpEcV1\x13?J\x12d\xden|SpEcV1q\xa3z;6\xa6R\x01SpEcV1q^\xe2&\x9di\x9d\x0eSpEcV1Y\xa66\xb3\xecxE\x13SpEcV1\xcf@%X\xde+J@SpEcV1\xb6\x1c\xfd\xdfhY-dSpEcV1 \xfbl\x04B\x82\xc0\xb4SpEcV1\xe3\xf2\x9b5%a\xfb\xd6SpEcV1\r\xd6\r \xfc\xdb\xea\xf3SpEcV1\x9a\x14*\xbc\x82a\x08XSpEcV1\x7f\xc5\xceo\xc3ST\x08SpEcV1\xe6Q\xd5T\x13\x8a\xb7lSpEcV1[\xf4R\xdf\xdd\xb4\xb0\xbcSpEcV1\xaaX8\xde\xef\xbb6%SpEcV1k\xe4zxB\xd1+\x02amount\x00\x00L\x02\x10\x00\x06\x00\x00\x00used_export_false_eventval\x00\x00s\x02\x10\x00\x03\x00\x00\x00StellarAssetAccount\x00\xc4\x04\x10\x00\x04\x00\x00\x00\x80\x02\x10\x00\x0c\x00\x00\x00\x8c\x02\x10\x00\x07\x00\x00\x00anested\x00\xac\x02\x10\x00\x01\x00\x00\x00\xad\x02\x10\x00\x06\x00\x00\x00data\xc4\x02\x10\x00\x04\x00\x00\x00NotRecursiveRecursive\x00\x00\x00\xd0\x02\x10\x00\x0c\x00\x00\x00\xdc\x02\x10\x00\t\x00\x00\x00ContractCreateContractHostFnCreateContractWithCtorHostFn\xf8\x02\x10\x00\x08\x00\x00\x00\x00\x03\x10\x00\x14\x00\x00\x00\x14\x03\x10\x00\x1c\x00\x00\x00A\x00\x00\x00\xad\x02\x10\x00\x06\x00\x00\x00xy\x00\x00T\x03\x10\x00\x01\x00\x00\x00U\x03\x10\x00\x01\x00\x00\x00inner\x00\x00\x00h\x03\x10\x00\x05\x00\x00\x00transfercoordsefused_event_simplepayload\x99\x03\x10\x00\x07\x00\x00\x00used_event_with_refsused_event_with_data_typeused_event_with_topic_typeused_event_with_nested_dataused_event_with_nested_topicSpEcV1\xb6\xb1Hy\xda\xca\xaf\xccSpEcV1\x9e)H\x8e\xf0\x01{{SpEcV1ULqD\xd3\xfa:\x1fSpEcV1\x15\xe5\x1a,\xc0\xc7\xef\xd4SpEcV1s\x94\x0c\x1926\x1d\x90SpEcV1\xa3J\xcf\xf7D\x93\x0bBSpEcV1L|{\r\xf4\xf2\x1a\xa8SpEcV1\xf1\xf9\x90\x07E*e\xfdargscontractfn_name\x00\x00\x00\x96\x04\x10\x00\x04\x00\x00\x00\x9a\x04\x10\x00\x08\x00\x00\x00\xa2\x04\x10\x00\x07\x00\x00\x00Wasm\xc4\x04\x10\x00\x04\x00\x00\x00contextsub_invocations\x00\x00\xd0\x04\x10\x00\x07\x00\x00\x00\xd7\x04\x10\x00\x0f\x00\x00\x00executablesalt\x00\x00\xf8\x04\x10\x00\n\x00\x00\x00\x02\x05\x10\x00\x04\x00\x00\x00constructor_args\x18\x05\x10\x00\x10\x00\x00\x00\xf8\x04\x10\x00\n\x00\x00\x00\x02\x05\x10\x00\x04\x00\x00\x00SpEcV1\xa3\x16\n\x8f\xc9\x92\xd2\x11f1f2\x00\x00N\x05\x10\x00\x02\x00\x00\x00P\x05\x10\x00\x02\x00\x00\x00\x00\xebb\x0econtractspecv0\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x05EnumA\x00\x00\x00\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02V1\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02V2\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02V3\x00\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x05EnumB\x00\x00\x00\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02V1\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x02V2\x00\x00\x00\x00\x00\x01\x00\x00\x00\x07\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x02V3\x00\x00\x00\x00\x00\x02\x00\x00\x00\x07\x00\x00\x00\x07\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x05EnumC\x00\x00\x00\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02V1\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x02V2\x00\x00\x00\x00\x00\x01\x00\x00\x07\xd0\x00\x00\x00\x07StructA\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x02V3\x00\x00\x00\x00\x00\x01\x00\x00\x07\xd0\x00\x00\x00\x0cStructTupleA\x00\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x06ErrorA\x00\x00\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x02E1\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x02E2\x00\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x02E3\x00\x00\x00\x00\x00\x03\x00\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x06ErrorB\x00\x00\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x02E1\x00\x00\x00\x00\x00\n\x00\x00\x00\x00\x00\x00\x00\x02E2\x00\x00\x00\x00\x00\x0b\x00\x00\x00\x00\x00\x00\x00\x02E3\x00\x00\x00\x00\x00\x0c\x00\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x06ErrorC\x00\x00\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x02E1\x00\x00\x00\x00\x00d\x00\x00\x00\x00\x00\x00\x00\x02E2\x00\x00\x00\x00\x00e\x00\x00\x00\x00\x00\x00\x00\x02E3\x00\x00\x00\x00\x00f\x00\x00\x00\x05\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x06EventA\x00\x00\x00\x00\x00\x01\x00\x00\x00\x07event_a\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x02f1\x00\x00\x00\x00\x00\x13\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x02f2\x00\x00\x00\x00\x00\x10\x00\x00\x00\x00\x00\x00\x00\x02\x00\x00\x00\x05\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x06EventB\x00\x00\x00\x00\x00\x01\x00\x00\x00\x07event_b\x00\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x02f1\x00\x00\x00\x00\x00\x13\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x02f2\x00\x00\x00\x00\x00\x13\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x02f3\x00\x00\x00\x00\x00\x0b\x00\x00\x00\x00\x00\x00\x00\x02\x00\x00\x00\x05\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x06EventC\x00\x00\x00\x00\x00\x01\x00\x00\x00\x07event_c\x00\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x02f1\x00\x00\x00\x00\x00\x11\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x02f2\x00\x00\x00\x00\x00\x07\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02f3\x00\x00\x00\x00\x00\x07\x00\x00\x00\x00\x00\x00\x00\x02\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x07Context\x00\x00\x00\x00\x03\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x08Contract\x00\x00\x00\x01\x00\x00\x07\xd0\x00\x00\x00\x0fContractContext\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x14CreateContractHostFn\x00\x00\x00\x01\x00\x00\x07\xd0\x00\x00\x00\x1bCreateContractHostFnContext\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x1cCreateContractWithCtorHostFn\x00\x00\x00\x01\x00\x00\x07\xd0\x00\x00\x00*CreateContractWithConstructorHostFnContext\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x07StructA\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x02f1\x00\x00\x00\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00\x02f2\x00\x00\x00\x00\x00\x01\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x07StructB\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x02f1\x00\x00\x00\x00\x00\x07\x00\x00\x00\x00\x00\x00\x00\x02f2\x00\x00\x00\x00\x00\x10\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x07StructC\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x02f1\x00\x00\x00\x00\x03\xea\x00\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00\x02f2\x00\x00\x00\x00\x00\x13\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x08EnumIntA\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x02V1\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x02V2\x00\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x02V3\x00\x00\x00\x00\x00\x03\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x08EnumIntB\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x02V1\x00\x00\x00\x00\x00\n\x00\x00\x00\x00\x00\x00\x00\x02V2\x00\x00\x00\x00\x00\x14\x00\x00\x00\x00\x00\x00\x00\x02V3\x00\x00\x00\x00\x00\x1e\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x08EnumIntC\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x02V1\x00\x00\x00\x00\x00d\x00\x00\x00\x00\x00\x00\x00\x02V2\x00\x00\x00\x00\x00\xc8\x00\x00\x00\x00\x00\x00\x00\x02V3\x00\x00\x00\x00\x01,\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\nExecutable\x00\x00\x00\x00\x00\x03\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x04Wasm\x00\x00\x00\x01\x00\x00\x03\xee\x00\x00\x00 \x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x0cStellarAsset\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x07Account\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x0cStructTupleA\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x010\x00\x00\x00\x00\x00\x00\x07\x00\x00\x00\x00\x00\x00\x00\x011\x00\x00\x00\x00\x00\x00\x07\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x0cStructTupleB\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x010\x00\x00\x00\x00\x00\x00\n\x00\x00\x00\x00\x00\x00\x00\x011\x00\x00\x00\x00\x00\x00\n\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x0cStructTupleC\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x010\x00\x00\x00\x00\x00\x00\x13\x00\x00\x00\x00\x00\x00\x00\x011\x00\x00\x00\x00\x00\x00\x0b\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x0fContractContext\x00\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x04args\x00\x00\x03\xea\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x08contract\x00\x00\x00\x13\x00\x00\x00\x00\x00\x00\x00\x07fn_name\x00\x00\x00\x00\x11\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x12ContractExecutable\x00\x00\x00\x00\x00\x01\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x04Wasm\x00\x00\x00\x01\x00\x00\x03\xee\x00\x00\x00 \x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x15SubContractInvocation\x00\x00\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x07context\x00\x00\x00\x07\xd0\x00\x00\x00\x0fContractContext\x00\x00\x00\x00\x00\x00\x00\x00\x0fsub_invocations\x00\x00\x00\x03\xea\x00\x00\x07\xd0\x00\x00\x00\x18InvokerContractAuthEntry\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x18InvokerContractAuthEntry\x00\x00\x00\x03\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x08Contract\x00\x00\x00\x01\x00\x00\x07\xd0\x00\x00\x00\x15SubContractInvocation\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x14CreateContractHostFn\x00\x00\x00\x01\x00\x00\x07\xd0\x00\x00\x00\x1bCreateContractHostFnContext\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x1cCreateContractWithCtorHostFn\x00\x00\x00\x01\x00\x00\x07\xd0\x00\x00\x00*CreateContractWithConstructorHostFnContext\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x1bCreateContractHostFnContext\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\nexecutable\x00\x00\x00\x00\x07\xd0\x00\x00\x00\x12ContractExecutable\x00\x00\x00\x00\x00\x00\x00\x00\x00\x04salt\x00\x00\x03\xee\x00\x00\x00 \x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00*CreateContractWithConstructorHostFnContext\x00\x00\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x10constructor_args\x00\x00\x03\xea\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\nexecutable\x00\x00\x00\x00\x07\xd0\x00\x00\x00\x12ContractExecutable\x00\x00\x00\x00\x00\x00\x00\x00\x00\x04salt\x00\x00\x03\xee\x00\x00\x00 \x00\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x14UsedExportFalseError\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x04Fail\x00\x00\x00\x01\x00\x00\x00\x05\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x14UsedExportFalseEvent\x00\x00\x00\x01\x00\x00\x00\x17used_export_false_event\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x04kind\x00\x00\x00\x11\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x06amount\x00\x00\x00\x00\x00\x0b\x00\x00\x00\x00\x00\x00\x00\x02\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x15UsedExportFalseStruct\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x03val\x00\x00\x00\x00\x04\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x08UsedLeaf\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x03val\x00\x00\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x08with_map\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x01m\x00\x00\x00\x00\x00\x03\xec\x00\x00\x07\xd0\x00\x00\x00\nUsedMapKey\x00\x00\x00\x00\x07\xd0\x00\x00\x00\nUsedMapVal\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x08with_vec\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x01v\x00\x00\x00\x00\x00\x03\xea\x00\x00\x07\xd0\x00\x00\x00\x0eUsedVecElement\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\nUnusedEnum\x00\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01A\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x01B\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x07\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\nUsedMapKey\x00\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x02K1\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x02K2\x00\x00\x00\x00\x00\x02\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\nUsedMapVal\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x01v\x00\x00\x00\x00\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\nwith_error\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x03\xe9\x00\x00\x00\x04\x00\x00\x07\xd0\x00\x00\x00\rUsedErrorEnum\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\nwith_param\x00\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x01s\x00\x00\x00\x00\x00\x07\xd0\x00\x00\x00\x0fUsedParamStruct\x00\x00\x00\x00\x00\x00\x00\x00\x02ie\x00\x00\x00\x00\x07\xd0\x00\x00\x00\x10UsedParamIntEnum\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\nwith_tuple\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x01t\x00\x00\x00\x00\x00\x03\xed\x00\x00\x00\x02\x00\x00\x07\xd0\x00\x00\x00\x10UsedTupleElement\x00\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00\x05\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x0bUnusedEvent\x00\x00\x00\x00\x01\x00\x00\x00\x0cunused_event\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x04kind\x00\x00\x00\x11\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x04data\x00\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00\x02\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x0cUnusedStruct\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x01x\x00\x00\x00\x00\x00\x00\x04\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x0cUsedResultOk\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x04data\x00\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x0bwith_option\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x01o\x00\x00\x00\x00\x00\x03\xe8\x00\x00\x07\xd0\x00\x00\x00\x11UsedOptionElement\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x0bwith_result\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x03\xe9\x00\x00\x07\xd0\x00\x00\x00\x0cUsedResultOk\x00\x00\x07\xd0\x00\x00\x00\rUsedErrorEnum\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x0bwith_return\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x07\xd0\x00\x00\x00\x0eUsedReturnEnum\x00\x00\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\rUnusedIntEnum\x00\x00\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x02U1\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x02U2\x00\x00\x00\x00\x00\x02\x00\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\rUsedErrorEnum\x00\x00\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x08NotFound\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x07Invalid\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x0cwith_non_pub\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x01s\x00\x00\x00\x00\x00\x07\xd0\x00\x00\x00\x10UsedNonPubStruct\x00\x00\x00\x00\x00\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x0eUnusedPubError\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x04Nope\x00\x00\x00\x01\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x0eUsedReturnEnum\x00\x00\x00\x00\x00\x02\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x01A\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x04\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x01B\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x07\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x0eUsedVecElement\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x04data\x00\x00\x00\x04\x00\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x0fUsedNonPubError\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x04Fail\x00\x00\x00\x01\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x0fUsedParamStruct\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x01a\x00\x00\x00\x00\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00\x06nested\x00\x00\x00\x00\x07\xd0\x00\x00\x00\x12UsedNestedInStruct\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x0fUsedRefDataType\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x06nested\x00\x00\x00\x00\x07\xd0\x00\x00\x00\x10UsedRefDataInner\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x0epublish_simple\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x0ewith_recursion\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x01r\x00\x00\x00\x00\x00\x07\xd0\x00\x00\x00\x11UsedRecursiveRoot\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x05\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x0fUsedEventSimple\x00\x00\x00\x00\x01\x00\x00\x00\x11used_event_simple\x00\x00\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x04kind\x00\x00\x00\x11\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x06amount\x00\x00\x00\x00\x00\x0b\x00\x00\x00\x00\x00\x00\x00\x02\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x10UsedNonPubStruct\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x03val\x00\x00\x00\x00\x04\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x10UsedParamIntEnum\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x01X\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x01Y\x00\x00\x00\x00\x00\x00\x02\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x10UsedRefDataInner\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x03val\x00\x00\x00\x00\x04\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x10UsedRefTopicType\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x04Send\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x04Recv\x00\x00\x00\x02\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x10UsedTupleElement\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x03val\x00\x00\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x0fwith_executable\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x01e\x00\x00\x00\x00\x00\x07\xd0\x00\x00\x00\nExecutable\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x0fwith_lib_struct\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x01s\x00\x00\x00\x00\x00\x07\xd0\x00\x00\x00\x07StructC\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x0fwith_vec_nested\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x01v\x00\x00\x00\x00\x00\x03\xea\x00\x00\x07\xd0\x00\x00\x00\x14UsedVecElementNested\x00\x00\x00\x00\x00\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x11UnusedNonPubError\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x03Bad\x00\x00\x00\x00\x01\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x11UsedEventDataType\x00\x00\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x01x\x00\x00\x00\x00\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00\x01y\x00\x00\x00\x00\x00\x00\x04\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x11UsedOptionElement\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x04data\x00\x00\x00\x04\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x11UsedRecursiveLeaf\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x03val\x00\x00\x00\x03\xea\x00\x00\x07\xd0\x00\x00\x00\x11UsedRecursiveRoot\x00\x00\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x11UsedRecursiveNode\x00\x00\x00\x00\x00\x00\x02\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x0cNotRecursive\x00\x00\x00\x01\x00\x00\x07\xd0\x00\x00\x00\x08UsedLeaf\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\tRecursive\x00\x00\x00\x00\x00\x00\x01\x00\x00\x07\xd0\x00\x00\x00\x11UsedRecursiveLeaf\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x11UsedRecursiveRoot\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x03val\x00\x00\x00\x07\xd0\x00\x00\x00\x11UsedRecursiveNode\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x10with_panic_error\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x04fail\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x05\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x11UsedEventWithRefs\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x14used_event_with_refs\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x04kind\x00\x00\x07\xd0\x00\x00\x00\x10UsedRefTopicType\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x07payload\x00\x00\x00\x07\xd0\x00\x00\x00\x0fUsedRefDataType\x00\x00\x00\x00\x00\x00\x00\x00\x02\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x12UnusedNonPubStruct\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x01x\x00\x00\x00\x00\x00\x00\x04\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x12UsedEventDataInner\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x03val\x00\x00\x00\x00\x04\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x12UsedEventDataOuter\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x05inner\x00\x00\x00\x00\x00\x07\xd0\x00\x00\x00\x12UsedEventDataInner\x00\x00\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x12UsedEventTopicType\x00\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x08Transfer\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x04Mint\x00\x00\x00\x02\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x12UsedNestedInStruct\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x03val\x00\x00\x00\x00\x07\x00\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x12UsedPanicErrorEnum\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x04Boom\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x11publish_data_type\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x11publish_ref_event\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x11with_assert_error\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x02ok\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x11with_invoker_auth\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x01i\x00\x00\x00\x00\x00\x07\xd0\x00\x00\x00\x18InvokerContractAuthEntry\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x11with_tuple_return\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x03\xed\x00\x00\x00\x02\x00\x00\x07\xd0\x00\x00\x00\x16UsedTupleReturnElement\x00\x00\x00\x00\x00\x04\x00\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x13UsedAssertErrorEnum\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x03Bad\x00\x00\x00\x00\x01\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x13UsedEventTopicInner\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x03val\x00\x00\x00\x00\x04\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x13UsedEventTopicOuter\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x05inner\x00\x00\x00\x00\x00\x07\xd0\x00\x00\x00\x13UsedEventTopicInner\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x13UsedVecInnerElement\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x03val\x00\x00\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x12publish_topic_type\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x12with_auth_contexts\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x01c\x00\x00\x00\x00\x00\x03\xea\x00\x00\x07\xd0\x00\x00\x00\x07Context\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x12with_non_pub_error\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x03\xe9\x00\x00\x00\x04\x00\x00\x07\xd0\x00\x00\x00\x0fUsedNonPubError\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x12with_wasm_imported\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x01s\x00\x00\x00\x00\x00\x07\xd0\x00\x00\x00\x07StructA\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x14UsedVecElementNested\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x05inner\x00\x00\x00\x00\x00\x07\xd0\x00\x00\x00\x13UsedVecInnerElement\x00\x00\x00\x00\x00\x00\x00\x00\x03val\x00\x00\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00\tvec_inner\x00\x00\x00\x00\x00\x03\xea\x00\x00\x07\xd0\x00\x00\x00\x16UsedVecInnerVecElement\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x13publish_nested_data\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x14publish_nested_topic\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x14with_panic_raw_error\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x04fail\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x05\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x15UsedEventWithDataType\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x19used_event_with_data_type\x00\x00\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x04kind\x00\x00\x00\x11\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x07payload\x00\x00\x00\x07\xd0\x00\x00\x00\x11UsedEventDataType\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x16UsedTupleReturnElement\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x03val\x00\x00\x00\x00\x04\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x16UsedVecInnerVecElement\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x03val\x00\x00\x00\x00\x04\x00\x00\x00\x05\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x16UsedEventWithTopicType\x00\x00\x00\x00\x00\x01\x00\x00\x00\x1aused_event_with_topic_type\x00\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x04kind\x00\x00\x07\xd0\x00\x00\x00\x12UsedEventTopicType\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x06amount\x00\x00\x00\x00\x00\x0b\x00\x00\x00\x00\x00\x00\x00\x02\x00\x00\x00\x05\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x17UsedEventWithNestedData\x00\x00\x00\x00\x01\x00\x00\x00\x1bused_event_with_nested_data\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x04kind\x00\x00\x00\x11\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x07payload\x00\x00\x00\x07\xd0\x00\x00\x00\x12UsedEventDataOuter\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x18UnusedNonContractFnParam\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x01x\x00\x00\x00\x00\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x17with_export_false_error\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x03\xe9\x00\x00\x00\x04\x00\x00\x07\xd0\x00\x00\x00\x14UsedExportFalseError\x00\x00\x00\x05\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x18UsedEventWithNestedTopic\x00\x00\x00\x01\x00\x00\x00\x1cused_event_with_nested_topic\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x04info\x00\x00\x07\xd0\x00\x00\x00\x13UsedEventTopicOuter\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x06amount\x00\x00\x00\x00\x00\x0b\x00\x00\x00\x00\x00\x00\x00\x02\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x19UnusedNonContractFnReturn\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x01x\x00\x00\x00\x00\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x18with_export_false_struct\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x01s\x00\x00\x00\x00\x00\x07\xd0\x00\x00\x00\x15UsedExportFalseStruct\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x1apublish_export_false_event\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02\x00\x00\x00\xe3Context of a single authorized call performed by an address.\n\nCustom account contracts that implement `__check_auth` special function\nreceive a list of `Context` values corresponding to all the calls that\nneed to be authorized.\x00\x00\x00\x00\x00\x00\x00\x00\x07Context\x00\x00\x00\x00\x03\x00\x00\x00\x01\x00\x00\x00\x14Contract invocation.\x00\x00\x00\x08Contract\x00\x00\x00\x01\x00\x00\x07\xd0\x00\x00\x00\x0fContractContext\x00\x00\x00\x00\x01\x00\x00\x00=Contract that has a constructor with no arguments is created.\x00\x00\x00\x00\x00\x00\x14CreateContractHostFn\x00\x00\x00\x01\x00\x00\x07\xd0\x00\x00\x00\x1bCreateContractHostFnContext\x00\x00\x00\x00\x01\x00\x00\x00DContract that has a constructor with 1 or more arguments is created.\x00\x00\x00\x1cCreateContractWithCtorHostFn\x00\x00\x00\x01\x00\x00\x07\xd0\x00\x00\x00*CreateContractWithConstructorHostFnContext\x00\x00\x00\x00\x00\x01\x00\x00\x00\xbdAuthorization context of a single contract call.\n\nThis struct corresponds to a `require_auth_for_args` call for an address\nfrom `contract` function with `fn_name` name and `args` arguments.\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x0fContractContext\x00\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x04args\x00\x00\x03\xea\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x08contract\x00\x00\x00\x13\x00\x00\x00\x00\x00\x00\x00\x07fn_name\x00\x00\x00\x00\x11\x00\x00\x00\x02\x00\x00\x00_Contract executable used for creating a new contract and used in\n`CreateContractHostFnContext`.\x00\x00\x00\x00\x00\x00\x00\x00\x12ContractExecutable\x00\x00\x00\x00\x00\x01\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x04Wasm\x00\x00\x00\x01\x00\x00\x03\xee\x00\x00\x00 \x00\x00\x00\x01\x00\x00\x008Value of contract node in InvokerContractAuthEntry tree.\x00\x00\x00\x00\x00\x00\x00\x15SubContractInvocation\x00\x00\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x07context\x00\x00\x00\x07\xd0\x00\x00\x00\x0fContractContext\x00\x00\x00\x00\x00\x00\x00\x00\x0fsub_invocations\x00\x00\x00\x03\xea\x00\x00\x07\xd0\x00\x00\x00\x18InvokerContractAuthEntry\x00\x00\x00\x02\x00\x00\x01/A node in the tree of authorizations performed on behalf of the current\ncontract as invoker of the contracts deeper in the call stack.\n\nThis is used as an argument of `authorize_as_current_contract` host function.\n\nThis tree corresponds `require_auth[_for_args]` calls on behalf of the\ncurrent contract.\x00\x00\x00\x00\x00\x00\x00\x00\x18InvokerContractAuthEntry\x00\x00\x00\x03\x00\x00\x00\x01\x00\x00\x00\x12Invoke a contract.\x00\x00\x00\x00\x00\x08Contract\x00\x00\x00\x01\x00\x00\x07\xd0\x00\x00\x00\x15SubContractInvocation\x00\x00\x00\x00\x00\x00\x01\x00\x00\x005Create a contract passing 0 arguments to constructor.\x00\x00\x00\x00\x00\x00\x14CreateContractHostFn\x00\x00\x00\x01\x00\x00\x07\xd0\x00\x00\x00\x1bCreateContractHostFnContext\x00\x00\x00\x00\x01\x00\x00\x00=Create a contract passing 0 or more arguments to constructor.\x00\x00\x00\x00\x00\x00\x1cCreateContractWithCtorHostFn\x00\x00\x00\x01\x00\x00\x07\xd0\x00\x00\x00*CreateContractWithConstructorHostFnContext\x00\x00\x00\x00\x00\x01\x00\x00\x00vAuthorization context for `create_contract` host function that creates a\nnew contract on behalf of authorizer address.\x00\x00\x00\x00\x00\x00\x00\x00\x00\x1bCreateContractHostFnContext\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\nexecutable\x00\x00\x00\x00\x07\xd0\x00\x00\x00\x12ContractExecutable\x00\x00\x00\x00\x00\x00\x00\x00\x00\x04salt\x00\x00\x03\xee\x00\x00\x00 \x00\x00\x00\x01\x00\x00\x00\xd6Authorization context for `create_contract` host function that creates a\nnew contract on behalf of authorizer address.\nThis is the same as `CreateContractHostFnContext`, but also has\ncontract constructor arguments.\x00\x00\x00\x00\x00\x00\x00\x00\x00*CreateContractWithConstructorHostFnContext\x00\x00\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x10constructor_args\x00\x00\x03\xea\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\nexecutable\x00\x00\x00\x00\x07\xd0\x00\x00\x00\x12ContractExecutable\x00\x00\x00\x00\x00\x00\x00\x00\x00\x04salt\x00\x00\x03\xee\x00\x00\x00 \x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\nExecutable\x00\x00\x00\x00\x00\x03\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x04Wasm\x00\x00\x00\x01\x00\x00\x03\xee\x00\x00\x00 \x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x0cStellarAsset\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x07Account\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x05EnumA\x00\x00\x00\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02V1\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02V2\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02V3\x00\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x05EnumB\x00\x00\x00\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02V1\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x02V2\x00\x00\x00\x00\x00\x01\x00\x00\x00\x07\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x02V3\x00\x00\x00\x00\x00\x02\x00\x00\x00\x07\x00\x00\x00\x07\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x05EnumC\x00\x00\x00\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02V1\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x02V2\x00\x00\x00\x00\x00\x01\x00\x00\x07\xd0\x00\x00\x00\x07StructA\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x02V3\x00\x00\x00\x00\x00\x01\x00\x00\x07\xd0\x00\x00\x00\x0cStructTupleA\x00\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x06ErrorA\x00\x00\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x02E1\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x02E2\x00\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x02E3\x00\x00\x00\x00\x00\x03\x00\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x06ErrorB\x00\x00\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x02E1\x00\x00\x00\x00\x00\n\x00\x00\x00\x00\x00\x00\x00\x02E2\x00\x00\x00\x00\x00\x0b\x00\x00\x00\x00\x00\x00\x00\x02E3\x00\x00\x00\x00\x00\x0c\x00\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x06ErrorC\x00\x00\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x02E1\x00\x00\x00\x00\x00d\x00\x00\x00\x00\x00\x00\x00\x02E2\x00\x00\x00\x00\x00e\x00\x00\x00\x00\x00\x00\x00\x02E3\x00\x00\x00\x00\x00f\x00\x00\x00\x05\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x06EventA\x00\x00\x00\x00\x00\x01\x00\x00\x00\x07event_a\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x02f1\x00\x00\x00\x00\x00\x13\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x02f2\x00\x00\x00\x00\x00\x10\x00\x00\x00\x00\x00\x00\x00\x02\x00\x00\x00\x05\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x06EventB\x00\x00\x00\x00\x00\x01\x00\x00\x00\x07event_b\x00\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x02f1\x00\x00\x00\x00\x00\x13\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x02f2\x00\x00\x00\x00\x00\x13\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x02f3\x00\x00\x00\x00\x00\x0b\x00\x00\x00\x00\x00\x00\x00\x02\x00\x00\x00\x05\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x06EventC\x00\x00\x00\x00\x00\x01\x00\x00\x00\x07event_c\x00\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x02f1\x00\x00\x00\x00\x00\x11\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x02f2\x00\x00\x00\x00\x00\x07\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02f3\x00\x00\x00\x00\x00\x07\x00\x00\x00\x00\x00\x00\x00\x02\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x07StructA\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x02f1\x00\x00\x00\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00\x02f2\x00\x00\x00\x00\x00\x01\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x07StructB\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x02f1\x00\x00\x00\x00\x00\x07\x00\x00\x00\x00\x00\x00\x00\x02f2\x00\x00\x00\x00\x00\x10\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x07StructC\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x02f1\x00\x00\x00\x00\x03\xea\x00\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00\x02f2\x00\x00\x00\x00\x00\x13\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x08EnumIntA\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x02V1\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x02V2\x00\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x02V3\x00\x00\x00\x00\x00\x03\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x08EnumIntB\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x02V1\x00\x00\x00\x00\x00\n\x00\x00\x00\x00\x00\x00\x00\x02V2\x00\x00\x00\x00\x00\x14\x00\x00\x00\x00\x00\x00\x00\x02V3\x00\x00\x00\x00\x00\x1e\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x08EnumIntC\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x02V1\x00\x00\x00\x00\x00d\x00\x00\x00\x00\x00\x00\x00\x02V2\x00\x00\x00\x00\x00\xc8\x00\x00\x00\x00\x00\x00\x00\x02V3\x00\x00\x00\x00\x01,\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x0cStructTupleA\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x010\x00\x00\x00\x00\x00\x00\x07\x00\x00\x00\x00\x00\x00\x00\x011\x00\x00\x00\x00\x00\x00\x07\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x0cStructTupleB\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x010\x00\x00\x00\x00\x00\x00\n\x00\x00\x00\x00\x00\x00\x00\x011\x00\x00\x00\x00\x00\x00\n\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x0cStructTupleC\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x010\x00\x00\x00\x00\x00\x00\x13\x00\x00\x00\x00\x00\x00\x00\x011\x00\x00\x00\x00\x00\x00\x0b\x00\x1e\x11contractenvmetav0\x00\x00\x00\x00\x00\x00\x00\x1a\x00\x00\x00\x00\x00O\x0econtractmetav0\x00\x00\x00\x00\x00\x00\x00\x05rsver\x00\x00\x00\x00\x00\x00\x061.91.0\x00\x00\x00\x00\x00\x00\x00\x00\x00\x12rssdk_spec_shaking\x00\x00\x00\x00\x00\x012\x00\x00\x00";
     extern crate test;
     #[rustc_test_marker = "test::test_spec_shaking_v2"]
     #[doc(hidden)]

--- a/tests-expanded/test_spec_shaking_v2_wasm32v1-none.rs
+++ b/tests-expanded/test_spec_shaking_v2_wasm32v1-none.rs
@@ -3594,7 +3594,7 @@ mod export_false_used {
     }
     #[doc(hidden)]
     #[allow(non_upper_case_globals)]
-    #[deprecated = "`export` is a no-op under `experimental_spec_shaking_v2` (specs are determined by reachability) and will be removed in a future release"]
+    #[deprecated = "`export` is a no-op under spec shaking v2 (the default; specs are determined by reachability) and will be removed in a future release"]
     const __SOROBAN_EXPORT_ARG_DEPRECATED_FOR_UsedExportFalseStruct: () = ();
     const _: () = __SOROBAN_EXPORT_ARG_DEPRECATED_FOR_UsedExportFalseStruct;
     #[link_section = "contractspecv0"]
@@ -3700,7 +3700,7 @@ mod export_false_used {
     }
     #[doc(hidden)]
     #[allow(non_upper_case_globals)]
-    #[deprecated = "`export` is a no-op under `experimental_spec_shaking_v2` (specs are determined by reachability) and will be removed in a future release"]
+    #[deprecated = "`export` is a no-op under spec shaking v2 (the default; specs are determined by reachability) and will be removed in a future release"]
     const __SOROBAN_EXPORT_ARG_DEPRECATED_FOR_UsedExportFalseError: () = ();
     const _: () = __SOROBAN_EXPORT_ARG_DEPRECATED_FOR_UsedExportFalseError;
     #[link_section = "contractspecv0"]
@@ -3875,7 +3875,7 @@ mod export_false_used {
     }
     #[doc(hidden)]
     #[allow(non_upper_case_globals)]
-    #[deprecated = "`export` is a no-op under `experimental_spec_shaking_v2` (specs are determined by reachability) and will be removed in a future release"]
+    #[deprecated = "`export` is a no-op under spec shaking v2 (the default; specs are determined by reachability) and will be removed in a future release"]
     const __SOROBAN_EXPORT_ARG_DEPRECATED_FOR_UsedExportFalseEvent: () = ();
     const _: () = __SOROBAN_EXPORT_ARG_DEPRECATED_FOR_UsedExportFalseEvent;
     #[link_section = "contractspecv0"]
@@ -4651,7 +4651,7 @@ impl soroban_sdk::TryFromVal<soroban_sdk::Env, &UsedLeaf> for soroban_sdk::Val {
     }
 }
 mod wasm_imported {
-    pub const WASM: &[u8] = b"\x00asm\x01\x00\x00\x00\x01*\x07`\x02~~\x01~`\x03~~~\x01~`\x01~\x01~`\x00\x01~`\x02\x7f\x7f\x01~`\x04\x7f\x7f\x7f\x7f\x01~`\x02\x7f~\x00\x02%\x06\x01b\x01j\x00\x00\x01x\x011\x00\x00\x01v\x01g\x00\x00\x01m\x019\x00\x01\x01i\x012\x00\x02\x01i\x011\x00\x02\x03\x0b\n\x03\x04\x03\x02\x00\x05\x00\x00\x06\x06\x05\x03\x01\x00\x11\x06!\x04\x7f\x01A\x80\x80\xc0\x00\x0b\x7f\x00A\x82\x80\xc0\x00\x0b\x7f\x00A\xa0\x80\xc0\x00\x0b\x7f\x00A\xa0\x80\xc0\x00\x0b\x07\x81\x01\n\x06memory\x02\x00\tfn_enum_a\x00\x06\rfn_enum_int_a\x00\x08\nfn_error_a\x00\t\nfn_event_a\x00\n\x0bfn_struct_a\x00\x0c\x11fn_struct_tuple_a\x00\r\x01_\x03\x01\n__data_end\x03\x02\x0b__heap_base\x03\x03\n\xbd\x08\n\x8b\x02\x03\x01\x7f\x01~\x03\x7f#\x80\x80\x80\x80\x00A\x10k\"\x00$\x80\x80\x80\x80\x00B\x00!\x01A~!\x02\x03~\x02@\x02@\x02@\x02@\x02@ \x02E\r\x00A\x01!\x03 \x02A\x82\x80\xc0\x80\x00j-\x00\x00\"\x04A\xdf\x00F\r\x04 \x04APjA\xff\x01qA\nI\r\x02 \x04A\xbf\x7fjA\xff\x01qA\x1aI\r\x03\x02@ \x04A\x9f\x7fjA\xff\x01qA\x1aO\r\x00 \x04AEj!\x03\x0c\x05\x0b \x00 \x04\xadB\x08\x86B\x01\x847\x03\x00A\x80\x80\xc0\x80\x00\xadB \x86B\x04\x84B\x84\x80\x80\x80 \x10\x80\x80\x80\x80\x00!\x01\x0c\x01\x0b \x00 \x01B\x08\x86B\x0e\x84\"\x017\x02\x04\x0b \x00 \x017\x03\x00 \x00A\x01\x10\x87\x80\x80\x80\x00!\x01 \x00A\x10j$\x80\x80\x80\x80\x00 \x01\x0f\x0b \x04ARj!\x03\x0c\x01\x0b \x04AKj!\x03\x0b \x01B\x06\x86 \x03\xadB\xff\x01\x83\x84!\x01 \x02A\x01j!\x02\x0c\x00\x0b\x0b\x1a\x00 \x00\xadB \x86B\x04\x84 \x01\xadB \x86B\x04\x84\x10\x82\x80\x80\x80\x00\x0b\x08\x00B\x84\x80\x80\x800\x0b*\x00\x02@ \x00B\xff\x01\x83B\x04Q\r\x00\x00\x0bB\x83\x80\x80\x80  \x00B\x84\x80\x80\x80p\x83 \x00B\x80\x80\x80\x80\x10T\x1b\x0b\xdc\x01\x01\x02\x7f#\x80\x80\x80\x80\x00A k\"\x02$\x80\x80\x80\x80\x00\x02@ \x00B\xff\x01\x83B\xcd\x00R\r\x00 \x01B\xff\x01\x83B\xc9\x00R\r\x00 \x02 \x007\x03\x08 \x02B\x8e\xcc\xc1\xfc\xac\xdd\xab\x017\x03\x00A\x00!\x03\x03@\x02@ \x03A\x10G\r\x00A\x00!\x03\x02@\x03@ \x03A\x10F\r\x01 \x02A\x10j \x03j \x02 \x03j)\x03\x007\x03\x00 \x03A\x08j!\x03\x0c\x00\x0b\x0b \x02A\x10jA\x02\x10\x87\x80\x80\x80\x00!\x00 \x02 \x017\x03\x10 \x00A\x98\x80\xc0\x80\x00A\x01 \x02A\x10jA\x01\x10\x8b\x80\x80\x80\x00\x10\x81\x80\x80\x80\x00\x1a \x02A j$\x80\x80\x80\x80\x00B\x02\x0f\x0b \x02A\x10j \x03jB\x027\x03\x00 \x03A\x08j!\x03\x0c\x00\x0b\x0b\x00\x0b.\x00\x02@ \x01 \x03F\r\x00\x00\x0b \x00\xadB \x86B\x04\x84 \x02\xadB \x86B\x04\x84 \x01\xadB \x86B\x04\x84\x10\x83\x80\x80\x80\x00\x0by\x01\x02\x7f#\x80\x80\x80\x80\x00A\x10k\"\x02$\x80\x80\x80\x80\x00\x02@ \x00B\xff\x01\x83B\x04R\r\x00A\x01A\x02A\x00 \x01\xa7A\xff\x01q\"\x03\x1b \x03A\x01F\x1b\"\x03A\x02F\r\x00 \x02 \x03\xad7\x03\x08 \x02 \x00B\x84\x80\x80\x80p\x837\x03\x00A\x88\x80\xc0\x80\x00A\x02 \x02A\x02\x10\x8b\x80\x80\x80\x00!\x00 \x02A\x10j$\x80\x80\x80\x80\x00 \x00\x0f\x0b\x00\x0b\xb2\x01\x01\x01\x7f#\x80\x80\x80\x80\x00A k\"\x02$\x80\x80\x80\x80\x00 \x02A\x10j \x00\x10\x8e\x80\x80\x80\x00\x02@ \x02(\x02\x10A\x01F\r\x00 \x02)\x03\x18!\x00 \x02A\x10j \x01\x10\x8e\x80\x80\x80\x00 \x02(\x02\x10A\x01F\r\x00 \x02)\x03\x18!\x01 \x02A\x10j \x00\x10\x8f\x80\x80\x80\x00 \x02(\x02\x10\r\x00 \x02)\x03\x18!\x00 \x02A\x10j \x01\x10\x8f\x80\x80\x80\x00 \x02(\x02\x10A\x01F\r\x00 \x02 \x02)\x03\x187\x03\x08 \x02 \x007\x03\x00 \x02A\x02\x10\x87\x80\x80\x80\x00!\x00 \x02A j$\x80\x80\x80\x80\x00 \x00\x0f\x0b\x00\x0b]\x02\x01\x7f\x01~\x02@\x02@ \x01\xa7A\xff\x01q\"\x02A\xc1\x00F\r\x00\x02@ \x02A\x07F\r\x00B\x01!\x03B\x83\x90\x80\x80\x80\x01!\x01\x0c\x02\x0b \x01B\x08\x87!\x01B\x00!\x03\x0c\x01\x0bB\x00!\x03 \x01\x10\x84\x80\x80\x80\x00!\x01\x0b \x00 \x037\x03\x00 \x00 \x017\x03\x08\x0bF\x00\x02@\x02@ \x01B\x80\x80\x80\x80\x80\x80\x80\xc0\x00|B\xff\xff\xff\xff\xff\xff\xff\xff\x00V\r\x00 \x01B\x08\x86B\x07\x84!\x01\x0c\x01\x0b \x01\x10\x85\x80\x80\x80\x00!\x01\x0b \x00B\x007\x03\x00 \x00 \x017\x03\x08\x0b\x0b)\x01\x00A\x80\x80\xc0\x00\x0b V2f1f2\x00\x00\x02\x00\x10\x00\x02\x00\x00\x00\x04\x00\x10\x00\x02\x00\x00\x00\x04\x00\x10\x00\x02\x00\x00\x00\x00\xbf\x0e\x0econtractspecv0\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\tfn_enum_a\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x07\xd0\x00\x00\x00\x05EnumA\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\nfn_error_a\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x05input\x00\x00\x00\x00\x00\x00\x04\x00\x00\x00\x01\x00\x00\x03\xe9\x00\x00\x00\x04\x00\x00\x07\xd0\x00\x00\x00\x06ErrorA\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\nfn_event_a\x00\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x02f1\x00\x00\x00\x00\x00\x13\x00\x00\x00\x00\x00\x00\x00\x02f2\x00\x00\x00\x00\x00\x10\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x0bfn_struct_a\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x02f1\x00\x00\x00\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00\x02f2\x00\x00\x00\x00\x00\x01\x00\x00\x00\x01\x00\x00\x07\xd0\x00\x00\x00\x07StructA\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\rfn_enum_int_a\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x07\xd0\x00\x00\x00\x08EnumIntA\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x11fn_struct_tuple_a\x00\x00\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x02f1\x00\x00\x00\x00\x00\x07\x00\x00\x00\x00\x00\x00\x00\x02f2\x00\x00\x00\x00\x00\x07\x00\x00\x00\x01\x00\x00\x07\xd0\x00\x00\x00\x0cStructTupleA\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x05EnumA\x00\x00\x00\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02V1\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02V2\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02V3\x00\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x05EnumB\x00\x00\x00\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02V1\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x02V2\x00\x00\x00\x00\x00\x01\x00\x00\x00\x07\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x02V3\x00\x00\x00\x00\x00\x02\x00\x00\x00\x07\x00\x00\x00\x07\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x05EnumC\x00\x00\x00\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02V1\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x02V2\x00\x00\x00\x00\x00\x01\x00\x00\x07\xd0\x00\x00\x00\x07StructA\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x02V3\x00\x00\x00\x00\x00\x01\x00\x00\x07\xd0\x00\x00\x00\x0cStructTupleA\x00\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x06ErrorA\x00\x00\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x02E1\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x02E2\x00\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x02E3\x00\x00\x00\x00\x00\x03\x00\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x06ErrorB\x00\x00\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x02E1\x00\x00\x00\x00\x00\n\x00\x00\x00\x00\x00\x00\x00\x02E2\x00\x00\x00\x00\x00\x0b\x00\x00\x00\x00\x00\x00\x00\x02E3\x00\x00\x00\x00\x00\x0c\x00\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x06ErrorC\x00\x00\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x02E1\x00\x00\x00\x00\x00d\x00\x00\x00\x00\x00\x00\x00\x02E2\x00\x00\x00\x00\x00e\x00\x00\x00\x00\x00\x00\x00\x02E3\x00\x00\x00\x00\x00f\x00\x00\x00\x05\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x06EventA\x00\x00\x00\x00\x00\x01\x00\x00\x00\x07event_a\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x02f1\x00\x00\x00\x00\x00\x13\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x02f2\x00\x00\x00\x00\x00\x10\x00\x00\x00\x00\x00\x00\x00\x02\x00\x00\x00\x05\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x06EventB\x00\x00\x00\x00\x00\x01\x00\x00\x00\x07event_b\x00\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x02f1\x00\x00\x00\x00\x00\x13\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x02f2\x00\x00\x00\x00\x00\x13\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x02f3\x00\x00\x00\x00\x00\x0b\x00\x00\x00\x00\x00\x00\x00\x02\x00\x00\x00\x05\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x06EventC\x00\x00\x00\x00\x00\x01\x00\x00\x00\x07event_c\x00\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x02f1\x00\x00\x00\x00\x00\x11\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x02f2\x00\x00\x00\x00\x00\x07\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02f3\x00\x00\x00\x00\x00\x07\x00\x00\x00\x00\x00\x00\x00\x02\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x07StructA\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x02f1\x00\x00\x00\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00\x02f2\x00\x00\x00\x00\x00\x01\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x07StructB\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x02f1\x00\x00\x00\x00\x00\x07\x00\x00\x00\x00\x00\x00\x00\x02f2\x00\x00\x00\x00\x00\x10\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x07StructC\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x02f1\x00\x00\x00\x00\x03\xea\x00\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00\x02f2\x00\x00\x00\x00\x00\x13\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x08EnumIntA\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x02V1\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x02V2\x00\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x02V3\x00\x00\x00\x00\x00\x03\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x08EnumIntB\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x02V1\x00\x00\x00\x00\x00\n\x00\x00\x00\x00\x00\x00\x00\x02V2\x00\x00\x00\x00\x00\x14\x00\x00\x00\x00\x00\x00\x00\x02V3\x00\x00\x00\x00\x00\x1e\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x08EnumIntC\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x02V1\x00\x00\x00\x00\x00d\x00\x00\x00\x00\x00\x00\x00\x02V2\x00\x00\x00\x00\x00\xc8\x00\x00\x00\x00\x00\x00\x00\x02V3\x00\x00\x00\x00\x01,\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x0cStructTupleA\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x010\x00\x00\x00\x00\x00\x00\x07\x00\x00\x00\x00\x00\x00\x00\x011\x00\x00\x00\x00\x00\x00\x07\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x0cStructTupleB\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x010\x00\x00\x00\x00\x00\x00\n\x00\x00\x00\x00\x00\x00\x00\x011\x00\x00\x00\x00\x00\x00\n\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x0cStructTupleC\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x010\x00\x00\x00\x00\x00\x00\x13\x00\x00\x00\x00\x00\x00\x00\x011\x00\x00\x00\x00\x00\x00\x0b\x00\x1e\x11contractenvmetav0\x00\x00\x00\x00\x00\x00\x00\x1a\x00\x00\x00\x00\x00+\x0econtractmetav0\x00\x00\x00\x00\x00\x00\x00\x05rsver\x00\x00\x00\x00\x00\x00\x061.91.0\x00\x00";
+    pub const WASM: &[u8] = b"\x00asm\x01\x00\x00\x00\x01*\x07`\x02~~\x01~`\x03~~~\x01~`\x01~\x01~`\x00\x01~`\x02\x7f\x7f\x01~`\x04\x7f\x7f\x7f\x7f\x01~`\x02\x7f~\x00\x02%\x06\x01b\x01j\x00\x00\x01x\x011\x00\x00\x01v\x01g\x00\x00\x01m\x019\x00\x01\x01i\x012\x00\x02\x01i\x011\x00\x02\x03\x0b\n\x03\x04\x03\x02\x00\x05\x00\x00\x06\x06\x05\x03\x01\x00\x11\x06!\x04\x7f\x01A\x80\x80\xc0\x00\x0b\x7f\x00A\x82\x80\xc0\x00\x0b\x7f\x00A\xf4\x80\xc0\x00\x0b\x7f\x00A\x80\x81\xc0\x00\x0b\x07\x81\x01\n\x06memory\x02\x00\tfn_enum_a\x00\x06\rfn_enum_int_a\x00\x08\nfn_error_a\x00\t\nfn_event_a\x00\n\x0bfn_struct_a\x00\x0c\x11fn_struct_tuple_a\x00\r\x01_\x03\x01\n__data_end\x03\x02\x0b__heap_base\x03\x03\n\xfa\x08\n\x95\x02\x03\x01\x7f\x01~\x03\x7f#\x80\x80\x80\x80\x00A\x10k\"\x00$\x80\x80\x80\x80\x00A\x00-\x00\x82\x80\xc0\x80\x00\x1aB\x00!\x01A~!\x02\x03~\x02@\x02@\x02@\x02@\x02@ \x02E\r\x00A\x01!\x03 \x02A\x82\x80\xc0\x80\x00j-\x00\x00\"\x04A\xdf\x00F\r\x04 \x04APjA\xff\x01qA\nI\r\x02 \x04A\xbf\x7fjA\xff\x01qA\x1aI\r\x03\x02@ \x04A\x9f\x7fjA\xff\x01qA\x1aO\r\x00 \x04AEj!\x03\x0c\x05\x0b \x00 \x04\xadB\x08\x86B\x01\x847\x03\x00A\x80\x80\xc0\x80\x00\xadB \x86B\x04\x84B\x84\x80\x80\x80 \x10\x80\x80\x80\x80\x00!\x01\x0c\x01\x0b \x00 \x01B\x08\x86B\x0e\x84\"\x017\x02\x04\x0b \x00 \x017\x03\x00 \x00A\x01\x10\x87\x80\x80\x80\x00!\x01 \x00A\x10j$\x80\x80\x80\x80\x00 \x01\x0f\x0b \x04ARj!\x03\x0c\x01\x0b \x04AKj!\x03\x0b \x01B\x06\x86 \x03\xadB\xff\x01\x83\x84!\x01 \x02A\x01j!\x02\x0c\x00\x0b\x0b\x1a\x00 \x00\xadB \x86B\x04\x84 \x01\xadB \x86B\x04\x84\x10\x82\x80\x80\x80\x00\x0b\x12\x00A\x00-\x00\xba\x80\xc0\x80\x00\x1aB\x84\x80\x80\x800\x0b4\x00\x02@ \x00B\xff\x01\x83B\x04Q\r\x00\x00\x0bA\x00-\x00\x90\x80\xc0\x80\x00\x1aB\x83\x80\x80\x80  \x00B\x84\x80\x80\x80p\x83 \x00B\x80\x80\x80\x80\x10T\x1b\x0b\xe6\x01\x01\x02\x7f#\x80\x80\x80\x80\x00A k\"\x02$\x80\x80\x80\x80\x00\x02@ \x00B\xff\x01\x83B\xcd\x00R\r\x00 \x01B\xff\x01\x83B\xc9\x00R\r\x00A\x00!\x03A\x00-\x00\x9e\x80\xc0\x80\x00\x1a \x02 \x007\x03\x08 \x02B\x8e\xcc\xc1\xfc\xac\xdd\xab\x017\x03\x00\x03@\x02@ \x03A\x10G\r\x00A\x00!\x03\x02@\x03@ \x03A\x10F\r\x01 \x02A\x10j \x03j \x02 \x03j)\x03\x007\x03\x00 \x03A\x08j!\x03\x0c\x00\x0b\x0b \x02A\x10jA\x02\x10\x87\x80\x80\x80\x00!\x00 \x02 \x017\x03\x10 \x00A\xec\x80\xc0\x80\x00A\x01 \x02A\x10jA\x01\x10\x8b\x80\x80\x80\x00\x10\x81\x80\x80\x80\x00\x1a \x02A j$\x80\x80\x80\x80\x00B\x02\x0f\x0b \x02A\x10j \x03jB\x027\x03\x00 \x03A\x08j!\x03\x0c\x00\x0b\x0b\x00\x0b.\x00\x02@ \x01 \x03F\r\x00\x00\x0b \x00\xadB \x86B\x04\x84 \x02\xadB \x86B\x04\x84 \x01\xadB \x86B\x04\x84\x10\x83\x80\x80\x80\x00\x0b\x83\x01\x01\x02\x7f#\x80\x80\x80\x80\x00A\x10k\"\x02$\x80\x80\x80\x80\x00\x02@ \x00B\xff\x01\x83B\x04R\r\x00A\x01A\x02A\x00 \x01\xa7A\xff\x01q\"\x03\x1b \x03A\x01F\x1b\"\x03A\x02F\r\x00A\x00-\x00\xac\x80\xc0\x80\x00\x1a \x02 \x03\xad7\x03\x08 \x02 \x00B\x84\x80\x80\x80p\x837\x03\x00A\xdc\x80\xc0\x80\x00A\x02 \x02A\x02\x10\x8b\x80\x80\x80\x00!\x00 \x02A\x10j$\x80\x80\x80\x80\x00 \x00\x0f\x0b\x00\x0b\xbc\x01\x01\x01\x7f#\x80\x80\x80\x80\x00A k\"\x02$\x80\x80\x80\x80\x00 \x02A\x10j \x00\x10\x8e\x80\x80\x80\x00\x02@ \x02(\x02\x10A\x01F\r\x00 \x02)\x03\x18!\x00 \x02A\x10j \x01\x10\x8e\x80\x80\x80\x00 \x02(\x02\x10A\x01F\r\x00 \x02)\x03\x18!\x01A\x00-\x00\xc8\x80\xc0\x80\x00\x1a \x02A\x10j \x00\x10\x8f\x80\x80\x80\x00 \x02(\x02\x10\r\x00 \x02)\x03\x18!\x00 \x02A\x10j \x01\x10\x8f\x80\x80\x80\x00 \x02(\x02\x10A\x01F\r\x00 \x02 \x02)\x03\x187\x03\x08 \x02 \x007\x03\x00 \x02A\x02\x10\x87\x80\x80\x80\x00!\x00 \x02A j$\x80\x80\x80\x80\x00 \x00\x0f\x0b\x00\x0b]\x02\x01\x7f\x01~\x02@\x02@ \x01\xa7A\xff\x01q\"\x02A\xc1\x00F\r\x00\x02@ \x02A\x07F\r\x00B\x01!\x03B\x83\x90\x80\x80\x80\x01!\x01\x0c\x02\x0b \x01B\x08\x87!\x01B\x00!\x03\x0c\x01\x0bB\x00!\x03 \x01\x10\x84\x80\x80\x80\x00!\x01\x0b \x00 \x037\x03\x00 \x00 \x017\x03\x08\x0bF\x00\x02@\x02@ \x01B\x80\x80\x80\x80\x80\x80\x80\xc0\x00|B\xff\xff\xff\xff\xff\xff\xff\xff\x00V\r\x00 \x01B\x08\x86B\x07\x84!\x01\x0c\x01\x0b \x01\x10\x85\x80\x80\x80\x00!\x01\x0b \x00B\x007\x03\x00 \x00 \x017\x03\x08\x0b\x0b}\x01\x00A\x80\x80\xc0\x00\x0btV2SpEcV1\xa2=N\xc1p\x95\x90\xb2SpEcV1\xe9R\xa7\xe8b\x99\xa2\xc3SpEcV1K\xe6\x8ej\x19\x9en\xbdSpEcV1\xb6\x1c\xfd\xdfhY-dSpEcV1V]\x80\\~\x1a\x08/SpEcV1\xcf)\x97]S\xb2\xfd)f1f2\x00\x00V\x00\x10\x00\x02\x00\x00\x00X\x00\x10\x00\x02\x00\x00\x00X\x00\x10\x00\x02\x00\x00\x00\x00\xd3#\x0econtractspecv0\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\tfn_enum_a\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x07\xd0\x00\x00\x00\x05EnumA\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\nfn_error_a\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x05input\x00\x00\x00\x00\x00\x00\x04\x00\x00\x00\x01\x00\x00\x03\xe9\x00\x00\x00\x04\x00\x00\x07\xd0\x00\x00\x00\x06ErrorA\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\nfn_event_a\x00\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x02f1\x00\x00\x00\x00\x00\x13\x00\x00\x00\x00\x00\x00\x00\x02f2\x00\x00\x00\x00\x00\x10\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x0bfn_struct_a\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x02f1\x00\x00\x00\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00\x02f2\x00\x00\x00\x00\x00\x01\x00\x00\x00\x01\x00\x00\x07\xd0\x00\x00\x00\x07StructA\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\rfn_enum_int_a\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x07\xd0\x00\x00\x00\x08EnumIntA\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x11fn_struct_tuple_a\x00\x00\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x02f1\x00\x00\x00\x00\x00\x07\x00\x00\x00\x00\x00\x00\x00\x02f2\x00\x00\x00\x00\x00\x07\x00\x00\x00\x01\x00\x00\x07\xd0\x00\x00\x00\x0cStructTupleA\x00\x00\x00\x02\x00\x00\x00\xe3Context of a single authorized call performed by an address.\n\nCustom account contracts that implement `__check_auth` special function\nreceive a list of `Context` values corresponding to all the calls that\nneed to be authorized.\x00\x00\x00\x00\x00\x00\x00\x00\x07Context\x00\x00\x00\x00\x03\x00\x00\x00\x01\x00\x00\x00\x14Contract invocation.\x00\x00\x00\x08Contract\x00\x00\x00\x01\x00\x00\x07\xd0\x00\x00\x00\x0fContractContext\x00\x00\x00\x00\x01\x00\x00\x00=Contract that has a constructor with no arguments is created.\x00\x00\x00\x00\x00\x00\x14CreateContractHostFn\x00\x00\x00\x01\x00\x00\x07\xd0\x00\x00\x00\x1bCreateContractHostFnContext\x00\x00\x00\x00\x01\x00\x00\x00DContract that has a constructor with 1 or more arguments is created.\x00\x00\x00\x1cCreateContractWithCtorHostFn\x00\x00\x00\x01\x00\x00\x07\xd0\x00\x00\x00*CreateContractWithConstructorHostFnContext\x00\x00\x00\x00\x00\x01\x00\x00\x00\xbdAuthorization context of a single contract call.\n\nThis struct corresponds to a `require_auth_for_args` call for an address\nfrom `contract` function with `fn_name` name and `args` arguments.\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x0fContractContext\x00\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x04args\x00\x00\x03\xea\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x08contract\x00\x00\x00\x13\x00\x00\x00\x00\x00\x00\x00\x07fn_name\x00\x00\x00\x00\x11\x00\x00\x00\x02\x00\x00\x00_Contract executable used for creating a new contract and used in\n`CreateContractHostFnContext`.\x00\x00\x00\x00\x00\x00\x00\x00\x12ContractExecutable\x00\x00\x00\x00\x00\x01\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x04Wasm\x00\x00\x00\x01\x00\x00\x03\xee\x00\x00\x00 \x00\x00\x00\x01\x00\x00\x008Value of contract node in InvokerContractAuthEntry tree.\x00\x00\x00\x00\x00\x00\x00\x15SubContractInvocation\x00\x00\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x07context\x00\x00\x00\x07\xd0\x00\x00\x00\x0fContractContext\x00\x00\x00\x00\x00\x00\x00\x00\x0fsub_invocations\x00\x00\x00\x03\xea\x00\x00\x07\xd0\x00\x00\x00\x18InvokerContractAuthEntry\x00\x00\x00\x02\x00\x00\x01/A node in the tree of authorizations performed on behalf of the current\ncontract as invoker of the contracts deeper in the call stack.\n\nThis is used as an argument of `authorize_as_current_contract` host function.\n\nThis tree corresponds `require_auth[_for_args]` calls on behalf of the\ncurrent contract.\x00\x00\x00\x00\x00\x00\x00\x00\x18InvokerContractAuthEntry\x00\x00\x00\x03\x00\x00\x00\x01\x00\x00\x00\x12Invoke a contract.\x00\x00\x00\x00\x00\x08Contract\x00\x00\x00\x01\x00\x00\x07\xd0\x00\x00\x00\x15SubContractInvocation\x00\x00\x00\x00\x00\x00\x01\x00\x00\x005Create a contract passing 0 arguments to constructor.\x00\x00\x00\x00\x00\x00\x14CreateContractHostFn\x00\x00\x00\x01\x00\x00\x07\xd0\x00\x00\x00\x1bCreateContractHostFnContext\x00\x00\x00\x00\x01\x00\x00\x00=Create a contract passing 0 or more arguments to constructor.\x00\x00\x00\x00\x00\x00\x1cCreateContractWithCtorHostFn\x00\x00\x00\x01\x00\x00\x07\xd0\x00\x00\x00*CreateContractWithConstructorHostFnContext\x00\x00\x00\x00\x00\x01\x00\x00\x00vAuthorization context for `create_contract` host function that creates a\nnew contract on behalf of authorizer address.\x00\x00\x00\x00\x00\x00\x00\x00\x00\x1bCreateContractHostFnContext\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\nexecutable\x00\x00\x00\x00\x07\xd0\x00\x00\x00\x12ContractExecutable\x00\x00\x00\x00\x00\x00\x00\x00\x00\x04salt\x00\x00\x03\xee\x00\x00\x00 \x00\x00\x00\x01\x00\x00\x00\xd6Authorization context for `create_contract` host function that creates a\nnew contract on behalf of authorizer address.\nThis is the same as `CreateContractHostFnContext`, but also has\ncontract constructor arguments.\x00\x00\x00\x00\x00\x00\x00\x00\x00*CreateContractWithConstructorHostFnContext\x00\x00\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x10constructor_args\x00\x00\x03\xea\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\nexecutable\x00\x00\x00\x00\x07\xd0\x00\x00\x00\x12ContractExecutable\x00\x00\x00\x00\x00\x00\x00\x00\x00\x04salt\x00\x00\x03\xee\x00\x00\x00 \x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\nExecutable\x00\x00\x00\x00\x00\x03\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x04Wasm\x00\x00\x00\x01\x00\x00\x03\xee\x00\x00\x00 \x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x0cStellarAsset\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x07Account\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x05EnumA\x00\x00\x00\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02V1\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02V2\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02V3\x00\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x05EnumB\x00\x00\x00\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02V1\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x02V2\x00\x00\x00\x00\x00\x01\x00\x00\x00\x07\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x02V3\x00\x00\x00\x00\x00\x02\x00\x00\x00\x07\x00\x00\x00\x07\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x05EnumC\x00\x00\x00\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02V1\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x02V2\x00\x00\x00\x00\x00\x01\x00\x00\x07\xd0\x00\x00\x00\x07StructA\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x02V3\x00\x00\x00\x00\x00\x01\x00\x00\x07\xd0\x00\x00\x00\x0cStructTupleA\x00\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x06ErrorA\x00\x00\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x02E1\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x02E2\x00\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x02E3\x00\x00\x00\x00\x00\x03\x00\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x06ErrorB\x00\x00\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x02E1\x00\x00\x00\x00\x00\n\x00\x00\x00\x00\x00\x00\x00\x02E2\x00\x00\x00\x00\x00\x0b\x00\x00\x00\x00\x00\x00\x00\x02E3\x00\x00\x00\x00\x00\x0c\x00\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x06ErrorC\x00\x00\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x02E1\x00\x00\x00\x00\x00d\x00\x00\x00\x00\x00\x00\x00\x02E2\x00\x00\x00\x00\x00e\x00\x00\x00\x00\x00\x00\x00\x02E3\x00\x00\x00\x00\x00f\x00\x00\x00\x05\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x06EventA\x00\x00\x00\x00\x00\x01\x00\x00\x00\x07event_a\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x02f1\x00\x00\x00\x00\x00\x13\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x02f2\x00\x00\x00\x00\x00\x10\x00\x00\x00\x00\x00\x00\x00\x02\x00\x00\x00\x05\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x06EventB\x00\x00\x00\x00\x00\x01\x00\x00\x00\x07event_b\x00\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x02f1\x00\x00\x00\x00\x00\x13\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x02f2\x00\x00\x00\x00\x00\x13\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x02f3\x00\x00\x00\x00\x00\x0b\x00\x00\x00\x00\x00\x00\x00\x02\x00\x00\x00\x05\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x06EventC\x00\x00\x00\x00\x00\x01\x00\x00\x00\x07event_c\x00\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x02f1\x00\x00\x00\x00\x00\x11\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x02f2\x00\x00\x00\x00\x00\x07\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02f3\x00\x00\x00\x00\x00\x07\x00\x00\x00\x00\x00\x00\x00\x02\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x07StructA\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x02f1\x00\x00\x00\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00\x02f2\x00\x00\x00\x00\x00\x01\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x07StructB\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x02f1\x00\x00\x00\x00\x00\x07\x00\x00\x00\x00\x00\x00\x00\x02f2\x00\x00\x00\x00\x00\x10\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x07StructC\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x02f1\x00\x00\x00\x00\x03\xea\x00\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00\x02f2\x00\x00\x00\x00\x00\x13\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x08EnumIntA\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x02V1\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x02V2\x00\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x02V3\x00\x00\x00\x00\x00\x03\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x08EnumIntB\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x02V1\x00\x00\x00\x00\x00\n\x00\x00\x00\x00\x00\x00\x00\x02V2\x00\x00\x00\x00\x00\x14\x00\x00\x00\x00\x00\x00\x00\x02V3\x00\x00\x00\x00\x00\x1e\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x08EnumIntC\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x02V1\x00\x00\x00\x00\x00d\x00\x00\x00\x00\x00\x00\x00\x02V2\x00\x00\x00\x00\x00\xc8\x00\x00\x00\x00\x00\x00\x00\x02V3\x00\x00\x00\x00\x01,\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x0cStructTupleA\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x010\x00\x00\x00\x00\x00\x00\x07\x00\x00\x00\x00\x00\x00\x00\x011\x00\x00\x00\x00\x00\x00\x07\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x0cStructTupleB\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x010\x00\x00\x00\x00\x00\x00\n\x00\x00\x00\x00\x00\x00\x00\x011\x00\x00\x00\x00\x00\x00\n\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x0cStructTupleC\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x010\x00\x00\x00\x00\x00\x00\x13\x00\x00\x00\x00\x00\x00\x00\x011\x00\x00\x00\x00\x00\x00\x0b\x00\x1e\x11contractenvmetav0\x00\x00\x00\x00\x00\x00\x00\x1a\x00\x00\x00\x00\x00O\x0econtractmetav0\x00\x00\x00\x00\x00\x00\x00\x05rsver\x00\x00\x00\x00\x00\x00\x061.91.0\x00\x00\x00\x00\x00\x00\x00\x00\x00\x12rssdk_spec_shaking\x00\x00\x00\x00\x00\x012\x00\x00\x00";
     pub trait Contract {
         fn fn_enum_a(env: soroban_sdk::Env) -> EnumA;
         fn fn_error_a(env: soroban_sdk::Env, input: u32) -> Result<u32, ErrorA>;
@@ -4908,6 +4908,666 @@ mod wasm_imported {
         #[allow(clippy::unused_unit)]
         pub fn fn_struct_tuple_a<'i>(f1: &'i i64, f2: &'i i64) -> (&'i i64, &'i i64) {
             (f1, f2)
+        }
+    }
+    pub struct ContractContext {
+        pub args: soroban_sdk::Vec<soroban_sdk::Val>,
+        pub contract: soroban_sdk::Address,
+        pub fn_name: soroban_sdk::Symbol,
+    }
+    #[automatically_derived]
+    impl ::core::fmt::Debug for ContractContext {
+        #[inline]
+        fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+            ::core::fmt::Formatter::debug_struct_field3_finish(
+                f,
+                "ContractContext",
+                "args",
+                &self.args,
+                "contract",
+                &self.contract,
+                "fn_name",
+                &&self.fn_name,
+            )
+        }
+    }
+    #[automatically_derived]
+    impl ::core::clone::Clone for ContractContext {
+        #[inline]
+        fn clone(&self) -> ContractContext {
+            ContractContext {
+                args: ::core::clone::Clone::clone(&self.args),
+                contract: ::core::clone::Clone::clone(&self.contract),
+                fn_name: ::core::clone::Clone::clone(&self.fn_name),
+            }
+        }
+    }
+    #[automatically_derived]
+    impl ::core::cmp::Eq for ContractContext {
+        #[inline]
+        #[doc(hidden)]
+        #[coverage(off)]
+        fn assert_receiver_is_total_eq(&self) -> () {
+            let _: ::core::cmp::AssertParamIsEq<soroban_sdk::Vec<soroban_sdk::Val>>;
+            let _: ::core::cmp::AssertParamIsEq<soroban_sdk::Address>;
+            let _: ::core::cmp::AssertParamIsEq<soroban_sdk::Symbol>;
+        }
+    }
+    #[automatically_derived]
+    impl ::core::marker::StructuralPartialEq for ContractContext {}
+    #[automatically_derived]
+    impl ::core::cmp::PartialEq for ContractContext {
+        #[inline]
+        fn eq(&self, other: &ContractContext) -> bool {
+            self.args == other.args
+                && self.contract == other.contract
+                && self.fn_name == other.fn_name
+        }
+    }
+    #[automatically_derived]
+    impl ::core::cmp::Ord for ContractContext {
+        #[inline]
+        fn cmp(&self, other: &ContractContext) -> ::core::cmp::Ordering {
+            match ::core::cmp::Ord::cmp(&self.args, &other.args) {
+                ::core::cmp::Ordering::Equal => {
+                    match ::core::cmp::Ord::cmp(&self.contract, &other.contract) {
+                        ::core::cmp::Ordering::Equal => {
+                            ::core::cmp::Ord::cmp(&self.fn_name, &other.fn_name)
+                        }
+                        cmp => cmp,
+                    }
+                }
+                cmp => cmp,
+            }
+        }
+    }
+    #[automatically_derived]
+    impl ::core::cmp::PartialOrd for ContractContext {
+        #[inline]
+        fn partial_cmp(
+            &self,
+            other: &ContractContext,
+        ) -> ::core::option::Option<::core::cmp::Ordering> {
+            match ::core::cmp::PartialOrd::partial_cmp(&self.args, &other.args) {
+                ::core::option::Option::Some(::core::cmp::Ordering::Equal) => {
+                    match ::core::cmp::PartialOrd::partial_cmp(&self.contract, &other.contract) {
+                        ::core::option::Option::Some(::core::cmp::Ordering::Equal) => {
+                            ::core::cmp::PartialOrd::partial_cmp(&self.fn_name, &other.fn_name)
+                        }
+                        cmp => cmp,
+                    }
+                }
+                cmp => cmp,
+            }
+        }
+    }
+    #[link_section = "contractspecv0"]
+    pub static __SPEC_XDR_TYPE_CONTRACTCONTEXT: [u8; 96usize] = ContractContext::spec_xdr();
+    impl ContractContext {
+        pub const fn spec_xdr() -> [u8; 96usize] {
+            *b"\0\0\0\x01\0\0\0\0\0\0\0\0\0\0\0\x0fContractContext\0\0\0\0\x03\0\0\0\0\0\0\0\x04args\0\0\x03\xea\0\0\0\0\0\0\0\0\0\0\0\x08contract\0\0\0\x13\0\0\0\0\0\0\0\x07fn_name\0\0\0\0\x11"
+        }
+    }
+    impl soroban_sdk::SpecShakingMarker for ContractContext {
+        #[doc(hidden)]
+        #[inline(always)]
+        fn spec_shaking_marker() {
+            <soroban_sdk::Vec<
+                soroban_sdk::Val,
+            > as soroban_sdk::SpecShakingMarker>::spec_shaking_marker();
+            <soroban_sdk::Address as soroban_sdk::SpecShakingMarker>::spec_shaking_marker();
+            <soroban_sdk::Symbol as soroban_sdk::SpecShakingMarker>::spec_shaking_marker();
+            {
+                static MARKER: [u8; 14usize] = *b"SpEcV1\x03\x04uN\xea\xd7[\x13";
+                let _ = unsafe { ::core::ptr::read_volatile(MARKER.as_ptr()) };
+            }
+        }
+    }
+    impl soroban_sdk::TryFromVal<soroban_sdk::Env, soroban_sdk::Val> for ContractContext {
+        type Error = soroban_sdk::ConversionError;
+        fn try_from_val(
+            env: &soroban_sdk::Env,
+            val: &soroban_sdk::Val,
+        ) -> Result<Self, soroban_sdk::ConversionError> {
+            use soroban_sdk::{ConversionError, EnvBase, MapObject, TryIntoVal, Val};
+            const KEYS: [&'static str; 3usize] = ["args", "contract", "fn_name"];
+            let mut vals: [Val; 3usize] = [Val::VOID.to_val(); 3usize];
+            let map: MapObject = val.try_into().map_err(|_| ConversionError)?;
+            env.map_unpack_to_slice(map, &KEYS, &mut vals)
+                .map_err(|_| ConversionError)?;
+            Ok(Self {
+                args: vals[0]
+                    .try_into_val(env)
+                    .map_err(|_| soroban_sdk::ConversionError)?,
+                contract: vals[1]
+                    .try_into_val(env)
+                    .map_err(|_| soroban_sdk::ConversionError)?,
+                fn_name: vals[2]
+                    .try_into_val(env)
+                    .map_err(|_| soroban_sdk::ConversionError)?,
+            })
+        }
+    }
+    impl soroban_sdk::TryFromVal<soroban_sdk::Env, ContractContext> for soroban_sdk::Val {
+        type Error = soroban_sdk::ConversionError;
+        fn try_from_val(
+            env: &soroban_sdk::Env,
+            val: &ContractContext,
+        ) -> Result<Self, soroban_sdk::ConversionError> {
+            use soroban_sdk::{ConversionError, EnvBase, TryIntoVal, Val};
+            const KEYS: [&'static str; 3usize] = ["args", "contract", "fn_name"];
+            let vals: [Val; 3usize] = [
+                (&val.args).try_into_val(env).map_err(|_| ConversionError)?,
+                (&val.contract)
+                    .try_into_val(env)
+                    .map_err(|_| ConversionError)?,
+                (&val.fn_name)
+                    .try_into_val(env)
+                    .map_err(|_| ConversionError)?,
+            ];
+            Ok(env
+                .map_new_from_slices(&KEYS, &vals)
+                .map_err(|_| ConversionError)?
+                .into())
+        }
+    }
+    impl soroban_sdk::TryFromVal<soroban_sdk::Env, &ContractContext> for soroban_sdk::Val {
+        type Error = soroban_sdk::ConversionError;
+        #[inline(always)]
+        fn try_from_val(
+            env: &soroban_sdk::Env,
+            val: &&ContractContext,
+        ) -> Result<Self, soroban_sdk::ConversionError> {
+            <_ as soroban_sdk::TryFromVal<soroban_sdk::Env, ContractContext>>::try_from_val(
+                env, *val,
+            )
+        }
+    }
+    pub struct SubContractInvocation {
+        pub context: ContractContext,
+        pub sub_invocations: soroban_sdk::Vec<InvokerContractAuthEntry>,
+    }
+    #[automatically_derived]
+    impl ::core::fmt::Debug for SubContractInvocation {
+        #[inline]
+        fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+            ::core::fmt::Formatter::debug_struct_field2_finish(
+                f,
+                "SubContractInvocation",
+                "context",
+                &self.context,
+                "sub_invocations",
+                &&self.sub_invocations,
+            )
+        }
+    }
+    #[automatically_derived]
+    impl ::core::clone::Clone for SubContractInvocation {
+        #[inline]
+        fn clone(&self) -> SubContractInvocation {
+            SubContractInvocation {
+                context: ::core::clone::Clone::clone(&self.context),
+                sub_invocations: ::core::clone::Clone::clone(&self.sub_invocations),
+            }
+        }
+    }
+    #[automatically_derived]
+    impl ::core::cmp::Eq for SubContractInvocation {
+        #[inline]
+        #[doc(hidden)]
+        #[coverage(off)]
+        fn assert_receiver_is_total_eq(&self) -> () {
+            let _: ::core::cmp::AssertParamIsEq<ContractContext>;
+            let _: ::core::cmp::AssertParamIsEq<soroban_sdk::Vec<InvokerContractAuthEntry>>;
+        }
+    }
+    #[automatically_derived]
+    impl ::core::marker::StructuralPartialEq for SubContractInvocation {}
+    #[automatically_derived]
+    impl ::core::cmp::PartialEq for SubContractInvocation {
+        #[inline]
+        fn eq(&self, other: &SubContractInvocation) -> bool {
+            self.context == other.context && self.sub_invocations == other.sub_invocations
+        }
+    }
+    #[automatically_derived]
+    impl ::core::cmp::Ord for SubContractInvocation {
+        #[inline]
+        fn cmp(&self, other: &SubContractInvocation) -> ::core::cmp::Ordering {
+            match ::core::cmp::Ord::cmp(&self.context, &other.context) {
+                ::core::cmp::Ordering::Equal => {
+                    ::core::cmp::Ord::cmp(&self.sub_invocations, &other.sub_invocations)
+                }
+                cmp => cmp,
+            }
+        }
+    }
+    #[automatically_derived]
+    impl ::core::cmp::PartialOrd for SubContractInvocation {
+        #[inline]
+        fn partial_cmp(
+            &self,
+            other: &SubContractInvocation,
+        ) -> ::core::option::Option<::core::cmp::Ordering> {
+            match ::core::cmp::PartialOrd::partial_cmp(&self.context, &other.context) {
+                ::core::option::Option::Some(::core::cmp::Ordering::Equal) => {
+                    ::core::cmp::PartialOrd::partial_cmp(
+                        &self.sub_invocations,
+                        &other.sub_invocations,
+                    )
+                }
+                cmp => cmp,
+            }
+        }
+    }
+    #[link_section = "contractspecv0"]
+    pub static __SPEC_XDR_TYPE_SUBCONTRACTINVOCATION: [u8; 144usize] =
+        SubContractInvocation::spec_xdr();
+    impl SubContractInvocation {
+        pub const fn spec_xdr() -> [u8; 144usize] {
+            *b"\0\0\0\x01\0\0\0\0\0\0\0\0\0\0\0\x15SubContractInvocation\0\0\0\0\0\0\x02\0\0\0\0\0\0\0\x07context\0\0\0\x07\xd0\0\0\0\x0fContractContext\0\0\0\0\0\0\0\0\x0fsub_invocations\0\0\0\x03\xea\0\0\x07\xd0\0\0\0\x18InvokerContractAuthEntry"
+        }
+    }
+    impl soroban_sdk::SpecShakingMarker for SubContractInvocation {
+        #[doc(hidden)]
+        #[inline(always)]
+        fn spec_shaking_marker() {
+            <ContractContext as soroban_sdk::SpecShakingMarker>::spec_shaking_marker();
+            <soroban_sdk::Vec<
+                InvokerContractAuthEntry,
+            > as soroban_sdk::SpecShakingMarker>::spec_shaking_marker();
+            {
+                static MARKER: [u8; 14usize] = *b"SpEcV1 \x9d\xc5_\xba\x8fv\x18";
+                let _ = unsafe { ::core::ptr::read_volatile(MARKER.as_ptr()) };
+            }
+        }
+    }
+    impl soroban_sdk::TryFromVal<soroban_sdk::Env, soroban_sdk::Val> for SubContractInvocation {
+        type Error = soroban_sdk::ConversionError;
+        fn try_from_val(
+            env: &soroban_sdk::Env,
+            val: &soroban_sdk::Val,
+        ) -> Result<Self, soroban_sdk::ConversionError> {
+            use soroban_sdk::{ConversionError, EnvBase, MapObject, TryIntoVal, Val};
+            const KEYS: [&'static str; 2usize] = ["context", "sub_invocations"];
+            let mut vals: [Val; 2usize] = [Val::VOID.to_val(); 2usize];
+            let map: MapObject = val.try_into().map_err(|_| ConversionError)?;
+            env.map_unpack_to_slice(map, &KEYS, &mut vals)
+                .map_err(|_| ConversionError)?;
+            Ok(Self {
+                context: vals[0]
+                    .try_into_val(env)
+                    .map_err(|_| soroban_sdk::ConversionError)?,
+                sub_invocations: vals[1]
+                    .try_into_val(env)
+                    .map_err(|_| soroban_sdk::ConversionError)?,
+            })
+        }
+    }
+    impl soroban_sdk::TryFromVal<soroban_sdk::Env, SubContractInvocation> for soroban_sdk::Val {
+        type Error = soroban_sdk::ConversionError;
+        fn try_from_val(
+            env: &soroban_sdk::Env,
+            val: &SubContractInvocation,
+        ) -> Result<Self, soroban_sdk::ConversionError> {
+            use soroban_sdk::{ConversionError, EnvBase, TryIntoVal, Val};
+            const KEYS: [&'static str; 2usize] = ["context", "sub_invocations"];
+            let vals: [Val; 2usize] = [
+                (&val.context)
+                    .try_into_val(env)
+                    .map_err(|_| ConversionError)?,
+                (&val.sub_invocations)
+                    .try_into_val(env)
+                    .map_err(|_| ConversionError)?,
+            ];
+            Ok(env
+                .map_new_from_slices(&KEYS, &vals)
+                .map_err(|_| ConversionError)?
+                .into())
+        }
+    }
+    impl soroban_sdk::TryFromVal<soroban_sdk::Env, &SubContractInvocation> for soroban_sdk::Val {
+        type Error = soroban_sdk::ConversionError;
+        #[inline(always)]
+        fn try_from_val(
+            env: &soroban_sdk::Env,
+            val: &&SubContractInvocation,
+        ) -> Result<Self, soroban_sdk::ConversionError> {
+            <_ as soroban_sdk::TryFromVal<soroban_sdk::Env, SubContractInvocation>>::try_from_val(
+                env, *val,
+            )
+        }
+    }
+    pub struct CreateContractHostFnContext {
+        pub executable: ContractExecutable,
+        pub salt: soroban_sdk::BytesN<32>,
+    }
+    #[automatically_derived]
+    impl ::core::fmt::Debug for CreateContractHostFnContext {
+        #[inline]
+        fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+            ::core::fmt::Formatter::debug_struct_field2_finish(
+                f,
+                "CreateContractHostFnContext",
+                "executable",
+                &self.executable,
+                "salt",
+                &&self.salt,
+            )
+        }
+    }
+    #[automatically_derived]
+    impl ::core::clone::Clone for CreateContractHostFnContext {
+        #[inline]
+        fn clone(&self) -> CreateContractHostFnContext {
+            CreateContractHostFnContext {
+                executable: ::core::clone::Clone::clone(&self.executable),
+                salt: ::core::clone::Clone::clone(&self.salt),
+            }
+        }
+    }
+    #[automatically_derived]
+    impl ::core::cmp::Eq for CreateContractHostFnContext {
+        #[inline]
+        #[doc(hidden)]
+        #[coverage(off)]
+        fn assert_receiver_is_total_eq(&self) -> () {
+            let _: ::core::cmp::AssertParamIsEq<ContractExecutable>;
+            let _: ::core::cmp::AssertParamIsEq<soroban_sdk::BytesN<32>>;
+        }
+    }
+    #[automatically_derived]
+    impl ::core::marker::StructuralPartialEq for CreateContractHostFnContext {}
+    #[automatically_derived]
+    impl ::core::cmp::PartialEq for CreateContractHostFnContext {
+        #[inline]
+        fn eq(&self, other: &CreateContractHostFnContext) -> bool {
+            self.executable == other.executable && self.salt == other.salt
+        }
+    }
+    #[automatically_derived]
+    impl ::core::cmp::Ord for CreateContractHostFnContext {
+        #[inline]
+        fn cmp(&self, other: &CreateContractHostFnContext) -> ::core::cmp::Ordering {
+            match ::core::cmp::Ord::cmp(&self.executable, &other.executable) {
+                ::core::cmp::Ordering::Equal => ::core::cmp::Ord::cmp(&self.salt, &other.salt),
+                cmp => cmp,
+            }
+        }
+    }
+    #[automatically_derived]
+    impl ::core::cmp::PartialOrd for CreateContractHostFnContext {
+        #[inline]
+        fn partial_cmp(
+            &self,
+            other: &CreateContractHostFnContext,
+        ) -> ::core::option::Option<::core::cmp::Ordering> {
+            match ::core::cmp::PartialOrd::partial_cmp(&self.executable, &other.executable) {
+                ::core::option::Option::Some(::core::cmp::Ordering::Equal) => {
+                    ::core::cmp::PartialOrd::partial_cmp(&self.salt, &other.salt)
+                }
+                cmp => cmp,
+            }
+        }
+    }
+    #[link_section = "contractspecv0"]
+    pub static __SPEC_XDR_TYPE_CREATECONTRACTHOSTFNCONTEXT: [u8; 116usize] =
+        CreateContractHostFnContext::spec_xdr();
+    impl CreateContractHostFnContext {
+        pub const fn spec_xdr() -> [u8; 116usize] {
+            *b"\0\0\0\x01\0\0\0\0\0\0\0\0\0\0\0\x1bCreateContractHostFnContext\0\0\0\0\x02\0\0\0\0\0\0\0\nexecutable\0\0\0\0\x07\xd0\0\0\0\x12ContractExecutable\0\0\0\0\0\0\0\0\0\x04salt\0\0\x03\xee\0\0\0 "
+        }
+    }
+    impl soroban_sdk::SpecShakingMarker for CreateContractHostFnContext {
+        #[doc(hidden)]
+        #[inline(always)]
+        fn spec_shaking_marker() {
+            <ContractExecutable as soroban_sdk::SpecShakingMarker>::spec_shaking_marker();
+            <soroban_sdk::BytesN<32> as soroban_sdk::SpecShakingMarker>::spec_shaking_marker();
+            {
+                static MARKER: [u8; 14usize] = *b"SpEcV1\xe1\"T\xf0&\x19?P";
+                let _ = unsafe { ::core::ptr::read_volatile(MARKER.as_ptr()) };
+            }
+        }
+    }
+    impl soroban_sdk::TryFromVal<soroban_sdk::Env, soroban_sdk::Val> for CreateContractHostFnContext {
+        type Error = soroban_sdk::ConversionError;
+        fn try_from_val(
+            env: &soroban_sdk::Env,
+            val: &soroban_sdk::Val,
+        ) -> Result<Self, soroban_sdk::ConversionError> {
+            use soroban_sdk::{ConversionError, EnvBase, MapObject, TryIntoVal, Val};
+            const KEYS: [&'static str; 2usize] = ["executable", "salt"];
+            let mut vals: [Val; 2usize] = [Val::VOID.to_val(); 2usize];
+            let map: MapObject = val.try_into().map_err(|_| ConversionError)?;
+            env.map_unpack_to_slice(map, &KEYS, &mut vals)
+                .map_err(|_| ConversionError)?;
+            Ok(Self {
+                executable: vals[0]
+                    .try_into_val(env)
+                    .map_err(|_| soroban_sdk::ConversionError)?,
+                salt: vals[1]
+                    .try_into_val(env)
+                    .map_err(|_| soroban_sdk::ConversionError)?,
+            })
+        }
+    }
+    impl soroban_sdk::TryFromVal<soroban_sdk::Env, CreateContractHostFnContext> for soroban_sdk::Val {
+        type Error = soroban_sdk::ConversionError;
+        fn try_from_val(
+            env: &soroban_sdk::Env,
+            val: &CreateContractHostFnContext,
+        ) -> Result<Self, soroban_sdk::ConversionError> {
+            use soroban_sdk::{ConversionError, EnvBase, TryIntoVal, Val};
+            const KEYS: [&'static str; 2usize] = ["executable", "salt"];
+            let vals: [Val; 2usize] = [
+                (&val.executable)
+                    .try_into_val(env)
+                    .map_err(|_| ConversionError)?,
+                (&val.salt).try_into_val(env).map_err(|_| ConversionError)?,
+            ];
+            Ok(env
+                .map_new_from_slices(&KEYS, &vals)
+                .map_err(|_| ConversionError)?
+                .into())
+        }
+    }
+    impl soroban_sdk::TryFromVal<soroban_sdk::Env, &CreateContractHostFnContext> for soroban_sdk::Val {
+        type Error = soroban_sdk::ConversionError;
+        #[inline(always)]
+        fn try_from_val(
+            env: &soroban_sdk::Env,
+            val: &&CreateContractHostFnContext,
+        ) -> Result<Self, soroban_sdk::ConversionError> {
+            <_ as soroban_sdk::TryFromVal<
+                soroban_sdk::Env,
+                CreateContractHostFnContext,
+            >>::try_from_val(env, *val)
+        }
+    }
+    pub struct CreateContractWithConstructorHostFnContext {
+        pub constructor_args: soroban_sdk::Vec<soroban_sdk::Val>,
+        pub executable: ContractExecutable,
+        pub salt: soroban_sdk::BytesN<32>,
+    }
+    #[automatically_derived]
+    impl ::core::fmt::Debug for CreateContractWithConstructorHostFnContext {
+        #[inline]
+        fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+            ::core::fmt::Formatter::debug_struct_field3_finish(
+                f,
+                "CreateContractWithConstructorHostFnContext",
+                "constructor_args",
+                &self.constructor_args,
+                "executable",
+                &self.executable,
+                "salt",
+                &&self.salt,
+            )
+        }
+    }
+    #[automatically_derived]
+    impl ::core::clone::Clone for CreateContractWithConstructorHostFnContext {
+        #[inline]
+        fn clone(&self) -> CreateContractWithConstructorHostFnContext {
+            CreateContractWithConstructorHostFnContext {
+                constructor_args: ::core::clone::Clone::clone(&self.constructor_args),
+                executable: ::core::clone::Clone::clone(&self.executable),
+                salt: ::core::clone::Clone::clone(&self.salt),
+            }
+        }
+    }
+    #[automatically_derived]
+    impl ::core::cmp::Eq for CreateContractWithConstructorHostFnContext {
+        #[inline]
+        #[doc(hidden)]
+        #[coverage(off)]
+        fn assert_receiver_is_total_eq(&self) -> () {
+            let _: ::core::cmp::AssertParamIsEq<soroban_sdk::Vec<soroban_sdk::Val>>;
+            let _: ::core::cmp::AssertParamIsEq<ContractExecutable>;
+            let _: ::core::cmp::AssertParamIsEq<soroban_sdk::BytesN<32>>;
+        }
+    }
+    #[automatically_derived]
+    impl ::core::marker::StructuralPartialEq for CreateContractWithConstructorHostFnContext {}
+    #[automatically_derived]
+    impl ::core::cmp::PartialEq for CreateContractWithConstructorHostFnContext {
+        #[inline]
+        fn eq(&self, other: &CreateContractWithConstructorHostFnContext) -> bool {
+            self.constructor_args == other.constructor_args
+                && self.executable == other.executable
+                && self.salt == other.salt
+        }
+    }
+    #[automatically_derived]
+    impl ::core::cmp::Ord for CreateContractWithConstructorHostFnContext {
+        #[inline]
+        fn cmp(&self, other: &CreateContractWithConstructorHostFnContext) -> ::core::cmp::Ordering {
+            match ::core::cmp::Ord::cmp(&self.constructor_args, &other.constructor_args) {
+                ::core::cmp::Ordering::Equal => {
+                    match ::core::cmp::Ord::cmp(&self.executable, &other.executable) {
+                        ::core::cmp::Ordering::Equal => {
+                            ::core::cmp::Ord::cmp(&self.salt, &other.salt)
+                        }
+                        cmp => cmp,
+                    }
+                }
+                cmp => cmp,
+            }
+        }
+    }
+    #[automatically_derived]
+    impl ::core::cmp::PartialOrd for CreateContractWithConstructorHostFnContext {
+        #[inline]
+        fn partial_cmp(
+            &self,
+            other: &CreateContractWithConstructorHostFnContext,
+        ) -> ::core::option::Option<::core::cmp::Ordering> {
+            match ::core::cmp::PartialOrd::partial_cmp(
+                &self.constructor_args,
+                &other.constructor_args,
+            ) {
+                ::core::option::Option::Some(::core::cmp::Ordering::Equal) => {
+                    match ::core::cmp::PartialOrd::partial_cmp(&self.executable, &other.executable)
+                    {
+                        ::core::option::Option::Some(::core::cmp::Ordering::Equal) => {
+                            ::core::cmp::PartialOrd::partial_cmp(&self.salt, &other.salt)
+                        }
+                        cmp => cmp,
+                    }
+                }
+                cmp => cmp,
+            }
+        }
+    }
+    #[link_section = "contractspecv0"]
+    pub static __SPEC_XDR_TYPE_CREATECONTRACTWITHCONSTRUCTORHOSTFNCONTEXT: [u8; 164usize] =
+        CreateContractWithConstructorHostFnContext::spec_xdr();
+    impl CreateContractWithConstructorHostFnContext {
+        pub const fn spec_xdr() -> [u8; 164usize] {
+            *b"\0\0\0\x01\0\0\0\0\0\0\0\0\0\0\0*CreateContractWithConstructorHostFnContext\0\0\0\0\0\x03\0\0\0\0\0\0\0\x10constructor_args\0\0\x03\xea\0\0\0\0\0\0\0\0\0\0\0\nexecutable\0\0\0\0\x07\xd0\0\0\0\x12ContractExecutable\0\0\0\0\0\0\0\0\0\x04salt\0\0\x03\xee\0\0\0 "
+        }
+    }
+    impl soroban_sdk::SpecShakingMarker for CreateContractWithConstructorHostFnContext {
+        #[doc(hidden)]
+        #[inline(always)]
+        fn spec_shaking_marker() {
+            <soroban_sdk::Vec<
+                soroban_sdk::Val,
+            > as soroban_sdk::SpecShakingMarker>::spec_shaking_marker();
+            <ContractExecutable as soroban_sdk::SpecShakingMarker>::spec_shaking_marker();
+            <soroban_sdk::BytesN<32> as soroban_sdk::SpecShakingMarker>::spec_shaking_marker();
+            {
+                static MARKER: [u8; 14usize] = *b"SpEcV1\xd2;\xff\xe6\x97\xda;\x83";
+                let _ = unsafe { ::core::ptr::read_volatile(MARKER.as_ptr()) };
+            }
+        }
+    }
+    impl soroban_sdk::TryFromVal<soroban_sdk::Env, soroban_sdk::Val>
+        for CreateContractWithConstructorHostFnContext
+    {
+        type Error = soroban_sdk::ConversionError;
+        fn try_from_val(
+            env: &soroban_sdk::Env,
+            val: &soroban_sdk::Val,
+        ) -> Result<Self, soroban_sdk::ConversionError> {
+            use soroban_sdk::{ConversionError, EnvBase, MapObject, TryIntoVal, Val};
+            const KEYS: [&'static str; 3usize] = ["constructor_args", "executable", "salt"];
+            let mut vals: [Val; 3usize] = [Val::VOID.to_val(); 3usize];
+            let map: MapObject = val.try_into().map_err(|_| ConversionError)?;
+            env.map_unpack_to_slice(map, &KEYS, &mut vals)
+                .map_err(|_| ConversionError)?;
+            Ok(Self {
+                constructor_args: vals[0]
+                    .try_into_val(env)
+                    .map_err(|_| soroban_sdk::ConversionError)?,
+                executable: vals[1]
+                    .try_into_val(env)
+                    .map_err(|_| soroban_sdk::ConversionError)?,
+                salt: vals[2]
+                    .try_into_val(env)
+                    .map_err(|_| soroban_sdk::ConversionError)?,
+            })
+        }
+    }
+    impl soroban_sdk::TryFromVal<soroban_sdk::Env, CreateContractWithConstructorHostFnContext>
+        for soroban_sdk::Val
+    {
+        type Error = soroban_sdk::ConversionError;
+        fn try_from_val(
+            env: &soroban_sdk::Env,
+            val: &CreateContractWithConstructorHostFnContext,
+        ) -> Result<Self, soroban_sdk::ConversionError> {
+            use soroban_sdk::{ConversionError, EnvBase, TryIntoVal, Val};
+            const KEYS: [&'static str; 3usize] = ["constructor_args", "executable", "salt"];
+            let vals: [Val; 3usize] = [
+                (&val.constructor_args)
+                    .try_into_val(env)
+                    .map_err(|_| ConversionError)?,
+                (&val.executable)
+                    .try_into_val(env)
+                    .map_err(|_| ConversionError)?,
+                (&val.salt).try_into_val(env).map_err(|_| ConversionError)?,
+            ];
+            Ok(env
+                .map_new_from_slices(&KEYS, &vals)
+                .map_err(|_| ConversionError)?
+                .into())
+        }
+    }
+    impl soroban_sdk::TryFromVal<soroban_sdk::Env, &CreateContractWithConstructorHostFnContext>
+        for soroban_sdk::Val
+    {
+        type Error = soroban_sdk::ConversionError;
+        #[inline(always)]
+        fn try_from_val(
+            env: &soroban_sdk::Env,
+            val: &&CreateContractWithConstructorHostFnContext,
+        ) -> Result<Self, soroban_sdk::ConversionError> {
+            <_ as soroban_sdk::TryFromVal<
+                soroban_sdk::Env,
+                CreateContractWithConstructorHostFnContext,
+            >>::try_from_val(env, *val)
         }
     }
     pub struct StructA {
@@ -5686,6 +6346,873 @@ mod wasm_imported {
             val: &&StructTupleC,
         ) -> Result<Self, soroban_sdk::ConversionError> {
             <_ as soroban_sdk::TryFromVal<soroban_sdk::Env, StructTupleC>>::try_from_val(env, *val)
+        }
+    }
+    pub enum Context {
+        Contract(ContractContext),
+        CreateContractHostFn(CreateContractHostFnContext),
+        CreateContractWithCtorHostFn(CreateContractWithConstructorHostFnContext),
+    }
+    #[automatically_derived]
+    impl ::core::fmt::Debug for Context {
+        #[inline]
+        fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+            match self {
+                Context::Contract(__self_0) => {
+                    ::core::fmt::Formatter::debug_tuple_field1_finish(f, "Contract", &__self_0)
+                }
+                Context::CreateContractHostFn(__self_0) => {
+                    ::core::fmt::Formatter::debug_tuple_field1_finish(
+                        f,
+                        "CreateContractHostFn",
+                        &__self_0,
+                    )
+                }
+                Context::CreateContractWithCtorHostFn(__self_0) => {
+                    ::core::fmt::Formatter::debug_tuple_field1_finish(
+                        f,
+                        "CreateContractWithCtorHostFn",
+                        &__self_0,
+                    )
+                }
+            }
+        }
+    }
+    #[automatically_derived]
+    impl ::core::clone::Clone for Context {
+        #[inline]
+        fn clone(&self) -> Context {
+            match self {
+                Context::Contract(__self_0) => {
+                    Context::Contract(::core::clone::Clone::clone(__self_0))
+                }
+                Context::CreateContractHostFn(__self_0) => {
+                    Context::CreateContractHostFn(::core::clone::Clone::clone(__self_0))
+                }
+                Context::CreateContractWithCtorHostFn(__self_0) => {
+                    Context::CreateContractWithCtorHostFn(::core::clone::Clone::clone(__self_0))
+                }
+            }
+        }
+    }
+    #[automatically_derived]
+    impl ::core::cmp::Eq for Context {
+        #[inline]
+        #[doc(hidden)]
+        #[coverage(off)]
+        fn assert_receiver_is_total_eq(&self) -> () {
+            let _: ::core::cmp::AssertParamIsEq<ContractContext>;
+            let _: ::core::cmp::AssertParamIsEq<CreateContractHostFnContext>;
+            let _: ::core::cmp::AssertParamIsEq<CreateContractWithConstructorHostFnContext>;
+        }
+    }
+    #[automatically_derived]
+    impl ::core::marker::StructuralPartialEq for Context {}
+    #[automatically_derived]
+    impl ::core::cmp::PartialEq for Context {
+        #[inline]
+        fn eq(&self, other: &Context) -> bool {
+            let __self_discr = ::core::intrinsics::discriminant_value(self);
+            let __arg1_discr = ::core::intrinsics::discriminant_value(other);
+            __self_discr == __arg1_discr
+                && match (self, other) {
+                    (Context::Contract(__self_0), Context::Contract(__arg1_0)) => {
+                        __self_0 == __arg1_0
+                    }
+                    (
+                        Context::CreateContractHostFn(__self_0),
+                        Context::CreateContractHostFn(__arg1_0),
+                    ) => __self_0 == __arg1_0,
+                    (
+                        Context::CreateContractWithCtorHostFn(__self_0),
+                        Context::CreateContractWithCtorHostFn(__arg1_0),
+                    ) => __self_0 == __arg1_0,
+                    _ => unsafe { ::core::intrinsics::unreachable() },
+                }
+        }
+    }
+    #[automatically_derived]
+    impl ::core::cmp::Ord for Context {
+        #[inline]
+        fn cmp(&self, other: &Context) -> ::core::cmp::Ordering {
+            let __self_discr = ::core::intrinsics::discriminant_value(self);
+            let __arg1_discr = ::core::intrinsics::discriminant_value(other);
+            match ::core::cmp::Ord::cmp(&__self_discr, &__arg1_discr) {
+                ::core::cmp::Ordering::Equal => match (self, other) {
+                    (Context::Contract(__self_0), Context::Contract(__arg1_0)) => {
+                        ::core::cmp::Ord::cmp(__self_0, __arg1_0)
+                    }
+                    (
+                        Context::CreateContractHostFn(__self_0),
+                        Context::CreateContractHostFn(__arg1_0),
+                    ) => ::core::cmp::Ord::cmp(__self_0, __arg1_0),
+                    (
+                        Context::CreateContractWithCtorHostFn(__self_0),
+                        Context::CreateContractWithCtorHostFn(__arg1_0),
+                    ) => ::core::cmp::Ord::cmp(__self_0, __arg1_0),
+                    _ => unsafe { ::core::intrinsics::unreachable() },
+                },
+                cmp => cmp,
+            }
+        }
+    }
+    #[automatically_derived]
+    impl ::core::cmp::PartialOrd for Context {
+        #[inline]
+        fn partial_cmp(&self, other: &Context) -> ::core::option::Option<::core::cmp::Ordering> {
+            let __self_discr = ::core::intrinsics::discriminant_value(self);
+            let __arg1_discr = ::core::intrinsics::discriminant_value(other);
+            match (self, other) {
+                (Context::Contract(__self_0), Context::Contract(__arg1_0)) => {
+                    ::core::cmp::PartialOrd::partial_cmp(__self_0, __arg1_0)
+                }
+                (
+                    Context::CreateContractHostFn(__self_0),
+                    Context::CreateContractHostFn(__arg1_0),
+                ) => ::core::cmp::PartialOrd::partial_cmp(__self_0, __arg1_0),
+                (
+                    Context::CreateContractWithCtorHostFn(__self_0),
+                    Context::CreateContractWithCtorHostFn(__arg1_0),
+                ) => ::core::cmp::PartialOrd::partial_cmp(__self_0, __arg1_0),
+                _ => ::core::cmp::PartialOrd::partial_cmp(&__self_discr, &__arg1_discr),
+            }
+        }
+    }
+    #[link_section = "contractspecv0"]
+    pub static __SPEC_XDR_TYPE_CONTEXT: [u8; 244usize] = Context::spec_xdr();
+    impl Context {
+        pub const fn spec_xdr() -> [u8; 244usize] {
+            *b"\0\0\0\x02\0\0\0\0\0\0\0\0\0\0\0\x07Context\0\0\0\0\x03\0\0\0\x01\0\0\0\0\0\0\0\x08Contract\0\0\0\x01\0\0\x07\xd0\0\0\0\x0fContractContext\0\0\0\0\x01\0\0\0\0\0\0\0\x14CreateContractHostFn\0\0\0\x01\0\0\x07\xd0\0\0\0\x1bCreateContractHostFnContext\0\0\0\0\x01\0\0\0\0\0\0\0\x1cCreateContractWithCtorHostFn\0\0\0\x01\0\0\x07\xd0\0\0\0*CreateContractWithConstructorHostFnContext\0\0"
+        }
+    }
+    impl soroban_sdk::SpecShakingMarker for Context {
+        #[doc(hidden)]
+        #[inline(always)]
+        fn spec_shaking_marker() {
+            <ContractContext as soroban_sdk::SpecShakingMarker>::spec_shaking_marker();
+            <CreateContractHostFnContext as soroban_sdk::SpecShakingMarker>::spec_shaking_marker();
+            <CreateContractWithConstructorHostFnContext as soroban_sdk::SpecShakingMarker>::spec_shaking_marker();
+            {
+                static MARKER: [u8; 14usize] = *b"SpEcV1\r\xb6\x0b\xec\x8f\xd04l";
+                let _ = unsafe { ::core::ptr::read_volatile(MARKER.as_ptr()) };
+            }
+        }
+    }
+    impl soroban_sdk::TryFromVal<soroban_sdk::Env, soroban_sdk::Val> for Context {
+        type Error = soroban_sdk::ConversionError;
+        #[inline(always)]
+        fn try_from_val(
+            env: &soroban_sdk::Env,
+            val: &soroban_sdk::Val,
+        ) -> Result<Self, soroban_sdk::ConversionError> {
+            use soroban_sdk::{EnvBase, TryFromVal, TryIntoVal};
+            const CASES: &'static [&'static str] = &[
+                "Contract",
+                "CreateContractHostFn",
+                "CreateContractWithCtorHostFn",
+            ];
+            let vec: soroban_sdk::Vec<soroban_sdk::Val> = val.try_into_val(env)?;
+            let mut iter = vec.try_iter();
+            let discriminant: soroban_sdk::Symbol = iter
+                .next()
+                .ok_or(soroban_sdk::ConversionError)??
+                .try_into_val(env)
+                .map_err(|_| soroban_sdk::ConversionError)?;
+            Ok(
+                match u32::from(env.symbol_index_in_strs(discriminant.to_symbol_val(), CASES)?)
+                    as usize
+                {
+                    0 => {
+                        if iter.len() > 1usize {
+                            return Err(soroban_sdk::ConversionError);
+                        }
+                        Self::Contract(
+                            iter.next()
+                                .ok_or(soroban_sdk::ConversionError)??
+                                .try_into_val(env)?,
+                        )
+                    }
+                    1 => {
+                        if iter.len() > 1usize {
+                            return Err(soroban_sdk::ConversionError);
+                        }
+                        Self::CreateContractHostFn(
+                            iter.next()
+                                .ok_or(soroban_sdk::ConversionError)??
+                                .try_into_val(env)?,
+                        )
+                    }
+                    2 => {
+                        if iter.len() > 1usize {
+                            return Err(soroban_sdk::ConversionError);
+                        }
+                        Self::CreateContractWithCtorHostFn(
+                            iter.next()
+                                .ok_or(soroban_sdk::ConversionError)??
+                                .try_into_val(env)?,
+                        )
+                    }
+                    _ => Err(soroban_sdk::ConversionError {})?,
+                },
+            )
+        }
+    }
+    impl soroban_sdk::TryFromVal<soroban_sdk::Env, Context> for soroban_sdk::Val {
+        type Error = soroban_sdk::ConversionError;
+        #[inline(always)]
+        fn try_from_val(
+            env: &soroban_sdk::Env,
+            val: &Context,
+        ) -> Result<Self, soroban_sdk::ConversionError> {
+            use soroban_sdk::{TryFromVal, TryIntoVal};
+            match val {
+                Context::Contract(ref value0) => {
+                    let tup: (soroban_sdk::Val, soroban_sdk::Val) = (
+                        soroban_sdk::Symbol::try_from_val(env, &"Contract")?.to_val(),
+                        value0.try_into_val(env)?,
+                    );
+                    tup.try_into_val(env).map_err(Into::into)
+                }
+                Context::CreateContractHostFn(ref value0) => {
+                    let tup: (soroban_sdk::Val, soroban_sdk::Val) = (
+                        soroban_sdk::Symbol::try_from_val(env, &"CreateContractHostFn")?.to_val(),
+                        value0.try_into_val(env)?,
+                    );
+                    tup.try_into_val(env).map_err(Into::into)
+                }
+                Context::CreateContractWithCtorHostFn(ref value0) => {
+                    let tup: (soroban_sdk::Val, soroban_sdk::Val) = (
+                        soroban_sdk::Symbol::try_from_val(env, &"CreateContractWithCtorHostFn")?
+                            .to_val(),
+                        value0.try_into_val(env)?,
+                    );
+                    tup.try_into_val(env).map_err(Into::into)
+                }
+            }
+        }
+    }
+    impl soroban_sdk::TryFromVal<soroban_sdk::Env, &Context> for soroban_sdk::Val {
+        type Error = soroban_sdk::ConversionError;
+        #[inline(always)]
+        fn try_from_val(
+            env: &soroban_sdk::Env,
+            val: &&Context,
+        ) -> Result<Self, soroban_sdk::ConversionError> {
+            <_ as soroban_sdk::TryFromVal<soroban_sdk::Env, Context>>::try_from_val(env, *val)
+        }
+    }
+    pub enum ContractExecutable {
+        Wasm(soroban_sdk::BytesN<32>),
+    }
+    #[automatically_derived]
+    impl ::core::fmt::Debug for ContractExecutable {
+        #[inline]
+        fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+            match self {
+                ContractExecutable::Wasm(__self_0) => {
+                    ::core::fmt::Formatter::debug_tuple_field1_finish(f, "Wasm", &__self_0)
+                }
+            }
+        }
+    }
+    #[automatically_derived]
+    impl ::core::clone::Clone for ContractExecutable {
+        #[inline]
+        fn clone(&self) -> ContractExecutable {
+            match self {
+                ContractExecutable::Wasm(__self_0) => {
+                    ContractExecutable::Wasm(::core::clone::Clone::clone(__self_0))
+                }
+            }
+        }
+    }
+    #[automatically_derived]
+    impl ::core::cmp::Eq for ContractExecutable {
+        #[inline]
+        #[doc(hidden)]
+        #[coverage(off)]
+        fn assert_receiver_is_total_eq(&self) -> () {
+            let _: ::core::cmp::AssertParamIsEq<soroban_sdk::BytesN<32>>;
+        }
+    }
+    #[automatically_derived]
+    impl ::core::marker::StructuralPartialEq for ContractExecutable {}
+    #[automatically_derived]
+    impl ::core::cmp::PartialEq for ContractExecutable {
+        #[inline]
+        fn eq(&self, other: &ContractExecutable) -> bool {
+            match (self, other) {
+                (ContractExecutable::Wasm(__self_0), ContractExecutable::Wasm(__arg1_0)) => {
+                    __self_0 == __arg1_0
+                }
+            }
+        }
+    }
+    #[automatically_derived]
+    impl ::core::cmp::Ord for ContractExecutable {
+        #[inline]
+        fn cmp(&self, other: &ContractExecutable) -> ::core::cmp::Ordering {
+            match (self, other) {
+                (ContractExecutable::Wasm(__self_0), ContractExecutable::Wasm(__arg1_0)) => {
+                    ::core::cmp::Ord::cmp(__self_0, __arg1_0)
+                }
+            }
+        }
+    }
+    #[automatically_derived]
+    impl ::core::cmp::PartialOrd for ContractExecutable {
+        #[inline]
+        fn partial_cmp(
+            &self,
+            other: &ContractExecutable,
+        ) -> ::core::option::Option<::core::cmp::Ordering> {
+            match (self, other) {
+                (ContractExecutable::Wasm(__self_0), ContractExecutable::Wasm(__arg1_0)) => {
+                    ::core::cmp::PartialOrd::partial_cmp(__self_0, __arg1_0)
+                }
+            }
+        }
+    }
+    #[link_section = "contractspecv0"]
+    pub static __SPEC_XDR_TYPE_CONTRACTEXECUTABLE: [u8; 68usize] = ContractExecutable::spec_xdr();
+    impl ContractExecutable {
+        pub const fn spec_xdr() -> [u8; 68usize] {
+            *b"\0\0\0\x02\0\0\0\0\0\0\0\0\0\0\0\x12ContractExecutable\0\0\0\0\0\x01\0\0\0\x01\0\0\0\0\0\0\0\x04Wasm\0\0\0\x01\0\0\x03\xee\0\0\0 "
+        }
+    }
+    impl soroban_sdk::SpecShakingMarker for ContractExecutable {
+        #[doc(hidden)]
+        #[inline(always)]
+        fn spec_shaking_marker() {
+            <soroban_sdk::BytesN<32> as soroban_sdk::SpecShakingMarker>::spec_shaking_marker();
+            {
+                static MARKER: [u8; 14usize] = *b"SpEcV1^\xbe34\xd8\x99\x84\x91";
+                let _ = unsafe { ::core::ptr::read_volatile(MARKER.as_ptr()) };
+            }
+        }
+    }
+    impl soroban_sdk::TryFromVal<soroban_sdk::Env, soroban_sdk::Val> for ContractExecutable {
+        type Error = soroban_sdk::ConversionError;
+        #[inline(always)]
+        fn try_from_val(
+            env: &soroban_sdk::Env,
+            val: &soroban_sdk::Val,
+        ) -> Result<Self, soroban_sdk::ConversionError> {
+            use soroban_sdk::{EnvBase, TryFromVal, TryIntoVal};
+            const CASES: &'static [&'static str] = &["Wasm"];
+            let vec: soroban_sdk::Vec<soroban_sdk::Val> = val.try_into_val(env)?;
+            let mut iter = vec.try_iter();
+            let discriminant: soroban_sdk::Symbol = iter
+                .next()
+                .ok_or(soroban_sdk::ConversionError)??
+                .try_into_val(env)
+                .map_err(|_| soroban_sdk::ConversionError)?;
+            Ok(
+                match u32::from(env.symbol_index_in_strs(discriminant.to_symbol_val(), CASES)?)
+                    as usize
+                {
+                    0 => {
+                        if iter.len() > 1usize {
+                            return Err(soroban_sdk::ConversionError);
+                        }
+                        Self::Wasm(
+                            iter.next()
+                                .ok_or(soroban_sdk::ConversionError)??
+                                .try_into_val(env)?,
+                        )
+                    }
+                    _ => Err(soroban_sdk::ConversionError {})?,
+                },
+            )
+        }
+    }
+    impl soroban_sdk::TryFromVal<soroban_sdk::Env, ContractExecutable> for soroban_sdk::Val {
+        type Error = soroban_sdk::ConversionError;
+        #[inline(always)]
+        fn try_from_val(
+            env: &soroban_sdk::Env,
+            val: &ContractExecutable,
+        ) -> Result<Self, soroban_sdk::ConversionError> {
+            use soroban_sdk::{TryFromVal, TryIntoVal};
+            match val {
+                ContractExecutable::Wasm(ref value0) => {
+                    let tup: (soroban_sdk::Val, soroban_sdk::Val) = (
+                        soroban_sdk::Symbol::try_from_val(env, &"Wasm")?.to_val(),
+                        value0.try_into_val(env)?,
+                    );
+                    tup.try_into_val(env).map_err(Into::into)
+                }
+            }
+        }
+    }
+    impl soroban_sdk::TryFromVal<soroban_sdk::Env, &ContractExecutable> for soroban_sdk::Val {
+        type Error = soroban_sdk::ConversionError;
+        #[inline(always)]
+        fn try_from_val(
+            env: &soroban_sdk::Env,
+            val: &&ContractExecutable,
+        ) -> Result<Self, soroban_sdk::ConversionError> {
+            <_ as soroban_sdk::TryFromVal<soroban_sdk::Env, ContractExecutable>>::try_from_val(
+                env, *val,
+            )
+        }
+    }
+    pub enum InvokerContractAuthEntry {
+        Contract(SubContractInvocation),
+        CreateContractHostFn(CreateContractHostFnContext),
+        CreateContractWithCtorHostFn(CreateContractWithConstructorHostFnContext),
+    }
+    #[automatically_derived]
+    impl ::core::fmt::Debug for InvokerContractAuthEntry {
+        #[inline]
+        fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+            match self {
+                InvokerContractAuthEntry::Contract(__self_0) => {
+                    ::core::fmt::Formatter::debug_tuple_field1_finish(f, "Contract", &__self_0)
+                }
+                InvokerContractAuthEntry::CreateContractHostFn(__self_0) => {
+                    ::core::fmt::Formatter::debug_tuple_field1_finish(
+                        f,
+                        "CreateContractHostFn",
+                        &__self_0,
+                    )
+                }
+                InvokerContractAuthEntry::CreateContractWithCtorHostFn(__self_0) => {
+                    ::core::fmt::Formatter::debug_tuple_field1_finish(
+                        f,
+                        "CreateContractWithCtorHostFn",
+                        &__self_0,
+                    )
+                }
+            }
+        }
+    }
+    #[automatically_derived]
+    impl ::core::clone::Clone for InvokerContractAuthEntry {
+        #[inline]
+        fn clone(&self) -> InvokerContractAuthEntry {
+            match self {
+                InvokerContractAuthEntry::Contract(__self_0) => {
+                    InvokerContractAuthEntry::Contract(::core::clone::Clone::clone(__self_0))
+                }
+                InvokerContractAuthEntry::CreateContractHostFn(__self_0) => {
+                    InvokerContractAuthEntry::CreateContractHostFn(::core::clone::Clone::clone(
+                        __self_0,
+                    ))
+                }
+                InvokerContractAuthEntry::CreateContractWithCtorHostFn(__self_0) => {
+                    InvokerContractAuthEntry::CreateContractWithCtorHostFn(
+                        ::core::clone::Clone::clone(__self_0),
+                    )
+                }
+            }
+        }
+    }
+    #[automatically_derived]
+    impl ::core::cmp::Eq for InvokerContractAuthEntry {
+        #[inline]
+        #[doc(hidden)]
+        #[coverage(off)]
+        fn assert_receiver_is_total_eq(&self) -> () {
+            let _: ::core::cmp::AssertParamIsEq<SubContractInvocation>;
+            let _: ::core::cmp::AssertParamIsEq<CreateContractHostFnContext>;
+            let _: ::core::cmp::AssertParamIsEq<CreateContractWithConstructorHostFnContext>;
+        }
+    }
+    #[automatically_derived]
+    impl ::core::marker::StructuralPartialEq for InvokerContractAuthEntry {}
+    #[automatically_derived]
+    impl ::core::cmp::PartialEq for InvokerContractAuthEntry {
+        #[inline]
+        fn eq(&self, other: &InvokerContractAuthEntry) -> bool {
+            let __self_discr = ::core::intrinsics::discriminant_value(self);
+            let __arg1_discr = ::core::intrinsics::discriminant_value(other);
+            __self_discr == __arg1_discr
+                && match (self, other) {
+                    (
+                        InvokerContractAuthEntry::Contract(__self_0),
+                        InvokerContractAuthEntry::Contract(__arg1_0),
+                    ) => __self_0 == __arg1_0,
+                    (
+                        InvokerContractAuthEntry::CreateContractHostFn(__self_0),
+                        InvokerContractAuthEntry::CreateContractHostFn(__arg1_0),
+                    ) => __self_0 == __arg1_0,
+                    (
+                        InvokerContractAuthEntry::CreateContractWithCtorHostFn(__self_0),
+                        InvokerContractAuthEntry::CreateContractWithCtorHostFn(__arg1_0),
+                    ) => __self_0 == __arg1_0,
+                    _ => unsafe { ::core::intrinsics::unreachable() },
+                }
+        }
+    }
+    #[automatically_derived]
+    impl ::core::cmp::Ord for InvokerContractAuthEntry {
+        #[inline]
+        fn cmp(&self, other: &InvokerContractAuthEntry) -> ::core::cmp::Ordering {
+            let __self_discr = ::core::intrinsics::discriminant_value(self);
+            let __arg1_discr = ::core::intrinsics::discriminant_value(other);
+            match ::core::cmp::Ord::cmp(&__self_discr, &__arg1_discr) {
+                ::core::cmp::Ordering::Equal => match (self, other) {
+                    (
+                        InvokerContractAuthEntry::Contract(__self_0),
+                        InvokerContractAuthEntry::Contract(__arg1_0),
+                    ) => ::core::cmp::Ord::cmp(__self_0, __arg1_0),
+                    (
+                        InvokerContractAuthEntry::CreateContractHostFn(__self_0),
+                        InvokerContractAuthEntry::CreateContractHostFn(__arg1_0),
+                    ) => ::core::cmp::Ord::cmp(__self_0, __arg1_0),
+                    (
+                        InvokerContractAuthEntry::CreateContractWithCtorHostFn(__self_0),
+                        InvokerContractAuthEntry::CreateContractWithCtorHostFn(__arg1_0),
+                    ) => ::core::cmp::Ord::cmp(__self_0, __arg1_0),
+                    _ => unsafe { ::core::intrinsics::unreachable() },
+                },
+                cmp => cmp,
+            }
+        }
+    }
+    #[automatically_derived]
+    impl ::core::cmp::PartialOrd for InvokerContractAuthEntry {
+        #[inline]
+        fn partial_cmp(
+            &self,
+            other: &InvokerContractAuthEntry,
+        ) -> ::core::option::Option<::core::cmp::Ordering> {
+            let __self_discr = ::core::intrinsics::discriminant_value(self);
+            let __arg1_discr = ::core::intrinsics::discriminant_value(other);
+            match (self, other) {
+                (
+                    InvokerContractAuthEntry::Contract(__self_0),
+                    InvokerContractAuthEntry::Contract(__arg1_0),
+                ) => ::core::cmp::PartialOrd::partial_cmp(__self_0, __arg1_0),
+                (
+                    InvokerContractAuthEntry::CreateContractHostFn(__self_0),
+                    InvokerContractAuthEntry::CreateContractHostFn(__arg1_0),
+                ) => ::core::cmp::PartialOrd::partial_cmp(__self_0, __arg1_0),
+                (
+                    InvokerContractAuthEntry::CreateContractWithCtorHostFn(__self_0),
+                    InvokerContractAuthEntry::CreateContractWithCtorHostFn(__arg1_0),
+                ) => ::core::cmp::PartialOrd::partial_cmp(__self_0, __arg1_0),
+                _ => ::core::cmp::PartialOrd::partial_cmp(&__self_discr, &__arg1_discr),
+            }
+        }
+    }
+    #[link_section = "contractspecv0"]
+    pub static __SPEC_XDR_TYPE_INVOKERCONTRACTAUTHENTRY: [u8; 268usize] =
+        InvokerContractAuthEntry::spec_xdr();
+    impl InvokerContractAuthEntry {
+        pub const fn spec_xdr() -> [u8; 268usize] {
+            *b"\0\0\0\x02\0\0\0\0\0\0\0\0\0\0\0\x18InvokerContractAuthEntry\0\0\0\x03\0\0\0\x01\0\0\0\0\0\0\0\x08Contract\0\0\0\x01\0\0\x07\xd0\0\0\0\x15SubContractInvocation\0\0\0\0\0\0\x01\0\0\0\0\0\0\0\x14CreateContractHostFn\0\0\0\x01\0\0\x07\xd0\0\0\0\x1bCreateContractHostFnContext\0\0\0\0\x01\0\0\0\0\0\0\0\x1cCreateContractWithCtorHostFn\0\0\0\x01\0\0\x07\xd0\0\0\0*CreateContractWithConstructorHostFnContext\0\0"
+        }
+    }
+    impl soroban_sdk::SpecShakingMarker for InvokerContractAuthEntry {
+        #[doc(hidden)]
+        #[inline(always)]
+        fn spec_shaking_marker() {
+            <SubContractInvocation as soroban_sdk::SpecShakingMarker>::spec_shaking_marker();
+            <CreateContractHostFnContext as soroban_sdk::SpecShakingMarker>::spec_shaking_marker();
+            <CreateContractWithConstructorHostFnContext as soroban_sdk::SpecShakingMarker>::spec_shaking_marker();
+            {
+                static MARKER: [u8; 14usize] = *b"SpEcV1\xf0{\xa6\xe9r\xf3\x10\xf6";
+                let _ = unsafe { ::core::ptr::read_volatile(MARKER.as_ptr()) };
+            }
+        }
+    }
+    impl soroban_sdk::TryFromVal<soroban_sdk::Env, soroban_sdk::Val> for InvokerContractAuthEntry {
+        type Error = soroban_sdk::ConversionError;
+        #[inline(always)]
+        fn try_from_val(
+            env: &soroban_sdk::Env,
+            val: &soroban_sdk::Val,
+        ) -> Result<Self, soroban_sdk::ConversionError> {
+            use soroban_sdk::{EnvBase, TryFromVal, TryIntoVal};
+            const CASES: &'static [&'static str] = &[
+                "Contract",
+                "CreateContractHostFn",
+                "CreateContractWithCtorHostFn",
+            ];
+            let vec: soroban_sdk::Vec<soroban_sdk::Val> = val.try_into_val(env)?;
+            let mut iter = vec.try_iter();
+            let discriminant: soroban_sdk::Symbol = iter
+                .next()
+                .ok_or(soroban_sdk::ConversionError)??
+                .try_into_val(env)
+                .map_err(|_| soroban_sdk::ConversionError)?;
+            Ok(
+                match u32::from(env.symbol_index_in_strs(discriminant.to_symbol_val(), CASES)?)
+                    as usize
+                {
+                    0 => {
+                        if iter.len() > 1usize {
+                            return Err(soroban_sdk::ConversionError);
+                        }
+                        Self::Contract(
+                            iter.next()
+                                .ok_or(soroban_sdk::ConversionError)??
+                                .try_into_val(env)?,
+                        )
+                    }
+                    1 => {
+                        if iter.len() > 1usize {
+                            return Err(soroban_sdk::ConversionError);
+                        }
+                        Self::CreateContractHostFn(
+                            iter.next()
+                                .ok_or(soroban_sdk::ConversionError)??
+                                .try_into_val(env)?,
+                        )
+                    }
+                    2 => {
+                        if iter.len() > 1usize {
+                            return Err(soroban_sdk::ConversionError);
+                        }
+                        Self::CreateContractWithCtorHostFn(
+                            iter.next()
+                                .ok_or(soroban_sdk::ConversionError)??
+                                .try_into_val(env)?,
+                        )
+                    }
+                    _ => Err(soroban_sdk::ConversionError {})?,
+                },
+            )
+        }
+    }
+    impl soroban_sdk::TryFromVal<soroban_sdk::Env, InvokerContractAuthEntry> for soroban_sdk::Val {
+        type Error = soroban_sdk::ConversionError;
+        #[inline(always)]
+        fn try_from_val(
+            env: &soroban_sdk::Env,
+            val: &InvokerContractAuthEntry,
+        ) -> Result<Self, soroban_sdk::ConversionError> {
+            use soroban_sdk::{TryFromVal, TryIntoVal};
+            match val {
+                InvokerContractAuthEntry::Contract(ref value0) => {
+                    let tup: (soroban_sdk::Val, soroban_sdk::Val) = (
+                        soroban_sdk::Symbol::try_from_val(env, &"Contract")?.to_val(),
+                        value0.try_into_val(env)?,
+                    );
+                    tup.try_into_val(env).map_err(Into::into)
+                }
+                InvokerContractAuthEntry::CreateContractHostFn(ref value0) => {
+                    let tup: (soroban_sdk::Val, soroban_sdk::Val) = (
+                        soroban_sdk::Symbol::try_from_val(env, &"CreateContractHostFn")?.to_val(),
+                        value0.try_into_val(env)?,
+                    );
+                    tup.try_into_val(env).map_err(Into::into)
+                }
+                InvokerContractAuthEntry::CreateContractWithCtorHostFn(ref value0) => {
+                    let tup: (soroban_sdk::Val, soroban_sdk::Val) = (
+                        soroban_sdk::Symbol::try_from_val(env, &"CreateContractWithCtorHostFn")?
+                            .to_val(),
+                        value0.try_into_val(env)?,
+                    );
+                    tup.try_into_val(env).map_err(Into::into)
+                }
+            }
+        }
+    }
+    impl soroban_sdk::TryFromVal<soroban_sdk::Env, &InvokerContractAuthEntry> for soroban_sdk::Val {
+        type Error = soroban_sdk::ConversionError;
+        #[inline(always)]
+        fn try_from_val(
+            env: &soroban_sdk::Env,
+            val: &&InvokerContractAuthEntry,
+        ) -> Result<Self, soroban_sdk::ConversionError> {
+            <_ as soroban_sdk::TryFromVal<soroban_sdk::Env, InvokerContractAuthEntry>>::try_from_val(
+                env, *val,
+            )
+        }
+    }
+    pub enum Executable {
+        Wasm(soroban_sdk::BytesN<32>),
+        StellarAsset,
+        Account,
+    }
+    #[automatically_derived]
+    impl ::core::fmt::Debug for Executable {
+        #[inline]
+        fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+            match self {
+                Executable::Wasm(__self_0) => {
+                    ::core::fmt::Formatter::debug_tuple_field1_finish(f, "Wasm", &__self_0)
+                }
+                Executable::StellarAsset => ::core::fmt::Formatter::write_str(f, "StellarAsset"),
+                Executable::Account => ::core::fmt::Formatter::write_str(f, "Account"),
+            }
+        }
+    }
+    #[automatically_derived]
+    impl ::core::clone::Clone for Executable {
+        #[inline]
+        fn clone(&self) -> Executable {
+            match self {
+                Executable::Wasm(__self_0) => {
+                    Executable::Wasm(::core::clone::Clone::clone(__self_0))
+                }
+                Executable::StellarAsset => Executable::StellarAsset,
+                Executable::Account => Executable::Account,
+            }
+        }
+    }
+    #[automatically_derived]
+    impl ::core::cmp::Eq for Executable {
+        #[inline]
+        #[doc(hidden)]
+        #[coverage(off)]
+        fn assert_receiver_is_total_eq(&self) -> () {
+            let _: ::core::cmp::AssertParamIsEq<soroban_sdk::BytesN<32>>;
+        }
+    }
+    #[automatically_derived]
+    impl ::core::marker::StructuralPartialEq for Executable {}
+    #[automatically_derived]
+    impl ::core::cmp::PartialEq for Executable {
+        #[inline]
+        fn eq(&self, other: &Executable) -> bool {
+            let __self_discr = ::core::intrinsics::discriminant_value(self);
+            let __arg1_discr = ::core::intrinsics::discriminant_value(other);
+            __self_discr == __arg1_discr
+                && match (self, other) {
+                    (Executable::Wasm(__self_0), Executable::Wasm(__arg1_0)) => {
+                        __self_0 == __arg1_0
+                    }
+                    _ => true,
+                }
+        }
+    }
+    #[automatically_derived]
+    impl ::core::cmp::Ord for Executable {
+        #[inline]
+        fn cmp(&self, other: &Executable) -> ::core::cmp::Ordering {
+            let __self_discr = ::core::intrinsics::discriminant_value(self);
+            let __arg1_discr = ::core::intrinsics::discriminant_value(other);
+            match ::core::cmp::Ord::cmp(&__self_discr, &__arg1_discr) {
+                ::core::cmp::Ordering::Equal => match (self, other) {
+                    (Executable::Wasm(__self_0), Executable::Wasm(__arg1_0)) => {
+                        ::core::cmp::Ord::cmp(__self_0, __arg1_0)
+                    }
+                    _ => ::core::cmp::Ordering::Equal,
+                },
+                cmp => cmp,
+            }
+        }
+    }
+    #[automatically_derived]
+    impl ::core::cmp::PartialOrd for Executable {
+        #[inline]
+        fn partial_cmp(&self, other: &Executable) -> ::core::option::Option<::core::cmp::Ordering> {
+            let __self_discr = ::core::intrinsics::discriminant_value(self);
+            let __arg1_discr = ::core::intrinsics::discriminant_value(other);
+            match (self, other) {
+                (Executable::Wasm(__self_0), Executable::Wasm(__arg1_0)) => {
+                    ::core::cmp::PartialOrd::partial_cmp(__self_0, __arg1_0)
+                }
+                _ => ::core::cmp::PartialOrd::partial_cmp(&__self_discr, &__arg1_discr),
+            }
+        }
+    }
+    #[link_section = "contractspecv0"]
+    pub static __SPEC_XDR_TYPE_EXECUTABLE: [u8; 104usize] = Executable::spec_xdr();
+    impl Executable {
+        pub const fn spec_xdr() -> [u8; 104usize] {
+            *b"\0\0\0\x02\0\0\0\0\0\0\0\0\0\0\0\nExecutable\0\0\0\0\0\x03\0\0\0\x01\0\0\0\0\0\0\0\x04Wasm\0\0\0\x01\0\0\x03\xee\0\0\0 \0\0\0\0\0\0\0\0\0\0\0\x0cStellarAsset\0\0\0\0\0\0\0\0\0\0\0\x07Account\0"
+        }
+    }
+    impl soroban_sdk::SpecShakingMarker for Executable {
+        #[doc(hidden)]
+        #[inline(always)]
+        fn spec_shaking_marker() {
+            <soroban_sdk::BytesN<32> as soroban_sdk::SpecShakingMarker>::spec_shaking_marker();
+            {
+                static MARKER: [u8; 14usize] = *b"SpEcV1L|{\r\xf4\xf2\x1a\xa8";
+                let _ = unsafe { ::core::ptr::read_volatile(MARKER.as_ptr()) };
+            }
+        }
+    }
+    impl soroban_sdk::TryFromVal<soroban_sdk::Env, soroban_sdk::Val> for Executable {
+        type Error = soroban_sdk::ConversionError;
+        #[inline(always)]
+        fn try_from_val(
+            env: &soroban_sdk::Env,
+            val: &soroban_sdk::Val,
+        ) -> Result<Self, soroban_sdk::ConversionError> {
+            use soroban_sdk::{EnvBase, TryFromVal, TryIntoVal};
+            const CASES: &'static [&'static str] = &["Wasm", "StellarAsset", "Account"];
+            let vec: soroban_sdk::Vec<soroban_sdk::Val> = val.try_into_val(env)?;
+            let mut iter = vec.try_iter();
+            let discriminant: soroban_sdk::Symbol = iter
+                .next()
+                .ok_or(soroban_sdk::ConversionError)??
+                .try_into_val(env)
+                .map_err(|_| soroban_sdk::ConversionError)?;
+            Ok(
+                match u32::from(env.symbol_index_in_strs(discriminant.to_symbol_val(), CASES)?)
+                    as usize
+                {
+                    0 => {
+                        if iter.len() > 1usize {
+                            return Err(soroban_sdk::ConversionError);
+                        }
+                        Self::Wasm(
+                            iter.next()
+                                .ok_or(soroban_sdk::ConversionError)??
+                                .try_into_val(env)?,
+                        )
+                    }
+                    1 => {
+                        if iter.len() > 0 {
+                            return Err(soroban_sdk::ConversionError);
+                        }
+                        Self::StellarAsset
+                    }
+                    2 => {
+                        if iter.len() > 0 {
+                            return Err(soroban_sdk::ConversionError);
+                        }
+                        Self::Account
+                    }
+                    _ => Err(soroban_sdk::ConversionError {})?,
+                },
+            )
+        }
+    }
+    impl soroban_sdk::TryFromVal<soroban_sdk::Env, Executable> for soroban_sdk::Val {
+        type Error = soroban_sdk::ConversionError;
+        #[inline(always)]
+        fn try_from_val(
+            env: &soroban_sdk::Env,
+            val: &Executable,
+        ) -> Result<Self, soroban_sdk::ConversionError> {
+            use soroban_sdk::{TryFromVal, TryIntoVal};
+            match val {
+                Executable::Wasm(ref value0) => {
+                    let tup: (soroban_sdk::Val, soroban_sdk::Val) = (
+                        soroban_sdk::Symbol::try_from_val(env, &"Wasm")?.to_val(),
+                        value0.try_into_val(env)?,
+                    );
+                    tup.try_into_val(env).map_err(Into::into)
+                }
+                Executable::StellarAsset => {
+                    let tup: (soroban_sdk::Val,) =
+                        (soroban_sdk::Symbol::try_from_val(env, &"StellarAsset")?.to_val(),);
+                    tup.try_into_val(env).map_err(Into::into)
+                }
+                Executable::Account => {
+                    let tup: (soroban_sdk::Val,) =
+                        (soroban_sdk::Symbol::try_from_val(env, &"Account")?.to_val(),);
+                    tup.try_into_val(env).map_err(Into::into)
+                }
+            }
+        }
+    }
+    impl soroban_sdk::TryFromVal<soroban_sdk::Env, &Executable> for soroban_sdk::Val {
+        type Error = soroban_sdk::ConversionError;
+        #[inline(always)]
+        fn try_from_val(
+            env: &soroban_sdk::Env,
+            val: &&Executable,
+        ) -> Result<Self, soroban_sdk::ConversionError> {
+            <_ as soroban_sdk::TryFromVal<soroban_sdk::Env, Executable>>::try_from_val(env, *val)
         }
     }
     pub enum EnumA {

--- a/tests/account/Cargo.toml
+++ b/tests/account/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["cdylib"]
 doctest = false
 
 [dependencies]
-soroban-sdk = {path = "../../soroban-sdk", features = ["experimental_spec_shaking_v2"]}
+soroban-sdk = {path = "../../soroban-sdk", features = []}
 
 [dev-dependencies]
 soroban-sdk = {path = "../../soroban-sdk", features = ["testutils"]}

--- a/tests/add_i128/Cargo.toml
+++ b/tests/add_i128/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["cdylib"]
 doctest = false
 
 [dependencies]
-soroban-sdk = {path = "../../soroban-sdk", features = ["experimental_spec_shaking_v2"]}
+soroban-sdk = {path = "../../soroban-sdk", features = []}
 
 [dev-dependencies]
 soroban-sdk = {path = "../../soroban-sdk", features = ["testutils"]}

--- a/tests/add_u128/Cargo.toml
+++ b/tests/add_u128/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["cdylib"]
 doctest = false
 
 [dependencies]
-soroban-sdk = {path = "../../soroban-sdk", features = ["experimental_spec_shaking_v2"]}
+soroban-sdk = {path = "../../soroban-sdk", features = []}
 
 [dev-dependencies]
 soroban-sdk = {path = "../../soroban-sdk", features = ["testutils"]}

--- a/tests/add_u64/Cargo.toml
+++ b/tests/add_u64/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["cdylib"]
 doctest = false
 
 [dependencies]
-soroban-sdk = {path = "../../soroban-sdk", features = ["experimental_spec_shaking_v2"]}
+soroban-sdk = {path = "../../soroban-sdk", features = []}
 
 [dev-dependencies]
 soroban-sdk = {path = "../../soroban-sdk", features = ["testutils"]}

--- a/tests/alloc/Cargo.toml
+++ b/tests/alloc/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["cdylib"]
 doctest = false
 
 [dependencies]
-soroban-sdk = {path = "../../soroban-sdk", features = ["alloc", "experimental_spec_shaking_v2"]}
+soroban-sdk = {path = "../../soroban-sdk", features = ["alloc"]}
 
 [dev-dependencies]
 soroban-sdk = {path = "../../soroban-sdk", features = ["alloc", "testutils"]}

--- a/tests/associated_type/Cargo.toml
+++ b/tests/associated_type/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["cdylib"]
 doctest = false
 
 [dependencies]
-soroban-sdk = {path = "../../soroban-sdk", features = ["experimental_spec_shaking_v2"]}
+soroban-sdk = {path = "../../soroban-sdk", features = []}
 
 [dev-dependencies]
 soroban-sdk = {path = "../../soroban-sdk", features = ["testutils"]}

--- a/tests/associated_type_chained/Cargo.toml
+++ b/tests/associated_type_chained/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["cdylib"]
 doctest = false
 
 [dependencies]
-soroban-sdk = {path = "../../soroban-sdk", features = ["experimental_spec_shaking_v2"]}
+soroban-sdk = {path = "../../soroban-sdk", features = []}
 
 [dev-dependencies]
 soroban-sdk = {path = "../../soroban-sdk", features = ["testutils"]}

--- a/tests/associated_type_contracttrait/Cargo.toml
+++ b/tests/associated_type_contracttrait/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["cdylib"]
 doctest = false
 
 [dependencies]
-soroban-sdk = {path = "../../soroban-sdk", features = ["experimental_spec_shaking_v2"]}
+soroban-sdk = {path = "../../soroban-sdk", features = []}
 
 [dev-dependencies]
 soroban-sdk = {path = "../../soroban-sdk", features = ["testutils"]}

--- a/tests/attributes/Cargo.toml
+++ b/tests/attributes/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["cdylib"]
 doctest = false
 
 [dependencies]
-soroban-sdk = { path = "../../soroban-sdk", features = ["experimental_spec_shaking_v2"] }
+soroban-sdk = { path = "../../soroban-sdk", features = [] }
 
 [dev-dependencies]
 soroban-sdk = { path = "../../soroban-sdk", features = ["testutils"] }

--- a/tests/auth/Cargo.toml
+++ b/tests/auth/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["cdylib"]
 doctest = false
 
 [dependencies]
-soroban-sdk = {path = "../../soroban-sdk", features = ["experimental_spec_shaking_v2"]}
+soroban-sdk = {path = "../../soroban-sdk", features = []}
 
 [dev-dependencies]
 soroban-sdk = {path = "../../soroban-sdk", features = ["testutils"]}

--- a/tests/bls/Cargo.toml
+++ b/tests/bls/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["cdylib"]
 doctest = false
 
 [dependencies]
-soroban-sdk = {path = "../../soroban-sdk", features = ["experimental_spec_shaking_v2"]}
+soroban-sdk = {path = "../../soroban-sdk", features = []}
 
 [dev-dependencies]
 soroban-sdk = {path = "../../soroban-sdk", features = ["testutils"]}

--- a/tests/bn254/Cargo.toml
+++ b/tests/bn254/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["cdylib"]
 doctest = false
 
 [dependencies]
-soroban-sdk = {path = "../../soroban-sdk", features = ["experimental_spec_shaking_v2"]}
+soroban-sdk = {path = "../../soroban-sdk", features = []}
 
 [dev-dependencies]
 soroban-sdk = {path = "../../soroban-sdk", features = ["testutils"]}

--- a/tests/constructor/Cargo.toml
+++ b/tests/constructor/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["cdylib"]
 doctest = false
 
 [dependencies]
-soroban-sdk = {path = "../../soroban-sdk", features = ["experimental_spec_shaking_v2"]}
+soroban-sdk = {path = "../../soroban-sdk", features = []}
 
 [dev-dependencies]
 soroban-sdk = {path = "../../soroban-sdk", features = ["testutils"]}

--- a/tests/contract_data/Cargo.toml
+++ b/tests/contract_data/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["cdylib"]
 doctest = false
 
 [dependencies]
-soroban-sdk = {path = "../../soroban-sdk", features = ["experimental_spec_shaking_v2"]}
+soroban-sdk = {path = "../../soroban-sdk", features = []}
 
 [dev-dependencies]
 soroban-sdk = {path = "../../soroban-sdk", features = ["testutils"]}

--- a/tests/contracttrait_impl_full/Cargo.toml
+++ b/tests/contracttrait_impl_full/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["cdylib"]
 doctest = false
 
 [dependencies]
-soroban-sdk = {path = "../../soroban-sdk", features = ["experimental_spec_shaking_v2"]}
+soroban-sdk = {path = "../../soroban-sdk", features = []}
 test_contracttrait_trait = {path = "../contracttrait_trait"}
 
 [dev-dependencies]

--- a/tests/contracttrait_impl_partial/Cargo.toml
+++ b/tests/contracttrait_impl_partial/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["cdylib"]
 doctest = false
 
 [dependencies]
-soroban-sdk = {path = "../../soroban-sdk", features = ["experimental_spec_shaking_v2"]}
+soroban-sdk = {path = "../../soroban-sdk", features = []}
 test_contracttrait_trait = {path = "../contracttrait_trait"}
 
 [dev-dependencies]

--- a/tests/contracttrait_path_crate/Cargo.toml
+++ b/tests/contracttrait_path_crate/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["cdylib"]
 doctest = false
 
 [dependencies]
-soroban-sdk = {path = "../../soroban-sdk", features = ["experimental_spec_shaking_v2"]}
+soroban-sdk = {path = "../../soroban-sdk", features = []}
 
 [dev-dependencies]
 soroban-sdk = {path = "../../soroban-sdk", features = ["testutils"]}

--- a/tests/contracttrait_path_global/Cargo.toml
+++ b/tests/contracttrait_path_global/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["cdylib"]
 doctest = false
 
 [dependencies]
-soroban-sdk = {path = "../../soroban-sdk", features = ["experimental_spec_shaking_v2"]}
+soroban-sdk = {path = "../../soroban-sdk", features = []}
 test_contracttrait_trait = {path = "../contracttrait_trait"}
 
 [dev-dependencies]

--- a/tests/contracttrait_path_relative/Cargo.toml
+++ b/tests/contracttrait_path_relative/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["cdylib"]
 doctest = false
 
 [dependencies]
-soroban-sdk = {path = "../../soroban-sdk", features = ["experimental_spec_shaking_v2"]}
+soroban-sdk = {path = "../../soroban-sdk", features = []}
 
 [dev-dependencies]
 soroban-sdk = {path = "../../soroban-sdk", features = ["testutils"]}

--- a/tests/contracttrait_path_self/Cargo.toml
+++ b/tests/contracttrait_path_self/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["cdylib"]
 doctest = false
 
 [dependencies]
-soroban-sdk = {path = "../../soroban-sdk", features = ["experimental_spec_shaking_v2"]}
+soroban-sdk = {path = "../../soroban-sdk", features = []}
 
 [dev-dependencies]
 soroban-sdk = {path = "../../soroban-sdk", features = ["testutils"]}

--- a/tests/contracttrait_path_super/Cargo.toml
+++ b/tests/contracttrait_path_super/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["cdylib"]
 doctest = false
 
 [dependencies]
-soroban-sdk = {path = "../../soroban-sdk", features = ["experimental_spec_shaking_v2"]}
+soroban-sdk = {path = "../../soroban-sdk", features = []}
 
 [dev-dependencies]
 soroban-sdk = {path = "../../soroban-sdk", features = ["testutils"]}

--- a/tests/contracttrait_trait/Cargo.toml
+++ b/tests/contracttrait_trait/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["lib"]
 doctest = false
 
 [dependencies]
-soroban-sdk = {path = "../../soroban-sdk", features = ["experimental_spec_shaking_v2"]}
+soroban-sdk = {path = "../../soroban-sdk", features = []}
 
 [dev-dependencies]
 soroban-sdk = {path = "../../soroban-sdk", features = ["testutils"]}

--- a/tests/empty/Cargo.toml
+++ b/tests/empty/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["cdylib"]
 doctest = false
 
 [dependencies]
-soroban-sdk = {path = "../../soroban-sdk", features = ["experimental_spec_shaking_v2"]}
+soroban-sdk = {path = "../../soroban-sdk", features = []}
 
 [dev-dependencies]
 soroban-sdk = {path = "../../soroban-sdk", features = ["testutils"]}

--- a/tests/empty2/Cargo.toml
+++ b/tests/empty2/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["cdylib"]
 doctest = false
 
 [dependencies]
-soroban-sdk = {path = "../../soroban-sdk", features = ["experimental_spec_shaking_v2"]}
+soroban-sdk = {path = "../../soroban-sdk", features = []}
 
 [dev-dependencies]
 soroban-sdk = {path = "../../soroban-sdk", features = ["testutils"]}

--- a/tests/errors/Cargo.toml
+++ b/tests/errors/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["cdylib"]
 doctest = false
 
 [dependencies]
-soroban-sdk = {path = "../../soroban-sdk", features = ["experimental_spec_shaking_v2"]}
+soroban-sdk = {path = "../../soroban-sdk", features = []}
 
 [dev-dependencies]
 soroban-sdk = {path = "../../soroban-sdk", features = ["testutils"]}

--- a/tests/events/Cargo.toml
+++ b/tests/events/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["cdylib"]
 doctest = false
 
 [dependencies]
-soroban-sdk = {path = "../../soroban-sdk", features = ["experimental_spec_shaking_v2"]}
+soroban-sdk = {path = "../../soroban-sdk", features = []}
 
 [dev-dependencies]
 soroban-sdk = {path = "../../soroban-sdk", features = ["testutils"]}

--- a/tests/events_ref/Cargo.toml
+++ b/tests/events_ref/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["cdylib"]
 doctest = false
 
 [dependencies]
-soroban-sdk = {path = "../../soroban-sdk", features = ["experimental_spec_shaking_v2"]}
+soroban-sdk = {path = "../../soroban-sdk", features = []}
 
 [dev-dependencies]
 soroban-sdk = {path = "../../soroban-sdk", features = ["testutils"]}

--- a/tests/fuzz/Cargo.toml
+++ b/tests/fuzz/Cargo.toml
@@ -16,7 +16,7 @@ crate-type = ["cdylib", "rlib"]
 doctest = false
 
 [dependencies]
-soroban-sdk = {path = "../../soroban-sdk", features = ["experimental_spec_shaking_v2"]}
+soroban-sdk = {path = "../../soroban-sdk", features = []}
 
 [dev-dependencies]
 soroban-sdk = {path = "../../soroban-sdk", features = ["testutils"]}

--- a/tests/generics/Cargo.toml
+++ b/tests/generics/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["cdylib"]
 doctest = false
 
 [dependencies]
-soroban-sdk = {path = "../../soroban-sdk", features = ["experimental_spec_shaking_v2"]}
+soroban-sdk = {path = "../../soroban-sdk", features = []}
 
 [dev-dependencies]
 soroban-sdk = {path = "../../soroban-sdk", features = ["testutils"]}

--- a/tests/import_contract/Cargo.toml
+++ b/tests/import_contract/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["cdylib"]
 doctest = false
 
 [dependencies]
-soroban-sdk = {path = "../../soroban-sdk", features = ["experimental_spec_shaking_v2"]}
+soroban-sdk = {path = "../../soroban-sdk", features = []}
 
 [dev-dependencies]
 soroban-sdk = {path = "../../soroban-sdk", features = ["testutils"]}

--- a/tests/invoke_contract/Cargo.toml
+++ b/tests/invoke_contract/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["cdylib"]
 doctest = false
 
 [dependencies]
-soroban-sdk = {path = "../../soroban-sdk", features = ["experimental_spec_shaking_v2"]}
+soroban-sdk = {path = "../../soroban-sdk", features = []}
 
 [dev-dependencies]
 soroban-sdk = {path = "../../soroban-sdk", features = ["testutils"]}

--- a/tests/logging/Cargo.toml
+++ b/tests/logging/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["cdylib"]
 doctest = false
 
 [dependencies]
-soroban-sdk = {path = "../../soroban-sdk", features = ["experimental_spec_shaking_v2"]}
+soroban-sdk = {path = "../../soroban-sdk", features = []}
 
 [dev-dependencies]
 soroban-sdk = {path = "../../soroban-sdk", features = ["testutils"]}

--- a/tests/macros/Cargo.toml
+++ b/tests/macros/Cargo.toml
@@ -13,7 +13,7 @@ crate-type = ["cdylib"]
 doctest = false
 
 [dependencies]
-soroban-sdk = {path = "../../soroban-sdk", features = ["experimental_spec_shaking_v2"]}
+soroban-sdk = {path = "../../soroban-sdk", features = []}
 proc_macros = {path = "./proc_macros"}
 
 [dev-dependencies]

--- a/tests/modular/Cargo.toml
+++ b/tests/modular/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["cdylib"]
 doctest = false
 
 [dependencies]
-soroban-sdk = {path = "../../soroban-sdk", features = ["experimental_spec_shaking_v2"]}
+soroban-sdk = {path = "../../soroban-sdk", features = []}
 
 [dev-dependencies]
 soroban-sdk = {path = "../../soroban-sdk", features = ["testutils"]}

--- a/tests/multiimpl/Cargo.toml
+++ b/tests/multiimpl/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["cdylib"]
 doctest = false
 
 [dependencies]
-soroban-sdk = {path = "../../soroban-sdk", features = ["experimental_spec_shaking_v2"]}
+soroban-sdk = {path = "../../soroban-sdk", features = []}
 
 [dev-dependencies]
 soroban-sdk = {path = "../../soroban-sdk", features = ["testutils"]}

--- a/tests/mutability/Cargo.toml
+++ b/tests/mutability/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["cdylib"]
 doctest = false
 
 [dependencies]
-soroban-sdk = {path = "../../soroban-sdk", features = ["experimental_spec_shaking_v2"]}
+soroban-sdk = {path = "../../soroban-sdk", features = []}
 
 [dev-dependencies]
 soroban-sdk = {path = "../../soroban-sdk", features = ["testutils"]}

--- a/tests/spec_shaking_v1/Cargo.toml
+++ b/tests/spec_shaking_v1/Cargo.toml
@@ -12,9 +12,9 @@ crate-type = ["cdylib"]
 doctest = false
 
 [dependencies]
-soroban-sdk = {path = "../../soroban-sdk"}
+soroban-sdk = {path = "../../soroban-sdk", features = ["disable_spec_shaking_v2"]}
 test_spec_lib = {path = "../spec_lib"}
 
 [dev-dependencies]
-soroban-sdk = {path = "../../soroban-sdk", features = ["testutils"]}
+soroban-sdk = {path = "../../soroban-sdk", features = ["testutils", "disable_spec_shaking_v2"]}
 soroban-spec = {path = "../../soroban-spec"}

--- a/tests/spec_shaking_v1/src/test.rs
+++ b/tests/spec_shaking_v1/src/test.rs
@@ -12,11 +12,11 @@ fn test_spec_shaking_v1() {
     // Read all spec entries from the WASM.
     let entries = soroban_spec::read::from_wasm(WASM).unwrap();
 
-    // No markers should be embedded without the experimental feature.
+    // No markers should be embedded under v1 (disable_spec_shaking_v2).
     let markers = soroban_spec::shaking::find_all(WASM);
     assert!(
         markers.is_empty(),
-        "no markers should be present without experimental_spec_shaking_v2, found {}",
+        "no markers should be present under disable_spec_shaking_v2 (v1), found {}",
         markers.len()
     );
 

--- a/tests/spec_shaking_v2/Cargo.toml
+++ b/tests/spec_shaking_v2/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["cdylib"]
 doctest = false
 
 [dependencies]
-soroban-sdk = {path = "../../soroban-sdk", features = ["experimental_spec_shaking_v2"]}
+soroban-sdk = {path = "../../soroban-sdk", features = []}
 test_spec_lib = {path = "../spec_lib"}
 
 [dev-dependencies]

--- a/tests/spec_shaking_v2/src/lib.rs
+++ b/tests/spec_shaking_v2/src/lib.rs
@@ -247,7 +247,7 @@ pub struct UsedVecElementNested {
 }
 
 // Used types declared with `export = false`: the argument is a no-op under
-// `experimental_spec_shaking_v2` (a deprecation warning is emitted by the
+// spec shaking v2 (the default; a deprecation warning is emitted by the
 // macro).
 #[allow(deprecated)]
 mod export_false_used {

--- a/tests/tuples/Cargo.toml
+++ b/tests/tuples/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["cdylib"]
 doctest = false
 
 [dependencies]
-soroban-sdk = {path = "../../soroban-sdk", features = ["experimental_spec_shaking_v2"]}
+soroban-sdk = {path = "../../soroban-sdk", features = []}
 
 [dev-dependencies]
 soroban-sdk = {path = "../../soroban-sdk", features = ["testutils"]}

--- a/tests/udt/Cargo.toml
+++ b/tests/udt/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["cdylib"]
 doctest = false
 
 [dependencies]
-soroban-sdk = {path = "../../soroban-sdk", features = ["experimental_spec_shaking_v2"]}
+soroban-sdk = {path = "../../soroban-sdk", features = []}
 
 [dev-dependencies]
 soroban-sdk = {path = "../../soroban-sdk", features = ["testutils"]}

--- a/tests/workspace_contract/Cargo.toml
+++ b/tests/workspace_contract/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["cdylib"]
 doctest = false
 
 [dependencies]
-soroban-sdk = {path = "../../soroban-sdk", features = ["experimental_spec_shaking_v2"]}
+soroban-sdk = {path = "../../soroban-sdk", features = []}
 test_workspace_lib = {path = "../workspace_lib"}
 
 [dev-dependencies]

--- a/tests/workspace_lib/Cargo.toml
+++ b/tests/workspace_lib/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["rlib"]
 doctest = false
 
 [dependencies]
-soroban-sdk = {path = "../../soroban-sdk", features = ["experimental_spec_shaking_v2"]}
+soroban-sdk = {path = "../../soroban-sdk", features = []}
 
 [dev-dependencies]
 soroban-sdk = {path = "../../soroban-sdk", features = ["testutils"]}

--- a/tests/zero/Cargo.toml
+++ b/tests/zero/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["cdylib"]
 doctest = false
 
 [dependencies]
-soroban-sdk = {path = "../../soroban-sdk", features = ["experimental_spec_shaking_v2"]}
+soroban-sdk = {path = "../../soroban-sdk", features = []}
 
 [dev-dependencies]
 soroban-sdk = {path = "../../soroban-sdk", features = ["testutils"]}


### PR DESCRIPTION
### What

Make spec shaking v2 the SDK's default behaviour by removing the opt-in `experimental_spec_shaking_v2` feature and introducing a `disable_spec_shaking_v2` feature that reverts to the previous v1 behaviour for anyone who needs it during the v26 period.

### Why

Spec shaking v2 has been available as an experimental opt-in since v25.2.0 and has been validated, so for the v26 major version it should become the standard behaviour rather than something contracts have to know to turn on, as proposed in #1759. An earlier attempt to enable it by simply adding the experimental feature to the default set (#1812) was reverted (#1850) because it left no clean way to opt out; this change addresses that by pairing the new default with an explicit `disable_spec_shaking_v2` escape hatch, so a contract that hits an edge case during v26 can fall back to v1 without disabling default features wholesale. Removing the `disable_spec_shaking_v2` flag entirely and making v2 unconditional remains future (v27) work and is intentionally out of scope here.

### Known limitations

Because v2 markers require post-build processing by `stellar contract build`, building a contract for wasm with plain cargo and no supporting build system now fails by default instead of only when the feature was explicitly enabled; the build error explains the three remedies (build with stellar-cli v25.2.0+, set `SOROBAN_SDK_BUILD_SYSTEM_SUPPORTS_SPEC_SHAKING_V2`, or add `disable_spec_shaking_v2`). The `disable_spec_shaking_v2` opt-out is retained for the v26 period and is expected to be removed in v27.

Close #1759

---
_Generated by [Claude Code](https://claude.ai/code/session_01QGA3B4WCipq46RqXLHvt25)_