### PR TITLE
Temp: add ability to skip semver checks

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -97,6 +97,9 @@ jobs:
     - uses: stellar/actions/rust-check-git-rev-deps@main
 
   semver-checks:
+    # Skippable via 'skip-semver-checks' label for the 27.0.0 release: https://github.com/stellar/rs-soroban-sdk/pull/1925
+    # This should be removed after 27.0.0 is released and soroban-env is patched
+    if: "!contains(github.event.pull_request.labels.*.name, 'skip-semver-checks') && github.event_name != 'merge_group'"
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -97,8 +97,8 @@ jobs:
     - uses: stellar/actions/rust-check-git-rev-deps@main
 
   semver-checks:
-    # Skippable via 'skip-semver-checks' label for the 27.0.0 release: https://github.com/stellar/rs-soroban-sdk/pull/1925
-    # This should be removed after 27.0.0 is released and soroban-env is patched
+    # When a PR enters the merge queue, the event context changes from pull_request to merge_group,
+    # so github.event.pull_request becomes null/empty, so we don't do this check in the merge queue.
     if: "!contains(github.event.pull_request.labels.*.name, 'skip-semver-checks') && github.event_name != 'merge_group'"
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
### What

Add label to skip semver check for 27.0.0 release

### Why

The error originates in the `rs-soroban-env` repo, which needs another release to fix.

### Known limitations

None
