### PR TITLE
Update SAC set_admin event doc-comments to CAP-67 shape

### DIFF
--- a/soroban-sdk/src/token.rs
+++ b/soroban-sdk/src/token.rs
@@ -410,8 +410,8 @@ pub trait StellarAssetInterface {
     ///
     /// # Events
     ///
-    /// Emits an event with topics `["set_admin", admin: Address], data =
-    /// [new_admin: Address]`
+    /// Emits an event with topics `["set_admin", admin: Address,
+    /// sep0011_asset: String], data = new_admin: Address`
     fn set_admin(env: Env, new_admin: Address);
 
     /// Returns the admin of the contract.

--- a/stellar-asset-spec/src/lib.rs
+++ b/stellar-asset-spec/src/lib.rs
@@ -54,7 +54,7 @@ pub(crate) const XDR_INPUT: &[&[u8]] = &[
     &SetAuthorized::spec_xdr(),
 ];
 
-pub(crate) const XDR_LEN: usize = 9184;
+pub(crate) const XDR_LEN: usize = 9208;
 
 /// Returns the contract spec for Stellar Asset contract.
 pub const fn xdr() -> &'static [u8] {


### PR DESCRIPTION
Follows #1956, which corrected `mint`, `clawback`, and `set_authorized` to their CAP-67 shapes. `set_admin` is the one remaining SAC-only function still carrying a stale one, and it is wrong in two independent ways.

## The defect

`soroban-env-host` 27.0.1 — the version this workspace pins — `builtin_contracts/stellar_asset_contract/event.rs`:

```rust
pub(crate) fn set_admin(e: &Host, admin: Address, new_admin: Address) -> Result<(), HostError> {
    let topics = host_vec![e, Symbol::try_from_val(e, &"set_admin")?, admin, read_name(e)?]?;
    e.contract_event(topics.into(), new_admin.try_into_val(e)?)?;
    Ok(())
}
```

| | documented | emitted |
| --- | --- | --- |
| topics | `["set_admin", admin: Address]` | `["set_admin", admin: Address, sep0011_asset: String]` |
| data | `[new_admin: Address]` | `new_admin: Address` |

The missing topic is the same CAP-67 correction #1956 made for the other three — `read_name(e)?` closes every SAC topic vec.

The data shape is a separate error and, I think, the more misleading of the two: the brackets say vec, the host passes a bare `Address`. `approve` in the same trait really does build one (`host_vec![e, amount, live_until_ledger]`), so the notation is meaningful here and a decoder written against the comment would look for the wrong `ScVal` type.

## XDR_LEN

`stellar-asset-spec` moves 9184 → 9208, since doc-comments serialize into the spec XDR.

Measured rather than guessed: I temporarily replaced the literal with a const-eval sum over `XDR_INPUT`, read the value back, then restored the literal. `soroban-token-spec`'s `XDR_LEN` stays at 6620, which is the check that this touched only the asset trait.

## What is deliberately not in this PR

`transfer`, `transfer_from`, `burn`, `burn_from`, and `approve` inside the same trait also carry pre-CAP-67 shapes. They are **not** fixable this way: `test_stellar_asset_spec_includes_token_spec` requires `TokenInterface`'s spec entries to be a subset of `StellarAssetInterface`'s, and `ScSpecEntry` carries the doc string, so the ten shared functions must stay byte-identical — and the asset-free shapes are correct in the generic trait, where a SEP-41 token has no SEP-11 asset to append.

I found that by making all six edits and watching the invariant fail. Filed as #1979 with the evidence and the options I could see; it needs a design decision rather than a doc edit. It also means #1956's scope was structurally forced rather than an oversight, which is not obvious from the outside — I misread it that way myself at first.

## Verification

- `cargo test -p stellar-asset-spec -p soroban-token-spec` — 6 passed, 0 failed, including `test_stellar_asset_spec_includes_token_spec`
- `cargo build -p stellar-asset-spec` — clean
- `cargo test -p soroban-sdk --lib` does not compile here, but fails identically on a clean checkout of `main` (8 errors, missing `../target/wasm32v1-none/release/*.wasm` fixtures). Verified by stashing this change and re-running; unrelated to it.

Happy to drop the `data` half if you would rather keep this diff to the topic correction alone.
