### PR TITLE
Update SAC event doc-comments to CAP-67 shapes

### DIFF
--- a/soroban-sdk/src/token.rs
+++ b/soroban-sdk/src/token.rs
@@ -432,7 +432,7 @@ pub trait StellarAssetInterface {
     /// # Events
     ///
     /// Emits an event with topics `["set_authorized", id: Address,
-    /// sep0011_asset: String], data = [authorize: bool]`
+    /// sep0011_asset: String], data = authorize: bool`
     fn set_authorized(env: Env, id: Address, authorize: bool);
 
     /// Returns true if `id` is authorized to use its balance.

--- a/soroban-sdk/src/token.rs
+++ b/soroban-sdk/src/token.rs
@@ -431,8 +431,8 @@ pub trait StellarAssetInterface {
     ///
     /// # Events
     ///
-    /// Emits an event with topics `["set_authorized", id: Address], data =
-    /// [authorize: bool]`
+    /// Emits an event with topics `["set_authorized", id: Address,
+    /// sep0011_asset: String], data = [authorize: bool]`
     fn set_authorized(env: Env, id: Address, authorize: bool);
 
     /// Returns true if `id` is authorized to use its balance.
@@ -451,8 +451,8 @@ pub trait StellarAssetInterface {
     ///
     /// # Events
     ///
-    /// Emits an event with topics `["mint", to: Address], data
-    /// = amount: i128`
+    /// Emits an event with topics `["mint", to: Address,
+    /// sep0011_asset: String], data = amount: i128`
     fn mint(env: Env, to: Address, amount: i128);
 
     /// Clawback `amount` from `from` account. `amount` is burned in the
@@ -466,8 +466,8 @@ pub trait StellarAssetInterface {
     ///
     /// # Events
     ///
-    /// Emits an event with topics `["clawback", admin: Address, to: Address],
-    /// data = amount: i128`
+    /// Emits an event with topics `["clawback", from: Address,
+    /// sep0011_asset: String], data = amount: i128`
     fn clawback(env: Env, from: Address, amount: i128);
 
     /// Creates this contract asset's unlimited trustline for the provided

--- a/stellar-asset-spec/src/lib.rs
+++ b/stellar-asset-spec/src/lib.rs
@@ -54,7 +54,7 @@ pub(crate) const XDR_INPUT: &[&[u8]] = &[
     &SetAuthorized::spec_xdr(),
 ];
 
-pub(crate) const XDR_LEN: usize = 9128;
+pub(crate) const XDR_LEN: usize = 9184;
 
 /// Returns the contract spec for Stellar Asset contract.
 pub const fn xdr() -> &'static [u8] {


### PR DESCRIPTION
### What

The `StellarAssetInterface` doc-comments for `mint`, `clawback`, and `set_authorized` now describe the CAP-67 Stellar Asset Contract event shapes.

### Why

CAP-0067 removed the `admin` topic from these SAC events. Also the trailing SEP-11 asset topic has been there for a while.

Close #1955
Close https://github.com/stellar/stellar-docs/issues/2593

### Known limitations

N/A
