### PR TITLE
Remove semver-checks job from rust workflow

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -22,7 +22,7 @@ jobs:
 
   complete:
     if: always()
-    needs: [fmt, check-git-rev-deps, semver-checks, build, test, expand-test-wasms, build-fuzz, docs, readme, migration-docs]
+    needs: [fmt, check-git-rev-deps, build, test, expand-test-wasms, build-fuzz, docs, readme, migration-docs]
     runs-on: ubuntu-slim
     steps:
     - if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
@@ -95,41 +95,6 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: stellar/actions/rust-check-git-rev-deps@main
-
-  semver-checks:
-    # Push and merge queue events do not include PR labels, so only check pull request events.
-    if: "github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'skip-semver-checks')"
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v3
-    - run: rustup update stable
-    - name: Determine Rust n-2 version since cargo-semver-checks is rarely available for the latest version
-      id: rust-version
-      run: |
-        current_version=$(rustc +stable --version | grep -oE '[0-9]+\.[0-9]+' | head -1)
-        major=$(echo $current_version | cut -d. -f1)
-        minor=$(echo $current_version | cut -d. -f2)
-        prev_minor=$((minor - 2))
-        prev_version="${major}.${prev_minor}"
-        echo "Latest stable: $current_version, using n-2: $prev_version"
-        echo "version=$prev_version" >> $GITHUB_OUTPUT
-    - name: Install Rust ${{ steps.rust-version.outputs.version }}
-      run: |
-        rustup install ${{ steps.rust-version.outputs.version }}
-        rustup override set ${{ steps.rust-version.outputs.version }}
-    - name: Verify Rust version
-      run: |
-        rustc --version
-        cargo --version
-    - uses: stellar/binaries@v55
-      with:
-        name: cargo-semver-checks
-        version: 0.46.0
-    - run: >
-        cargo semver-checks
-        --exclude soroban-meta
-        --exclude soroban-token-spec
-        --exclude stellar-asset-spec
 
   build:
     needs: setup


### PR DESCRIPTION
### What
Removes the `semver-checks` job from `.github/workflows/rust.yml`.

### Why
The `semver-checks` job runs `cargo semver-checks` as a required CI check, blocking merges on detected semver violations. This has been replaced by the new `semver` agentic workflow (`.github/workflows/semver.md` / `semver.lock.yml`), which runs the same `cargo semver-checks` analysis but labels PRs with their semver category (`semver:major`/`semver:minor`/`semver:patch`) instead of gating the merge. This is a better fit: it surfaces the same information to help maintainers make the right merge decisions, without blocking merges outright.

Follow up of https://github.com/stellar/rs-soroban-sdk/pull/1960