### PR TITLE
Reference mainnet limits instead of listing them

### DIFF
--- a/soroban-sdk/src/_migrating/v25_resource_limits.rs
+++ b/soroban-sdk/src/_migrating/v25_resource_limits.rs
@@ -120,23 +120,13 @@
 //! ## Mainnet Resource Limits
 //!
 //! The [`NetworkInvocationResourceLimits`] trait provides the `mainnet()` method on
-//! [`InvocationResourceLimits`] to get the current mainnet limits:
-//!
-//! - Instructions: 600,000,000
-//! - Memory: 41,943,040 bytes
-//! - Disk read entries: 100
-//! - Write entries: 50
-//! - Ledger entries: 100
-//! - Disk read bytes: 200,000
-//! - Write bytes: 132,096
-//! - Contract events size: 16,384 bytes
-//! - Max contract data key size: 250 bytes
-//! - Max contract data entry size: 65,536 bytes
-//! - Max contract code entry size: 131,072 bytes
+//! [`InvocationResourceLimits`] to get the mainnet limits. Its docs list the values that the SDK
+//! uses.
 //!
 //! Note: These values are not pulled dynamically. The SDK will be updated from time-to-time to
 //! pick up changes to mainnet limits. These changes may occur in any major, minor, or patch
-//! release.
+//! release. The limits currently configured on Mainnet and the test networks can be found on
+//! Stellar Lab: <https://lab.stellar.org/network-limits>.
 //!
 //! [`Env::default()`]: crate::Env::default
 //! [`CostEstimate::disable_resource_limits()`]: crate::testutils::cost_estimate::CostEstimate::disable_resource_limits

--- a/soroban-sdk/src/_migrating/v25_resource_limits.rs
+++ b/soroban-sdk/src/_migrating/v25_resource_limits.rs
@@ -119,9 +119,9 @@
 //!
 //! ## Mainnet Resource Limits
 //!
-//! The [`NetworkInvocationResourceLimits`] trait provides the `mainnet()` method on
-//! [`InvocationResourceLimits`] to get the mainnet limits. Its docs list the values that the SDK
-//! uses.
+//! The [`NetworkInvocationResourceLimits`] trait provides the [`mainnet()`] method on
+//! [`InvocationResourceLimits`], which returns a snapshot of the mainnet limits taken when the SDK
+//! was released.
 //!
 //! Note: These values are not pulled dynamically. The SDK will be updated from time-to-time to
 //! pick up changes to mainnet limits. These changes may occur in any major, minor, or patch
@@ -133,3 +133,4 @@
 //! [`CostEstimate::enforce_resource_limits()`]: crate::testutils::cost_estimate::CostEstimate::enforce_resource_limits
 //! [`InvocationResourceLimits`]: soroban_env_host::InvocationResourceLimits
 //! [`NetworkInvocationResourceLimits`]: crate::testutils::cost_estimate::NetworkInvocationResourceLimits
+//! [`mainnet()`]: crate::testutils::cost_estimate::NetworkInvocationResourceLimits::mainnet

--- a/soroban-sdk/src/_migrating/v25_resource_limits.rs
+++ b/soroban-sdk/src/_migrating/v25_resource_limits.rs
@@ -125,7 +125,7 @@
 //!
 //! Note: These values are not pulled dynamically. The SDK will be updated from time-to-time to
 //! pick up changes to mainnet limits. These changes may occur in any major, minor, or patch
-//! release. The limits currently configured on Mainnet and the test networks can be found on
+//! release. The limits currently configured on mainnet and the test networks can be found on
 //! Stellar Lab: <https://lab.stellar.org/network-limits>.
 //!
 //! [`Env::default()`]: crate::Env::default


### PR DESCRIPTION
### What

Replace the v25 migration guide's hardcoded list of mainnet resource limits with a pointer to `InvocationResourceLimits::mainnet()`, whose docs carry the values the SDK uses, and to Stellar Lab for the limits the networks are currently running.

### Why

The values are changing and we shouldn't have captured them anywhere really in the docs as someone might look at this and mistakenly think that's what they will still be set to. They'll change from time to time and we won't document them in the migration guides every time they change in the SDK.
