### PR TITLE
Extract shared contract type spec emission

### DIFF
--- a/soroban-sdk-macros/src/derive_enum.rs
+++ b/soroban-sdk-macros/src/derive_enum.rs
@@ -11,7 +11,7 @@ use stellar_xdr::{
     ScSpecUdtUnionCaseVoidV0, ScSpecUdtUnionV0, StringM, VecM, WriteXdr, SCSYMBOL_LIMIT,
 };
 
-use crate::{doc::docs_from_attrs, map_type::map_type, shaking, DEFAULT_XDR_RW_LIMITS};
+use crate::{doc::docs_from_attrs, map_type::map_type, shaking, spec, DEFAULT_XDR_RW_LIMITS};
 
 pub fn derive_type_enum(
     path: &Path,
@@ -159,26 +159,9 @@ pub fn derive_type_enum(
     };
 
     // Generated code spec.
-    let spec_gen = if let Some(ref spec_xdr) = spec_xdr {
-        let spec_xdr_lit = proc_macro2::Literal::byte_string(spec_xdr.as_slice());
-        let spec_xdr_len = spec_xdr.len();
-        let spec_ident = format_ident!(
-            "__SPEC_XDR_TYPE_{}",
-            enum_ident.unraw().to_string().to_uppercase()
-        );
-        Some(quote! {
-            #[cfg_attr(target_family = "wasm", link_section = "contractspecv0")]
-            pub static #spec_ident: [u8; #spec_xdr_len] = #enum_ident::spec_xdr();
-
-            impl #enum_ident {
-                pub const fn spec_xdr() -> [u8; #spec_xdr_len] {
-                    *#spec_xdr_lit
-                }
-            }
-        })
-    } else {
-        None
-    };
+    let spec_gen = spec_xdr
+        .as_ref()
+        .map(|spec_xdr| spec::type_spec(enum_ident, spec_xdr));
 
     // SpecShakingMarker impl - only generated when spec is true and the
     // experimental_spec_shaking_v2 feature is enabled.

--- a/soroban-sdk-macros/src/derive_enum_int.rs
+++ b/soroban-sdk-macros/src/derive_enum_int.rs
@@ -1,6 +1,6 @@
 use itertools::MultiUnzip;
 use proc_macro2::TokenStream as TokenStream2;
-use quote::{format_ident, quote};
+use quote::quote;
 use stellar_xdr::{ScSpecUdtEnumV0, StringM};
 use syn::{
     ext::IdentExt as _, spanned::Spanned, Attribute, DataEnum, Error, ExprLit, Ident, Lit, Path,
@@ -9,7 +9,7 @@ use syn::{
 
 use stellar_xdr::{ScSpecEntry, ScSpecUdtEnumCaseV0, WriteXdr};
 
-use crate::{doc::docs_from_attrs, shaking, DEFAULT_XDR_RW_LIMITS};
+use crate::{doc::docs_from_attrs, shaking, spec, DEFAULT_XDR_RW_LIMITS};
 
 // TODO: Add conversions to/from ScVal types.
 
@@ -81,26 +81,9 @@ pub fn derive_type_enum_int(
     };
 
     // Generated code spec.
-    let spec_gen = if let Some(ref spec_xdr) = spec_xdr {
-        let spec_xdr_lit = proc_macro2::Literal::byte_string(spec_xdr.as_slice());
-        let spec_xdr_len = spec_xdr.len();
-        let spec_ident = format_ident!(
-            "__SPEC_XDR_TYPE_{}",
-            enum_ident.unraw().to_string().to_uppercase()
-        );
-        Some(quote! {
-            #[cfg_attr(target_family = "wasm", link_section = "contractspecv0")]
-            pub static #spec_ident: [u8; #spec_xdr_len] = #enum_ident::spec_xdr();
-
-            impl #enum_ident {
-                pub const fn spec_xdr() -> [u8; #spec_xdr_len] {
-                    *#spec_xdr_lit
-                }
-            }
-        })
-    } else {
-        None
-    };
+    let spec_gen = spec_xdr
+        .as_ref()
+        .map(|spec_xdr| spec::type_spec(enum_ident, spec_xdr));
 
     // SpecShakingMarker impl - only generated when spec is true and the
     // experimental_spec_shaking_v2 feature is enabled.

--- a/soroban-sdk-macros/src/derive_error_enum_int.rs
+++ b/soroban-sdk-macros/src/derive_error_enum_int.rs
@@ -1,12 +1,12 @@
 use itertools::MultiUnzip;
 use proc_macro2::TokenStream as TokenStream2;
-use quote::{format_ident, quote};
+use quote::quote;
 use stellar_xdr::{ScSpecEntry, ScSpecUdtErrorEnumCaseV0, ScSpecUdtErrorEnumV0, StringM, WriteXdr};
 use syn::{
     ext::IdentExt as _, spanned::Spanned, Attribute, DataEnum, Error, ExprLit, Ident, Lit, Path,
 };
 
-use crate::{doc::docs_from_attrs, shaking, DEFAULT_XDR_RW_LIMITS};
+use crate::{doc::docs_from_attrs, shaking, spec, DEFAULT_XDR_RW_LIMITS};
 
 pub fn derive_type_error_enum_int(
     path: &Path,
@@ -78,26 +78,9 @@ pub fn derive_type_error_enum_int(
     };
 
     // Generated code spec.
-    let spec_gen = if let Some(ref spec_xdr) = spec_xdr {
-        let spec_xdr_lit = proc_macro2::Literal::byte_string(spec_xdr.as_slice());
-        let spec_xdr_len = spec_xdr.len();
-        let spec_ident = format_ident!(
-            "__SPEC_XDR_TYPE_{}",
-            enum_ident.unraw().to_string().to_uppercase()
-        );
-        Some(quote! {
-            #[cfg_attr(target_family = "wasm", link_section = "contractspecv0")]
-            pub static #spec_ident: [u8; #spec_xdr_len] = #enum_ident::spec_xdr();
-
-            impl #enum_ident {
-                pub const fn spec_xdr() -> [u8; #spec_xdr_len] {
-                    *#spec_xdr_lit
-                }
-            }
-        })
-    } else {
-        None
-    };
+    let spec_gen = spec_xdr
+        .as_ref()
+        .map(|spec_xdr| spec::type_spec(enum_ident, spec_xdr));
 
     // SpecShakingMarker impl - only generated when spec is true and the
     // experimental_spec_shaking_v2 feature is enabled.

--- a/soroban-sdk-macros/src/derive_struct.rs
+++ b/soroban-sdk-macros/src/derive_struct.rs
@@ -1,13 +1,13 @@
 use itertools::Itertools;
 use proc_macro2::{Literal, TokenStream as TokenStream2};
-use quote::{format_ident, quote};
+use quote::quote;
 use syn::{ext::IdentExt as _, Attribute, DataStruct, Error, Ident, Path, Visibility};
 
 use stellar_xdr::{
     ScSpecEntry, ScSpecTypeDef, ScSpecUdtStructFieldV0, ScSpecUdtStructV0, StringM, WriteXdr,
 };
 
-use crate::{doc::docs_from_attrs, map_type::map_type, shaking, DEFAULT_XDR_RW_LIMITS};
+use crate::{doc::docs_from_attrs, map_type::map_type, shaking, spec, DEFAULT_XDR_RW_LIMITS};
 
 // TODO: Add field attribute for including/excluding fields in types.
 // TODO: Better handling of partial types and types without all their fields and
@@ -88,26 +88,9 @@ pub fn derive_type_struct(
     };
 
     // Generated code spec.
-    let spec_gen = if let Some(ref spec_xdr) = spec_xdr {
-        let spec_xdr_lit = proc_macro2::Literal::byte_string(spec_xdr.as_slice());
-        let spec_xdr_len = spec_xdr.len();
-        let spec_ident = format_ident!(
-            "__SPEC_XDR_TYPE_{}",
-            ident.unraw().to_string().to_uppercase()
-        );
-        Some(quote! {
-            #[cfg_attr(target_family = "wasm", link_section = "contractspecv0")]
-            pub static #spec_ident: [u8; #spec_xdr_len] = #ident::spec_xdr();
-
-            impl #ident {
-                pub const fn spec_xdr() -> [u8; #spec_xdr_len] {
-                    *#spec_xdr_lit
-                }
-            }
-        })
-    } else {
-        None
-    };
+    let spec_gen = spec_xdr
+        .as_ref()
+        .map(|spec_xdr| spec::type_spec(ident, spec_xdr));
 
     // SpecShakingMarker impl - only generated when spec is true and the
     // experimental_spec_shaking_v2 feature is enabled.

--- a/soroban-sdk-macros/src/derive_struct_tuple.rs
+++ b/soroban-sdk-macros/src/derive_struct_tuple.rs
@@ -1,13 +1,13 @@
 use itertools::MultiUnzip;
 use proc_macro2::{Literal, TokenStream as TokenStream2};
-use quote::{format_ident, quote};
+use quote::quote;
 use syn::{ext::IdentExt as _, Attribute, DataStruct, Error, Ident, Path, Visibility};
 
 use stellar_xdr::{
     ScSpecEntry, ScSpecTypeDef, ScSpecUdtStructFieldV0, ScSpecUdtStructV0, StringM, WriteXdr,
 };
 
-use crate::{doc::docs_from_attrs, map_type::map_type, shaking, DEFAULT_XDR_RW_LIMITS};
+use crate::{doc::docs_from_attrs, map_type::map_type, shaking, spec, DEFAULT_XDR_RW_LIMITS};
 
 pub fn derive_type_struct_tuple(
     path: &Path,
@@ -77,26 +77,9 @@ pub fn derive_type_struct_tuple(
     };
 
     // Generated code spec.
-    let spec_gen = if let Some(ref spec_xdr) = spec_xdr {
-        let spec_xdr_lit = proc_macro2::Literal::byte_string(spec_xdr.as_slice());
-        let spec_xdr_len = spec_xdr.len();
-        let spec_ident = format_ident!(
-            "__SPEC_XDR_TYPE_{}",
-            ident.unraw().to_string().to_uppercase()
-        );
-        Some(quote! {
-            #[cfg_attr(target_family = "wasm", link_section = "contractspecv0")]
-            pub static #spec_ident: [u8; #spec_xdr_len] = #ident::spec_xdr();
-
-            impl #ident {
-                pub const fn spec_xdr() -> [u8; #spec_xdr_len] {
-                    *#spec_xdr_lit
-                }
-            }
-        })
-    } else {
-        None
-    };
+    let spec_gen = spec_xdr
+        .as_ref()
+        .map(|spec_xdr| spec::type_spec(ident, spec_xdr));
 
     // SpecShakingMarker impl - only generated when spec is true and the
     // experimental_spec_shaking_v2 feature is enabled.

--- a/soroban-sdk-macros/src/lib.rs
+++ b/soroban-sdk-macros/src/lib.rs
@@ -20,6 +20,7 @@ mod doc;
 mod map_type;
 mod path;
 mod shaking;
+mod spec;
 mod symbol;
 mod syn_ext;
 

--- a/soroban-sdk-macros/src/spec.rs
+++ b/soroban-sdk-macros/src/spec.rs
@@ -1,0 +1,27 @@
+//! Generates the contract spec for a contract type.
+
+use proc_macro2::{Literal, TokenStream as TokenStream2};
+use quote::{format_ident, quote};
+use syn::{ext::IdentExt as _, Ident};
+
+/// Emits the contract spec for a contract type: the `spec_xdr` const fn holding
+/// the spec entry's XDR, and the static that places its bytes in the contract's
+/// spec section.
+pub fn type_spec(ident: &Ident, spec_xdr: &[u8]) -> TokenStream2 {
+    let spec_xdr_lit = Literal::byte_string(spec_xdr);
+    let spec_xdr_len = spec_xdr.len();
+    let spec_ident = format_ident!(
+        "__SPEC_XDR_TYPE_{}",
+        ident.unraw().to_string().to_uppercase()
+    );
+    quote! {
+        #[cfg_attr(target_family = "wasm", link_section = "contractspecv0")]
+        pub static #spec_ident: [u8; #spec_xdr_len] = #ident::spec_xdr();
+
+        impl #ident {
+            pub const fn spec_xdr() -> [u8; #spec_xdr_len] {
+                *#spec_xdr_lit
+            }
+        }
+    }
+}


### PR DESCRIPTION
### What

Move the identical spec-emission block copied across the struct, tuple struct, enum, enum int, and error enum derives into one `spec::type_spec` helper.

### Why

Five copies of the same `__SPEC_XDR_TYPE_*` static and `spec_xdr()` const fn had to be edited in lockstep on every change to how type specs are emitted.

### Known limitations

N/A
