### PR TITLE
Rename allowance expiration argument to live_until_ledger

### DIFF
--- a/soroban-sdk/src/token.rs
+++ b/soroban-sdk/src/token.rs
@@ -114,16 +114,16 @@ pub trait TokenInterface {
     /// * `spender` - The address being authorized to spend the tokens held by
     ///   `from`.
     /// * `amount` - The tokens to be made available to `spender`.
-    /// * `expiration_ledger` - The ledger number where this allowance expires. Cannot
+    /// * `live_until_ledger` - The ledger number where this allowance expires. Cannot
     ///    be less than the current ledger number unless the amount is being set to 0.
-    ///    An expired entry (where expiration_ledger < the current ledger number)
+    ///    An expired entry (where live_until_ledger < the current ledger number)
     ///    should be treated as a 0 amount allowance.
     ///
     /// # Events
     ///
     /// Emits an event with topics `["approve", from: Address,
     /// spender: Address], data = [amount: i128, expiration_ledger: u32]`
-    fn approve(env: Env, from: Address, spender: Address, amount: i128, expiration_ledger: u32);
+    fn approve(env: Env, from: Address, spender: Address, amount: i128, live_until_ledger: u32);
 
     /// Returns the balance of `id`.
     ///
@@ -276,16 +276,16 @@ pub trait StellarAssetInterface {
     /// * `spender` - The address being authorized to spend the tokens held by
     ///   `from`.
     /// * `amount` - The tokens to be made available to `spender`.
-    /// * `expiration_ledger` - The ledger number where this allowance expires. Cannot
+    /// * `live_until_ledger` - The ledger number where this allowance expires. Cannot
     ///    be less than the current ledger number unless the amount is being set to 0.
-    ///    An expired entry (where expiration_ledger < the current ledger number)
+    ///    An expired entry (where live_until_ledger < the current ledger number)
     ///    should be treated as a 0 amount allowance.
     ///
     /// # Events
     ///
     /// Emits an event with topics `["approve", from: Address,
     /// spender: Address], data = [amount: i128, expiration_ledger: u32]`
-    fn approve(env: Env, from: Address, spender: Address, amount: i128, expiration_ledger: u32);
+    fn approve(env: Env, from: Address, spender: Address, amount: i128, live_until_ledger: u32);
 
     /// Returns the balance of `id`.
     ///


### PR DESCRIPTION
### What

Renames the `approve` allowance-expiration argument from `expiration_ledger` to `live_until_ledger` in both the `TokenInterface` and `StellarAssetInterface` traits, aligning the SDK with the SEP-41 spec. The `Approve` event's data field doc is left as `expiration_ledger` to preserve on-chain event compatibility.

### Why

The argument name is part of the generated contract spec XDR. `TokenInterface` had been updated to `live_until_ledger` (matching SEP-41), but `StellarAssetInterface` still used `expiration_ledger`, so the two `approve` spec entries no longer matched and `test_stellar_asset_spec_includes_token_spec` failed. Aligning both traits to the SEP-41 name fixes the mismatch. All ten SEP-41 functions and their argument names were checked; `approve` was the only discrepancy.

### Known limitations

N/A