### PR TITLE
Fix pr template markdown rendering

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,6 +14,6 @@
 
 [TODO: Check one. Merge only when confirmed that the main branch is accepting changes for the matching type of release. See the [semver-rules.md](./semver-rules.md).
 
-- [ ] Major (vX._._) - Breaking change to the public API.
-- [ ] Minor (v_.Y._) - Additive change to the public API.
-- [ ] Patch (v_._.Z) - No change to the public API.
+- [ ] Major (vX.\_.\_) - Breaking change to the public API.
+- [ ] Minor (v\_.Y.\_) - Additive change to the public API.
+- [ ] Patch (v\_.\_.Z) - No change to the public API.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,6 +14,6 @@
 
 [TODO: Check one. Merge only when confirmed that the main branch is accepting changes for the matching type of release. See the [semver-rules.md](./semver-rules.md).
 
-- [ ] Major (vX.\_.\_) - Breaking change to the public API.
-- [ ] Minor (v\_.Y.\_) - Additive change to the public API.
-- [ ] Patch (v\_.\_.Z) - No change to the public API.
+- [ ] Major (`vX._._`) - Breaking change to the public API.
+- [ ] Minor (`v_.Y._`) - Additive change to the public API.
+- [ ] Patch (`v_._.Z`) - No change to the public API.


### PR DESCRIPTION
### What

Make the underscore (`_`) use in the pr template render as an underscore.

### Why

The underscores were being interpreted as modifiers for italicising text. The underscore usage in the pr template is intended to be rendered as an underscore.

### Known limitations

N/A

### SemVer Change

- [ ] Major (`vX._._`) - Breaking change to the public API.
- [ ] Minor (`v_.Y._`) - Additive change to the public API.
- [x] Patch (`v_._.Z`) - No change to the public API.
