### PR TITLE
Update stellar-strkey to 0.0.18

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1676,7 +1676,8 @@ dependencies = [
 [[package]]
 name = "stellar-strkey"
 version = "0.0.18"
-source = "git+https://github.com/stellar/rs-stellar-strkey?rev=73bf43778a4acad5e7b3589f54a5ec3607c4b7b1#73bf43778a4acad5e7b3589f54a5ec3607c4b7b1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f34ff61c0ca6f1c2b4169e8d1633417bd9225f58b6175e4e317204565d16277"
 dependencies = [
  "crate-git-revision 0.0.9",
  "data-encoding",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1547,7 +1547,7 @@ dependencies = [
  "soroban-ledger-snapshot",
  "soroban-sdk-macros",
  "soroban-spec",
- "stellar-strkey 0.0.17",
+ "stellar-strkey 0.0.18",
  "stellar-xdr",
  "trybuild",
  "visibility",
@@ -1675,9 +1675,8 @@ dependencies = [
 
 [[package]]
 name = "stellar-strkey"
-version = "0.0.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0247b168bdee20244445e3d9cdea697dde6211e88742dd04acfd1b498661e936"
+version = "0.0.18"
+source = "git+https://github.com/stellar/rs-stellar-strkey?rev=73bf43778a4acad5e7b3589f54a5ec3607c4b7b1#73bf43778a4acad5e7b3589f54a5ec3607c4b7b1"
 dependencies = [
  "crate-git-revision 0.0.9",
  "data-encoding",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -769,12 +769,13 @@ dependencies = [
 
 [[package]]
 name = "heapless"
-version = "0.8.0"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
+checksum = "25ba4bd83f9415b58b4ed8dc5714c76e626a105be4646c02630ad730ad3b5aa4"
 dependencies = [
  "hash32",
  "stable_deref_trait",
+ "zeroize",
 ]
 
 [[package]]
@@ -1546,7 +1547,7 @@ dependencies = [
  "soroban-ledger-snapshot",
  "soroban-sdk-macros",
  "soroban-spec",
- "stellar-strkey 0.0.16",
+ "stellar-strkey 0.0.17",
  "stellar-xdr",
  "trybuild",
  "visibility",
@@ -1674,13 +1675,14 @@ dependencies = [
 
 [[package]]
 name = "stellar-strkey"
-version = "0.0.16"
+version = "0.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "084afcb0d458c3d5d5baa2d294b18f881e62cc258ef539d8fdf68be7dbe45520"
+checksum = "0247b168bdee20244445e3d9cdea697dde6211e88742dd04acfd1b498661e936"
 dependencies = [
- "crate-git-revision 0.0.6",
+ "crate-git-revision 0.0.9",
  "data-encoding",
  "heapless",
+ "zeroize",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,13 +45,19 @@ version = "=27.0.0"
 #rev = "7fb0a840812fe8921bb48bebf7b4aa7160467ec8"
 
 [workspace.dependencies.stellar-strkey]
-version = "=0.0.17"
+version = "=0.0.18"
 
 [workspace.dependencies.stellar-xdr]
 version = "=27.0.0"
 #git = "https://github.com/stellar/rs-stellar-xdr"
 #rev = "a749b69b3471aec0c20ec431b0297f3414d66421"
 default-features = false
+
+# Temporary: stellar-strkey 0.0.18 is not yet published to crates.io. Point at
+# the release/v0.0.18 branch so this PR can be validated against the actual
+# 0.0.18 code ahead of the release. Remove once 0.0.18 is published.
+[patch.crates-io]
+stellar-strkey = { git = "https://github.com/stellar/rs-stellar-strkey", rev = "73bf43778a4acad5e7b3589f54a5ec3607c4b7b1" }
 
 #[patch.crates-io]
 #soroban-env-common = { path = "../rs-soroban-env/soroban-env-common" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ version = "=27.0.0"
 #rev = "7fb0a840812fe8921bb48bebf7b4aa7160467ec8"
 
 [workspace.dependencies.stellar-strkey]
-version = "=0.0.16"
+version = "=0.0.17"
 
 [workspace.dependencies.stellar-xdr]
 version = "=27.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,12 +53,6 @@ version = "=27.0.0"
 #rev = "a749b69b3471aec0c20ec431b0297f3414d66421"
 default-features = false
 
-# Temporary: stellar-strkey 0.0.18 is not yet published to crates.io. Point at
-# the release/v0.0.18 branch so this PR can be validated against the actual
-# 0.0.18 code ahead of the release. Remove once 0.0.18 is published.
-[patch.crates-io]
-stellar-strkey = { git = "https://github.com/stellar/rs-stellar-strkey", rev = "73bf43778a4acad5e7b3589f54a5ec3607c4b7b1" }
-
 #[patch.crates-io]
 #soroban-env-common = { path = "../rs-soroban-env/soroban-env-common" }
 #soroban-env-guest = { path = "../rs-soroban-env/soroban-env-guest" }

--- a/tests/fuzz/fuzz/Cargo.lock
+++ b/tests/fuzz/fuzz/Cargo.lock
@@ -1329,7 +1329,7 @@ dependencies = [
  "soroban-env-host",
  "soroban-ledger-snapshot",
  "soroban-sdk-macros",
- "stellar-strkey 0.0.17",
+ "stellar-strkey 0.0.18",
  "visibility",
 ]
 
@@ -1429,9 +1429,8 @@ dependencies = [
 
 [[package]]
 name = "stellar-strkey"
-version = "0.0.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0247b168bdee20244445e3d9cdea697dde6211e88742dd04acfd1b498661e936"
+version = "0.0.18"
+source = "git+https://github.com/stellar/rs-stellar-strkey?rev=73bf43778a4acad5e7b3589f54a5ec3607c4b7b1#73bf43778a4acad5e7b3589f54a5ec3607c4b7b1"
 dependencies = [
  "crate-git-revision 0.0.9",
  "data-encoding",

--- a/tests/fuzz/fuzz/Cargo.lock
+++ b/tests/fuzz/fuzz/Cargo.lock
@@ -702,12 +702,13 @@ dependencies = [
 
 [[package]]
 name = "heapless"
-version = "0.8.0"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
+checksum = "25ba4bd83f9415b58b4ed8dc5714c76e626a105be4646c02630ad730ad3b5aa4"
 dependencies = [
  "hash32",
  "stable_deref_trait",
+ "zeroize",
 ]
 
 [[package]]
@@ -1328,7 +1329,7 @@ dependencies = [
  "soroban-env-host",
  "soroban-ledger-snapshot",
  "soroban-sdk-macros",
- "stellar-strkey 0.0.16",
+ "stellar-strkey 0.0.17",
  "visibility",
 ]
 
@@ -1428,13 +1429,14 @@ dependencies = [
 
 [[package]]
 name = "stellar-strkey"
-version = "0.0.16"
+version = "0.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "084afcb0d458c3d5d5baa2d294b18f881e62cc258ef539d8fdf68be7dbe45520"
+checksum = "0247b168bdee20244445e3d9cdea697dde6211e88742dd04acfd1b498661e936"
 dependencies = [
- "crate-git-revision 0.0.6",
+ "crate-git-revision 0.0.9",
  "data-encoding",
  "heapless",
+ "zeroize",
 ]
 
 [[package]]

--- a/tests/fuzz/fuzz/Cargo.lock
+++ b/tests/fuzz/fuzz/Cargo.lock
@@ -1430,7 +1430,8 @@ dependencies = [
 [[package]]
 name = "stellar-strkey"
 version = "0.0.18"
-source = "git+https://github.com/stellar/rs-stellar-strkey?rev=73bf43778a4acad5e7b3589f54a5ec3607c4b7b1#73bf43778a4acad5e7b3589f54a5ec3607c4b7b1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f34ff61c0ca6f1c2b4169e8d1633417bd9225f58b6175e4e317204565d16277"
 dependencies = [
  "crate-git-revision 0.0.9",
  "data-encoding",

--- a/tests/fuzz/fuzz/Cargo.toml
+++ b/tests/fuzz/fuzz/Cargo.toml
@@ -16,6 +16,12 @@ test_fuzz = { path = ".." }
 [workspace]
 members = ["."]
 
+# Temporary: stellar-strkey 0.0.18 is not yet published to crates.io. Point at
+# the release/v0.0.18 branch so this PR can be validated against the actual
+# 0.0.18 code ahead of the release. Remove once 0.0.18 is published.
+[patch.crates-io]
+stellar-strkey = { git = "https://github.com/stellar/rs-stellar-strkey", rev = "73bf43778a4acad5e7b3589f54a5ec3607c4b7b1" }
+
 [profile.release]
 debug = 1
 

--- a/tests/fuzz/fuzz/Cargo.toml
+++ b/tests/fuzz/fuzz/Cargo.toml
@@ -16,12 +16,6 @@ test_fuzz = { path = ".." }
 [workspace]
 members = ["."]
 
-# Temporary: stellar-strkey 0.0.18 is not yet published to crates.io. Point at
-# the release/v0.0.18 branch so this PR can be validated against the actual
-# 0.0.18 code ahead of the release. Remove once 0.0.18 is published.
-[patch.crates-io]
-stellar-strkey = { git = "https://github.com/stellar/rs-stellar-strkey", rev = "73bf43778a4acad5e7b3589f54a5ec3607c4b7b1" }
-
 [profile.release]
 debug = 1
 


### PR DESCRIPTION
### What

Bump the workspace `stellar-strkey` dependency from `=0.0.16` to `=0.0.18` and update `Cargo.lock` (and the fuzz `tests/fuzz/fuzz/Cargo.lock`) accordingly. The transitive `stellar-strkey 0.0.13` brought in via published `stellar-xdr 27.0.0` is unaffected and remains. The lockfile update also pulls in the transitive dependency changes required by 0.0.17+ (`heapless` 0.8.0 to 0.9.3, `crate-git-revision`, and `zeroize`).

### Why

This adopts the latest `stellar-strkey` release, which targets the stellar-strkey release line for protocol 28. `cargo check -p soroban-sdk` compiles cleanly against 0.0.18 with no API changes required.

This supersedes the earlier 0.0.17 bump: 0.0.17 contained a CLI bug (`Decoded<Strkey>` rejected owned JSON keys, breaking `strkey encode`), fixed in 0.0.18 by stellar/rs-stellar-strkey#125.

### Known limitations

N/A

---

## Protocol 28 coordination

⚠️ This change targets versions of software that will ship for **Protocol 28**, and should **not** be merged unless this repository is ready to accept Protocol 28 changes.

This is one of a coordinated set of PRs bumping `stellar-strkey` to **0.0.18** across the Protocol 28 component stack. It is preferred that all Protocol 28 releases of these components depend on the **same** version of `stellar-strkey`:

- stellar/rs-stellar-xdr#547
- stellar/rs-soroban-env#1694
- stellar/rs-soroban-sdk#1913
- stellar/rs-stellar-rpc-client#99
- stellar/stellar-cli#2614

`stellar-strkey` 0.0.18 raises the minimum supported Rust version to 1.87 and updates/adds transitive dependencies (`heapless` 0.9, `zeroize`), so MSRV and supply-chain policy (cargo-deny / cackle) updates may be required in some repositories before CI is green.