### PR TITLE
Refresh mainnet() resource limits and fees

### DIFF
--- a/soroban-sdk/src/tests/cost_estimate.rs
+++ b/soroban-sdk/src/tests/cost_estimate.rs
@@ -37,14 +37,14 @@ fn test_cost_estimate_with_storage() {
     .assert_eq(format!("{:#?}", e.cost_estimate().resources()).as_str());
     expect![[r#"
         FeeEstimate {
-            total: 29122,
-            instructions: 607,
-            disk_read_entries: 6250,
-            write_entries: 10000,
+            total: 10004,
+            instructions: 170,
+            disk_read_entries: 1563,
+            write_entries: 2500,
             disk_read_bytes: 0,
-            write_bytes: 274,
+            write_bytes: 69,
             contract_events: 0,
-            persistent_entry_rent: 11991,
+            persistent_entry_rent: 5702,
             temporary_entry_rent: 0,
         }"#]]
     .assert_eq(format!("{:#?}", e.cost_estimate().fee()).as_str());
@@ -70,8 +70,8 @@ fn test_cost_estimate_with_storage() {
     .assert_eq(format!("{:#?}", e.cost_estimate().resources()).as_str());
     expect![[r#"
         FeeEstimate {
-            total: 603,
-            instructions: 603,
+            total: 169,
+            instructions: 169,
             disk_read_entries: 0,
             write_entries: 0,
             disk_read_bytes: 0,
@@ -103,10 +103,10 @@ fn test_cost_estimate_with_storage() {
     .assert_eq(format!("{:#?}", e.cost_estimate().resources()).as_str());
     expect![[r#"
         FeeEstimate {
-            total: 16847,
-            instructions: 597,
-            disk_read_entries: 6250,
-            write_entries: 10000,
+            total: 4231,
+            instructions: 168,
+            disk_read_entries: 1563,
+            write_entries: 2500,
             disk_read_bytes: 0,
             write_bytes: 0,
             contract_events: 0,
@@ -136,8 +136,8 @@ fn test_cost_estimate_with_storage() {
     .assert_eq(format!("{:#?}", e.cost_estimate().resources()).as_str());
     expect![[r#"
         FeeEstimate {
-            total: 598,
-            instructions: 598,
+            total: 168,
+            instructions: 168,
             disk_read_entries: 0,
             write_entries: 0,
             disk_read_bytes: 0,

--- a/soroban-sdk/src/testutils/cost_estimate.rs
+++ b/soroban-sdk/src/testutils/cost_estimate.rs
@@ -40,7 +40,10 @@ impl CostEstimate {
     /// on 2026-07-10. Because the fees are hardcoded rather than pulled
     /// dynamically, they may drift from the live network over time; the current
     /// values can be checked via `stellar network settings --network mainnet`
-    /// or on Stellar Lab: <https://lab.stellar.org/network-limits>.
+    /// or on Stellar Lab: <https://lab.stellar.org/network-limits>. The one
+    /// exception is the per-1KB storage rent rate, which is a deliberate
+    /// conservative overestimate rather than the snapshot value, so storage
+    /// rent estimates may be higher than the live network charges.
     ///
     /// Take the return value with a grain of salt as both the resource estimate
     /// and the fee rates may be imprecise.

--- a/soroban-sdk/src/testutils/cost_estimate.rs
+++ b/soroban-sdk/src/testutils/cost_estimate.rs
@@ -36,8 +36,11 @@ impl CostEstimate {
     /// Estimates the fee for the last invocation's resources, i.e. the
     /// resources returned by `resources()`.
     ///
-    /// The fees are computed using the snapshot of the Stellar Pubnet fees made
-    /// on 2024-12-11.
+    /// The fees are computed using a snapshot of the Stellar Mainnet fees made
+    /// on 2026-07-10. Because the fees are hardcoded rather than pulled
+    /// dynamically, they may drift from the live network over time; the current
+    /// values can be checked via `stellar network settings --network mainnet`
+    /// or on Stellar Lab: <https://lab.stellar.org/network-limits>.
     ///
     /// Take the return value with a grain of salt as both the resource estimate
     /// and the fee rates may be imprecise.
@@ -45,24 +48,23 @@ impl CostEstimate {
     /// The returned value is as useful as the preceding setup, e.g. if a test
     /// contract is used instead of a Wasm contract, all the costs related to
     /// VM instantiation and execution, as well as Wasm reads/rent bumps will be
-    /// missed.    
+    /// missed.
     pub fn fee(&self) -> FeeEstimate {
-        // This is a snapshot of the fees as of 2024-12-11 with slight
-        // adjustments for p23.
-        // This has to be updated before p23 goes live with the configuration
-        // used at the network upgrade time.
+        // This is a snapshot of the Stellar Mainnet fees as of 2026-07-10.
+        // Refresh it with the values from `stellar network settings --network
+        // mainnet` (or <https://lab.stellar.org/network-limits>) when it drifts.
         let pubnet_fee_config = FeeConfiguration {
-            fee_per_instruction_increment: 25,
-            fee_per_disk_read_entry: 6250,
-            fee_per_write_entry: 10000,
-            fee_per_disk_read_1kb: 1786,
-            fee_per_write_1kb: 3500,
-            fee_per_historical_1kb: 16235,
-            fee_per_contract_event_1kb: 10000,
-            fee_per_transaction_size_1kb: 1624,
+            fee_per_instruction_increment: 7,
+            fee_per_disk_read_entry: 1563,
+            fee_per_write_entry: 2500,
+            fee_per_disk_read_1kb: 447,
+            fee_per_write_1kb: 875,
+            fee_per_historical_1kb: 4059,
+            fee_per_contract_event_1kb: 5000,
+            fee_per_transaction_size_1kb: 406,
         };
-        let pubnet_persistent_rent_rate_denominator = 2103;
-        let pubnet_temp_rent_rate_denominator = 4206;
+        let pubnet_persistent_rent_rate_denominator = 1215;
+        let pubnet_temp_rent_rate_denominator = 2430;
         // This is a bit higher than the current network fee, it's an
         // overestimate for the sake of providing a bit more conservative
         // results in case if the state grows.
@@ -133,15 +135,18 @@ pub trait NetworkInvocationResourceLimits {
 impl NetworkInvocationResourceLimits for InvocationResourceLimits {
     /// Returns the invocation resource limits used on Stellar Mainnet.
     ///
-    /// This is not pulling the values dynamically, so updating the SDK is
-    /// necessary to pick up the most recent values.
+    /// These values are a snapshot of the Mainnet network settings as of
+    /// 2026-07-10; they are hardcoded rather than pulled dynamically, so
+    /// updating the SDK is necessary to pick up the most recent values. The
+    /// current values can be checked via `stellar network settings --network
+    /// mainnet` or on Stellar Lab: <https://lab.stellar.org/network-limits>.
     fn mainnet() -> Self {
         InvocationResourceLimits {
-            instructions: 600_000_000,
+            instructions: 400_000_000,
             mem_bytes: 41943040,
-            disk_read_entries: 100,
-            write_entries: 50,
-            ledger_entries: 100,
+            disk_read_entries: 200,
+            write_entries: 200,
+            ledger_entries: 400,
             disk_read_bytes: 200000,
             write_bytes: 132096,
             contract_events_size_bytes: 16384,


### PR DESCRIPTION
### What

Refresh the `InvocationResourceLimits::mainnet()` limits and the fee-rate snapshot used by `CostEstimate::fee()` to the Stellar Mainnet settings as of 2026-07-10, and update their rustdocs (including the duplicated limits table in the v25 resource-limits migration guide) to point readers to `stellar network settings --network mainnet` and Stellar Lab as the live source of truth.

### Why

`InvocationResourceLimits::mainnet()` has been enforced by `Env::default()` on every test invocation since v25 but still carried the values from when resource-limit enforcement was first introduced, which had drifted from Mainnet in both directions: the instruction ceiling was too high (600,000,000 vs 400,000,000), letting a contract pass tests yet exceed Mainnet's per-transaction limit in production and defeating the early-warning purpose of the enforcement, while the entry ceilings were too low (disk read entries 100 vs 200, write entries 50 vs 200, ledger entries 100 vs 400).

### Known limitations

The values remain a hardcoded snapshot rather than being pulled dynamically, so they will drift again.

On the one hand this is bad, but also, if they kept moving tests could become flakey, so timing this update with new major releases on some cadence is probably a good idea.

Follow up to introduce CI to help us keep it updated:

- https://github.com/stellar/rs-soroban-sdk/issues/1948