### PR TITLE
Reset budget in disable_resource_limits

### DIFF
--- a/soroban-sdk/src/tests/cost_estimate.rs
+++ b/soroban-sdk/src/tests/cost_estimate.rs
@@ -149,6 +149,29 @@ fn test_cost_estimate_with_storage() {
     .assert_eq(format!("{:#?}", e.cost_estimate().fee()).as_str());
 }
 
+// A single call to `disable_resource_limits()` should be sufficient to run
+// invocations without any limits, including the CPU/memory budget that is
+// enforced separately from the invocation resource limits.
+#[test]
+fn test_disable_resource_limits_also_disables_budget() {
+    let e = Env::default();
+
+    let contract_id = e.register(contract_data::WASM, ());
+    let client = contract_data::Client::new(&e, &contract_id);
+
+    // Constrain the CPU/memory budget so tightly that any invocation would
+    // otherwise exceed it and fail with `Error(Budget, ExceededLimit)`. The
+    // limit persists across invocations until it is reset.
+    e.cost_estimate().budget().reset_limits(1, 1);
+
+    // Disabling resource limits alone should also clear the budget limit, so
+    // no separate call to `budget().reset_unlimited()` is needed.
+    e.cost_estimate().disable_resource_limits();
+
+    client.put(&symbol_short!("k1"), &symbol_short!("v1"));
+    assert_eq!(client.get(&symbol_short!("k1")), Some(symbol_short!("v1")));
+}
+
 #[test]
 fn test_cost_estimate_budget() {
     let e = Env::default();

--- a/soroban-sdk/src/testutils/cost_estimate.rs
+++ b/soroban-sdk/src/testutils/cost_estimate.rs
@@ -118,15 +118,27 @@ impl CostEstimate {
             .unwrap();
     }
 
-    /// Disables resource limit enforcement for contract invocations in tests.
+    /// Disables all resource limit enforcement for contract invocations in
+    /// tests.
     ///
     /// This may be useful for the experimental contracts that are still being
     /// optimized.
+    ///
+    /// A single call is sufficient to run invocations without any limits: it
+    /// disables both the invocation resource limit checks (see
+    /// `enforce_resource_limits()`) and the CPU instruction and memory budget
+    /// that is metered and enforced separately during execution. Without
+    /// resetting the budget as well, a heavy invocation could still fail with
+    /// `Error(Budget, ExceededLimit)`.
     pub fn disable_resource_limits(&self) {
         self.env
             .host()
             .set_invocation_resource_limits(None)
             .unwrap();
+        // The invocation resource limits above only gate the post-invocation
+        // resource check. The CPU instruction and memory budget is a separate
+        // limit enforced during execution, so reset it to unlimited too.
+        self.budget().reset_unlimited();
     }
 }
 

--- a/soroban-sdk/test_snapshots/tests/cost_estimate/test_disable_resource_limits_also_disables_budget.1.json
+++ b/soroban-sdk/test_snapshots/tests/cost_estimate/test_disable_resource_limits_also_disables_budget.1.json
@@ -1,0 +1,140 @@
+{
+  "generators": {
+    "address": 1,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+        {
+          "function": {
+            "create_contract_v2_host_fn": {
+              "contract_id_preimage": {
+                "address": {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                  "salt": "0000000000000000000000000000000000000000000000000000000000000000"
+                }
+              },
+              "executable": {
+                "wasm": "fd41d2f77920ca07b723e05f732a82db4c2f6459eb2be6b40c4f225434569550"
+              },
+              "constructor_args": []
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 27,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": {
+                "ledger_key_nonce": {
+                  "nonce": "801925984706572462"
+                }
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 6311999
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CBKMUZNFQIAL775XBB2W2GP5CNHBM5YGH6C3XB7AY6SUVO2IBU3VYK2V",
+              "key": {
+                "symbol": "k1"
+              },
+              "durability": "persistent",
+              "val": {
+                "symbol": "v1"
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CBKMUZNFQIAL775XBB2W2GP5CNHBM5YGH6C3XB7AY6SUVO2IBU3VYK2V",
+              "key": "ledger_key_contract_instance",
+              "durability": "persistent",
+              "val": {
+                "contract_instance": {
+                  "executable": {
+                    "wasm": "fd41d2f77920ca07b723e05f732a82db4c2f6459eb2be6b40c4f225434569550"
+                  },
+                  "storage": null
+                }
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_code": {
+              "ext": {
+                "v1": {
+                  "ext": "v0",
+                  "cost_inputs": {
+                    "ext": "v0",
+                    "n_instructions": 137,
+                    "n_functions": 5,
+                    "n_globals": 3,
+                    "n_table_entries": 0,
+                    "n_types": 5,
+                    "n_data_segments": 0,
+                    "n_elem_segments": 0,
+                    "n_imports": 4,
+                    "n_exports": 7,
+                    "n_data_segment_bytes": 0
+                  }
+                }
+              },
+              "hash": "fd41d2f77920ca07b723e05f732a82db4c2f6459eb2be6b40c4f225434569550",
+              "code": "0061736d01000000011b0560037e7e7e017e60027e7e017e60027f7e0060017e017e600000021904016c015f0000016c01300001016c01310001016c01320001030605010203030405030100100619037f01418080c0000b7f00418080c0000b7f00418080c0000b073b07066d656d6f727902000370757400040367657400060364656c0007015f00080a5f5f646174615f656e6403010b5f5f686561705f6261736503020ad502056601017f23808080800041206b2202248080808000200241106a200010858080800002402002290310a70d0020022903182100200220011085808080002002290300a70d002000200229030842011080808080001a200241206a24808080800042020f0b00000b2401017f2000200137030820002001a741ff01712202410e47200241ca004771ad3703000b7b02017f017e23808080800041206b2201248080808000200141106a200010858080800002402001290310a70d004202210002402001290318220242011081808080004201520d002001200242011082808080001085808080002001290300a70d01200129030821000b200141206a24808080800020000f0b00000b4801017f23808080800041106b22012480808080002001200010858080800002402001290300a7450d0000000b200129030842011083808080001a200141106a24808080800042020b02000b009f010e636f6e7472616374737065637630000000000000000000000003707574000000000200000000000000036b65790000000011000000000000000376616c000000001100000000000000000000000000000003676574000000000100000000000000036b6579000000001100000001000003e80000001100000000000000000000000364656c000000000100000000000000036b6579000000001100000000001e11636f6e7472616374656e766d657461763000000000000000160000000000770e636f6e74726163746d65746176300000000000000005727376657200000000000006312e38312e3000000000000000000008727373646b7665720000003532322e302e3223646665383939626331326332323937353531303633653330313531666636353466393762383265382d6469727479000000"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      }
+    ]
+  },
+  "events": []
+}


### PR DESCRIPTION
### What

`CostEstimate::disable_resource_limits()` now also resets the CPU instruction and memory budget to unlimited, so a single call is enough to run invocations without any limits.

### Why

The CPU/memory budget is metered and enforced separately from the invocation resource limits, so disabling the latter alone still left heavy invocations failing with `Error(Budget, ExceededLimit)` until `budget().reset_unlimited()` was also called, which was surprising and unintuitive.

### Known limitations

N/A

Close #1949