### PR TITLE
feat: add current_address alias to Env

### DIFF
--- a/soroban-sdk/src/env.rs
+++ b/soroban-sdk/src/env.rs
@@ -386,9 +386,19 @@ impl Env {
     }
 
     /// Get the Address object corresponding to the current executing contract.
+    ///
+    /// See [`Env::current_address`] for a shorter alias of this function.
     pub fn current_contract_address(&self) -> Address {
         let address = internal::Env::get_current_contract_address(self).unwrap_infallible();
         unsafe { Address::unchecked_new(self.clone(), address) }
+    }
+
+    /// Get the Address object corresponding to the current executing contract.
+    ///
+    /// Shorter alias for [`Env::current_contract_address`].
+    #[inline(always)]
+    pub fn current_address(&self) -> Address {
+        self.current_contract_address()
     }
 
     #[doc(hidden)]

--- a/soroban-sdk/src/tests/env.rs
+++ b/soroban-sdk/src/tests/env.rs
@@ -36,6 +36,10 @@ impl Contract {
         // This should fail because auths aren't mocked.
         env.require_auth(&address);
     }
+
+    pub fn get_addresses(env: Env) -> (Address, Address) {
+        (env.current_contract_address(), env.current_address())
+    }
 }
 
 #[contracterror]
@@ -356,3 +360,14 @@ fn test_register_restores_auth_before_panics() {
     assert!(post_register.is_err());
     assert_eq!(pre_register, post_register);
 }
+
+#[test]
+fn test_current_address_alias() {
+    let env = Env::default();
+    let addr = env.register(Contract, ());
+    let client = ContractClient::new(&env, &addr);
+    let (addr1, addr2) = client.get_addresses();
+    assert_eq!(addr1, addr);
+    assert_eq!(addr2, addr);
+}
+

--- a/soroban-sdk/test_snapshots/tests/env/test_current_address_alias.1.json
+++ b/soroban-sdk/test_snapshots/tests/env/test_current_address_alias.1.json
@@ -1,0 +1,61 @@
+{
+  "generators": {
+    "address": 1,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 27,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": "ledger_key_contract_instance",
+              "durability": "persistent",
+              "val": {
+                "contract_instance": {
+                  "executable": {
+                    "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  },
+                  "storage": null
+                }
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_code": {
+              "ext": "v0",
+              "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+              "code": ""
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      }
+    ]
+  },
+  "events": []
+}


### PR DESCRIPTION
This PR addresses:
- **Issue #1778**: Add a short convenience alias \current_address()\ for \current_contract_address()\ on \Env\.

\Env::current_contract_address()\ is extremely verbose for a commonly used method in contracts. Having a shorter \current_address()\ alias improves readability.

### Highlights
- Exposes \current_address(&self) -> Address\ which calls \self.current_contract_address()\.
- Documented the relationship between the two methods in doc comments.
- Added a unit test validating correctness.