### PR TITLE
Fix External CI tests so they run even for major version bumps

### DIFF
--- a/.github/workflows/test-with-openzeppelin-stellar-contracts.yml
+++ b/.github/workflows/test-with-openzeppelin-stellar-contracts.yml
@@ -67,6 +67,36 @@ jobs:
         is_a_contract=$(cargo metadata --no-deps --format-version 1 | jq -r --arg pwd "$(pwd)" '.packages[] | select(.manifest_path == "\($pwd)/Cargo.toml") | (any(.dependencies[]; .name == "soroban-sdk") and any(.targets[]; any(.crate_types[]; . == "cdylib")))')
         echo "is-a-contract=$is_a_contract" | tee -a $GITHUB_OUTPUT
 
+    - name: Align the local soroban-sdk version with the destination
+      working-directory: ${{ github.workspace }}
+      run: |
+        # The destination workspace pins soroban-sdk (and the other published
+        # rs-soroban-sdk crates) to a released version, and pulls crates such as
+        # soroban-poseidon from crates.io that depend on that same major. When the
+        # local checkout has bumped to a newer major (for example a 27.0.0-rc
+        # release), the [patch.crates-io] + `cargo update --precise` step below can't
+        # redirect those transitive soroban-sdk edges, because Cargo only applies a
+        # patch when the local version satisfies the requirement (soroban-poseidon's
+        # ^26). Relabel the local crates with the version the destination already
+        # resolves so the patch satisfies the requirement, collapsing every
+        # soroban-sdk edge onto the local checkout's code regardless of the bump.
+        dest_version=$(
+          cargo metadata --manifest-path stellar-contracts/Cargo.toml --format-version 1 \
+            | jq -r '.packages[] | select(.name == "soroban-sdk") | .version' \
+            | head -n1
+        )
+        local_version=$(
+          cargo metadata --manifest-path rs-soroban-sdk/Cargo.toml --format-version 1 --no-deps \
+            | jq -r '.packages[] | select(.name == "soroban-sdk") | .version'
+        )
+        echo "destination soroban-sdk version: ${dest_version:?could not determine destination soroban-sdk version}"
+        echo "local soroban-sdk version: $local_version"
+        if [ "$dest_version" != "$local_version" ]; then
+          escaped=$(printf '%s' "$local_version" | sed 's/[.]/\\./g')
+          sed -i "s|\"$escaped\"|\"$dest_version\"|g" rs-soroban-sdk/Cargo.toml
+          echo "Relabelled local rs-soroban-sdk crates from $local_version to $dest_version"
+        fi
+
     - name: Collect publishable rs-soroban-sdk crates
       working-directory: stellar-contracts
       run: |
@@ -118,8 +148,10 @@ jobs:
         #      checkout's version with `cargo update --precise`, so the transitive
         #      edges move onto it. Pinning (rather than letting cargo pick the highest
         #      compatible version) stops a newer *published* SDK from being chosen for a
-        #      transitive edge and re-splitting the graph. (Can't rescue an
-        #      incompatible-major transitive dep; that would need the remedy in #1723.)
+        #      transitive edge and re-splitting the graph. (When the local checkout is
+        #      an incompatible major, the "Align the local soroban-sdk version with the
+        #      destination" step above first relabels it to the destination's version,
+        #      so these requirements stay satisfiable; see #1723.)
         if [ -s "$RUNNER_TEMP/sdk-crates.tsv" ]; then
           # Don't emit a second [patch.crates-io] header if one already exists upstream.
           grep -q '^\[patch\.crates-io\]' Cargo.toml || printf '\n[patch.crates-io]\n' >> Cargo.toml

--- a/.github/workflows/test-with-soroban-examples.yml
+++ b/.github/workflows/test-with-soroban-examples.yml
@@ -42,16 +42,6 @@ jobs:
       matrix:
         working-directory: ${{ fromJSON(needs.collect-examples.outputs.dirs) }}
         experimental_spec_shaking_v2: [true, false]
-        # Exclude examples that depend on a crates.io package whose own soroban-sdk
-        # dependency is an incompatible major to the soroban-sdk under test. The
-        # [patch.crates-io] step below redirects transitive soroban-sdk copies to the
-        # local checkout, but Cargo only applies the patch when the local version
-        # satisfies the requirement. privacy-pools pulls soroban-poseidon 25.0.0
-        # (soroban-sdk ^25), which the local soroban-sdk (26.x) does not satisfy, so two
-        # soroban-sdk copies are compiled and linking fails with a duplicate lang item
-        # (panic_impl). https://github.com/stellar/rs-soroban-sdk/issues/1723
-        exclude:
-        - working-directory: privacy-pools
     defaults:
       run:
         working-directory: soroban-examples/${{ matrix.working-directory }}
@@ -81,6 +71,35 @@ jobs:
     - uses: stellar/stellar-cli@v23.1.4
 
     - uses: stellar/actions/rust-cache@main
+
+    - name: Align the local soroban-sdk version with the example
+      working-directory: ${{ github.workspace }}
+      run: |
+        # The example pins soroban-sdk and may pull crates such as soroban-poseidon
+        # from crates.io that depend on a specific soroban-sdk major. When the local
+        # checkout has bumped to a newer major (for example a 27.0.0-rc release), the
+        # [patch.crates-io] + `cargo update --precise` step below can't redirect those
+        # transitive soroban-sdk edges, because Cargo only applies a patch when the
+        # local version satisfies the requirement (for example soroban-poseidon's ^25
+        # in privacy-pools). Relabel the local crates with the version the example
+        # already resolves so the patch satisfies the requirement, collapsing every
+        # soroban-sdk edge onto the local checkout's code regardless of the bump.
+        dest_version=$(
+          cargo metadata --manifest-path "soroban-examples/${{ matrix.working-directory }}/Cargo.toml" --format-version 1 \
+            | jq -r '.packages[] | select(.name == "soroban-sdk") | .version' \
+            | head -n1
+        )
+        local_version=$(
+          cargo metadata --manifest-path rs-soroban-sdk/Cargo.toml --format-version 1 --no-deps \
+            | jq -r '.packages[] | select(.name == "soroban-sdk") | .version'
+        )
+        echo "example soroban-sdk version: ${dest_version:?could not determine the example soroban-sdk version}"
+        echo "local soroban-sdk version: $local_version"
+        if [ "$dest_version" != "$local_version" ]; then
+          escaped=$(printf '%s' "$local_version" | sed 's/[.]/\\./g')
+          sed -i "s|\"$escaped\"|\"$dest_version\"|g" rs-soroban-sdk/Cargo.toml
+          echo "Relabelled local rs-soroban-sdk crates from $local_version to $dest_version"
+        fi
 
     - name: Collect publishable rs-soroban-sdk crates
       run: |
@@ -143,9 +162,10 @@ jobs:
         #      checkout's version with `cargo update --precise`, so the transitive
         #      edges move onto it. Pinning (rather than letting cargo pick the highest
         #      compatible version) stops a newer *published* SDK from being chosen for a
-        #      transitive edge and re-splitting the graph. (Can't rescue an
-        #      incompatible-major transitive dep, so the matrix exclusion is still
-        #      needed.)
+        #      transitive edge and re-splitting the graph. (When the local checkout is
+        #      an incompatible major, the "Align the local soroban-sdk version with the
+        #      example" step above first relabels it to the example's version, so these
+        #      requirements stay satisfiable; see #1723.)
         workspace_root=$(cargo metadata --format-version 1 --no-deps | jq -r '.workspace_root')
         if [ -s "$RUNNER_TEMP/sdk-crates.tsv" ]; then
           # Don't emit a second [patch.crates-io] header if one already exists upstream.


### PR DESCRIPTION
### What

Add a step to both external-contract CI workflows ("Test with OpenZeppelin Contracts" and "Test with soroban-examples") that relabels the locally checked-out rs-soroban-sdk crates to the soroban-sdk version the destination already resolves, running before the existing path-patching so the `[patch.crates-io]` redirect collapses every transitive soroban-sdk edge onto the local checkout even when the local crates have bumped to a newer major. With the relabel in place, also drop the privacy-pools matrix exclusion in the soroban-examples workflow, since that example is now buildable against the local SDK.

### Why

Both workflows build external contracts against the local soroban-sdk by rewriting direct dependency edges to path overrides and adding a `[patch.crates-io]` table, but Cargo only applies a patch when the local version satisfies the requirement. The external repos pull soroban-poseidon from crates.io, which pins soroban-sdk to a specific major (`^26` for OpenZeppelin's stellar-tokens, `^25` for the privacy-pools example), so once the release bumped the local checkout to 27.0.0-rc.1 the `cargo update --precise` step could no longer redirect those transitive soroban-sdk edges and failed to resolve — breaking every OpenZeppelin job (turning the OZ check red on the 27.0.0-rc.1 release PR #1912) and previously forcing privacy-pools to be excluded from the soroban-examples matrix. Reading the destination's resolved soroban-sdk version with `cargo metadata` and relabelling the local crates to it keeps those requirements satisfiable, so the patch resolves and the contracts compile against the local soroban-sdk code regardless of the version bump.

### Known limitations

The relabel only changes the version Cargo resolves against; it does not address a destination whose source is genuinely incompatible with the newer SDK's API, which would still surface as a normal build or test failure. However, we try really hard not to introduce breaking changes into sdk's, even though there are major version bumps, so most of the time this should result in a passing build and if not then we've detected the type of breakage we want to avoid.