### PR TITLE
Add tests for contracttype with aliased imports

### DIFF
--- a/soroban-sdk/src/tests.rs
+++ b/soroban-sdk/src/tests.rs
@@ -29,6 +29,7 @@ mod contract_udt_enum_option;
 mod contract_udt_option;
 mod contract_udt_raw_identifier;
 mod contract_udt_struct;
+mod contract_udt_struct_aliased_import;
 mod contract_udt_struct_tuple;
 mod contractimpl_trait_call_resolution;
 mod contractimport;

--- a/soroban-sdk/src/tests/contract_udt_struct_aliased_import.rs
+++ b/soroban-sdk/src/tests/contract_udt_struct_aliased_import.rs
@@ -98,4 +98,29 @@ fn test_spec() {
         .unwrap(),
     });
     assert_eq!(entries, expect);
+
+    // The aliased import, Renamed, is the same type as inner::Inner, so its
+    // spec is registered under the type's original name, Inner, not the
+    // aliased name used at the field-declaration site above.
+    let entries = ScSpecEntry::from_xdr(Renamed::spec_xdr(), Limits::none()).unwrap();
+    let expect = ScSpecEntry::UdtStructV0(ScSpecUdtStructV0 {
+        doc: "".try_into().unwrap(),
+        lib: "".try_into().unwrap(),
+        name: "Inner".try_into().unwrap(),
+        fields: vec![
+            ScSpecUdtStructFieldV0 {
+                doc: "".try_into().unwrap(),
+                name: "a".try_into().unwrap(),
+                type_: ScSpecTypeDef::I32,
+            },
+            ScSpecUdtStructFieldV0 {
+                doc: "".try_into().unwrap(),
+                name: "b".try_into().unwrap(),
+                type_: ScSpecTypeDef::I32,
+            },
+        ]
+        .try_into()
+        .unwrap(),
+    });
+    assert_eq!(entries, expect);
 }

--- a/soroban-sdk/src/tests/contract_udt_struct_aliased_import.rs
+++ b/soroban-sdk/src/tests/contract_udt_struct_aliased_import.rs
@@ -1,0 +1,50 @@
+use crate::{self as soroban_sdk};
+use soroban_sdk::{contract, contractimpl, contracttype, Env};
+
+mod inner {
+    use crate::{self as soroban_sdk};
+    use soroban_sdk::contracttype;
+
+    #[derive(Copy, Clone, Debug, Eq, PartialEq)]
+    #[contracttype]
+    pub struct Inner {
+        pub a: i32,
+        pub b: i32,
+    }
+}
+
+use inner::Inner as Renamed;
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[contracttype]
+pub struct Outer {
+    pub inner: Renamed,
+    pub c: i32,
+}
+
+#[contract]
+pub struct Contract;
+
+#[contractimpl]
+impl Contract {
+    pub fn add(a: Outer, b: Outer) -> (Outer, Outer) {
+        (a, b)
+    }
+}
+
+#[test]
+fn test_functional() {
+    let env = Env::default();
+    let contract_id = env.register(Contract, ());
+
+    let a = Outer {
+        inner: Renamed { a: 5, b: 7 },
+        c: 1,
+    };
+    let b = Outer {
+        inner: Renamed { a: 10, b: 14 },
+        c: 2,
+    };
+    let c = ContractClient::new(&env, &contract_id).add(&a, &b);
+    assert_eq!(c, (a, b));
+}

--- a/soroban-sdk/src/tests/contract_udt_struct_aliased_import.rs
+++ b/soroban-sdk/src/tests/contract_udt_struct_aliased_import.rs
@@ -1,3 +1,20 @@
+//! Tests that `#[contracttype]` works on a struct with a field whose type
+//! is a struct imported into scope under an alias, i.e. `use path::Type as
+//! Renamed;`.
+//!
+//! - `test_functional` and `test_functional_with_original_type` confirm the
+//!   generated type round-trips through a contract call correctly, whether
+//!   values are constructed using the aliased name (`Renamed`) or the
+//!   type's original name (`inner::Inner`) — they are the same type.
+//! - `test_spec` documents a limitation of the macros: the spec generated
+//!   for a field names its UDT after whatever identifier is written at the
+//!   field-declaration site (`Renamed`), while the referenced type's own
+//!   spec entry is generated under its original definition name (`Inner`).
+//!   The macros have no way to resolve an aliased import back to the UDT
+//!   entry of the type it refers to, so the spec for `Outer` ends up
+//!   referencing a UDT name, `Renamed`, that no `UdtStructV0` entry actually
+//!   defines.
+
 use crate::{self as soroban_sdk};
 use soroban_sdk::{contract, contractimpl, contracttype, Env};
 use stellar_xdr::{
@@ -87,9 +104,8 @@ fn test_spec() {
                 doc: "".try_into().unwrap(),
                 name: "inner".try_into().unwrap(),
                 type_: ScSpecTypeDef::Udt(ScSpecTypeUdt {
-                    // The field is declared using the aliased import name,
-                    // so that is the name recorded in the spec, not the
-                    // name of the type at its original definition site.
+                    // See module doc comment: named after the aliased
+                    // import, not the type's own spec'd name (below).
                     name: "Renamed".try_into().unwrap(),
                 }),
             },
@@ -99,9 +115,8 @@ fn test_spec() {
     });
     assert_eq!(entries, expect);
 
-    // The aliased import, Renamed, is the same type as inner::Inner, so its
-    // spec is registered under the type's original name, Inner, not the
-    // aliased name used at the field-declaration site above.
+    // Renamed's own spec entry is generated under its original definition
+    // name, "Inner" — confirming no "Renamed" UdtStructV0 entry exists.
     let entries = ScSpecEntry::from_xdr(Renamed::spec_xdr(), Limits::none()).unwrap();
     let expect = ScSpecEntry::UdtStructV0(ScSpecUdtStructV0 {
         doc: "".try_into().unwrap(),

--- a/soroban-sdk/src/tests/contract_udt_struct_aliased_import.rs
+++ b/soroban-sdk/src/tests/contract_udt_struct_aliased_import.rs
@@ -1,19 +1,24 @@
-//! Tests that `#[contracttype]` works on a struct with a field whose type
+//! Demonstrates how `#[contracttype]` works on a struct with a field whose type
 //! is a struct imported into scope under an alias, i.e. `use path::Type as
 //! Renamed;`.
 //!
-//! - `test_functional` and `test_functional_with_original_type` confirm the
-//!   generated type round-trips through a contract call correctly, whether
-//!   values are constructed using the aliased name (`Renamed`) or the
-//!   type's original name (`inner::Inner`) — they are the same type.
+//! - `test_functional` and `test_functional_with_original_type` confirm that,
+//!   used directly within this crate (not via a client generated from the
+//!   contract spec), the generated type round-trips through a contract call
+//!   correctly, whether values are constructed using the aliased name
+//!   (`Renamed`) or the type's original name (`inner::Inner`) — they are the
+//!   same type, so Rust's own type checking is what makes this work.
 //! - `test_spec` documents a limitation of the macros: the spec generated
 //!   for a field names its UDT after whatever identifier is written at the
 //!   field-declaration site (`Renamed`), while the referenced type's own
 //!   spec entry is generated under its original definition name (`Inner`).
 //!   The macros have no way to resolve an aliased import back to the UDT
 //!   entry of the type it refers to, so the spec for `Outer` ends up
-//!   referencing a UDT name, `Renamed`, that no `UdtStructV0` entry actually
-//!   defines.
+//!   referencing a UDT name, `Renamed`, for which no `UdtStructV0` entry
+//!   actually exists. This is a real defect: anything that regenerates a
+//!   client from the spec (e.g. `contractimport!` in another crate) has no
+//!   way to know `Renamed` and `Inner` are the same type, and so cannot
+//!   correctly generate a type for that field.
 
 use crate::{self as soroban_sdk};
 use soroban_sdk::{contract, contractimpl, contracttype, Env};

--- a/soroban-sdk/src/tests/contract_udt_struct_aliased_import.rs
+++ b/soroban-sdk/src/tests/contract_udt_struct_aliased_import.rs
@@ -1,5 +1,9 @@
 use crate::{self as soroban_sdk};
 use soroban_sdk::{contract, contractimpl, contracttype, Env};
+use stellar_xdr::{
+    Limits, ReadXdr, ScSpecEntry, ScSpecTypeDef, ScSpecTypeUdt, ScSpecUdtStructFieldV0,
+    ScSpecUdtStructV0,
+};
 
 mod inner {
     use crate::{self as soroban_sdk};
@@ -47,4 +51,51 @@ fn test_functional() {
     };
     let c = ContractClient::new(&env, &contract_id).add(&a, &b);
     assert_eq!(c, (a, b));
+}
+
+#[test]
+fn test_functional_with_original_type() {
+    let env = Env::default();
+    let contract_id = env.register(Contract, ());
+
+    let a = Outer {
+        inner: inner::Inner { a: 5, b: 7 },
+        c: 1,
+    };
+    let b = Outer {
+        inner: inner::Inner { a: 10, b: 14 },
+        c: 2,
+    };
+    let c = ContractClient::new(&env, &contract_id).add(&a, &b);
+    assert_eq!(c, (a, b));
+}
+
+#[test]
+fn test_spec() {
+    let entries = ScSpecEntry::from_xdr(Outer::spec_xdr(), Limits::none()).unwrap();
+    let expect = ScSpecEntry::UdtStructV0(ScSpecUdtStructV0 {
+        doc: "".try_into().unwrap(),
+        lib: "".try_into().unwrap(),
+        name: "Outer".try_into().unwrap(),
+        fields: vec![
+            ScSpecUdtStructFieldV0 {
+                doc: "".try_into().unwrap(),
+                name: "c".try_into().unwrap(),
+                type_: ScSpecTypeDef::I32,
+            },
+            ScSpecUdtStructFieldV0 {
+                doc: "".try_into().unwrap(),
+                name: "inner".try_into().unwrap(),
+                type_: ScSpecTypeDef::Udt(ScSpecTypeUdt {
+                    // The field is declared using the aliased import name,
+                    // so that is the name recorded in the spec, not the
+                    // name of the type at its original definition site.
+                    name: "Renamed".try_into().unwrap(),
+                }),
+            },
+        ]
+        .try_into()
+        .unwrap(),
+    });
+    assert_eq!(entries, expect);
 }

--- a/soroban-sdk/test_snapshots/tests/contract_udt_struct_aliased_import/test_functional.1.json
+++ b/soroban-sdk/test_snapshots/tests/contract_udt_struct_aliased_import/test_functional.1.json
@@ -1,0 +1,61 @@
+{
+  "generators": {
+    "address": 1,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 27,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": "ledger_key_contract_instance",
+              "durability": "persistent",
+              "val": {
+                "contract_instance": {
+                  "executable": {
+                    "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  },
+                  "storage": null
+                }
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_code": {
+              "ext": "v0",
+              "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+              "code": ""
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      }
+    ]
+  },
+  "events": []
+}

--- a/soroban-sdk/test_snapshots/tests/contract_udt_struct_aliased_import/test_functional_with_original_type.1.json
+++ b/soroban-sdk/test_snapshots/tests/contract_udt_struct_aliased_import/test_functional_with_original_type.1.json
@@ -1,0 +1,61 @@
+{
+  "generators": {
+    "address": 1,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 27,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": "ledger_key_contract_instance",
+              "durability": "persistent",
+              "val": {
+                "contract_instance": {
+                  "executable": {
+                    "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  },
+                  "storage": null
+                }
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_code": {
+              "ext": "v0",
+              "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+              "code": ""
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      }
+    ]
+  },
+  "events": []
+}


### PR DESCRIPTION
### What

Add tests demonstrating how `#[contracttype]` behaves when a struct field's type is imported under an alias (`use path::Inner as Renamed;`).

### Why

Capture existing behaviour and limitations. The macros record a field's UDT spec type using the identifier written at the declaration site (`Renamed`), while the referenced type's own spec entry is generated under its original name (`Inner`), so a client regenerated from the spec can't tell the two are the same type.

### Known limitations

N/A

### SemVer Change

- [ ] Major (vX.\_.\_) - Breaking change to the public API.
- [ ] Minor (v\_.Y.\_) - Additive change to the public API.
- [x] Patch (v\_.\_.Z) - No change to the public API.