### PR TITLE
Add a delegated auth rustdoc example

### DIFF
--- a/soroban-sdk/src/auth.rs
+++ b/soroban-sdk/src/auth.rs
@@ -10,7 +10,7 @@ use crate::{
 /// Custom account contracts that implement `__check_auth` special function
 /// receive a list of `Context` values corresponding to all the calls that
 /// need to be authorized.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 #[cfg_attr(
     feature = "experimental_spec_shaking_v2",
     contracttype(crate_path = "crate")
@@ -32,7 +32,7 @@ pub enum Context {
 ///
 /// This struct corresponds to a `require_auth_for_args` call for an address
 /// from `contract` function with `fn_name` name and `args` arguments.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 #[cfg_attr(
     feature = "experimental_spec_shaking_v2",
     contracttype(crate_path = "crate")
@@ -49,7 +49,7 @@ pub struct ContractContext {
 
 /// Authorization context for `create_contract` host function that creates a
 /// new contract on behalf of authorizer address.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 #[cfg_attr(
     feature = "experimental_spec_shaking_v2",
     contracttype(crate_path = "crate")
@@ -67,7 +67,7 @@ pub struct CreateContractHostFnContext {
 /// new contract on behalf of authorizer address.
 /// This is the same as `CreateContractHostFnContext`, but also has
 /// contract constructor arguments.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 #[cfg_attr(
     feature = "experimental_spec_shaking_v2",
     contracttype(crate_path = "crate")
@@ -84,7 +84,7 @@ pub struct CreateContractWithConstructorHostFnContext {
 
 /// Contract executable used for creating a new contract and used in
 /// `CreateContractHostFnContext`.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 #[cfg_attr(
     feature = "experimental_spec_shaking_v2",
     contracttype(crate_path = "crate")

--- a/soroban-sdk/src/custom_account.rs
+++ b/soroban-sdk/src/custom_account.rs
@@ -82,8 +82,8 @@ impl CustomAccount {
     ///
     /// ### Examples
     ///
-    /// A "modular" custom account that performs no authentication itself, and
-    /// instead delegates it to a set of registered signer addresses. The user
+    /// A module custom account that performs authentication by delegating to
+    /// other accounts instead of doing the authentication itself. The user
     /// chooses which of the registered signers to authenticate with, by
     /// attaching them to the transaction as delegated signers.
     ///
@@ -101,10 +101,10 @@ impl CustomAccount {
     ///     UnknownDelegate = 1,
     /// }
     ///
-    /// // Marks an address as a signer allowed to authenticate for the modular
-    /// // account.
     /// #[contracttype]
     /// enum ModularAccountDataKey {
+    ///     // Marks an address as a signer allowed to authenticate for the
+    ///     // modular account.
     ///     Signer(Address),
     /// }
     ///
@@ -140,9 +140,7 @@ impl CustomAccount {
     ///         // account's authorization.
     ///         let delegates = env.custom_account().get_delegated_signers();
     ///
-    ///         // The host does not validate the delegates, so the account must
-    ///         // check that each one is actually a registered signer before
-    ///         // trusting it.
+    ///         // Check if the delegates are accepted by the modular account.
     ///         for delegate in delegates.iter() {
     ///             if !env
     ///                 .storage()
@@ -151,26 +149,24 @@ impl CustomAccount {
     ///             {
     ///                 return Err(Error::UnknownDelegate);
     ///             }
-    ///             // Forward the current authorization to the delegate. Its own
-    ///             // authentication is checked as if it had required auth
-    ///             // directly, but without needing a separate auth entry.
+    ///             // Forward the current authorization to the delegate.
     ///             env.custom_account().delegate_auth(&delegate);
     ///         }
     ///         Ok(())
     ///     }
     /// }
     ///
-    /// // Records the contexts the delegate approved so the test can verify the
-    /// // delegation reached it.
     /// #[contracttype]
     /// enum DelegateAccountDataKey {
+    ///     // Records the contexts the delegate approved so the test can verify
+    ///     // the delegation reached it.
     ///     ApprovedContexts,
     /// }
     ///
-    /// // A delegate account. Stands in for any address (a Stellar account or
-    /// // another contract) that knows how to authenticate itself. Here it
-    /// // records the context it approved so the test can verify the delegation
-    /// // reached it.
+    /// // A simple account that the ModularAccount can delegate to for auth.
+    /// //
+    /// // It will always authorise an auth request, and store a copy of the auth
+    /// // context for later comparing in tests.
     /// #[contract]
     /// pub struct DelegateAccount;
     ///

--- a/soroban-sdk/src/custom_account.rs
+++ b/soroban-sdk/src/custom_account.rs
@@ -5,7 +5,7 @@
 //!
 //! ### Examples
 //!
-//! A module custom account that performs authentication by delegating to
+//! A modular custom account that performs authentication by delegating to
 //! other accounts instead of doing the authentication itself. The user
 //! chooses which of the registered signers to authenticate with, by
 //! attaching them to the transaction as delegated signers.
@@ -72,7 +72,9 @@
 //!             {
 //!                 return Err(Error::UnknownDelegate);
 //!             }
-//!             // Forward the current authorization to the delegate.
+//!         }
+//!         // Forward the current authorization to each delegate.
+//!         for delegate in delegates.iter() {
 //!             env.custom_account().delegate_auth(&delegate);
 //!         }
 //!         Ok(())
@@ -88,7 +90,7 @@
 //!
 //! // A simple account that the ModularAccount can delegate to for auth.
 //! //
-//! // It will always authorise an auth request, and store a copy of the auth
+//! // It will always authorize an auth request, and store a copy of the auth
 //! // context for later comparing in tests.
 //! #[contract]
 //! pub struct DelegateAccount;

--- a/soroban-sdk/src/custom_account.rs
+++ b/soroban-sdk/src/custom_account.rs
@@ -101,6 +101,13 @@ impl CustomAccount {
     ///     UnknownDelegate = 1,
     /// }
     ///
+    /// // Marks an address as a signer allowed to authenticate for the modular
+    /// // account.
+    /// #[contracttype]
+    /// enum ModularAccountDataKey {
+    ///     Signer(Address),
+    /// }
+    ///
     /// #[contract]
     /// pub struct ModularAccount;
     ///
@@ -108,14 +115,10 @@ impl CustomAccount {
     /// impl ModularAccount {
     ///     // Registers the addresses allowed to authenticate for this account.
     ///     pub fn __constructor(env: Env, signers: Vec<Address>) {
-    ///         // Marks an address as a signer allowed to authenticate for this
-    ///         // account.
-    ///         #[contracttype]
-    ///         enum DataKey {
-    ///             Signer(Address),
-    ///         }
     ///         for signer in signers.iter() {
-    ///             env.storage().instance().set(&DataKey::Signer(signer), &());
+    ///             env.storage()
+    ///                 .instance()
+    ///                 .set(&ModularAccountDataKey::Signer(signer), &());
     ///         }
     ///     }
     /// }
@@ -133,10 +136,6 @@ impl CustomAccount {
     ///         _signatures: (),
     ///         _auth_contexts: Vec<Context>,
     ///     ) -> Result<(), Error> {
-    ///         #[contracttype]
-    ///         enum DataKey {
-    ///             Signer(Address),
-    ///         }
     ///         // The signers the user attached to the auth entry for this
     ///         // account's authorization.
     ///         let delegates = env.custom_account().get_delegated_signers();
@@ -145,7 +144,11 @@ impl CustomAccount {
     ///         // check that each one is actually a registered signer before
     ///         // trusting it.
     ///         for delegate in delegates.iter() {
-    ///             if !env.storage().instance().has(&DataKey::Signer(delegate.clone())) {
+    ///             if !env
+    ///                 .storage()
+    ///                 .instance()
+    ///                 .has(&ModularAccountDataKey::Signer(delegate.clone()))
+    ///             {
     ///                 return Err(Error::UnknownDelegate);
     ///             }
     ///             // Forward the current authorization to the delegate. Its own
@@ -155,6 +158,13 @@ impl CustomAccount {
     ///         }
     ///         Ok(())
     ///     }
+    /// }
+    ///
+    /// // Records the contexts the delegate approved so the test can verify the
+    /// // delegation reached it.
+    /// #[contracttype]
+    /// enum DelegateAccountDataKey {
+    ///     ApprovedContexts,
     /// }
     ///
     /// // A delegate account. Stands in for any address (a Stellar account or
@@ -174,13 +184,9 @@ impl CustomAccount {
     ///         _signatures: (),
     ///         auth_contexts: Vec<Context>,
     ///     ) -> Result<(), Error> {
-    ///         #[contracttype]
-    ///         enum DataKey {
-    ///             ApprovedContexts,
-    ///         }
     ///         env.storage()
     ///             .instance()
-    ///             .set(&DataKey::ApprovedContexts, &auth_contexts);
+    ///             .set(&DelegateAccountDataKey::ApprovedContexts, &auth_contexts);
     ///         // Returning `Ok(())` approves the delegated authentication;
     ///         // returning an error would reject it.
     ///         Ok(())
@@ -281,12 +287,11 @@ impl CustomAccount {
     ///
     ///     // The delegation actually reached `delegate`, which approved the
     ///     // same invocation that was authorized above.
-    ///     #[contracttype]
-    ///     enum DataKey {
-    ///         ApprovedContexts,
-    ///     }
     ///     let approved: Vec<Context> = env.as_contract(&delegate, || {
-    ///         env.storage().instance().get(&DataKey::ApprovedContexts).unwrap()
+    ///         env.storage()
+    ///             .instance()
+    ///             .get(&DelegateAccountDataKey::ApprovedContexts)
+    ///             .unwrap()
     ///     });
     ///     assert_eq!(
     ///         approved,

--- a/soroban-sdk/src/custom_account.rs
+++ b/soroban-sdk/src/custom_account.rs
@@ -278,18 +278,16 @@ impl CustomAccount {
     ///     let approved: Vec<Context> = env.as_contract(&delegate, || {
     ///         env.storage().instance().get(&DataKey::ApprovedContexts).unwrap()
     ///     });
-    ///     // `Context` does not implement `Debug`, so compare with `assert!`
-    ///     // rather than `assert_eq!`.
-    ///     assert!(
-    ///         approved
-    ///             == vec![
-    ///                 &env,
-    ///                 Context::Contract(ContractContext {
-    ///                     contract: protected.clone(),
-    ///                     fn_name: Symbol::new(&env, "protected"),
-    ///                     args: (account.clone(),).into_val(&env),
-    ///                 }),
-    ///             ]
+    ///     assert_eq!(
+    ///         approved,
+    ///         vec![
+    ///             &env,
+    ///             Context::Contract(ContractContext {
+    ///                 contract: protected.clone(),
+    ///                 fn_name: Symbol::new(&env, "protected"),
+    ///                 args: (account.clone(),).into_val(&env),
+    ///             }),
+    ///         ],
     ///     );
     /// }
     /// # #[cfg(not(feature = "testutils"))]

--- a/soroban-sdk/src/custom_account.rs
+++ b/soroban-sdk/src/custom_account.rs
@@ -90,8 +90,8 @@ impl CustomAccount {
     /// ```
     /// use soroban_sdk::{
     ///     auth::{Context, CustomAccountInterface},
-    ///     contract, contracterror, contractimpl, contracttype,
-    ///     crypto::Hash, vec, Address, Env, Vec,
+    ///     contract, contracterror, contractimpl,
+    ///     crypto::Hash, symbol_short, vec, Address, Env, Vec,
     /// };
     ///
     /// #[contracterror]
@@ -101,23 +101,16 @@ impl CustomAccount {
     ///     UnknownDelegate = 1,
     /// }
     ///
-    /// #[contracttype]
-    /// pub enum DataKey {
-    ///     // Marks an address as a signer allowed to authenticate for this
-    ///     // account.
-    ///     Signer(Address),
-    ///     ApprovedContexts,
-    /// }
-    ///
     /// #[contract]
     /// pub struct ModularAccount;
     ///
     /// #[contractimpl]
     /// impl ModularAccount {
-    ///     // Registers the addresses allowed to authenticate for this account.
+    ///     // Registers the addresses allowed to authenticate for this account by
+    ///     // storing each one as a key in the account's instance storage.
     ///     pub fn __constructor(env: Env, signers: Vec<Address>) {
     ///         for signer in signers.iter() {
-    ///             env.storage().instance().set(&DataKey::Signer(signer), &());
+    ///             env.storage().instance().set(&signer, &());
     ///         }
     ///     }
     /// }
@@ -143,7 +136,7 @@ impl CustomAccount {
     ///         // check that each one is actually a registered signer before
     ///         // trusting it.
     ///         for delegate in delegates.iter() {
-    ///             if !env.storage().instance().has(&DataKey::Signer(delegate.clone())) {
+    ///             if !env.storage().instance().has(&delegate) {
     ///                 return Err(Error::UnknownDelegate);
     ///             }
     ///             // Forward the current authorization to the delegate. Its own
@@ -174,7 +167,7 @@ impl CustomAccount {
     ///     ) -> Result<(), Error> {
     ///         env.storage()
     ///             .instance()
-    ///             .set(&DataKey::ApprovedContexts, &auth_contexts);
+    ///             .set(&symbol_short!("approved"), &auth_contexts);
     ///         // Returning `Ok(())` approves the delegated authentication;
     ///         // returning an error would reject it.
     ///         Ok(())
@@ -276,7 +269,7 @@ impl CustomAccount {
     ///     // The delegation actually reached `delegate`, which approved the
     ///     // same invocation that was authorized above.
     ///     let approved: Vec<Context> = env.as_contract(&delegate, || {
-    ///         env.storage().instance().get(&DataKey::ApprovedContexts).unwrap()
+    ///         env.storage().instance().get(&symbol_short!("approved")).unwrap()
     ///     });
     ///     assert_eq!(
     ///         approved,

--- a/soroban-sdk/src/custom_account.rs
+++ b/soroban-sdk/src/custom_account.rs
@@ -183,7 +183,7 @@ impl CustomAccount {
     ///         env.storage()
     ///             .instance()
     ///             .set(&DelegateAccountDataKey::ApprovedContexts, &auth_contexts);
-    ///         // Returning `Ok(())` approves the delegated authentication;
+    ///         // Returning `Ok(())` approves the auth;
     ///         // returning an error would reject it.
     ///         Ok(())
     ///     }

--- a/soroban-sdk/src/custom_account.rs
+++ b/soroban-sdk/src/custom_account.rs
@@ -278,15 +278,19 @@ impl CustomAccount {
     ///     let approved: Vec<Context> = env.as_contract(&delegate, || {
     ///         env.storage().instance().get(&DataKey::ApprovedContexts).unwrap()
     ///     });
-    ///     assert_eq!(approved.len(), 1);
-    ///     match approved.get(0).unwrap() {
-    ///         Context::Contract(ContractContext { contract, fn_name, args }) => {
-    ///             assert_eq!(contract, protected);
-    ///             assert_eq!(fn_name, Symbol::new(&env, "protected"));
-    ///             assert_eq!(args, (account.clone(),).into_val(&env));
-    ///         }
-    ///         _ => panic!("expected a contract invocation context"),
-    ///     }
+    ///     // `Context` does not implement `Debug`, so compare with `assert!`
+    ///     // rather than `assert_eq!`.
+    ///     assert!(
+    ///         approved
+    ///             == vec![
+    ///                 &env,
+    ///                 Context::Contract(ContractContext {
+    ///                     contract: protected.clone(),
+    ///                     fn_name: Symbol::new(&env, "protected"),
+    ///                     args: (account.clone(),).into_val(&env),
+    ///                 }),
+    ///             ]
+    ///     );
     /// }
     /// # #[cfg(not(feature = "testutils"))]
     /// # fn main() { }

--- a/soroban-sdk/src/custom_account.rs
+++ b/soroban-sdk/src/custom_account.rs
@@ -90,8 +90,8 @@ impl CustomAccount {
     /// ```
     /// use soroban_sdk::{
     ///     auth::{Context, CustomAccountInterface},
-    ///     contract, contracterror, contractimpl,
-    ///     crypto::Hash, symbol_short, vec, Address, Env, Vec,
+    ///     contract, contracterror, contractimpl, contracttype,
+    ///     crypto::Hash, vec, Address, Env, Vec,
     /// };
     ///
     /// #[contracterror]
@@ -106,11 +106,16 @@ impl CustomAccount {
     ///
     /// #[contractimpl]
     /// impl ModularAccount {
-    ///     // Registers the addresses allowed to authenticate for this account by
-    ///     // storing each one as a key in the account's instance storage.
+    ///     // Registers the addresses allowed to authenticate for this account.
     ///     pub fn __constructor(env: Env, signers: Vec<Address>) {
+    ///         // Marks an address as a signer allowed to authenticate for this
+    ///         // account.
+    ///         #[contracttype]
+    ///         enum DataKey {
+    ///             Signer(Address),
+    ///         }
     ///         for signer in signers.iter() {
-    ///             env.storage().instance().set(&signer, &());
+    ///             env.storage().instance().set(&DataKey::Signer(signer), &());
     ///         }
     ///     }
     /// }
@@ -128,6 +133,10 @@ impl CustomAccount {
     ///         _signatures: (),
     ///         _auth_contexts: Vec<Context>,
     ///     ) -> Result<(), Error> {
+    ///         #[contracttype]
+    ///         enum DataKey {
+    ///             Signer(Address),
+    ///         }
     ///         // The signers the user attached to the auth entry for this
     ///         // account's authorization.
     ///         let delegates = env.custom_account().get_delegated_signers();
@@ -136,7 +145,7 @@ impl CustomAccount {
     ///         // check that each one is actually a registered signer before
     ///         // trusting it.
     ///         for delegate in delegates.iter() {
-    ///             if !env.storage().instance().has(&delegate) {
+    ///             if !env.storage().instance().has(&DataKey::Signer(delegate.clone())) {
     ///                 return Err(Error::UnknownDelegate);
     ///             }
     ///             // Forward the current authorization to the delegate. Its own
@@ -165,9 +174,13 @@ impl CustomAccount {
     ///         _signatures: (),
     ///         auth_contexts: Vec<Context>,
     ///     ) -> Result<(), Error> {
+    ///         #[contracttype]
+    ///         enum DataKey {
+    ///             ApprovedContexts,
+    ///         }
     ///         env.storage()
     ///             .instance()
-    ///             .set(&symbol_short!("approved"), &auth_contexts);
+    ///             .set(&DataKey::ApprovedContexts, &auth_contexts);
     ///         // Returning `Ok(())` approves the delegated authentication;
     ///         // returning an error would reject it.
     ///         Ok(())
@@ -268,8 +281,12 @@ impl CustomAccount {
     ///
     ///     // The delegation actually reached `delegate`, which approved the
     ///     // same invocation that was authorized above.
+    ///     #[contracttype]
+    ///     enum DataKey {
+    ///         ApprovedContexts,
+    ///     }
     ///     let approved: Vec<Context> = env.as_contract(&delegate, || {
-    ///         env.storage().instance().get(&symbol_short!("approved")).unwrap()
+    ///         env.storage().instance().get(&DataKey::ApprovedContexts).unwrap()
     ///     });
     ///     assert_eq!(
     ///         approved,

--- a/soroban-sdk/src/custom_account.rs
+++ b/soroban-sdk/src/custom_account.rs
@@ -103,7 +103,9 @@ impl CustomAccount {
     ///
     /// #[contracttype]
     /// pub enum DataKey {
-    ///     Signers,
+    ///     // Marks an address as a signer allowed to authenticate for this
+    ///     // account.
+    ///     Signer(Address),
     ///     ApprovedContexts,
     /// }
     ///
@@ -114,7 +116,9 @@ impl CustomAccount {
     /// impl ModularAccount {
     ///     // Registers the addresses allowed to authenticate for this account.
     ///     pub fn __constructor(env: Env, signers: Vec<Address>) {
-    ///         env.storage().instance().set(&DataKey::Signers, &signers);
+    ///         for signer in signers.iter() {
+    ///             env.storage().instance().set(&DataKey::Signer(signer), &());
+    ///         }
     ///     }
     /// }
     ///
@@ -138,10 +142,8 @@ impl CustomAccount {
     ///         // The host does not validate the delegates, so the account must
     ///         // check that each one is actually a registered signer before
     ///         // trusting it.
-    ///         let signers: Vec<Address> =
-    ///             env.storage().instance().get(&DataKey::Signers).unwrap();
     ///         for delegate in delegates.iter() {
-    ///             if !signers.contains(&delegate) {
+    ///             if !env.storage().instance().has(&DataKey::Signer(delegate.clone())) {
     ///                 return Err(Error::UnknownDelegate);
     ///             }
     ///             // Forward the current authorization to the delegate. Its own
@@ -173,6 +175,8 @@ impl CustomAccount {
     ///         env.storage()
     ///             .instance()
     ///             .set(&DataKey::ApprovedContexts, &auth_contexts);
+    ///         // Returning `Ok(())` approves the delegated authentication;
+    ///         // returning an error would reject it.
     ///         Ok(())
     ///     }
     /// }

--- a/soroban-sdk/src/custom_account.rs
+++ b/soroban-sdk/src/custom_account.rs
@@ -37,6 +37,12 @@ impl CustomAccount {
     /// ### Panics
     ///
     /// If called outside of `__check_auth`.
+    ///
+    /// ### Examples
+    ///
+    /// See [`CustomAccount::delegate_auth`] for a complete, runnable example of
+    /// a modular custom account that retrieves its delegated signers with this
+    /// function, validates them, and delegates authentication to them.
     pub fn get_delegated_signers(&self) -> Vec<Address> {
         let addresses =
             Env::get_delegated_signers_for_current_auth_check(&self.env).unwrap_infallible();
@@ -73,6 +79,214 @@ impl CustomAccount {
     ///
     /// If called outside of `__check_auth`, or if this address has not
     /// authorized the invocation.
+    ///
+    /// ### Examples
+    ///
+    /// A "modular" custom account that performs no authentication itself, and
+    /// instead delegates it to a set of registered signer addresses. The user
+    /// chooses which of the registered signers to authenticate with, by
+    /// attaching them to the transaction as delegated signers.
+    ///
+    /// ```
+    /// use soroban_sdk::{
+    ///     auth::{Context, CustomAccountInterface},
+    ///     contract, contracterror, contractimpl, contracttype,
+    ///     crypto::Hash, vec, Address, Env, Vec,
+    /// };
+    ///
+    /// #[contracterror]
+    /// #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+    /// #[repr(u32)]
+    /// pub enum Error {
+    ///     UnknownDelegate = 1,
+    /// }
+    ///
+    /// #[contracttype]
+    /// pub enum DataKey {
+    ///     Signers,
+    ///     ApprovedContexts,
+    /// }
+    ///
+    /// #[contract]
+    /// pub struct ModularAccount;
+    ///
+    /// #[contractimpl]
+    /// impl ModularAccount {
+    ///     // Registers the addresses allowed to authenticate for this account.
+    ///     pub fn __constructor(env: Env, signers: Vec<Address>) {
+    ///         env.storage().instance().set(&DataKey::Signers, &signers);
+    ///     }
+    /// }
+    ///
+    /// #[contractimpl]
+    /// impl CustomAccountInterface for ModularAccount {
+    ///     // The account verifies no signature of its own, so it carries no
+    ///     // signature to check.
+    ///     type Signature = ();
+    ///     type Error = Error;
+    ///
+    ///     fn __check_auth(
+    ///         env: Env,
+    ///         _signature_payload: Hash<32>,
+    ///         _signatures: (),
+    ///         _auth_contexts: Vec<Context>,
+    ///     ) -> Result<(), Error> {
+    ///         // The signers the user attached to the auth entry for this
+    ///         // account's authorization.
+    ///         let delegates = env.custom_account().get_delegated_signers();
+    ///
+    ///         // The host does not validate the delegates, so the account must
+    ///         // check that each one is actually a registered signer before
+    ///         // trusting it.
+    ///         let signers: Vec<Address> =
+    ///             env.storage().instance().get(&DataKey::Signers).unwrap();
+    ///         for delegate in delegates.iter() {
+    ///             if !signers.contains(&delegate) {
+    ///                 return Err(Error::UnknownDelegate);
+    ///             }
+    ///             // Forward the current authorization to the delegate. Its own
+    ///             // authentication is checked as if it had required auth
+    ///             // directly, but without needing a separate auth entry.
+    ///             env.custom_account().delegate_auth(&delegate);
+    ///         }
+    ///         Ok(())
+    ///     }
+    /// }
+    ///
+    /// // A delegate account. Stands in for any address (a Stellar account or
+    /// // another contract) that knows how to authenticate itself. Here it
+    /// // records the context it approved so the test can verify the delegation
+    /// // reached it.
+    /// #[contract]
+    /// pub struct DelegateAccount;
+    ///
+    /// #[contractimpl]
+    /// impl CustomAccountInterface for DelegateAccount {
+    ///     type Signature = ();
+    ///     type Error = Error;
+    ///     fn __check_auth(
+    ///         env: Env,
+    ///         _signature_payload: Hash<32>,
+    ///         _signatures: (),
+    ///         auth_contexts: Vec<Context>,
+    ///     ) -> Result<(), Error> {
+    ///         env.storage()
+    ///             .instance()
+    ///             .set(&DataKey::ApprovedContexts, &auth_contexts);
+    ///         Ok(())
+    ///     }
+    /// }
+    ///
+    /// // A contract with an operation that requires the account's authorization.
+    /// #[contract]
+    /// pub struct Protected;
+    ///
+    /// #[contractimpl]
+    /// impl Protected {
+    ///     pub fn protected(account: Address) {
+    ///         account.require_auth();
+    ///     }
+    /// }
+    ///
+    /// #[test]
+    /// fn test() {
+    /// # }
+    /// # #[cfg(feature = "testutils")]
+    /// # fn main() {
+    ///     use soroban_sdk::xdr::{
+    ///         InvokeContractArgs, ScAddress, ScVal, SorobanAddressCredentials,
+    ///         SorobanAddressCredentialsWithDelegates, SorobanAuthorizationEntry,
+    ///         SorobanAuthorizedFunction, SorobanAuthorizedInvocation,
+    ///         SorobanCredentials, SorobanDelegateSignature, StringM, VecM,
+    ///     };
+    ///
+    ///     let env = Env::default();
+    ///     let delegate = env.register(DelegateAccount, ());
+    ///     // Register the modular account with `delegate` as an allowed signer.
+    ///     let account = env.register(ModularAccount, (vec![&env, delegate.clone()],));
+    ///     let protected = env.register(Protected, ());
+    ///
+    ///     let account_addr: ScAddress = account.clone().try_into().unwrap();
+    ///     let delegate_addr: ScAddress = delegate.clone().try_into().unwrap();
+    ///
+    ///     // This authorization entry is normally built by the user's
+    ///     // wallet/tooling and attached to the transaction. It authorizes
+    ///     // `protected` on behalf of the account, and attaches `delegate` as a
+    ///     // delegated signer. Delegates must be sorted by address with no
+    ///     // duplicates.
+    ///     env.set_auths(&[SorobanAuthorizationEntry {
+    ///         credentials: SorobanCredentials::AddressWithDelegates(
+    ///             SorobanAddressCredentialsWithDelegates {
+    ///                 address_credentials: SorobanAddressCredentials {
+    ///                     address: account_addr.clone(),
+    ///                     nonce: 1,
+    ///                     signature_expiration_ledger: 100,
+    ///                     // The account verifies no signature of its own.
+    ///                     signature: ScVal::Void,
+    ///                 },
+    ///                 delegates: std::vec![SorobanDelegateSignature {
+    ///                     address: delegate_addr,
+    ///                     signature: ScVal::Void,
+    ///                     nested_delegates: VecM::default(),
+    ///                 }]
+    ///                 .try_into()
+    ///                 .unwrap(),
+    ///             },
+    ///         ),
+    ///         root_invocation: SorobanAuthorizedInvocation {
+    ///             function: SorobanAuthorizedFunction::ContractFn(InvokeContractArgs {
+    ///                 contract_address: protected.clone().try_into().unwrap(),
+    ///                 function_name: StringM::try_from("protected").unwrap().into(),
+    ///                 args: std::vec![ScVal::Address(account_addr)].try_into().unwrap(),
+    ///             }),
+    ///             sub_invocations: VecM::default(),
+    ///         },
+    ///     }]);
+    ///
+    ///     // The call succeeds: the account delegates its authentication to
+    ///     // `delegate`, which approves it.
+    ///     ProtectedClient::new(&env, &protected).protected(&account);
+    ///
+    ///     // The account authorized the `protected` call. Delegating to
+    ///     // `delegate` is not recorded as a separate authorization.
+    ///     use soroban_sdk::{
+    ///         auth::ContractContext,
+    ///         testutils::{AuthorizedFunction, AuthorizedInvocation},
+    ///         IntoVal, Symbol,
+    ///     };
+    ///     assert_eq!(
+    ///         env.auths(),
+    ///         std::vec![(
+    ///             account.clone(),
+    ///             AuthorizedInvocation {
+    ///                 function: AuthorizedFunction::Contract((
+    ///                     protected.clone(),
+    ///                     Symbol::new(&env, "protected"),
+    ///                     (account.clone(),).into_val(&env),
+    ///                 )),
+    ///                 sub_invocations: std::vec![],
+    ///             }
+    ///         )]
+    ///     );
+    ///
+    ///     // The delegation actually reached `delegate`, which approved the
+    ///     // same invocation that was authorized above.
+    ///     let approved: Vec<Context> = env.as_contract(&delegate, || {
+    ///         env.storage().instance().get(&DataKey::ApprovedContexts).unwrap()
+    ///     });
+    ///     assert_eq!(approved.len(), 1);
+    ///     match approved.get(0).unwrap() {
+    ///         Context::Contract(ContractContext { contract, fn_name, args }) => {
+    ///             assert_eq!(contract, protected);
+    ///             assert_eq!(fn_name, Symbol::new(&env, "protected"));
+    ///             assert_eq!(args, (account.clone(),).into_val(&env));
+    ///         }
+    ///         _ => panic!("expected a contract invocation context"),
+    ///     }
+    /// }
+    /// # #[cfg(not(feature = "testutils"))]
+    /// # fn main() { }
+    /// ```
     pub fn delegate_auth(&self, address: &Address) {
         Env::delegate_account_auth(&self.env, address.to_object()).unwrap_infallible();
     }

--- a/soroban-sdk/src/custom_account.rs
+++ b/soroban-sdk/src/custom_account.rs
@@ -130,11 +130,16 @@
 //! # }
 //! # #[cfg(feature = "testutils")]
 //! # fn main() {
-//!     use soroban_sdk::xdr::{
-//!         InvokeContractArgs, ScAddress, ScVal, SorobanAddressCredentials,
-//!         SorobanAddressCredentialsWithDelegates, SorobanAuthorizationEntry,
-//!         SorobanAuthorizedFunction, SorobanAuthorizedInvocation,
-//!         SorobanCredentials, SorobanDelegateSignature, StringM, VecM,
+//!     use soroban_sdk::{
+//!         auth::ContractContext,
+//!         testutils::{AuthorizedFunction, AuthorizedInvocation},
+//!         xdr::{
+//!             InvokeContractArgs, ScAddress, ScVal, SorobanAddressCredentials,
+//!             SorobanAddressCredentialsWithDelegates, SorobanAuthorizationEntry,
+//!             SorobanAuthorizedFunction, SorobanAuthorizedInvocation,
+//!             SorobanCredentials, SorobanDelegateSignature, StringM, VecM,
+//!         },
+//!         IntoVal, Symbol,
 //!     };
 //!
 //!     let env = Env::default();
@@ -186,11 +191,6 @@
 //!
 //!     // The account authorized the `protected` call. Delegating to
 //!     // `delegate` is not recorded as a separate authorization.
-//!     use soroban_sdk::{
-//!         auth::ContractContext,
-//!         testutils::{AuthorizedFunction, AuthorizedInvocation},
-//!         IntoVal, Symbol,
-//!     };
 //!     assert_eq!(
 //!         env.auths(),
 //!         std::vec![(

--- a/soroban-sdk/src/custom_account.rs
+++ b/soroban-sdk/src/custom_account.rs
@@ -117,7 +117,7 @@ impl CustomAccount {
     ///     pub fn __constructor(env: Env, signers: Vec<Address>) {
     ///         for signer in signers.iter() {
     ///             env.storage()
-    ///                 .instance()
+    ///                 .persistent()
     ///                 .set(&ModularAccountDataKey::Signer(signer), &());
     ///         }
     ///     }
@@ -146,7 +146,7 @@ impl CustomAccount {
     ///         for delegate in delegates.iter() {
     ///             if !env
     ///                 .storage()
-    ///                 .instance()
+    ///                 .persistent()
     ///                 .has(&ModularAccountDataKey::Signer(delegate.clone()))
     ///             {
     ///                 return Err(Error::UnknownDelegate);

--- a/soroban-sdk/src/custom_account.rs
+++ b/soroban-sdk/src/custom_account.rs
@@ -2,6 +2,231 @@
 //! contracts.
 //!
 //! The accessor can be created using [Env::custom_account].
+//!
+//! ### Examples
+//!
+//! A module custom account that performs authentication by delegating to
+//! other accounts instead of doing the authentication itself. The user
+//! chooses which of the registered signers to authenticate with, by
+//! attaching them to the transaction as delegated signers.
+//!
+//! ```
+//! use soroban_sdk::{
+//!     auth::{Context, CustomAccountInterface},
+//!     contract, contracterror, contractimpl, contracttype,
+//!     crypto::Hash, vec, Address, Env, Vec,
+//! };
+//!
+//! #[contracterror]
+//! #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+//! #[repr(u32)]
+//! pub enum Error {
+//!     UnknownDelegate = 1,
+//! }
+//!
+//! #[contracttype]
+//! enum ModularAccountDataKey {
+//!     // Marks an address as a signer allowed to authenticate for the
+//!     // modular account.
+//!     Signer(Address),
+//! }
+//!
+//! #[contract]
+//! pub struct ModularAccount;
+//!
+//! #[contractimpl]
+//! impl ModularAccount {
+//!     // Registers the addresses allowed to authenticate for this account.
+//!     pub fn __constructor(env: Env, signers: Vec<Address>) {
+//!         for signer in signers.iter() {
+//!             env.storage()
+//!                 .persistent()
+//!                 .set(&ModularAccountDataKey::Signer(signer), &());
+//!         }
+//!     }
+//! }
+//!
+//! #[contractimpl]
+//! impl CustomAccountInterface for ModularAccount {
+//!     // The account verifies no signature of its own, so it carries no
+//!     // signature to check.
+//!     type Signature = ();
+//!     type Error = Error;
+//!
+//!     fn __check_auth(
+//!         env: Env,
+//!         _signature_payload: Hash<32>,
+//!         _signatures: (),
+//!         _auth_contexts: Vec<Context>,
+//!     ) -> Result<(), Error> {
+//!         // The signers the user attached to the auth entry for this
+//!         // account's authorization.
+//!         let delegates = env.custom_account().get_delegated_signers();
+//!
+//!         // Check if the delegates are accepted by the modular account.
+//!         for delegate in delegates.iter() {
+//!             if !env
+//!                 .storage()
+//!                 .persistent()
+//!                 .has(&ModularAccountDataKey::Signer(delegate.clone()))
+//!             {
+//!                 return Err(Error::UnknownDelegate);
+//!             }
+//!             // Forward the current authorization to the delegate.
+//!             env.custom_account().delegate_auth(&delegate);
+//!         }
+//!         Ok(())
+//!     }
+//! }
+//!
+//! #[contracttype]
+//! enum DelegateAccountDataKey {
+//!     // Records the contexts the delegate approved so the test can verify
+//!     // the delegation reached it.
+//!     ApprovedContexts,
+//! }
+//!
+//! // A simple account that the ModularAccount can delegate to for auth.
+//! //
+//! // It will always authorise an auth request, and store a copy of the auth
+//! // context for later comparing in tests.
+//! #[contract]
+//! pub struct DelegateAccount;
+//!
+//! #[contractimpl]
+//! impl CustomAccountInterface for DelegateAccount {
+//!     type Signature = ();
+//!     type Error = Error;
+//!     fn __check_auth(
+//!         env: Env,
+//!         _signature_payload: Hash<32>,
+//!         _signatures: (),
+//!         auth_contexts: Vec<Context>,
+//!     ) -> Result<(), Error> {
+//!         env.storage()
+//!             .instance()
+//!             .set(&DelegateAccountDataKey::ApprovedContexts, &auth_contexts);
+//!         // Returning `Ok(())` approves the auth;
+//!         // returning an error would reject it.
+//!         Ok(())
+//!     }
+//! }
+//!
+//! // A contract with an operation that requires the account's authorization.
+//! #[contract]
+//! pub struct Protected;
+//!
+//! #[contractimpl]
+//! impl Protected {
+//!     pub fn protected(account: Address) {
+//!         account.require_auth();
+//!     }
+//! }
+//!
+//! #[test]
+//! fn test() {
+//! # }
+//! # #[cfg(feature = "testutils")]
+//! # fn main() {
+//!     use soroban_sdk::xdr::{
+//!         InvokeContractArgs, ScAddress, ScVal, SorobanAddressCredentials,
+//!         SorobanAddressCredentialsWithDelegates, SorobanAuthorizationEntry,
+//!         SorobanAuthorizedFunction, SorobanAuthorizedInvocation,
+//!         SorobanCredentials, SorobanDelegateSignature, StringM, VecM,
+//!     };
+//!
+//!     let env = Env::default();
+//!     let delegate = env.register(DelegateAccount, ());
+//!     // Register the modular account with `delegate` as an allowed signer.
+//!     let account = env.register(ModularAccount, (vec![&env, delegate.clone()],));
+//!     let protected = env.register(Protected, ());
+//!
+//!     let account_addr: ScAddress = account.clone().try_into().unwrap();
+//!     let delegate_addr: ScAddress = delegate.clone().try_into().unwrap();
+//!
+//!     // This authorization entry is normally built by the user's
+//!     // wallet/tooling and attached to the transaction. It authorizes
+//!     // `protected` on behalf of the account, and attaches `delegate` as a
+//!     // delegated signer. Delegates must be sorted by address with no
+//!     // duplicates.
+//!     env.set_auths(&[SorobanAuthorizationEntry {
+//!         credentials: SorobanCredentials::AddressWithDelegates(
+//!             SorobanAddressCredentialsWithDelegates {
+//!                 address_credentials: SorobanAddressCredentials {
+//!                     address: account_addr.clone(),
+//!                     nonce: 1,
+//!                     signature_expiration_ledger: 100,
+//!                     // The account verifies no signature of its own.
+//!                     signature: ScVal::Void,
+//!                 },
+//!                 delegates: std::vec![SorobanDelegateSignature {
+//!                     address: delegate_addr,
+//!                     signature: ScVal::Void,
+//!                     nested_delegates: VecM::default(),
+//!                 }]
+//!                 .try_into()
+//!                 .unwrap(),
+//!             },
+//!         ),
+//!         root_invocation: SorobanAuthorizedInvocation {
+//!             function: SorobanAuthorizedFunction::ContractFn(InvokeContractArgs {
+//!                 contract_address: protected.clone().try_into().unwrap(),
+//!                 function_name: StringM::try_from("protected").unwrap().into(),
+//!                 args: std::vec![ScVal::Address(account_addr)].try_into().unwrap(),
+//!             }),
+//!             sub_invocations: VecM::default(),
+//!         },
+//!     }]);
+//!
+//!     // The call succeeds: the account delegates its authentication to
+//!     // `delegate`, which approves it.
+//!     ProtectedClient::new(&env, &protected).protected(&account);
+//!
+//!     // The account authorized the `protected` call. Delegating to
+//!     // `delegate` is not recorded as a separate authorization.
+//!     use soroban_sdk::{
+//!         auth::ContractContext,
+//!         testutils::{AuthorizedFunction, AuthorizedInvocation},
+//!         IntoVal, Symbol,
+//!     };
+//!     assert_eq!(
+//!         env.auths(),
+//!         std::vec![(
+//!             account.clone(),
+//!             AuthorizedInvocation {
+//!                 function: AuthorizedFunction::Contract((
+//!                     protected.clone(),
+//!                     Symbol::new(&env, "protected"),
+//!                     (account.clone(),).into_val(&env),
+//!                 )),
+//!                 sub_invocations: std::vec![],
+//!             }
+//!         )]
+//!     );
+//!
+//!     // The delegation actually reached `delegate`, which approved the
+//!     // same invocation that was authorized above.
+//!     let approved: Vec<Context> = env.as_contract(&delegate, || {
+//!         env.storage()
+//!             .instance()
+//!             .get(&DelegateAccountDataKey::ApprovedContexts)
+//!             .unwrap()
+//!     });
+//!     assert_eq!(
+//!         approved,
+//!         vec![
+//!             &env,
+//!             Context::Contract(ContractContext {
+//!                 contract: protected.clone(),
+//!                 fn_name: Symbol::new(&env, "protected"),
+//!                 args: (account.clone(),).into_val(&env),
+//!             }),
+//!         ],
+//!     );
+//! }
+//! # #[cfg(not(feature = "testutils"))]
+//! # fn main() { }
+//! ```
 
 use crate::{env::internal::Env as _, unwrap::UnwrapInfallible, Address, Env, IntoVal, Vec};
 
@@ -40,9 +265,10 @@ impl CustomAccount {
     ///
     /// ### Examples
     ///
-    /// See [`CustomAccount::delegate_auth`] for a complete, runnable example of
-    /// a modular custom account that retrieves its delegated signers with this
-    /// function, validates them, and delegates authentication to them.
+    /// See the [module-level documentation](crate::custom_account) for a
+    /// complete, runnable example of a modular custom account that retrieves
+    /// its delegated signers, validates them, and delegates authentication to
+    /// them.
     pub fn get_delegated_signers(&self) -> Vec<Address> {
         let addresses =
             Env::get_delegated_signers_for_current_auth_check(&self.env).unwrap_infallible();
@@ -82,228 +308,10 @@ impl CustomAccount {
     ///
     /// ### Examples
     ///
-    /// A module custom account that performs authentication by delegating to
-    /// other accounts instead of doing the authentication itself. The user
-    /// chooses which of the registered signers to authenticate with, by
-    /// attaching them to the transaction as delegated signers.
-    ///
-    /// ```
-    /// use soroban_sdk::{
-    ///     auth::{Context, CustomAccountInterface},
-    ///     contract, contracterror, contractimpl, contracttype,
-    ///     crypto::Hash, vec, Address, Env, Vec,
-    /// };
-    ///
-    /// #[contracterror]
-    /// #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
-    /// #[repr(u32)]
-    /// pub enum Error {
-    ///     UnknownDelegate = 1,
-    /// }
-    ///
-    /// #[contracttype]
-    /// enum ModularAccountDataKey {
-    ///     // Marks an address as a signer allowed to authenticate for the
-    ///     // modular account.
-    ///     Signer(Address),
-    /// }
-    ///
-    /// #[contract]
-    /// pub struct ModularAccount;
-    ///
-    /// #[contractimpl]
-    /// impl ModularAccount {
-    ///     // Registers the addresses allowed to authenticate for this account.
-    ///     pub fn __constructor(env: Env, signers: Vec<Address>) {
-    ///         for signer in signers.iter() {
-    ///             env.storage()
-    ///                 .persistent()
-    ///                 .set(&ModularAccountDataKey::Signer(signer), &());
-    ///         }
-    ///     }
-    /// }
-    ///
-    /// #[contractimpl]
-    /// impl CustomAccountInterface for ModularAccount {
-    ///     // The account verifies no signature of its own, so it carries no
-    ///     // signature to check.
-    ///     type Signature = ();
-    ///     type Error = Error;
-    ///
-    ///     fn __check_auth(
-    ///         env: Env,
-    ///         _signature_payload: Hash<32>,
-    ///         _signatures: (),
-    ///         _auth_contexts: Vec<Context>,
-    ///     ) -> Result<(), Error> {
-    ///         // The signers the user attached to the auth entry for this
-    ///         // account's authorization.
-    ///         let delegates = env.custom_account().get_delegated_signers();
-    ///
-    ///         // Check if the delegates are accepted by the modular account.
-    ///         for delegate in delegates.iter() {
-    ///             if !env
-    ///                 .storage()
-    ///                 .persistent()
-    ///                 .has(&ModularAccountDataKey::Signer(delegate.clone()))
-    ///             {
-    ///                 return Err(Error::UnknownDelegate);
-    ///             }
-    ///             // Forward the current authorization to the delegate.
-    ///             env.custom_account().delegate_auth(&delegate);
-    ///         }
-    ///         Ok(())
-    ///     }
-    /// }
-    ///
-    /// #[contracttype]
-    /// enum DelegateAccountDataKey {
-    ///     // Records the contexts the delegate approved so the test can verify
-    ///     // the delegation reached it.
-    ///     ApprovedContexts,
-    /// }
-    ///
-    /// // A simple account that the ModularAccount can delegate to for auth.
-    /// //
-    /// // It will always authorise an auth request, and store a copy of the auth
-    /// // context for later comparing in tests.
-    /// #[contract]
-    /// pub struct DelegateAccount;
-    ///
-    /// #[contractimpl]
-    /// impl CustomAccountInterface for DelegateAccount {
-    ///     type Signature = ();
-    ///     type Error = Error;
-    ///     fn __check_auth(
-    ///         env: Env,
-    ///         _signature_payload: Hash<32>,
-    ///         _signatures: (),
-    ///         auth_contexts: Vec<Context>,
-    ///     ) -> Result<(), Error> {
-    ///         env.storage()
-    ///             .instance()
-    ///             .set(&DelegateAccountDataKey::ApprovedContexts, &auth_contexts);
-    ///         // Returning `Ok(())` approves the auth;
-    ///         // returning an error would reject it.
-    ///         Ok(())
-    ///     }
-    /// }
-    ///
-    /// // A contract with an operation that requires the account's authorization.
-    /// #[contract]
-    /// pub struct Protected;
-    ///
-    /// #[contractimpl]
-    /// impl Protected {
-    ///     pub fn protected(account: Address) {
-    ///         account.require_auth();
-    ///     }
-    /// }
-    ///
-    /// #[test]
-    /// fn test() {
-    /// # }
-    /// # #[cfg(feature = "testutils")]
-    /// # fn main() {
-    ///     use soroban_sdk::xdr::{
-    ///         InvokeContractArgs, ScAddress, ScVal, SorobanAddressCredentials,
-    ///         SorobanAddressCredentialsWithDelegates, SorobanAuthorizationEntry,
-    ///         SorobanAuthorizedFunction, SorobanAuthorizedInvocation,
-    ///         SorobanCredentials, SorobanDelegateSignature, StringM, VecM,
-    ///     };
-    ///
-    ///     let env = Env::default();
-    ///     let delegate = env.register(DelegateAccount, ());
-    ///     // Register the modular account with `delegate` as an allowed signer.
-    ///     let account = env.register(ModularAccount, (vec![&env, delegate.clone()],));
-    ///     let protected = env.register(Protected, ());
-    ///
-    ///     let account_addr: ScAddress = account.clone().try_into().unwrap();
-    ///     let delegate_addr: ScAddress = delegate.clone().try_into().unwrap();
-    ///
-    ///     // This authorization entry is normally built by the user's
-    ///     // wallet/tooling and attached to the transaction. It authorizes
-    ///     // `protected` on behalf of the account, and attaches `delegate` as a
-    ///     // delegated signer. Delegates must be sorted by address with no
-    ///     // duplicates.
-    ///     env.set_auths(&[SorobanAuthorizationEntry {
-    ///         credentials: SorobanCredentials::AddressWithDelegates(
-    ///             SorobanAddressCredentialsWithDelegates {
-    ///                 address_credentials: SorobanAddressCredentials {
-    ///                     address: account_addr.clone(),
-    ///                     nonce: 1,
-    ///                     signature_expiration_ledger: 100,
-    ///                     // The account verifies no signature of its own.
-    ///                     signature: ScVal::Void,
-    ///                 },
-    ///                 delegates: std::vec![SorobanDelegateSignature {
-    ///                     address: delegate_addr,
-    ///                     signature: ScVal::Void,
-    ///                     nested_delegates: VecM::default(),
-    ///                 }]
-    ///                 .try_into()
-    ///                 .unwrap(),
-    ///             },
-    ///         ),
-    ///         root_invocation: SorobanAuthorizedInvocation {
-    ///             function: SorobanAuthorizedFunction::ContractFn(InvokeContractArgs {
-    ///                 contract_address: protected.clone().try_into().unwrap(),
-    ///                 function_name: StringM::try_from("protected").unwrap().into(),
-    ///                 args: std::vec![ScVal::Address(account_addr)].try_into().unwrap(),
-    ///             }),
-    ///             sub_invocations: VecM::default(),
-    ///         },
-    ///     }]);
-    ///
-    ///     // The call succeeds: the account delegates its authentication to
-    ///     // `delegate`, which approves it.
-    ///     ProtectedClient::new(&env, &protected).protected(&account);
-    ///
-    ///     // The account authorized the `protected` call. Delegating to
-    ///     // `delegate` is not recorded as a separate authorization.
-    ///     use soroban_sdk::{
-    ///         auth::ContractContext,
-    ///         testutils::{AuthorizedFunction, AuthorizedInvocation},
-    ///         IntoVal, Symbol,
-    ///     };
-    ///     assert_eq!(
-    ///         env.auths(),
-    ///         std::vec![(
-    ///             account.clone(),
-    ///             AuthorizedInvocation {
-    ///                 function: AuthorizedFunction::Contract((
-    ///                     protected.clone(),
-    ///                     Symbol::new(&env, "protected"),
-    ///                     (account.clone(),).into_val(&env),
-    ///                 )),
-    ///                 sub_invocations: std::vec![],
-    ///             }
-    ///         )]
-    ///     );
-    ///
-    ///     // The delegation actually reached `delegate`, which approved the
-    ///     // same invocation that was authorized above.
-    ///     let approved: Vec<Context> = env.as_contract(&delegate, || {
-    ///         env.storage()
-    ///             .instance()
-    ///             .get(&DelegateAccountDataKey::ApprovedContexts)
-    ///             .unwrap()
-    ///     });
-    ///     assert_eq!(
-    ///         approved,
-    ///         vec![
-    ///             &env,
-    ///             Context::Contract(ContractContext {
-    ///                 contract: protected.clone(),
-    ///                 fn_name: Symbol::new(&env, "protected"),
-    ///                 args: (account.clone(),).into_val(&env),
-    ///             }),
-    ///         ],
-    ///     );
-    /// }
-    /// # #[cfg(not(feature = "testutils"))]
-    /// # fn main() { }
-    /// ```
+    /// See the [module-level documentation](crate::custom_account) for a
+    /// complete, runnable example of a modular custom account that retrieves
+    /// its delegated signers, validates them, and delegates authentication to
+    /// them.
     pub fn delegate_auth(&self, address: &Address) {
         Env::delegate_account_auth(&self.env, address.to_object()).unwrap_infallible();
     }


### PR DESCRIPTION
### What

Add a complete, compiled rustdoc example to the custom_account module showing how a modular custom account uses `CustomAccount::get_delegated_signers` and `CustomAccount::delegate_auth` to delegate its `__check_auth` authentication to other accounts, and reference that example from both functions. Derive `Debug` for the `auth::Context` types so the example can compare the authorization contexts a delegate observed against an expected value with `assert_eq!`.

### Why

PR #1896 introduced the CAP-71 auth delegation API but deferred adding documentation examples for it. The delegation flow is intricate and easy to misuse — it spans constructing an `AddressWithDelegates` authorization entry, retrieving and validating the delegated signers, and forwarding the authorization to each — so a worked example that is compiled and run on every build both teaches the intended flow and guards it against regressions, in keeping with the SDK convention of providing examples for the auth-related functions.

### Known limitations

N/A

---
_Generated by [Claude Code](https://claude.ai/code/session_01CdHVScFCj5PZ3anXAikhV4)_