### PR TITLE
Update SAC set_admin event doc-comments to CAP-67 shape

### DIFF
--- a/soroban-sdk/src/token.rs
+++ b/soroban-sdk/src/token.rs
@@ -410,8 +410,8 @@ pub trait StellarAssetInterface {
     ///
     /// # Events
     ///
-    /// Emits an event with topics `["set_admin", admin: Address], data =
-    /// [new_admin: Address]`
+    /// Emits an event with topics `["set_admin", admin: Address,
+    /// sep0011_asset: String], data = new_admin: Address`
     fn set_admin(env: Env, new_admin: Address);
 
     /// Returns the admin of the contract.

--- a/stellar-asset-spec/src/lib.rs
+++ b/stellar-asset-spec/src/lib.rs
@@ -54,7 +54,7 @@ pub(crate) const XDR_INPUT: &[&[u8]] = &[
     &SetAuthorized::spec_xdr(),
 ];
 
-pub(crate) const XDR_LEN: usize = 9184;
+pub(crate) const XDR_LEN: usize = 9208;
 
 /// Returns the contract spec for Stellar Asset contract.
 pub const fn xdr() -> &'static [u8] {


### PR DESCRIPTION
Corrects the set_admin event documentation in StellarAssetInterface to include the trailing sep0011_asset topic and correct data shape. Fixes #1979.