### PR TITLE
Fix StellarAssetInterface shared-function event docs

### DIFF
--- a/soroban-sdk/src/token.rs
+++ b/soroban-sdk/src/token.rs
@@ -146,7 +146,7 @@ pub trait TokenInterface {
     ///
     /// Emits an event with:
     /// * topics `["transfer", from: Address, to: Address]`
-    /// * data `{ amount: i128, to_muxed_id: u64 }: Map`
+    /// * data `{ amount: i128, to_muxed_id: Option<u64> }: Map`
     ///
     /// Legacy implementations may emit an event with:
     /// * topics `["transfer", from: Address, to: Address]`
@@ -309,7 +309,7 @@ pub trait StellarAssetInterface {
     ///
     /// When `to` is a muxed address, emits an event with:
     /// * topics `["transfer", from: Address, to: Address, sep0011_asset: String]`
-    /// * data `{ amount: i128, to_muxed_id: u64 }: Map`
+    /// * data `{ amount: i128, to_muxed_id: Option<u64> }: Map`
     ///
     /// Otherwise, emits an event with:
     /// * topics `["transfer", from: Address, to: Address, sep0011_asset: String]`

--- a/soroban-sdk/src/token.rs
+++ b/soroban-sdk/src/token.rs
@@ -315,8 +315,8 @@ pub trait StellarAssetInterface {
     /// * topics `["transfer", from: Address, to: Address, sep0011_asset: String]`
     /// * data `amount: i128`
     ///
-    /// When `from` is the asset issuer, a `mint` event is emitted instead.
-    /// When `to` is the asset issuer, a `burn` event is emitted instead.
+    /// When `from != to` and `from` is the asset issuer, a `mint` event is emitted instead.
+    /// When `from != to` and `to` is the asset issuer, a `burn` event is emitted instead.
     fn transfer(env: Env, from: Address, to: MuxedAddress, amount: i128);
 
     /// Transfer `amount` from `from` to `to`, consuming the allowance that

--- a/soroban-sdk/src/token.rs
+++ b/soroban-sdk/src/token.rs
@@ -122,7 +122,7 @@ pub trait TokenInterface {
     /// # Events
     ///
     /// Emits an event with topics `["approve", from: Address,
-    /// spender: Address], data = [amount: i128, expiration_ledger: u32]`
+    /// spender: Address], data = [amount: i128, live_until_ledger: u32]`
     fn approve(env: Env, from: Address, spender: Address, amount: i128, live_until_ledger: u32);
 
     /// Returns the balance of `id`.
@@ -146,7 +146,7 @@ pub trait TokenInterface {
     ///
     /// Emits an event with:
     /// * topics `["transfer", from: Address, to: Address]`
-    /// * data `{ to_muxed_id: Option<u64>, amount: i128 }: Map`
+    /// * data `{ amount: i128, to_muxed_id: u64 }: Map`
     ///
     /// Legacy implementations may emit an event with:
     /// * topics `["transfer", from: Address, to: Address]`
@@ -284,7 +284,8 @@ pub trait StellarAssetInterface {
     /// # Events
     ///
     /// Emits an event with topics `["approve", from: Address,
-    /// spender: Address], data = [amount: i128, expiration_ledger: u32]`
+    /// spender: Address, sep0011_asset: String], data = [amount: i128,
+    /// live_until_ledger: u32]`
     fn approve(env: Env, from: Address, spender: Address, amount: i128, live_until_ledger: u32);
 
     /// Returns the balance of `id`.
@@ -306,13 +307,16 @@ pub trait StellarAssetInterface {
     ///
     /// # Events
     ///
-    /// Emits an event with:
-    /// * topics `["transfer", from: Address, to: Address]`
-    /// * data `{ to_muxed_id: Option<u64>, amount: i128 }: Map`
+    /// When `to` is a muxed address, emits an event with:
+    /// * topics `["transfer", from: Address, to: Address, sep0011_asset: String]`
+    /// * data `{ amount: i128, to_muxed_id: u64 }: Map`
     ///
-    /// Legacy implementations may emit an event with:
-    /// * topics `["transfer", from: Address, to: Address]`
+    /// Otherwise, emits an event with:
+    /// * topics `["transfer", from: Address, to: Address, sep0011_asset: String]`
     /// * data `amount: i128`
+    ///
+    /// When `from` is the asset issuer, a `mint` event is emitted instead.
+    /// When `to` is the asset issuer, a `burn` event is emitted instead.
     fn transfer(env: Env, from: Address, to: MuxedAddress, amount: i128);
 
     /// Transfer `amount` from `from` to `to`, consuming the allowance that
@@ -335,8 +339,8 @@ pub trait StellarAssetInterface {
     ///
     /// # Events
     ///
-    /// Emits an event with topics `["transfer", from: Address, to: Address],
-    /// data = amount: i128`
+    /// Emits an event with topics `["transfer", from: Address, to: Address,
+    /// sep0011_asset: String], data = amount: i128`
     fn transfer_from(env: Env, spender: Address, from: Address, to: Address, amount: i128);
 
     /// Burn `amount` from `from`.
@@ -352,8 +356,8 @@ pub trait StellarAssetInterface {
     ///
     /// # Events
     ///
-    /// Emits an event with topics `["burn", from: Address], data = amount:
-    /// i128`
+    /// Emits an event with topics `["burn", from: Address,
+    /// sep0011_asset: String], data = amount: i128`
     fn burn(env: Env, from: Address, amount: i128);
 
     /// Burn `amount` from `from`, consuming the allowance of `spender`.
@@ -376,8 +380,8 @@ pub trait StellarAssetInterface {
     ///
     /// # Events
     ///
-    /// Emits an event with topics `["burn", from: Address], data = amount:
-    /// i128`
+    /// Emits an event with topics `["burn", from: Address,
+    /// sep0011_asset: String], data = amount: i128`
     fn burn_from(env: Env, spender: Address, from: Address, amount: i128);
 
     /// Returns the number of decimals used to represent amounts of this token.

--- a/soroban-token-spec/src/lib.rs
+++ b/soroban-token-spec/src/lib.rs
@@ -76,7 +76,16 @@ pub(crate) const XDR_INPUT: &[&[u8]] = &[
     &soroban_token_sdk::events::Clawback::spec_xdr(),
 ];
 
-pub(crate) const XDR_LEN: usize = 6620;
+pub(crate) const XDR_LEN: usize = {
+    let input = XDR_INPUT;
+    let mut len = 0usize;
+    let mut i = 0;
+    while i < input.len() {
+        len += input[i].len();
+        i += 1;
+    }
+    len
+};
 
 /// Returns the contract spec for a SEP-41 Token contract.
 pub const fn xdr() -> &'static [u8] {

--- a/stellar-asset-spec/src/lib.rs
+++ b/stellar-asset-spec/src/lib.rs
@@ -2,15 +2,137 @@
 
 mod tests;
 
-use soroban_sdk::{contractevent, Address};
+use soroban_sdk::{contractevent, Address, BytesN, String};
 
 // Events that are unique to the Stellar Asset Contract and not part of SEP-41 are defined here
 // privately only for the purpose of generating the complete contract spec.
+// All SAC events include sep0011_asset (the SEP-0011 asset string, e.g. "native" or
+// "USDC:GABC...") as a trailing topic, per the SAC implementation in rs-soroban-env.
+// These structs share the same base names as the token-sdk event structs so the spec
+// `name` field matches and the subset invariant test can verify them.
+
+#[contractevent(topics = ["approve"], data_format = "vec", export = false)]
+pub(crate) struct Approve {
+    #[topic]
+    pub from: Address,
+    #[topic]
+    pub spender: Address,
+    #[topic]
+    pub sep0011_asset: String,
+    pub amount: i128,
+    pub expiration_ledger: u32,
+}
+
+#[contractevent(topics = ["transfer"], data_format = "single-value", export = false)]
+pub(crate) struct TransferWithAmountOnly {
+    #[topic]
+    pub from: Address,
+    #[topic]
+    pub to: Address,
+    #[topic]
+    pub sep0011_asset: String,
+    pub amount: i128,
+}
+
+#[contractevent(topics = ["transfer"], data_format = "map", export = false)]
+pub(crate) struct Transfer {
+    #[topic]
+    pub from: Address,
+    #[topic]
+    pub to: Address,
+    #[topic]
+    pub sep0011_asset: String,
+    pub to_muxed_id: Option<u64>,
+    pub amount: i128,
+}
+
+#[contractevent(topics = ["transfer"], data_format = "map", export = false)]
+pub(crate) struct TransferWithMuxedString {
+    #[topic]
+    pub from: Address,
+    #[topic]
+    pub to: Address,
+    #[topic]
+    pub sep0011_asset: String,
+    pub to_muxed_id: Option<String>,
+    pub amount: i128,
+}
+
+#[contractevent(topics = ["transfer"], data_format = "map", export = false)]
+pub(crate) struct TransferWithMuxedBytes {
+    #[topic]
+    pub from: Address,
+    #[topic]
+    pub to: Address,
+    #[topic]
+    pub sep0011_asset: String,
+    pub to_muxed_id: Option<BytesN<32>>,
+    pub amount: i128,
+}
+
+#[contractevent(topics = ["burn"], data_format = "single-value", export = false)]
+pub(crate) struct Burn {
+    #[topic]
+    pub from: Address,
+    #[topic]
+    pub sep0011_asset: String,
+    pub amount: i128,
+}
+
+#[contractevent(topics = ["mint"], data_format = "single-value", export = false)]
+pub(crate) struct MintWithAmountOnly {
+    #[topic]
+    pub to: Address,
+    #[topic]
+    pub sep0011_asset: String,
+    pub amount: i128,
+}
+
+#[contractevent(topics = ["mint"], data_format = "map", export = false)]
+pub(crate) struct Mint {
+    #[topic]
+    pub to: Address,
+    #[topic]
+    pub sep0011_asset: String,
+    pub to_muxed_id: Option<u64>,
+    pub amount: i128,
+}
+
+#[contractevent(topics = ["mint"], data_format = "map", export = false)]
+pub(crate) struct MintWithMuxedString {
+    #[topic]
+    pub to: Address,
+    #[topic]
+    pub sep0011_asset: String,
+    pub to_muxed_id: Option<String>,
+    pub amount: i128,
+}
+
+#[contractevent(topics = ["mint"], data_format = "map", export = false)]
+pub(crate) struct MintWithMuxedBytes {
+    #[topic]
+    pub to: Address,
+    #[topic]
+    pub sep0011_asset: String,
+    pub to_muxed_id: Option<BytesN<32>>,
+    pub amount: i128,
+}
+
+#[contractevent(topics = ["clawback"], data_format = "single-value", export = false)]
+pub(crate) struct Clawback {
+    #[topic]
+    pub from: Address,
+    #[topic]
+    pub sep0011_asset: String,
+    pub amount: i128,
+}
 
 #[contractevent(topics = ["set_admin"], data_format = "single-value", export = false)]
 pub(crate) struct SetAdmin {
     #[topic]
     pub admin: Address,
+    #[topic]
+    pub sep0011_asset: String,
     pub new_admin: Address,
 }
 
@@ -18,6 +140,8 @@ pub(crate) struct SetAdmin {
 pub(crate) struct SetAuthorized {
     #[topic]
     pub id: Address,
+    #[topic]
+    pub sep0011_asset: String,
     pub authorize: bool,
 }
 
@@ -39,22 +163,31 @@ pub(crate) const XDR_INPUT: &[&[u8]] = &[
     &soroban_sdk::token::StellarAssetFnSpec::spec_xdr_transfer(),
     &soroban_sdk::token::StellarAssetFnSpec::spec_xdr_transfer_from(),
     &soroban_sdk::token::StellarAssetFnSpec::spec_xdr_trust(),
-    &soroban_token_sdk::events::Approve::spec_xdr(),
-    &soroban_token_sdk::events::TransferWithAmountOnly::spec_xdr(),
-    &soroban_token_sdk::events::Transfer::spec_xdr(),
-    &soroban_token_spec::TransferWithMuxedString::spec_xdr(),
-    &soroban_token_spec::TransferWithMuxedBytes::spec_xdr(),
-    &soroban_token_sdk::events::Burn::spec_xdr(),
-    &soroban_token_sdk::events::MintWithAmountOnly::spec_xdr(),
-    &soroban_token_sdk::events::Mint::spec_xdr(),
-    &soroban_token_spec::MintWithMuxedString::spec_xdr(),
-    &soroban_token_spec::MintWithMuxedBytes::spec_xdr(),
-    &soroban_token_sdk::events::Clawback::spec_xdr(),
+    &Approve::spec_xdr(),
+    &TransferWithAmountOnly::spec_xdr(),
+    &Transfer::spec_xdr(),
+    &TransferWithMuxedString::spec_xdr(),
+    &TransferWithMuxedBytes::spec_xdr(),
+    &Burn::spec_xdr(),
+    &MintWithAmountOnly::spec_xdr(),
+    &Mint::spec_xdr(),
+    &MintWithMuxedString::spec_xdr(),
+    &MintWithMuxedBytes::spec_xdr(),
+    &Clawback::spec_xdr(),
     &SetAdmin::spec_xdr(),
     &SetAuthorized::spec_xdr(),
 ];
 
-pub(crate) const XDR_LEN: usize = 9208;
+pub(crate) const XDR_LEN: usize = {
+    let input = XDR_INPUT;
+    let mut len = 0usize;
+    let mut i = 0;
+    while i < input.len() {
+        len += input[i].len();
+        i += 1;
+    }
+    len
+};
 
 /// Returns the contract spec for Stellar Asset contract.
 pub const fn xdr() -> &'static [u8] {

--- a/stellar-asset-spec/src/lib.rs
+++ b/stellar-asset-spec/src/lib.rs
@@ -4,8 +4,8 @@ mod tests;
 
 use soroban_sdk::{contractevent, Address, BytesN, String};
 
-// Events that are unique to the Stellar Asset Contract and not part of SEP-41 are defined here
-// privately only for the purpose of generating the complete contract spec.
+// SAC-specific variants of SEP-41 events and events unique to the Stellar Asset Contract are
+// defined here privately only for generating the complete contract spec.
 // All SAC events include sep0011_asset (the SEP-0011 asset string, e.g. "native" or
 // "USDC:GABC...") as a trailing topic, per the SAC implementation in rs-soroban-env.
 // These structs share the same base names as the token-sdk event structs so the spec

--- a/stellar-asset-spec/src/tests/events.rs
+++ b/stellar-asset-spec/src/tests/events.rs
@@ -16,6 +16,71 @@ use std::rc::Rc;
 struct Contract;
 
 #[test]
+fn test_set_admin() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let new_admin = Address::generate(&env);
+
+    // Register the asset to get the SEP-0011 asset string it uses in events.
+    let asset = env.register_stellar_asset_contract_v2(admin.clone());
+    let client = StellarAssetClient::new(&env, &asset.address());
+    let sep0011_asset = client.name();
+
+    let event = SetAdmin {
+        admin: admin.clone(),
+        sep0011_asset: sep0011_asset.clone(),
+        new_admin: new_admin.clone(),
+    };
+
+    // Verify the event struct publishes topics and data matching its XDR form.
+    let id = env.register(Contract, ());
+    env.as_contract(&id, || event.publish(&env));
+    assert_eq!(env.events().all(), std::vec![event.to_xdr(&env, &id)]);
+
+    // Verify the SAC client emits an event matching the event struct.
+    client.set_admin(&new_admin);
+    assert_eq!(
+        env.events().all(),
+        std::vec![event.to_xdr(&env, &asset.address())]
+    );
+}
+
+#[test]
+fn test_set_authorized() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let authorizee = Address::generate(&env);
+    let authorize = true;
+
+    // Register the asset to get the SEP-0011 asset string it uses in events.
+    let asset = env.register_stellar_asset_contract_v2(admin.clone());
+    let client = StellarAssetClient::new(&env, &asset.address());
+    let sep0011_asset = client.name();
+
+    let event = SetAuthorized {
+        id: authorizee.clone(),
+        sep0011_asset: sep0011_asset.clone(),
+        authorize,
+    };
+
+    // Verify the event struct publishes topics and data matching its XDR form.
+    let id = env.register(Contract, ());
+    env.as_contract(&id, || event.publish(&env));
+    assert_eq!(env.events().all(), std::vec![event.to_xdr(&env, &id)]);
+
+    // Verify the SAC client emits an event matching the event struct.
+    client.set_authorized(&authorizee, &authorize);
+    assert_eq!(
+        env.events().all(),
+        std::vec![event.to_xdr(&env, &asset.address())]
+    );
+}
+
+#[test]
 fn test_approve() {
     let env = Env::default();
     env.mock_all_auths();
@@ -326,71 +391,6 @@ fn test_clawback() {
     // Verify the SAC client emits an event matching the event struct.
     client.mint(&from, &amount);
     client.clawback(&from, &amount);
-    assert_eq!(
-        env.events().all(),
-        std::vec![event.to_xdr(&env, &asset.address())]
-    );
-}
-
-#[test]
-fn test_set_admin() {
-    let env = Env::default();
-    env.mock_all_auths();
-
-    let admin = Address::generate(&env);
-    let new_admin = Address::generate(&env);
-
-    // Register the asset to get the SEP-0011 asset string it uses in events.
-    let asset = env.register_stellar_asset_contract_v2(admin.clone());
-    let client = StellarAssetClient::new(&env, &asset.address());
-    let sep0011_asset = client.name();
-
-    let event = SetAdmin {
-        admin: admin.clone(),
-        sep0011_asset: sep0011_asset.clone(),
-        new_admin: new_admin.clone(),
-    };
-
-    // Verify the event struct publishes topics and data matching its XDR form.
-    let id = env.register(Contract, ());
-    env.as_contract(&id, || event.publish(&env));
-    assert_eq!(env.events().all(), std::vec![event.to_xdr(&env, &id)]);
-
-    // Verify the SAC client emits an event matching the event struct.
-    client.set_admin(&new_admin);
-    assert_eq!(
-        env.events().all(),
-        std::vec![event.to_xdr(&env, &asset.address())]
-    );
-}
-
-#[test]
-fn test_set_authorized() {
-    let env = Env::default();
-    env.mock_all_auths();
-
-    let admin = Address::generate(&env);
-    let authorizee = Address::generate(&env);
-    let authorize = true;
-
-    // Register the asset to get the SEP-0011 asset string it uses in events.
-    let asset = env.register_stellar_asset_contract_v2(admin.clone());
-    let client = StellarAssetClient::new(&env, &asset.address());
-    let sep0011_asset = client.name();
-
-    let event = SetAuthorized {
-        id: authorizee.clone(),
-        sep0011_asset: sep0011_asset.clone(),
-        authorize,
-    };
-
-    // Verify the event struct publishes topics and data matching its XDR form.
-    let id = env.register(Contract, ());
-    env.as_contract(&id, || event.publish(&env));
-    assert_eq!(env.events().all(), std::vec![event.to_xdr(&env, &id)]);
-
-    // Verify the SAC client emits an event matching the event struct.
-    client.set_authorized(&authorizee, &authorize);
     assert_eq!(
         env.events().all(),
         std::vec![event.to_xdr(&env, &asset.address())]

--- a/stellar-asset-spec/src/tests/events.rs
+++ b/stellar-asset-spec/src/tests/events.rs
@@ -37,14 +37,11 @@ fn test_set_admin() {
     // Verify the event struct publishes topics and data matching its XDR form.
     let id = env.register(Contract, ());
     env.as_contract(&id, || event.publish(&env));
-    assert_eq!(env.events().all(), std::vec![event.to_xdr(&env, &id)]);
+    assert_eq!(env.events().all(), [event.to_xdr(&env, &id)]);
 
     // Verify the SAC client emits an event matching the event struct.
     client.set_admin(&new_admin);
-    assert_eq!(
-        env.events().all(),
-        std::vec![event.to_xdr(&env, &asset.address())]
-    );
+    assert_eq!(env.events().all(), [event.to_xdr(&env, &asset.address())]);
 }
 
 #[test]
@@ -70,14 +67,11 @@ fn test_set_authorized() {
     // Verify the event struct publishes topics and data matching its XDR form.
     let id = env.register(Contract, ());
     env.as_contract(&id, || event.publish(&env));
-    assert_eq!(env.events().all(), std::vec![event.to_xdr(&env, &id)]);
+    assert_eq!(env.events().all(), [event.to_xdr(&env, &id)]);
 
     // Verify the SAC client emits an event matching the event struct.
     client.set_authorized(&authorizee, &authorize);
-    assert_eq!(
-        env.events().all(),
-        std::vec![event.to_xdr(&env, &asset.address())]
-    );
+    assert_eq!(env.events().all(), [event.to_xdr(&env, &asset.address())]);
 }
 
 #[test]
@@ -105,14 +99,11 @@ fn test_approve() {
     // Verify the event struct publishes topics and data matching its XDR form.
     let id = env.register(Contract, ());
     env.as_contract(&id, || event.publish(&env));
-    assert_eq!(env.events().all(), std::vec![event.to_xdr(&env, &id)]);
+    assert_eq!(env.events().all(), [event.to_xdr(&env, &id)]);
 
     // Verify the SAC client emits an event matching the event struct.
     client.approve(&from, &spender, &amount, &live_until_ledger);
-    assert_eq!(
-        env.events().all(),
-        std::vec![event.to_xdr(&env, &asset.address())]
-    );
+    assert_eq!(env.events().all(), [event.to_xdr(&env, &asset.address())]);
 }
 
 #[test]
@@ -138,15 +129,12 @@ fn test_transfer() {
     // Verify the event struct publishes topics and data matching its XDR form.
     let id = env.register(Contract, ());
     env.as_contract(&id, || event.publish(&env));
-    assert_eq!(env.events().all(), std::vec![event.to_xdr(&env, &id)]);
+    assert_eq!(env.events().all(), [event.to_xdr(&env, &id)]);
 
     // Verify the SAC client emits an event matching the event struct.
     client.mint(&from, &amount);
     client.transfer(&from, &to, &amount);
-    assert_eq!(
-        env.events().all(),
-        std::vec![event.to_xdr(&env, &asset.address())]
-    );
+    assert_eq!(env.events().all(), [event.to_xdr(&env, &asset.address())]);
 }
 
 #[test]
@@ -173,7 +161,7 @@ fn test_transfer_with_id() {
     // Verify the event struct publishes topics and data matching its XDR form.
     let id = env.register(Contract, ());
     env.as_contract(&id, || event.publish(&env));
-    assert_eq!(env.events().all(), std::vec![event.to_xdr(&env, &id)]);
+    assert_eq!(env.events().all(), [event.to_xdr(&env, &id)]);
 
     // Verify the SAC client emits an event matching the event struct.
     let trust_line_asset = |asset: xdr::Asset| match asset {
@@ -206,10 +194,7 @@ fn test_transfer_with_id() {
         .unwrap();
 
     client.transfer(&from, &to, &amount);
-    assert_eq!(
-        env.events().all(),
-        std::vec![event.to_xdr(&env, &asset.address())]
-    );
+    assert_eq!(env.events().all(), [event.to_xdr(&env, &asset.address())]);
 }
 
 #[test]
@@ -238,10 +223,7 @@ fn test_transfer_from() {
     client.mint(&from, &amount);
     client.approve(&from, &spender, &amount, &200);
     client.transfer_from(&spender, &from, &to, &amount);
-    assert_eq!(
-        env.events().all(),
-        std::vec![event.to_xdr(&env, &asset.address())]
-    );
+    assert_eq!(env.events().all(), [event.to_xdr(&env, &asset.address())]);
 }
 
 #[test]
@@ -265,15 +247,12 @@ fn test_burn() {
     // Verify the event struct publishes topics and data matching its XDR form.
     let id = env.register(Contract, ());
     env.as_contract(&id, || event.publish(&env));
-    assert_eq!(env.events().all(), std::vec![event.to_xdr(&env, &id)]);
+    assert_eq!(env.events().all(), [event.to_xdr(&env, &id)]);
 
     // Verify the SAC client emits an event matching the event struct.
     client.mint(&from, &amount);
     client.burn(&from, &amount);
-    assert_eq!(
-        env.events().all(),
-        std::vec![event.to_xdr(&env, &asset.address())]
-    );
+    assert_eq!(env.events().all(), [event.to_xdr(&env, &asset.address())]);
 }
 
 #[test]
@@ -300,10 +279,7 @@ fn test_burn_from() {
     client.mint(&from, &amount);
     client.approve(&from, &spender, &amount, &200);
     client.burn_from(&spender, &from, &amount);
-    assert_eq!(
-        env.events().all(),
-        std::vec![event.to_xdr(&env, &asset.address())]
-    );
+    assert_eq!(env.events().all(), [event.to_xdr(&env, &asset.address())]);
 }
 
 #[test]
@@ -327,14 +303,11 @@ fn test_mint() {
     // Verify the event struct publishes topics and data matching its XDR form.
     let id = env.register(Contract, ());
     env.as_contract(&id, || event.publish(&env));
-    assert_eq!(env.events().all(), std::vec![event.to_xdr(&env, &id)]);
+    assert_eq!(env.events().all(), [event.to_xdr(&env, &id)]);
 
     // Verify the SAC client emits an event matching the event struct.
     client.mint(&to, &amount);
-    assert_eq!(
-        env.events().all(),
-        std::vec![event.to_xdr(&env, &asset.address())]
-    );
+    assert_eq!(env.events().all(), [event.to_xdr(&env, &asset.address())]);
 }
 
 #[test]
@@ -359,7 +332,7 @@ fn test_mint_with_id() {
     // Verify the event struct publishes topics and data matching its XDR form.
     let id = env.register(Contract, ());
     env.as_contract(&id, || event.publish(&env));
-    assert_eq!(env.events().all(), std::vec![event.to_xdr(&env, &id)]);
+    assert_eq!(env.events().all(), [event.to_xdr(&env, &id)]);
 }
 
 #[test]
@@ -386,13 +359,10 @@ fn test_clawback() {
     // Verify the event struct publishes topics and data matching its XDR form.
     let id = env.register(Contract, ());
     env.as_contract(&id, || event.publish(&env));
-    assert_eq!(env.events().all(), std::vec![event.to_xdr(&env, &id)]);
+    assert_eq!(env.events().all(), [event.to_xdr(&env, &id)]);
 
     // Verify the SAC client emits an event matching the event struct.
     client.mint(&from, &amount);
     client.clawback(&from, &amount);
-    assert_eq!(
-        env.events().all(),
-        std::vec![event.to_xdr(&env, &asset.address())]
-    );
+    assert_eq!(env.events().all(), [event.to_xdr(&env, &asset.address())]);
 }

--- a/stellar-asset-spec/src/tests/events.rs
+++ b/stellar-asset-spec/src/tests/events.rs
@@ -5,10 +5,10 @@ use crate::{
     TransferWithAmountOnly,
 };
 use soroban_sdk::{
-    contract, symbol_short,
+    contract,
     testutils::{Address as _, Events as _, MuxedAddress as _},
     token::StellarAssetClient,
-    vec, xdr, Address, Env, IntoVal, Map, MuxedAddress, Symbol, Val,
+    xdr, Address, Env, Event, MuxedAddress,
 };
 use std::rc::Rc;
 
@@ -37,39 +37,16 @@ fn test_approve() {
         expiration_ledger: live_until_ledger,
     };
 
-    // Verify the event publishes the expected topics and data.
-    let topics = (
-        symbol_short!("approve"),
-        from.clone(),
-        spender.clone(),
-        sep0011_asset.clone(),
-    );
-    let data = (amount, live_until_ledger);
-
+    // Verify the event struct publishes topics and data matching its XDR form.
     let id = env.register(Contract, ());
     env.as_contract(&id, || event.publish(&env));
-    let token_events = env.events().all();
-    assert_eq!(
-        token_events,
-        vec![
-            &env,
-            (id.clone(), topics.into_val(&env), data.into_val(&env)),
-        ]
-    );
+    assert_eq!(env.events().all(), std::vec![event.to_xdr(&env, &id)]);
 
-    // Verify the event published is consistent with the asset contract.
+    // Verify the SAC client emits an event matching the event struct.
     client.approve(&from, &spender, &amount, &live_until_ledger);
-    let asset_events = env.events().all();
     assert_eq!(
-        asset_events,
-        vec![
-            &env,
-            (
-                asset.address(),
-                (symbol_short!("approve"), from, spender, sep0011_asset,).into_val(&env),
-                data.into_val(&env),
-            ),
-        ]
+        env.events().all(),
+        std::vec![event.to_xdr(&env, &asset.address())]
     );
 }
 
@@ -93,40 +70,17 @@ fn test_transfer() {
         amount,
     };
 
-    // Verify the event publishes the expected topics and data.
-    let topics = (
-        symbol_short!("transfer"),
-        from.clone(),
-        to.clone(),
-        sep0011_asset.clone(),
-    );
-    let data = amount;
-
+    // Verify the event struct publishes topics and data matching its XDR form.
     let id = env.register(Contract, ());
     env.as_contract(&id, || event.publish(&env));
-    let token_events = env.events().all();
-    assert_eq!(
-        token_events,
-        vec![
-            &env,
-            (id.clone(), topics.into_val(&env), data.into_val(&env)),
-        ]
-    );
+    assert_eq!(env.events().all(), std::vec![event.to_xdr(&env, &id)]);
 
-    // Verify the event published is consistent with the asset contract.
+    // Verify the SAC client emits an event matching the event struct.
     client.mint(&from, &amount);
     client.transfer(&from, &to, &amount);
-    let asset_events = env.events().all();
     assert_eq!(
-        asset_events,
-        vec![
-            &env,
-            (
-                asset.address(),
-                (symbol_short!("transfer"), from, to, sep0011_asset).into_val(&env),
-                data.into_val(&env),
-            ),
-        ]
+        env.events().all(),
+        std::vec![event.to_xdr(&env, &asset.address())]
     );
 }
 
@@ -151,33 +105,12 @@ fn test_transfer_with_id() {
         amount,
     };
 
-    // Verify the event publishes the expected topics and data.
-    let topics = (
-        symbol_short!("transfer"),
-        from.clone(),
-        to.address(),
-        sep0011_asset.clone(),
-    );
-    let data = Map::<Symbol, Val>::from_array(
-        &env,
-        [
-            (Symbol::new(&env, "to_muxed_id"), to.id().into_val(&env)),
-            (Symbol::new(&env, "amount"), amount.into_val(&env)),
-        ],
-    );
-
+    // Verify the event struct publishes topics and data matching its XDR form.
     let id = env.register(Contract, ());
     env.as_contract(&id, || event.publish(&env));
-    let token_events = env.events().all();
-    assert_eq!(
-        token_events,
-        vec![
-            &env,
-            (id.clone(), topics.into_val(&env), data.into_val(&env))
-        ]
-    );
+    assert_eq!(env.events().all(), std::vec![event.to_xdr(&env, &id)]);
 
-    // Verify the event published is consistent with the asset contract.
+    // Verify the SAC client emits an event matching the event struct.
     let trust_line_asset = |asset: xdr::Asset| match asset {
         xdr::Asset::Native => xdr::TrustLineAsset::Native,
         xdr::Asset::CreditAlphanum4(a) => xdr::TrustLineAsset::CreditAlphanum4(a),
@@ -208,17 +141,9 @@ fn test_transfer_with_id() {
         .unwrap();
 
     client.transfer(&from, &to, &amount);
-    let asset_events = env.events().all();
     assert_eq!(
-        asset_events,
-        vec![
-            &env,
-            (
-                asset.address(),
-                (symbol_short!("transfer"), from, to.address(), sep0011_asset).into_val(&env),
-                data.into_val(&env),
-            ),
-        ]
+        env.events().all(),
+        std::vec![event.to_xdr(&env, &asset.address())]
     );
 }
 
@@ -236,22 +161,21 @@ fn test_transfer_from() {
     let client = StellarAssetClient::new(&env, &asset.address());
     let sep0011_asset = client.name();
 
-    // Verify the event published is consistent with the asset contract.
     // transfer_from emits a transfer event identical to transfer.
+    let event = TransferWithAmountOnly {
+        from: from.clone(),
+        to: to.clone(),
+        sep0011_asset: sep0011_asset.clone(),
+        amount,
+    };
+
+    // Verify the SAC client emits an event matching the event struct.
     client.mint(&from, &amount);
     client.approve(&from, &spender, &amount, &200);
     client.transfer_from(&spender, &from, &to, &amount);
-    let asset_events = env.events().all();
     assert_eq!(
-        asset_events,
-        vec![
-            &env,
-            (
-                asset.address(),
-                (symbol_short!("transfer"), from, to, sep0011_asset).into_val(&env),
-                amount.into_val(&env),
-            ),
-        ]
+        env.events().all(),
+        std::vec![event.to_xdr(&env, &asset.address())]
     );
 }
 
@@ -273,35 +197,17 @@ fn test_burn() {
         amount,
     };
 
-    // Verify the event publishes the expected topics and data.
-    let topics = (symbol_short!("burn"), from.clone(), sep0011_asset.clone());
-    let data = amount;
-
+    // Verify the event struct publishes topics and data matching its XDR form.
     let id = env.register(Contract, ());
     env.as_contract(&id, || event.publish(&env));
-    let token_events = env.events().all();
-    assert_eq!(
-        token_events,
-        vec![
-            &env,
-            (id.clone(), topics.into_val(&env), data.into_val(&env)),
-        ]
-    );
+    assert_eq!(env.events().all(), std::vec![event.to_xdr(&env, &id)]);
 
-    // Verify the event published is consistent with the asset contract.
+    // Verify the SAC client emits an event matching the event struct.
     client.mint(&from, &amount);
     client.burn(&from, &amount);
-    let asset_events = env.events().all();
     assert_eq!(
-        asset_events,
-        vec![
-            &env,
-            (
-                asset.address(),
-                (symbol_short!("burn"), from, sep0011_asset).into_val(&env),
-                data.into_val(&env),
-            ),
-        ]
+        env.events().all(),
+        std::vec![event.to_xdr(&env, &asset.address())]
     );
 }
 
@@ -318,22 +224,20 @@ fn test_burn_from() {
     let client = StellarAssetClient::new(&env, &asset.address());
     let sep0011_asset = client.name();
 
-    // Verify the event published is consistent with the asset contract.
     // burn_from emits a burn event identical to burn.
+    let event = Burn {
+        from: from.clone(),
+        sep0011_asset: sep0011_asset.clone(),
+        amount,
+    };
+
+    // Verify the SAC client emits an event matching the event struct.
     client.mint(&from, &amount);
     client.approve(&from, &spender, &amount, &200);
     client.burn_from(&spender, &from, &amount);
-    let asset_events = env.events().all();
     assert_eq!(
-        asset_events,
-        vec![
-            &env,
-            (
-                asset.address(),
-                (symbol_short!("burn"), from, sep0011_asset).into_val(&env),
-                amount.into_val(&env),
-            ),
-        ]
+        env.events().all(),
+        std::vec![event.to_xdr(&env, &asset.address())]
     );
 }
 
@@ -355,34 +259,16 @@ fn test_mint() {
         amount,
     };
 
-    // Verify the event publishes the expected topics and data.
-    let topics = (symbol_short!("mint"), to.clone(), sep0011_asset.clone());
-    let data = amount;
-
+    // Verify the event struct publishes topics and data matching its XDR form.
     let id = env.register(Contract, ());
     env.as_contract(&id, || event.publish(&env));
-    let token_events = env.events().all();
-    assert_eq!(
-        token_events,
-        vec![
-            &env,
-            (id.clone(), topics.into_val(&env), data.into_val(&env)),
-        ]
-    );
+    assert_eq!(env.events().all(), std::vec![event.to_xdr(&env, &id)]);
 
-    // Verify the event published is consistent with the asset contract.
+    // Verify the SAC client emits an event matching the event struct.
     client.mint(&to, &amount);
-    let asset_events = env.events().all();
     assert_eq!(
-        asset_events,
-        vec![
-            &env,
-            (
-                asset.address(),
-                (symbol_short!("mint"), to, sep0011_asset).into_val(&env),
-                data.into_val(&env),
-            ),
-        ]
+        env.events().all(),
+        std::vec![event.to_xdr(&env, &asset.address())]
     );
 }
 
@@ -405,26 +291,10 @@ fn test_mint_with_id() {
         amount,
     };
 
-    // Verify the event publishes the expected topics and data.
-    let topics = (symbol_short!("mint"), to.address(), sep0011_asset);
-    let data = Map::<Symbol, Val>::from_array(
-        &env,
-        [
-            (Symbol::new(&env, "to_muxed_id"), to.id().into_val(&env)),
-            (Symbol::new(&env, "amount"), amount.into_val(&env)),
-        ],
-    );
-
+    // Verify the event struct publishes topics and data matching its XDR form.
     let id = env.register(Contract, ());
     env.as_contract(&id, || event.publish(&env));
-    let token_events = env.events().all();
-    assert_eq!(
-        token_events,
-        vec![
-            &env,
-            (id.clone(), topics.into_val(&env), data.into_val(&env))
-        ]
-    );
+    assert_eq!(env.events().all(), std::vec![event.to_xdr(&env, &id)]);
 }
 
 #[test]
@@ -448,39 +318,17 @@ fn test_clawback() {
         amount,
     };
 
-    // Verify the event publishes the expected topics and data.
-    let topics = (
-        symbol_short!("clawback"),
-        from.clone(),
-        sep0011_asset.clone(),
-    );
-    let data = amount;
-
+    // Verify the event struct publishes topics and data matching its XDR form.
     let id = env.register(Contract, ());
     env.as_contract(&id, || event.publish(&env));
-    let token_events = env.events().all();
-    assert_eq!(
-        token_events,
-        vec![
-            &env,
-            (id.clone(), topics.into_val(&env), data.into_val(&env)),
-        ]
-    );
+    assert_eq!(env.events().all(), std::vec![event.to_xdr(&env, &id)]);
 
-    // Verify the event published is consistent with the asset contract.
+    // Verify the SAC client emits an event matching the event struct.
     client.mint(&from, &amount);
     client.clawback(&from, &amount);
-    let asset_events = env.events().all();
     assert_eq!(
-        asset_events,
-        vec![
-            &env,
-            (
-                asset.address(),
-                (symbol_short!("clawback"), from, sep0011_asset).into_val(&env),
-                data.into_val(&env),
-            ),
-        ]
+        env.events().all(),
+        std::vec![event.to_xdr(&env, &asset.address())]
     );
 }
 
@@ -503,38 +351,16 @@ fn test_set_admin() {
         new_admin: new_admin.clone(),
     };
 
-    // Verify the event publishes the expected topics and data.
-    let topics = (
-        symbol_short!("set_admin"),
-        admin.clone(),
-        sep0011_asset.clone(),
-    );
-    let data = new_admin.clone();
-
+    // Verify the event struct publishes topics and data matching its XDR form.
     let id = env.register(Contract, ());
     env.as_contract(&id, || event.publish(&env));
-    let token_events = env.events().all();
-    assert_eq!(
-        token_events,
-        vec![
-            &env,
-            (id.clone(), topics.into_val(&env), data.into_val(&env)),
-        ]
-    );
+    assert_eq!(env.events().all(), std::vec![event.to_xdr(&env, &id)]);
 
-    // Verify the event published is consistent with the asset contract.
+    // Verify the SAC client emits an event matching the event struct.
     client.set_admin(&new_admin);
-    let asset_events = env.events().all();
     assert_eq!(
-        asset_events,
-        vec![
-            &env,
-            (
-                asset.address(),
-                (symbol_short!("set_admin"), admin, sep0011_asset).into_val(&env),
-                new_admin.into_val(&env),
-            ),
-        ]
+        env.events().all(),
+        std::vec![event.to_xdr(&env, &asset.address())]
     );
 }
 
@@ -558,42 +384,15 @@ fn test_set_authorized() {
         authorize,
     };
 
-    // Verify the event publishes the expected topics and data.
-    let topics = (
-        Symbol::new(&env, "set_authorized"),
-        authorizee.clone(),
-        sep0011_asset.clone(),
-    );
-    let data = authorize;
-
+    // Verify the event struct publishes topics and data matching its XDR form.
     let id = env.register(Contract, ());
     env.as_contract(&id, || event.publish(&env));
-    let token_events = env.events().all();
-    assert_eq!(
-        token_events,
-        vec![
-            &env,
-            (id.clone(), topics.into_val(&env), data.into_val(&env)),
-        ]
-    );
+    assert_eq!(env.events().all(), std::vec![event.to_xdr(&env, &id)]);
 
-    // Verify the event published is consistent with the asset contract.
+    // Verify the SAC client emits an event matching the event struct.
     client.set_authorized(&authorizee, &authorize);
-    let asset_events = env.events().all();
     assert_eq!(
-        asset_events,
-        vec![
-            &env,
-            (
-                asset.address(),
-                (
-                    Symbol::new(&env, "set_authorized"),
-                    authorizee,
-                    sep0011_asset
-                )
-                    .into_val(&env),
-                authorize.into_val(&env),
-            ),
-        ]
+        env.events().all(),
+        std::vec![event.to_xdr(&env, &asset.address())]
     );
 }

--- a/stellar-asset-spec/src/tests/events.rs
+++ b/stellar-asset-spec/src/tests/events.rs
@@ -1,19 +1,15 @@
 extern crate std;
 
 use crate::{
-    Approve, Burn, Clawback, Mint, MintWithAmountOnly, SetAdmin, SetAuthorized, Transfer,
+    Approve, Burn, Clawback, MintWithAmountOnly, SetAdmin, SetAuthorized, Transfer,
     TransferWithAmountOnly,
 };
 use soroban_sdk::{
-    contract,
     testutils::{Address as _, Events as _, MuxedAddress as _},
     token::StellarAssetClient,
     xdr, Address, Env, Event, MuxedAddress,
 };
 use std::rc::Rc;
-
-#[contract]
-struct Contract;
 
 #[test]
 fn test_set_admin() {
@@ -23,7 +19,6 @@ fn test_set_admin() {
     let admin = Address::generate(&env);
     let new_admin = Address::generate(&env);
 
-    // Register the asset to get the SEP-0011 asset string it uses in events.
     let asset = env.register_stellar_asset_contract_v2(admin.clone());
     let client = StellarAssetClient::new(&env, &asset.address());
     let sep0011_asset = client.name();
@@ -34,12 +29,6 @@ fn test_set_admin() {
         new_admin: new_admin.clone(),
     };
 
-    // Verify the event struct publishes topics and data matching its XDR form.
-    let id = env.register(Contract, ());
-    env.as_contract(&id, || event.publish(&env));
-    assert_eq!(env.events().all(), [event.to_xdr(&env, &id)]);
-
-    // Verify the SAC client emits an event matching the event struct.
     client.set_admin(&new_admin);
     assert_eq!(env.events().all(), [event.to_xdr(&env, &asset.address())]);
 }
@@ -53,7 +42,6 @@ fn test_set_authorized() {
     let authorizee = Address::generate(&env);
     let authorize = true;
 
-    // Register the asset to get the SEP-0011 asset string it uses in events.
     let asset = env.register_stellar_asset_contract_v2(admin.clone());
     let client = StellarAssetClient::new(&env, &asset.address());
     let sep0011_asset = client.name();
@@ -64,12 +52,6 @@ fn test_set_authorized() {
         authorize,
     };
 
-    // Verify the event struct publishes topics and data matching its XDR form.
-    let id = env.register(Contract, ());
-    env.as_contract(&id, || event.publish(&env));
-    assert_eq!(env.events().all(), [event.to_xdr(&env, &id)]);
-
-    // Verify the SAC client emits an event matching the event struct.
     client.set_authorized(&authorizee, &authorize);
     assert_eq!(env.events().all(), [event.to_xdr(&env, &asset.address())]);
 }
@@ -96,12 +78,6 @@ fn test_approve() {
         expiration_ledger: live_until_ledger,
     };
 
-    // Verify the event struct publishes topics and data matching its XDR form.
-    let id = env.register(Contract, ());
-    env.as_contract(&id, || event.publish(&env));
-    assert_eq!(env.events().all(), [event.to_xdr(&env, &id)]);
-
-    // Verify the SAC client emits an event matching the event struct.
     client.approve(&from, &spender, &amount, &live_until_ledger);
     assert_eq!(env.events().all(), [event.to_xdr(&env, &asset.address())]);
 }
@@ -126,12 +102,6 @@ fn test_transfer() {
         amount,
     };
 
-    // Verify the event struct publishes topics and data matching its XDR form.
-    let id = env.register(Contract, ());
-    env.as_contract(&id, || event.publish(&env));
-    assert_eq!(env.events().all(), [event.to_xdr(&env, &id)]);
-
-    // Verify the SAC client emits an event matching the event struct.
     client.mint(&from, &amount);
     client.transfer(&from, &to, &amount);
     assert_eq!(env.events().all(), [event.to_xdr(&env, &asset.address())]);
@@ -158,12 +128,6 @@ fn test_transfer_with_id() {
         amount,
     };
 
-    // Verify the event struct publishes topics and data matching its XDR form.
-    let id = env.register(Contract, ());
-    env.as_contract(&id, || event.publish(&env));
-    assert_eq!(env.events().all(), [event.to_xdr(&env, &id)]);
-
-    // Verify the SAC client emits an event matching the event struct.
     let trust_line_asset = |asset: xdr::Asset| match asset {
         xdr::Asset::Native => xdr::TrustLineAsset::Native,
         xdr::Asset::CreditAlphanum4(a) => xdr::TrustLineAsset::CreditAlphanum4(a),
@@ -219,7 +183,6 @@ fn test_transfer_from() {
         amount,
     };
 
-    // Verify the SAC client emits an event matching the event struct.
     client.mint(&from, &amount);
     client.approve(&from, &spender, &amount, &200);
     client.transfer_from(&spender, &from, &to, &amount);
@@ -244,12 +207,6 @@ fn test_burn() {
         amount,
     };
 
-    // Verify the event struct publishes topics and data matching its XDR form.
-    let id = env.register(Contract, ());
-    env.as_contract(&id, || event.publish(&env));
-    assert_eq!(env.events().all(), [event.to_xdr(&env, &id)]);
-
-    // Verify the SAC client emits an event matching the event struct.
     client.mint(&from, &amount);
     client.burn(&from, &amount);
     assert_eq!(env.events().all(), [event.to_xdr(&env, &asset.address())]);
@@ -275,7 +232,6 @@ fn test_burn_from() {
         amount,
     };
 
-    // Verify the SAC client emits an event matching the event struct.
     client.mint(&from, &amount);
     client.approve(&from, &spender, &amount, &200);
     client.burn_from(&spender, &from, &amount);
@@ -300,39 +256,8 @@ fn test_mint() {
         amount,
     };
 
-    // Verify the event struct publishes topics and data matching its XDR form.
-    let id = env.register(Contract, ());
-    env.as_contract(&id, || event.publish(&env));
-    assert_eq!(env.events().all(), [event.to_xdr(&env, &id)]);
-
-    // Verify the SAC client emits an event matching the event struct.
     client.mint(&to, &amount);
     assert_eq!(env.events().all(), [event.to_xdr(&env, &asset.address())]);
-}
-
-#[test]
-fn test_mint_with_id() {
-    let env = Env::default();
-    env.mock_all_auths();
-
-    let to = MuxedAddress::generate(&env);
-    let amount = 123;
-
-    let asset = env.register_stellar_asset_contract_v2(Address::generate(&env));
-    let client = StellarAssetClient::new(&env, &asset.address());
-    let sep0011_asset = client.name();
-
-    let event = Mint {
-        to: to.address(),
-        sep0011_asset: sep0011_asset.clone(),
-        to_muxed_id: to.id(),
-        amount,
-    };
-
-    // Verify the event struct publishes topics and data matching its XDR form.
-    let id = env.register(Contract, ());
-    env.as_contract(&id, || event.publish(&env));
-    assert_eq!(env.events().all(), [event.to_xdr(&env, &id)]);
 }
 
 #[test]
@@ -356,12 +281,6 @@ fn test_clawback() {
         amount,
     };
 
-    // Verify the event struct publishes topics and data matching its XDR form.
-    let id = env.register(Contract, ());
-    env.as_contract(&id, || event.publish(&env));
-    assert_eq!(env.events().all(), [event.to_xdr(&env, &id)]);
-
-    // Verify the SAC client emits an event matching the event struct.
     client.mint(&from, &amount);
     client.clawback(&from, &amount);
     assert_eq!(env.events().all(), [event.to_xdr(&env, &asset.address())]);

--- a/stellar-asset-spec/src/tests/events.rs
+++ b/stellar-asset-spec/src/tests/events.rs
@@ -1,13 +1,488 @@
-use crate::{SetAdmin, SetAuthorized};
+extern crate std;
+
+use crate::{
+    Approve, Burn, Clawback, Mint, MintWithAmountOnly, SetAdmin, SetAuthorized, Transfer,
+    TransferWithAmountOnly,
+};
 use soroban_sdk::{
     contract, symbol_short,
-    testutils::{Address as _, Events as _},
+    testutils::{Address as _, Events as _, MuxedAddress as _},
     token::StellarAssetClient,
-    vec, Address, Env, IntoVal, Symbol,
+    vec, xdr, Address, Env, IntoVal, Map, MuxedAddress, Symbol, Val,
 };
+use std::rc::Rc;
 
 #[contract]
 struct Contract;
+
+#[test]
+fn test_approve() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let from = Address::generate(&env);
+    let spender = Address::generate(&env);
+    let amount = 123;
+    let live_until_ledger = 45;
+
+    let asset = env.register_stellar_asset_contract_v2(Address::generate(&env));
+    let client = StellarAssetClient::new(&env, &asset.address());
+    let sep0011_asset = client.name();
+
+    let event = Approve {
+        from: from.clone(),
+        spender: spender.clone(),
+        sep0011_asset: sep0011_asset.clone(),
+        amount,
+        expiration_ledger: live_until_ledger,
+    };
+
+    // Verify the event publishes the expected topics and data.
+    let topics = (
+        symbol_short!("approve"),
+        from.clone(),
+        spender.clone(),
+        sep0011_asset.clone(),
+    );
+    let data = (amount, live_until_ledger);
+
+    let id = env.register(Contract, ());
+    env.as_contract(&id, || event.publish(&env));
+    let token_events = env.events().all();
+    assert_eq!(
+        token_events,
+        vec![
+            &env,
+            (id.clone(), topics.into_val(&env), data.into_val(&env)),
+        ]
+    );
+
+    // Verify the event published is consistent with the asset contract.
+    client.approve(&from, &spender, &amount, &live_until_ledger);
+    let asset_events = env.events().all();
+    assert_eq!(
+        asset_events,
+        vec![
+            &env,
+            (
+                asset.address(),
+                (symbol_short!("approve"), from, spender, sep0011_asset,).into_val(&env),
+                data.into_val(&env),
+            ),
+        ]
+    );
+}
+
+#[test]
+fn test_transfer() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let from = Address::generate(&env);
+    let to = Address::generate(&env);
+    let amount = 123;
+
+    let asset = env.register_stellar_asset_contract_v2(Address::generate(&env));
+    let client = StellarAssetClient::new(&env, &asset.address());
+    let sep0011_asset = client.name();
+
+    let event = TransferWithAmountOnly {
+        from: from.clone(),
+        to: to.clone(),
+        sep0011_asset: sep0011_asset.clone(),
+        amount,
+    };
+
+    // Verify the event publishes the expected topics and data.
+    let topics = (
+        symbol_short!("transfer"),
+        from.clone(),
+        to.clone(),
+        sep0011_asset.clone(),
+    );
+    let data = amount;
+
+    let id = env.register(Contract, ());
+    env.as_contract(&id, || event.publish(&env));
+    let token_events = env.events().all();
+    assert_eq!(
+        token_events,
+        vec![
+            &env,
+            (id.clone(), topics.into_val(&env), data.into_val(&env)),
+        ]
+    );
+
+    // Verify the event published is consistent with the asset contract.
+    client.mint(&from, &amount);
+    client.transfer(&from, &to, &amount);
+    let asset_events = env.events().all();
+    assert_eq!(
+        asset_events,
+        vec![
+            &env,
+            (
+                asset.address(),
+                (symbol_short!("transfer"), from, to, sep0011_asset).into_val(&env),
+                data.into_val(&env),
+            ),
+        ]
+    );
+}
+
+#[test]
+fn test_transfer_with_id() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let from = Address::generate(&env);
+    let to = MuxedAddress::generate(&env);
+    let amount = 123;
+
+    let asset = env.register_stellar_asset_contract_v2(Address::generate(&env));
+    let client = StellarAssetClient::new(&env, &asset.address());
+    let sep0011_asset = client.name();
+
+    let event = Transfer {
+        from: from.clone(),
+        to: to.address(),
+        sep0011_asset: sep0011_asset.clone(),
+        to_muxed_id: to.id(),
+        amount,
+    };
+
+    // Verify the event publishes the expected topics and data.
+    let topics = (
+        symbol_short!("transfer"),
+        from.clone(),
+        to.address(),
+        sep0011_asset.clone(),
+    );
+    let data = Map::<Symbol, Val>::from_array(
+        &env,
+        [
+            (Symbol::new(&env, "to_muxed_id"), to.id().into_val(&env)),
+            (Symbol::new(&env, "amount"), amount.into_val(&env)),
+        ],
+    );
+
+    let id = env.register(Contract, ());
+    env.as_contract(&id, || event.publish(&env));
+    let token_events = env.events().all();
+    assert_eq!(
+        token_events,
+        vec![
+            &env,
+            (id.clone(), topics.into_val(&env), data.into_val(&env))
+        ]
+    );
+
+    // Verify the event published is consistent with the asset contract.
+    let trust_line_asset = |asset: xdr::Asset| match asset {
+        xdr::Asset::Native => xdr::TrustLineAsset::Native,
+        xdr::Asset::CreditAlphanum4(a) => xdr::TrustLineAsset::CreditAlphanum4(a),
+        xdr::Asset::CreditAlphanum12(a) => xdr::TrustLineAsset::CreditAlphanum12(a),
+    };
+
+    client.mint(&from, &amount);
+    env.host()
+        .add_ledger_entry(
+            &Rc::new(xdr::LedgerKey::Trustline(xdr::LedgerKeyTrustLine {
+                account_id: to.address().try_into().unwrap(),
+                asset: trust_line_asset(asset.asset()),
+            })),
+            &Rc::new(xdr::LedgerEntry {
+                data: xdr::LedgerEntryData::Trustline(xdr::TrustLineEntry {
+                    account_id: to.address().try_into().unwrap(),
+                    asset: trust_line_asset(asset.asset()),
+                    balance: 0,
+                    flags: xdr::TrustLineFlags::AuthorizedFlag as u32,
+                    limit: i64::MAX,
+                    ext: xdr::TrustLineEntryExt::V0,
+                }),
+                last_modified_ledger_seq: 0,
+                ext: xdr::LedgerEntryExt::V0,
+            }),
+            None,
+        )
+        .unwrap();
+
+    client.transfer(&from, &to, &amount);
+    let asset_events = env.events().all();
+    assert_eq!(
+        asset_events,
+        vec![
+            &env,
+            (
+                asset.address(),
+                (symbol_short!("transfer"), from, to.address(), sep0011_asset).into_val(&env),
+                data.into_val(&env),
+            ),
+        ]
+    );
+}
+
+#[test]
+fn test_transfer_from() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let spender = Address::generate(&env);
+    let from = Address::generate(&env);
+    let to = Address::generate(&env);
+    let amount = 123;
+
+    let asset = env.register_stellar_asset_contract_v2(Address::generate(&env));
+    let client = StellarAssetClient::new(&env, &asset.address());
+    let sep0011_asset = client.name();
+
+    // Verify the event published is consistent with the asset contract.
+    // transfer_from emits a transfer event identical to transfer.
+    client.mint(&from, &amount);
+    client.approve(&from, &spender, &amount, &200);
+    client.transfer_from(&spender, &from, &to, &amount);
+    let asset_events = env.events().all();
+    assert_eq!(
+        asset_events,
+        vec![
+            &env,
+            (
+                asset.address(),
+                (symbol_short!("transfer"), from, to, sep0011_asset).into_val(&env),
+                amount.into_val(&env),
+            ),
+        ]
+    );
+}
+
+#[test]
+fn test_burn() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let from = Address::generate(&env);
+    let amount = 123;
+
+    let asset = env.register_stellar_asset_contract_v2(Address::generate(&env));
+    let client = StellarAssetClient::new(&env, &asset.address());
+    let sep0011_asset = client.name();
+
+    let event = Burn {
+        from: from.clone(),
+        sep0011_asset: sep0011_asset.clone(),
+        amount,
+    };
+
+    // Verify the event publishes the expected topics and data.
+    let topics = (symbol_short!("burn"), from.clone(), sep0011_asset.clone());
+    let data = amount;
+
+    let id = env.register(Contract, ());
+    env.as_contract(&id, || event.publish(&env));
+    let token_events = env.events().all();
+    assert_eq!(
+        token_events,
+        vec![
+            &env,
+            (id.clone(), topics.into_val(&env), data.into_val(&env)),
+        ]
+    );
+
+    // Verify the event published is consistent with the asset contract.
+    client.mint(&from, &amount);
+    client.burn(&from, &amount);
+    let asset_events = env.events().all();
+    assert_eq!(
+        asset_events,
+        vec![
+            &env,
+            (
+                asset.address(),
+                (symbol_short!("burn"), from, sep0011_asset).into_val(&env),
+                data.into_val(&env),
+            ),
+        ]
+    );
+}
+
+#[test]
+fn test_burn_from() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let spender = Address::generate(&env);
+    let from = Address::generate(&env);
+    let amount = 123;
+
+    let asset = env.register_stellar_asset_contract_v2(Address::generate(&env));
+    let client = StellarAssetClient::new(&env, &asset.address());
+    let sep0011_asset = client.name();
+
+    // Verify the event published is consistent with the asset contract.
+    // burn_from emits a burn event identical to burn.
+    client.mint(&from, &amount);
+    client.approve(&from, &spender, &amount, &200);
+    client.burn_from(&spender, &from, &amount);
+    let asset_events = env.events().all();
+    assert_eq!(
+        asset_events,
+        vec![
+            &env,
+            (
+                asset.address(),
+                (symbol_short!("burn"), from, sep0011_asset).into_val(&env),
+                amount.into_val(&env),
+            ),
+        ]
+    );
+}
+
+#[test]
+fn test_mint() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let to = Address::generate(&env);
+    let amount = 123;
+
+    let asset = env.register_stellar_asset_contract_v2(Address::generate(&env));
+    let client = StellarAssetClient::new(&env, &asset.address());
+    let sep0011_asset = client.name();
+
+    let event = MintWithAmountOnly {
+        to: to.clone(),
+        sep0011_asset: sep0011_asset.clone(),
+        amount,
+    };
+
+    // Verify the event publishes the expected topics and data.
+    let topics = (symbol_short!("mint"), to.clone(), sep0011_asset.clone());
+    let data = amount;
+
+    let id = env.register(Contract, ());
+    env.as_contract(&id, || event.publish(&env));
+    let token_events = env.events().all();
+    assert_eq!(
+        token_events,
+        vec![
+            &env,
+            (id.clone(), topics.into_val(&env), data.into_val(&env)),
+        ]
+    );
+
+    // Verify the event published is consistent with the asset contract.
+    client.mint(&to, &amount);
+    let asset_events = env.events().all();
+    assert_eq!(
+        asset_events,
+        vec![
+            &env,
+            (
+                asset.address(),
+                (symbol_short!("mint"), to, sep0011_asset).into_val(&env),
+                data.into_val(&env),
+            ),
+        ]
+    );
+}
+
+#[test]
+fn test_mint_with_id() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let to = MuxedAddress::generate(&env);
+    let amount = 123;
+
+    let asset = env.register_stellar_asset_contract_v2(Address::generate(&env));
+    let client = StellarAssetClient::new(&env, &asset.address());
+    let sep0011_asset = client.name();
+
+    let event = Mint {
+        to: to.address(),
+        sep0011_asset: sep0011_asset.clone(),
+        to_muxed_id: to.id(),
+        amount,
+    };
+
+    // Verify the event publishes the expected topics and data.
+    let topics = (symbol_short!("mint"), to.address(), sep0011_asset);
+    let data = Map::<Symbol, Val>::from_array(
+        &env,
+        [
+            (Symbol::new(&env, "to_muxed_id"), to.id().into_val(&env)),
+            (Symbol::new(&env, "amount"), amount.into_val(&env)),
+        ],
+    );
+
+    let id = env.register(Contract, ());
+    env.as_contract(&id, || event.publish(&env));
+    let token_events = env.events().all();
+    assert_eq!(
+        token_events,
+        vec![
+            &env,
+            (id.clone(), topics.into_val(&env), data.into_val(&env))
+        ]
+    );
+}
+
+#[test]
+fn test_clawback() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let from = Address::generate(&env);
+    let amount = 123;
+
+    let asset = env.register_stellar_asset_contract_v2(Address::generate(&env));
+    asset
+        .issuer()
+        .set_flag(xdr::AccountFlags::ClawbackEnabledFlag);
+    let client = StellarAssetClient::new(&env, &asset.address());
+    let sep0011_asset = client.name();
+
+    let event = Clawback {
+        from: from.clone(),
+        sep0011_asset: sep0011_asset.clone(),
+        amount,
+    };
+
+    // Verify the event publishes the expected topics and data.
+    let topics = (
+        symbol_short!("clawback"),
+        from.clone(),
+        sep0011_asset.clone(),
+    );
+    let data = amount;
+
+    let id = env.register(Contract, ());
+    env.as_contract(&id, || event.publish(&env));
+    let token_events = env.events().all();
+    assert_eq!(
+        token_events,
+        vec![
+            &env,
+            (id.clone(), topics.into_val(&env), data.into_val(&env)),
+        ]
+    );
+
+    // Verify the event published is consistent with the asset contract.
+    client.mint(&from, &amount);
+    client.clawback(&from, &amount);
+    let asset_events = env.events().all();
+    assert_eq!(
+        asset_events,
+        vec![
+            &env,
+            (
+                asset.address(),
+                (symbol_short!("clawback"), from, sep0011_asset).into_val(&env),
+                data.into_val(&env),
+            ),
+        ]
+    );
+}
 
 #[test]
 fn test_set_admin() {

--- a/stellar-asset-spec/src/tests/events.rs
+++ b/stellar-asset-spec/src/tests/events.rs
@@ -17,13 +17,23 @@ fn test_set_admin() {
     let admin = Address::generate(&env);
     let new_admin = Address::generate(&env);
 
+    // Register the asset to get the SEP-0011 asset string it uses in events.
+    let asset = env.register_stellar_asset_contract_v2(admin.clone());
+    let client = StellarAssetClient::new(&env, &asset.address());
+    let sep0011_asset = client.name();
+
     let event = SetAdmin {
         admin: admin.clone(),
+        sep0011_asset: sep0011_asset.clone(),
         new_admin: new_admin.clone(),
     };
 
     // Verify the event publishes the expected topics and data.
-    let topics = (symbol_short!("set_admin"), admin.clone());
+    let topics = (
+        symbol_short!("set_admin"),
+        admin.clone(),
+        sep0011_asset.clone(),
+    );
     let data = new_admin.clone();
 
     let id = env.register(Contract, ());
@@ -38,19 +48,17 @@ fn test_set_admin() {
     );
 
     // Verify the event published is consistent with the asset contract.
-    let asset = env.register_stellar_asset_contract_v2(admin);
-    let client = StellarAssetClient::new(&env, &asset.address());
-
-    let (t0, t1) = topics;
-    let topics = (t0, t1, client.name());
-
     client.set_admin(&new_admin);
     let asset_events = env.events().all();
     assert_eq!(
         asset_events,
         vec![
             &env,
-            (asset.address(), topics.into_val(&env), data.into_val(&env)),
+            (
+                asset.address(),
+                (symbol_short!("set_admin"), admin, sep0011_asset).into_val(&env),
+                new_admin.into_val(&env),
+            ),
         ]
     );
 }
@@ -60,16 +68,27 @@ fn test_set_authorized() {
     let env = Env::default();
     env.mock_all_auths();
 
+    let admin = Address::generate(&env);
     let authorizee = Address::generate(&env);
     let authorize = true;
 
+    // Register the asset to get the SEP-0011 asset string it uses in events.
+    let asset = env.register_stellar_asset_contract_v2(admin.clone());
+    let client = StellarAssetClient::new(&env, &asset.address());
+    let sep0011_asset = client.name();
+
     let event = SetAuthorized {
         id: authorizee.clone(),
-        authorize: true,
+        sep0011_asset: sep0011_asset.clone(),
+        authorize,
     };
 
     // Verify the event publishes the expected topics and data.
-    let topics = (Symbol::new(&env, "set_authorized"), authorizee.clone());
+    let topics = (
+        Symbol::new(&env, "set_authorized"),
+        authorizee.clone(),
+        sep0011_asset.clone(),
+    );
     let data = authorize;
 
     let id = env.register(Contract, ());
@@ -84,20 +103,22 @@ fn test_set_authorized() {
     );
 
     // Verify the event published is consistent with the asset contract.
-    let admin = Address::generate(&env);
-    let asset = env.register_stellar_asset_contract_v2(admin);
-    let client = StellarAssetClient::new(&env, &asset.address());
-
-    let (t0, t1) = topics;
-    let topics = (t0, t1, client.name());
-
     client.set_authorized(&authorizee, &authorize);
     let asset_events = env.events().all();
     assert_eq!(
         asset_events,
         vec![
             &env,
-            (asset.address(), topics.into_val(&env), data.into_val(&env)),
+            (
+                asset.address(),
+                (
+                    Symbol::new(&env, "set_authorized"),
+                    authorizee,
+                    sep0011_asset
+                )
+                    .into_val(&env),
+                authorize.into_val(&env),
+            ),
         ]
     );
 }

--- a/stellar-asset-spec/src/tests/spec.rs
+++ b/stellar-asset-spec/src/tests/spec.rs
@@ -58,26 +58,31 @@ fn test_stellar_asset_spec_includes_token_spec() -> Result<(), Error> {
     // Read token spec entries, strip docs, and add sep0011_asset to event topics.
     let token_xdr = soroban_token_spec::xdr();
     let token_cursor = std::io::Cursor::new(token_xdr);
-    let mut token_entries: HashSet<ScSpecEntry> = HashSet::new();
-    for entry in ScSpecEntry::read_xdr_iter(&mut Limited::new(token_cursor, Limits::none())) {
-        let mut e = entry?;
-        strip_doc(&mut e);
-        if matches!(e, ScSpecEntry::EventV0(_)) {
-            add_sep0011_asset_topic(&mut e);
-        }
-        token_entries.insert(e);
-    }
+    let token_entries: HashSet<ScSpecEntry> =
+        ScSpecEntry::read_xdr_iter(&mut Limited::new(token_cursor, Limits::none()))
+            .map(|e| {
+                e.map(|mut e| {
+                    strip_doc(&mut e);
+                    if matches!(e, ScSpecEntry::EventV0(_)) {
+                        add_sep0011_asset_topic(&mut e);
+                    }
+                    e
+                })
+            })
+            .collect::<Result<HashSet<_>, _>>()?;
 
     // Read stellar asset spec entries and strip docs.
     let stellar_asset_xdr = crate::xdr();
     let stellar_asset_cursor = std::io::Cursor::new(stellar_asset_xdr);
-    let mut stellar_asset_entries: HashSet<ScSpecEntry> = HashSet::new();
-    for entry in ScSpecEntry::read_xdr_iter(&mut Limited::new(stellar_asset_cursor, Limits::none()))
-    {
-        let mut e = entry?;
-        strip_doc(&mut e);
-        stellar_asset_entries.insert(e);
-    }
+    let stellar_asset_entries: HashSet<ScSpecEntry> =
+        ScSpecEntry::read_xdr_iter(&mut Limited::new(stellar_asset_cursor, Limits::none()))
+            .map(|e| {
+                e.map(|mut e| {
+                    strip_doc(&mut e);
+                    e
+                })
+            })
+            .collect::<Result<HashSet<_>, _>>()?;
 
     // Check that all token entries (with sep0011_asset added to events) are
     // present in the stellar asset spec (which uses SAC-specific event types

--- a/stellar-asset-spec/src/tests/spec.rs
+++ b/stellar-asset-spec/src/tests/spec.rs
@@ -1,7 +1,10 @@
 extern crate std;
 
 use crate::{XDR_INPUT, XDR_LEN};
-use soroban_sdk::xdr::{Error, Limited, Limits, ReadXdr, ScSpecEntry};
+use soroban_sdk::xdr::{
+    Error, Limited, Limits, ReadXdr, ScSpecEntry, ScSpecEventParamLocationV0, ScSpecEventParamV0,
+    ScSpecTypeDef, StringM,
+};
 use std::collections::HashSet;
 
 #[test]
@@ -10,22 +13,75 @@ fn test_stellar_asset_spec_xdr_len() {
     assert_eq!(XDR_LEN, len);
 }
 
+fn strip_doc(entry: &mut ScSpecEntry) {
+    match entry {
+        ScSpecEntry::FunctionV0(f) => {
+            f.doc = StringM::default();
+            for input in f.inputs.iter_mut() {
+                input.doc = StringM::default();
+            }
+        }
+        ScSpecEntry::EventV0(e) => {
+            e.doc = StringM::default();
+            for param in e.params.iter_mut() {
+                param.doc = StringM::default();
+            }
+        }
+        _ => {}
+    }
+}
+
+fn add_sep0011_asset_topic(entry: &mut ScSpecEntry) {
+    if let ScSpecEntry::EventV0(ref mut e) = entry {
+        let mut params: std::vec::Vec<ScSpecEventParamV0> = e.params.iter().cloned().collect();
+        // Insert sep0011_asset topic after the last existing topic-list param.
+        let insert_pos = params
+            .iter()
+            .rposition(|p| p.location == ScSpecEventParamLocationV0::TopicList)
+            .map(|i| i + 1)
+            .unwrap_or(0);
+        params.insert(
+            insert_pos,
+            ScSpecEventParamV0 {
+                doc: StringM::default(),
+                name: "sep0011_asset".try_into().unwrap(),
+                type_: ScSpecTypeDef::String,
+                location: ScSpecEventParamLocationV0::TopicList,
+            },
+        );
+        e.params = params.try_into().unwrap();
+    }
+}
+
 #[test]
 fn test_stellar_asset_spec_includes_token_spec() -> Result<(), Error> {
-    // Read all token spec entries
+    // Read token spec entries, strip docs, and add sep0011_asset to event topics.
     let token_xdr = soroban_token_spec::xdr();
     let token_cursor = std::io::Cursor::new(token_xdr);
-    let token_entries: HashSet<ScSpecEntry> =
-        ScSpecEntry::read_xdr_iter(&mut Limited::new(token_cursor, Limits::none()))
-            .collect::<Result<HashSet<_>, _>>()?;
+    let mut token_entries: HashSet<ScSpecEntry> = HashSet::new();
+    for entry in ScSpecEntry::read_xdr_iter(&mut Limited::new(token_cursor, Limits::none())) {
+        let mut e = entry?;
+        strip_doc(&mut e);
+        if matches!(e, ScSpecEntry::EventV0(_)) {
+            add_sep0011_asset_topic(&mut e);
+        }
+        token_entries.insert(e);
+    }
 
-    // Read all StellarAssetSpec entries
+    // Read stellar asset spec entries and strip docs.
     let stellar_asset_xdr = crate::xdr();
     let stellar_asset_cursor = std::io::Cursor::new(stellar_asset_xdr);
-    let stellar_asset_entries: HashSet<ScSpecEntry> =
-        ScSpecEntry::read_xdr_iter(&mut Limited::new(stellar_asset_cursor, Limits::none()))
-            .collect::<Result<HashSet<_>, _>>()?;
-    // Check that the token entries are a subset of stellar entries
+    let mut stellar_asset_entries: HashSet<ScSpecEntry> = HashSet::new();
+    for entry in ScSpecEntry::read_xdr_iter(&mut Limited::new(stellar_asset_cursor, Limits::none()))
+    {
+        let mut e = entry?;
+        strip_doc(&mut e);
+        stellar_asset_entries.insert(e);
+    }
+
+    // Check that all token entries (with sep0011_asset added to events) are
+    // present in the stellar asset spec (which uses SAC-specific event types
+    // that already include the sep0011_asset topic).
     assert!(
         token_entries.is_subset(&stellar_asset_entries),
         "StellarAssetSpec is missing entries from TokenSpec"

--- a/stellar-asset-spec/test_snapshots/tests/events/test_approve.1.json
+++ b/stellar-asset-spec/test_snapshots/tests/events/test_approve.1.json
@@ -1,6 +1,6 @@
 {
   "generators": {
-    "address": 3,
+    "address": 4,
     "nonce": 0,
     "mux_id": 0
   },
@@ -8,15 +8,15 @@
     [],
     [
       [
-        "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGO6V",
+        "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAJXFF",
         {
           "function": {
             "contract_fn": {
-              "contract_address": "CBUSYNQKASUYFWYC3M2GUEDMX4AIVWPALDBYJPNK6554BREHTGZ2IUNF",
+              "contract_address": "CCABDO7UZXYE4W6GVSEGSNNZTKSLFQGKXXQTH6OX7M7GKZ4Z6CUJNGZN",
               "function_name": "set_admin",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                 }
               ]
             }
@@ -32,14 +32,20 @@
         {
           "function": {
             "contract_fn": {
-              "contract_address": "CBUSYNQKASUYFWYC3M2GUEDMX4AIVWPALDBYJPNK6554BREHTGZ2IUNF",
-              "function_name": "set_authorized",
+              "contract_address": "CCABDO7UZXYE4W6GVSEGSNNZTKSLFQGKXXQTH6OX7M7GKZ4Z6CUJNGZN",
+              "function_name": "approve",
               "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
                 },
                 {
-                  "bool": true
+                  "i128": "123"
+                },
+                {
+                  "u32": 45
                 }
               ]
             }
@@ -64,7 +70,7 @@
           "last_modified_ledger_seq": 0,
           "data": {
             "account": {
-              "account_id": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGO6V",
+              "account_id": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAJXFF",
               "balance": "0",
               "seq_num": "0",
               "num_sub_entries": 0,
@@ -86,7 +92,7 @@
           "data": {
             "contract_data": {
               "ext": "v0",
-              "contract": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGO6V",
+              "contract": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAJXFF",
               "key": {
                 "ledger_key_nonce": {
                   "nonce": "801925984706572462"
@@ -126,18 +132,35 @@
           "data": {
             "contract_data": {
               "ext": "v0",
-              "contract": "CBUSYNQKASUYFWYC3M2GUEDMX4AIVWPALDBYJPNK6554BREHTGZ2IUNF",
+              "contract": "CCABDO7UZXYE4W6GVSEGSNNZTKSLFQGKXXQTH6OX7M7GKZ4Z6CUJNGZN",
               "key": {
                 "vec": [
                   {
-                    "symbol": "Balance"
+                    "symbol": "Allowance"
                   },
                   {
-                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                    "map": [
+                      {
+                        "key": {
+                          "symbol": "from"
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "spender"
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                        }
+                      }
+                    ]
                   }
                 ]
               },
-              "durability": "persistent",
+              "durability": "temporary",
               "val": {
                 "map": [
                   {
@@ -145,23 +168,15 @@
                       "symbol": "amount"
                     },
                     "val": {
-                      "i128": "0"
+                      "i128": "123"
                     }
                   },
                   {
                     "key": {
-                      "symbol": "authorized"
+                      "symbol": "live_until_ledger"
                     },
                     "val": {
-                      "bool": true
-                    }
-                  },
-                  {
-                    "key": {
-                      "symbol": "clawback"
-                    },
-                    "val": {
-                      "bool": false
+                      "u32": 45
                     }
                   }
                 ]
@@ -170,7 +185,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 518400
+        "live_until": 45
       },
       {
         "entry": {
@@ -178,7 +193,7 @@
           "data": {
             "contract_data": {
               "ext": "v0",
-              "contract": "CBUSYNQKASUYFWYC3M2GUEDMX4AIVWPALDBYJPNK6554BREHTGZ2IUNF",
+              "contract": "CCABDO7UZXYE4W6GVSEGSNNZTKSLFQGKXXQTH6OX7M7GKZ4Z6CUJNGZN",
               "key": "ledger_key_contract_instance",
               "durability": "persistent",
               "val": {
@@ -204,7 +219,7 @@
                               "symbol": "name"
                             },
                             "val": {
-                              "string": "aaa:GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGO6V"
+                              "string": "aaa:GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAJXFF"
                             }
                           },
                           {
@@ -227,7 +242,7 @@
                         ]
                       },
                       "val": {
-                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                       }
                     },
                     {
@@ -258,7 +273,7 @@
                                   "symbol": "issuer"
                                 },
                                 "val": {
-                                  "bytes": "0000000000000000000000000000000000000000000000000000000000000003"
+                                  "bytes": "0000000000000000000000000000000000000000000000000000000000000004"
                                 }
                               }
                             ]
@@ -281,23 +296,33 @@
     {
       "event": {
         "ext": "v0",
-        "contract_id": "CBUSYNQKASUYFWYC3M2GUEDMX4AIVWPALDBYJPNK6554BREHTGZ2IUNF",
+        "contract_id": "CCABDO7UZXYE4W6GVSEGSNNZTKSLFQGKXXQTH6OX7M7GKZ4Z6CUJNGZN",
         "type_": "contract",
         "body": {
           "v0": {
             "topics": [
               {
-                "symbol": "set_authorized"
+                "symbol": "approve"
+              },
+              {
+                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
               },
               {
                 "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
               },
               {
-                "string": "aaa:GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGO6V"
+                "string": "aaa:GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAJXFF"
               }
             ],
             "data": {
-              "bool": true
+              "vec": [
+                {
+                  "i128": "123"
+                },
+                {
+                  "u32": 45
+                }
+              ]
             }
           }
         }

--- a/stellar-asset-spec/test_snapshots/tests/events/test_burn.1.json
+++ b/stellar-asset-spec/test_snapshots/tests/events/test_burn.1.json
@@ -16,7 +16,7 @@
               "function_name": "set_admin",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
                 }
               ]
             }
@@ -28,18 +28,40 @@
     [],
     [
       [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CBUSYNQKASUYFWYC3M2GUEDMX4AIVWPALDBYJPNK6554BREHTGZ2IUNF",
+              "function_name": "mint",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                },
+                {
+                  "i128": "123"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
         "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
         {
           "function": {
             "contract_fn": {
               "contract_address": "CBUSYNQKASUYFWYC3M2GUEDMX4AIVWPALDBYJPNK6554BREHTGZ2IUNF",
-              "function_name": "set_authorized",
+              "function_name": "burn",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
                 },
                 {
-                  "bool": true
+                  "i128": "123"
                 }
               ]
             }
@@ -109,6 +131,26 @@
               "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
               "key": {
                 "ledger_key_nonce": {
+                  "nonce": "1033654523790656264"
+                }
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 6311999
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+              "key": {
+                "ledger_key_nonce": {
                   "nonce": "5541220902715666415"
                 }
               },
@@ -133,7 +175,7 @@
                     "symbol": "Balance"
                   },
                   {
-                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
                   }
                 ]
               },
@@ -227,7 +269,7 @@
                         ]
                       },
                       "val": {
-                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
                       }
                     },
                     {
@@ -287,17 +329,17 @@
           "v0": {
             "topics": [
               {
-                "symbol": "set_authorized"
+                "symbol": "burn"
               },
               {
-                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
               },
               {
                 "string": "aaa:GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGO6V"
               }
             ],
             "data": {
-              "bool": true
+              "i128": "123"
             }
           }
         }

--- a/stellar-asset-spec/test_snapshots/tests/events/test_burn_from.1.json
+++ b/stellar-asset-spec/test_snapshots/tests/events/test_burn_from.1.json
@@ -1,6 +1,6 @@
 {
   "generators": {
-    "address": 3,
+    "address": 4,
     "nonce": 0,
     "mux_id": 0
   },
@@ -8,15 +8,15 @@
     [],
     [
       [
-        "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGO6V",
+        "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAJXFF",
         {
           "function": {
             "contract_fn": {
-              "contract_address": "CBUSYNQKASUYFWYC3M2GUEDMX4AIVWPALDBYJPNK6554BREHTGZ2IUNF",
+              "contract_address": "CCABDO7UZXYE4W6GVSEGSNNZTKSLFQGKXXQTH6OX7M7GKZ4Z6CUJNGZN",
               "function_name": "set_admin",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                 }
               ]
             }
@@ -28,18 +28,71 @@
     [],
     [
       [
-        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
         {
           "function": {
             "contract_fn": {
-              "contract_address": "CBUSYNQKASUYFWYC3M2GUEDMX4AIVWPALDBYJPNK6554BREHTGZ2IUNF",
-              "function_name": "set_authorized",
+              "contract_address": "CCABDO7UZXYE4W6GVSEGSNNZTKSLFQGKXXQTH6OX7M7GKZ4Z6CUJNGZN",
+              "function_name": "mint",
               "args": [
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
                 },
                 {
-                  "bool": true
+                  "i128": "123"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CCABDO7UZXYE4W6GVSEGSNNZTKSLFQGKXXQTH6OX7M7GKZ4Z6CUJNGZN",
+              "function_name": "approve",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                },
+                {
+                  "i128": "123"
+                },
+                {
+                  "u32": 200
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CCABDO7UZXYE4W6GVSEGSNNZTKSLFQGKXXQTH6OX7M7GKZ4Z6CUJNGZN",
+              "function_name": "burn_from",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "i128": "123"
                 }
               ]
             }
@@ -64,7 +117,7 @@
           "last_modified_ledger_seq": 0,
           "data": {
             "account": {
-              "account_id": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGO6V",
+              "account_id": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAJXFF",
               "balance": "0",
               "seq_num": "0",
               "num_sub_entries": 0,
@@ -86,7 +139,7 @@
           "data": {
             "contract_data": {
               "ext": "v0",
-              "contract": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGO6V",
+              "contract": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAJXFF",
               "key": {
                 "ledger_key_nonce": {
                   "nonce": "801925984706572462"
@@ -109,6 +162,46 @@
               "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
               "key": {
                 "ledger_key_nonce": {
+                  "nonce": "4837995959683129791"
+                }
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 6311999
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+              "key": {
+                "ledger_key_nonce": {
+                  "nonce": "1033654523790656264"
+                }
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 6311999
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+              "key": {
+                "ledger_key_nonce": {
                   "nonce": "5541220902715666415"
                 }
               },
@@ -126,7 +219,68 @@
           "data": {
             "contract_data": {
               "ext": "v0",
-              "contract": "CBUSYNQKASUYFWYC3M2GUEDMX4AIVWPALDBYJPNK6554BREHTGZ2IUNF",
+              "contract": "CCABDO7UZXYE4W6GVSEGSNNZTKSLFQGKXXQTH6OX7M7GKZ4Z6CUJNGZN",
+              "key": {
+                "vec": [
+                  {
+                    "symbol": "Allowance"
+                  },
+                  {
+                    "map": [
+                      {
+                        "key": {
+                          "symbol": "from"
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "spender"
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              "durability": "temporary",
+              "val": {
+                "map": [
+                  {
+                    "key": {
+                      "symbol": "amount"
+                    },
+                    "val": {
+                      "i128": "0"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "live_until_ledger"
+                    },
+                    "val": {
+                      "u32": 200
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 200
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CCABDO7UZXYE4W6GVSEGSNNZTKSLFQGKXXQTH6OX7M7GKZ4Z6CUJNGZN",
               "key": {
                 "vec": [
                   {
@@ -178,7 +332,7 @@
           "data": {
             "contract_data": {
               "ext": "v0",
-              "contract": "CBUSYNQKASUYFWYC3M2GUEDMX4AIVWPALDBYJPNK6554BREHTGZ2IUNF",
+              "contract": "CCABDO7UZXYE4W6GVSEGSNNZTKSLFQGKXXQTH6OX7M7GKZ4Z6CUJNGZN",
               "key": "ledger_key_contract_instance",
               "durability": "persistent",
               "val": {
@@ -204,7 +358,7 @@
                               "symbol": "name"
                             },
                             "val": {
-                              "string": "aaa:GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGO6V"
+                              "string": "aaa:GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAJXFF"
                             }
                           },
                           {
@@ -227,7 +381,7 @@
                         ]
                       },
                       "val": {
-                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                       }
                     },
                     {
@@ -258,7 +412,7 @@
                                   "symbol": "issuer"
                                 },
                                 "val": {
-                                  "bytes": "0000000000000000000000000000000000000000000000000000000000000003"
+                                  "bytes": "0000000000000000000000000000000000000000000000000000000000000004"
                                 }
                               }
                             ]
@@ -281,23 +435,23 @@
     {
       "event": {
         "ext": "v0",
-        "contract_id": "CBUSYNQKASUYFWYC3M2GUEDMX4AIVWPALDBYJPNK6554BREHTGZ2IUNF",
+        "contract_id": "CCABDO7UZXYE4W6GVSEGSNNZTKSLFQGKXXQTH6OX7M7GKZ4Z6CUJNGZN",
         "type_": "contract",
         "body": {
           "v0": {
             "topics": [
               {
-                "symbol": "set_authorized"
+                "symbol": "burn"
               },
               {
                 "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
               },
               {
-                "string": "aaa:GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGO6V"
+                "string": "aaa:GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAJXFF"
               }
             ],
             "data": {
-              "bool": true
+              "i128": "123"
             }
           }
         }

--- a/stellar-asset-spec/test_snapshots/tests/events/test_clawback.1.json
+++ b/stellar-asset-spec/test_snapshots/tests/events/test_clawback.1.json
@@ -16,7 +16,7 @@
               "function_name": "set_admin",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
                 }
               ]
             }
@@ -28,18 +28,40 @@
     [],
     [
       [
-        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
         {
           "function": {
             "contract_fn": {
               "contract_address": "CBUSYNQKASUYFWYC3M2GUEDMX4AIVWPALDBYJPNK6554BREHTGZ2IUNF",
-              "function_name": "set_authorized",
+              "function_name": "mint",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
                 },
                 {
-                  "bool": true
+                  "i128": "123"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CBUSYNQKASUYFWYC3M2GUEDMX4AIVWPALDBYJPNK6554BREHTGZ2IUNF",
+              "function_name": "clawback",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                },
+                {
+                  "i128": "123"
                 }
               ]
             }
@@ -69,7 +91,7 @@
               "seq_num": "0",
               "num_sub_entries": 0,
               "inflation_dest": null,
-              "flags": 0,
+              "flags": 8,
               "home_domain": "",
               "thresholds": "01010101",
               "signers": [],
@@ -106,7 +128,27 @@
           "data": {
             "contract_data": {
               "ext": "v0",
-              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+              "key": {
+                "ledger_key_nonce": {
+                  "nonce": "1033654523790656264"
+                }
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 6311999
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
               "key": {
                 "ledger_key_nonce": {
                   "nonce": "5541220902715666415"
@@ -133,7 +175,7 @@
                     "symbol": "Balance"
                   },
                   {
-                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
                   }
                 ]
               },
@@ -161,7 +203,7 @@
                       "symbol": "clawback"
                     },
                     "val": {
-                      "bool": false
+                      "bool": true
                     }
                   }
                 ]
@@ -227,7 +269,7 @@
                         ]
                       },
                       "val": {
-                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
                       }
                     },
                     {
@@ -287,17 +329,17 @@
           "v0": {
             "topics": [
               {
-                "symbol": "set_authorized"
+                "symbol": "clawback"
               },
               {
-                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
               },
               {
                 "string": "aaa:GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGO6V"
               }
             ],
             "data": {
-              "bool": true
+              "i128": "123"
             }
           }
         }

--- a/stellar-asset-spec/test_snapshots/tests/events/test_mint.1.json
+++ b/stellar-asset-spec/test_snapshots/tests/events/test_mint.1.json
@@ -16,7 +16,7 @@
               "function_name": "set_admin",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
                 }
               ]
             }
@@ -28,18 +28,18 @@
     [],
     [
       [
-        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
         {
           "function": {
             "contract_fn": {
               "contract_address": "CBUSYNQKASUYFWYC3M2GUEDMX4AIVWPALDBYJPNK6554BREHTGZ2IUNF",
-              "function_name": "set_authorized",
+              "function_name": "mint",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
                 },
                 {
-                  "bool": true
+                  "i128": "123"
                 }
               ]
             }
@@ -106,7 +106,7 @@
           "data": {
             "contract_data": {
               "ext": "v0",
-              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
               "key": {
                 "ledger_key_nonce": {
                   "nonce": "5541220902715666415"
@@ -133,7 +133,7 @@
                     "symbol": "Balance"
                   },
                   {
-                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
                   }
                 ]
               },
@@ -145,7 +145,7 @@
                       "symbol": "amount"
                     },
                     "val": {
-                      "i128": "0"
+                      "i128": "123"
                     }
                   },
                   {
@@ -227,7 +227,7 @@
                         ]
                       },
                       "val": {
-                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
                       }
                     },
                     {
@@ -287,17 +287,17 @@
           "v0": {
             "topics": [
               {
-                "symbol": "set_authorized"
+                "symbol": "mint"
               },
               {
-                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
               },
               {
                 "string": "aaa:GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGO6V"
               }
             ],
             "data": {
-              "bool": true
+              "i128": "123"
             }
           }
         }

--- a/stellar-asset-spec/test_snapshots/tests/events/test_set_admin.1.json
+++ b/stellar-asset-spec/test_snapshots/tests/events/test_set_admin.1.json
@@ -6,15 +6,13 @@
   },
   "auth": [
     [],
-    [],
-    [],
     [
       [
-        "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAJXFF",
+        "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGO6V",
         {
           "function": {
             "contract_fn": {
-              "contract_address": "CCABDO7UZXYE4W6GVSEGSNNZTKSLFQGKXXQTH6OX7M7GKZ4Z6CUJNGZN",
+              "contract_address": "CBUSYNQKASUYFWYC3M2GUEDMX4AIVWPALDBYJPNK6554BREHTGZ2IUNF",
               "function_name": "set_admin",
               "args": [
                 {
@@ -28,13 +26,15 @@
       ]
     ],
     [],
+    [],
+    [],
     [
       [
         "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
         {
           "function": {
             "contract_fn": {
-              "contract_address": "CCABDO7UZXYE4W6GVSEGSNNZTKSLFQGKXXQTH6OX7M7GKZ4Z6CUJNGZN",
+              "contract_address": "CBUSYNQKASUYFWYC3M2GUEDMX4AIVWPALDBYJPNK6554BREHTGZ2IUNF",
               "function_name": "set_admin",
               "args": [
                 {
@@ -63,7 +63,7 @@
           "last_modified_ledger_seq": 0,
           "data": {
             "account": {
-              "account_id": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAJXFF",
+              "account_id": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGO6V",
               "balance": "0",
               "seq_num": "0",
               "num_sub_entries": 0,
@@ -85,7 +85,7 @@
           "data": {
             "contract_data": {
               "ext": "v0",
-              "contract": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAJXFF",
+              "contract": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGO6V",
               "key": {
                 "ledger_key_nonce": {
                   "nonce": "801925984706572462"
@@ -125,7 +125,7 @@
           "data": {
             "contract_data": {
               "ext": "v0",
-              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
               "key": "ledger_key_contract_instance",
               "durability": "persistent",
               "val": {
@@ -148,7 +148,7 @@
           "data": {
             "contract_data": {
               "ext": "v0",
-              "contract": "CCABDO7UZXYE4W6GVSEGSNNZTKSLFQGKXXQTH6OX7M7GKZ4Z6CUJNGZN",
+              "contract": "CBUSYNQKASUYFWYC3M2GUEDMX4AIVWPALDBYJPNK6554BREHTGZ2IUNF",
               "key": "ledger_key_contract_instance",
               "durability": "persistent",
               "val": {
@@ -174,7 +174,7 @@
                               "symbol": "name"
                             },
                             "val": {
-                              "string": "aaa:GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAJXFF"
+                              "string": "aaa:GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGO6V"
                             }
                           },
                           {
@@ -228,7 +228,7 @@
                                   "symbol": "issuer"
                                 },
                                 "val": {
-                                  "bytes": "0000000000000000000000000000000000000000000000000000000000000004"
+                                  "bytes": "0000000000000000000000000000000000000000000000000000000000000003"
                                 }
                               }
                             ]
@@ -265,7 +265,7 @@
     {
       "event": {
         "ext": "v0",
-        "contract_id": "CCABDO7UZXYE4W6GVSEGSNNZTKSLFQGKXXQTH6OX7M7GKZ4Z6CUJNGZN",
+        "contract_id": "CBUSYNQKASUYFWYC3M2GUEDMX4AIVWPALDBYJPNK6554BREHTGZ2IUNF",
         "type_": "contract",
         "body": {
           "v0": {
@@ -277,7 +277,7 @@
                 "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
               },
               {
-                "string": "aaa:GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAJXFF"
+                "string": "aaa:GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGO6V"
               }
             ],
             "data": {

--- a/stellar-asset-spec/test_snapshots/tests/events/test_set_admin.1.json
+++ b/stellar-asset-spec/test_snapshots/tests/events/test_set_admin.1.json
@@ -1,6 +1,6 @@
 {
   "generators": {
-    "address": 4,
+    "address": 3,
     "nonce": 0,
     "mux_id": 0
   },
@@ -25,8 +25,6 @@
         }
       ]
     ],
-    [],
-    [],
     [],
     [
       [
@@ -118,29 +116,6 @@
           "ext": "v0"
         },
         "live_until": 6311999
-      },
-      {
-        "entry": {
-          "last_modified_ledger_seq": 0,
-          "data": {
-            "contract_data": {
-              "ext": "v0",
-              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
-              "key": "ledger_key_contract_instance",
-              "durability": "persistent",
-              "val": {
-                "contract_instance": {
-                  "executable": {
-                    "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
-                  },
-                  "storage": null
-                }
-              }
-            }
-          },
-          "ext": "v0"
-        },
-        "live_until": 4095
       },
       {
         "entry": {
@@ -244,20 +219,6 @@
           "ext": "v0"
         },
         "live_until": 120960
-      },
-      {
-        "entry": {
-          "last_modified_ledger_seq": 0,
-          "data": {
-            "contract_code": {
-              "ext": "v0",
-              "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-              "code": ""
-            }
-          },
-          "ext": "v0"
-        },
-        "live_until": 4095
       }
     ]
   },

--- a/stellar-asset-spec/test_snapshots/tests/events/test_set_authorized.1.json
+++ b/stellar-asset-spec/test_snapshots/tests/events/test_set_authorized.1.json
@@ -6,19 +6,17 @@
   },
   "auth": [
     [],
-    [],
-    [],
     [
       [
-        "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAJXFF",
+        "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGO6V",
         {
           "function": {
             "contract_fn": {
-              "contract_address": "CCABDO7UZXYE4W6GVSEGSNNZTKSLFQGKXXQTH6OX7M7GKZ4Z6CUJNGZN",
+              "contract_address": "CBUSYNQKASUYFWYC3M2GUEDMX4AIVWPALDBYJPNK6554BREHTGZ2IUNF",
               "function_name": "set_admin",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
                 }
               ]
             }
@@ -28,17 +26,19 @@
       ]
     ],
     [],
+    [],
+    [],
     [
       [
-        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
         {
           "function": {
             "contract_fn": {
-              "contract_address": "CCABDO7UZXYE4W6GVSEGSNNZTKSLFQGKXXQTH6OX7M7GKZ4Z6CUJNGZN",
+              "contract_address": "CBUSYNQKASUYFWYC3M2GUEDMX4AIVWPALDBYJPNK6554BREHTGZ2IUNF",
               "function_name": "set_authorized",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
                 },
                 {
                   "bool": true
@@ -66,7 +66,7 @@
           "last_modified_ledger_seq": 0,
           "data": {
             "account": {
-              "account_id": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAJXFF",
+              "account_id": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGO6V",
               "balance": "0",
               "seq_num": "0",
               "num_sub_entries": 0,
@@ -88,7 +88,7 @@
           "data": {
             "contract_data": {
               "ext": "v0",
-              "contract": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAJXFF",
+              "contract": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGO6V",
               "key": {
                 "ledger_key_nonce": {
                   "nonce": "801925984706572462"
@@ -108,7 +108,27 @@
           "data": {
             "contract_data": {
               "ext": "v0",
-              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": {
+                "ledger_key_nonce": {
+                  "nonce": "5541220902715666415"
+                }
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 6311999
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
               "key": "ledger_key_contract_instance",
               "durability": "persistent",
               "val": {
@@ -131,34 +151,14 @@
           "data": {
             "contract_data": {
               "ext": "v0",
-              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
-              "key": {
-                "ledger_key_nonce": {
-                  "nonce": "5541220902715666415"
-                }
-              },
-              "durability": "temporary",
-              "val": "void"
-            }
-          },
-          "ext": "v0"
-        },
-        "live_until": 6311999
-      },
-      {
-        "entry": {
-          "last_modified_ledger_seq": 0,
-          "data": {
-            "contract_data": {
-              "ext": "v0",
-              "contract": "CCABDO7UZXYE4W6GVSEGSNNZTKSLFQGKXXQTH6OX7M7GKZ4Z6CUJNGZN",
+              "contract": "CBUSYNQKASUYFWYC3M2GUEDMX4AIVWPALDBYJPNK6554BREHTGZ2IUNF",
               "key": {
                 "vec": [
                   {
                     "symbol": "Balance"
                   },
                   {
-                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
                   }
                 ]
               },
@@ -203,7 +203,7 @@
           "data": {
             "contract_data": {
               "ext": "v0",
-              "contract": "CCABDO7UZXYE4W6GVSEGSNNZTKSLFQGKXXQTH6OX7M7GKZ4Z6CUJNGZN",
+              "contract": "CBUSYNQKASUYFWYC3M2GUEDMX4AIVWPALDBYJPNK6554BREHTGZ2IUNF",
               "key": "ledger_key_contract_instance",
               "durability": "persistent",
               "val": {
@@ -229,7 +229,7 @@
                               "symbol": "name"
                             },
                             "val": {
-                              "string": "aaa:GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAJXFF"
+                              "string": "aaa:GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGO6V"
                             }
                           },
                           {
@@ -252,7 +252,7 @@
                         ]
                       },
                       "val": {
-                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
                       }
                     },
                     {
@@ -283,7 +283,7 @@
                                   "symbol": "issuer"
                                 },
                                 "val": {
-                                  "bytes": "0000000000000000000000000000000000000000000000000000000000000004"
+                                  "bytes": "0000000000000000000000000000000000000000000000000000000000000003"
                                 }
                               }
                             ]
@@ -320,7 +320,7 @@
     {
       "event": {
         "ext": "v0",
-        "contract_id": "CCABDO7UZXYE4W6GVSEGSNNZTKSLFQGKXXQTH6OX7M7GKZ4Z6CUJNGZN",
+        "contract_id": "CBUSYNQKASUYFWYC3M2GUEDMX4AIVWPALDBYJPNK6554BREHTGZ2IUNF",
         "type_": "contract",
         "body": {
           "v0": {
@@ -329,10 +329,10 @@
                 "symbol": "set_authorized"
               },
               {
-                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
               },
               {
-                "string": "aaa:GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAJXFF"
+                "string": "aaa:GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGO6V"
               }
             ],
             "data": {

--- a/stellar-asset-spec/test_snapshots/tests/events/test_transfer.1.json
+++ b/stellar-asset-spec/test_snapshots/tests/events/test_transfer.1.json
@@ -1,6 +1,6 @@
 {
   "generators": {
-    "address": 3,
+    "address": 4,
     "nonce": 0,
     "mux_id": 0
   },
@@ -8,15 +8,15 @@
     [],
     [
       [
-        "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGO6V",
+        "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAJXFF",
         {
           "function": {
             "contract_fn": {
-              "contract_address": "CBUSYNQKASUYFWYC3M2GUEDMX4AIVWPALDBYJPNK6554BREHTGZ2IUNF",
+              "contract_address": "CCABDO7UZXYE4W6GVSEGSNNZTKSLFQGKXXQTH6OX7M7GKZ4Z6CUJNGZN",
               "function_name": "set_admin",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                 }
               ]
             }
@@ -28,18 +28,43 @@
     [],
     [
       [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CCABDO7UZXYE4W6GVSEGSNNZTKSLFQGKXXQTH6OX7M7GKZ4Z6CUJNGZN",
+              "function_name": "mint",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                },
+                {
+                  "i128": "123"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
         "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
         {
           "function": {
             "contract_fn": {
-              "contract_address": "CBUSYNQKASUYFWYC3M2GUEDMX4AIVWPALDBYJPNK6554BREHTGZ2IUNF",
-              "function_name": "set_authorized",
+              "contract_address": "CCABDO7UZXYE4W6GVSEGSNNZTKSLFQGKXXQTH6OX7M7GKZ4Z6CUJNGZN",
+              "function_name": "transfer",
               "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
                 },
                 {
-                  "bool": true
+                  "i128": "123"
                 }
               ]
             }
@@ -64,7 +89,7 @@
           "last_modified_ledger_seq": 0,
           "data": {
             "account": {
-              "account_id": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGO6V",
+              "account_id": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAJXFF",
               "balance": "0",
               "seq_num": "0",
               "num_sub_entries": 0,
@@ -86,7 +111,7 @@
           "data": {
             "contract_data": {
               "ext": "v0",
-              "contract": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGO6V",
+              "contract": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAJXFF",
               "key": {
                 "ledger_key_nonce": {
                   "nonce": "801925984706572462"
@@ -109,6 +134,26 @@
               "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
               "key": {
                 "ledger_key_nonce": {
+                  "nonce": "1033654523790656264"
+                }
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 6311999
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+              "key": {
+                "ledger_key_nonce": {
                   "nonce": "5541220902715666415"
                 }
               },
@@ -126,14 +171,14 @@
           "data": {
             "contract_data": {
               "ext": "v0",
-              "contract": "CBUSYNQKASUYFWYC3M2GUEDMX4AIVWPALDBYJPNK6554BREHTGZ2IUNF",
+              "contract": "CCABDO7UZXYE4W6GVSEGSNNZTKSLFQGKXXQTH6OX7M7GKZ4Z6CUJNGZN",
               "key": {
                 "vec": [
                   {
                     "symbol": "Balance"
                   },
                   {
-                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
                   }
                 ]
               },
@@ -178,7 +223,59 @@
           "data": {
             "contract_data": {
               "ext": "v0",
-              "contract": "CBUSYNQKASUYFWYC3M2GUEDMX4AIVWPALDBYJPNK6554BREHTGZ2IUNF",
+              "contract": "CCABDO7UZXYE4W6GVSEGSNNZTKSLFQGKXXQTH6OX7M7GKZ4Z6CUJNGZN",
+              "key": {
+                "vec": [
+                  {
+                    "symbol": "Balance"
+                  },
+                  {
+                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                  }
+                ]
+              },
+              "durability": "persistent",
+              "val": {
+                "map": [
+                  {
+                    "key": {
+                      "symbol": "amount"
+                    },
+                    "val": {
+                      "i128": "123"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "authorized"
+                    },
+                    "val": {
+                      "bool": true
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "clawback"
+                    },
+                    "val": {
+                      "bool": false
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 518400
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CCABDO7UZXYE4W6GVSEGSNNZTKSLFQGKXXQTH6OX7M7GKZ4Z6CUJNGZN",
               "key": "ledger_key_contract_instance",
               "durability": "persistent",
               "val": {
@@ -204,7 +301,7 @@
                               "symbol": "name"
                             },
                             "val": {
-                              "string": "aaa:GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGO6V"
+                              "string": "aaa:GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAJXFF"
                             }
                           },
                           {
@@ -227,7 +324,7 @@
                         ]
                       },
                       "val": {
-                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                       }
                     },
                     {
@@ -258,7 +355,7 @@
                                   "symbol": "issuer"
                                 },
                                 "val": {
-                                  "bytes": "0000000000000000000000000000000000000000000000000000000000000003"
+                                  "bytes": "0000000000000000000000000000000000000000000000000000000000000004"
                                 }
                               }
                             ]
@@ -281,23 +378,26 @@
     {
       "event": {
         "ext": "v0",
-        "contract_id": "CBUSYNQKASUYFWYC3M2GUEDMX4AIVWPALDBYJPNK6554BREHTGZ2IUNF",
+        "contract_id": "CCABDO7UZXYE4W6GVSEGSNNZTKSLFQGKXXQTH6OX7M7GKZ4Z6CUJNGZN",
         "type_": "contract",
         "body": {
           "v0": {
             "topics": [
               {
-                "symbol": "set_authorized"
+                "symbol": "transfer"
+              },
+              {
+                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
               },
               {
                 "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
               },
               {
-                "string": "aaa:GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGO6V"
+                "string": "aaa:GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAJXFF"
               }
             ],
             "data": {
-              "bool": true
+              "i128": "123"
             }
           }
         }

--- a/stellar-asset-spec/test_snapshots/tests/events/test_transfer_from.1.json
+++ b/stellar-asset-spec/test_snapshots/tests/events/test_transfer_from.1.json
@@ -1,6 +1,6 @@
 {
   "generators": {
-    "address": 3,
+    "address": 5,
     "nonce": 0,
     "mux_id": 0
   },
@@ -8,15 +8,15 @@
     [],
     [
       [
-        "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGO6V",
+        "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAL7NV",
         {
           "function": {
             "contract_fn": {
-              "contract_address": "CBUSYNQKASUYFWYC3M2GUEDMX4AIVWPALDBYJPNK6554BREHTGZ2IUNF",
+              "contract_address": "CDLDVFKHEZ2RVB3NG4UQA4VPD3TSHV6XMHXMHP2BSGCJ2IIWVTOHGDSG",
               "function_name": "set_admin",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
                 }
               ]
             }
@@ -28,18 +28,74 @@
     [],
     [
       [
-        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
         {
           "function": {
             "contract_fn": {
-              "contract_address": "CBUSYNQKASUYFWYC3M2GUEDMX4AIVWPALDBYJPNK6554BREHTGZ2IUNF",
-              "function_name": "set_authorized",
+              "contract_address": "CDLDVFKHEZ2RVB3NG4UQA4VPD3TSHV6XMHXMHP2BSGCJ2IIWVTOHGDSG",
+              "function_name": "mint",
               "args": [
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
                 },
                 {
-                  "bool": true
+                  "i128": "123"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CDLDVFKHEZ2RVB3NG4UQA4VPD3TSHV6XMHXMHP2BSGCJ2IIWVTOHGDSG",
+              "function_name": "approve",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                },
+                {
+                  "i128": "123"
+                },
+                {
+                  "u32": 200
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CDLDVFKHEZ2RVB3NG4UQA4VPD3TSHV6XMHXMHP2BSGCJ2IIWVTOHGDSG",
+              "function_name": "transfer_from",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                },
+                {
+                  "i128": "123"
                 }
               ]
             }
@@ -64,7 +120,7 @@
           "last_modified_ledger_seq": 0,
           "data": {
             "account": {
-              "account_id": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGO6V",
+              "account_id": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAL7NV",
               "balance": "0",
               "seq_num": "0",
               "num_sub_entries": 0,
@@ -86,7 +142,7 @@
           "data": {
             "contract_data": {
               "ext": "v0",
-              "contract": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGO6V",
+              "contract": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAL7NV",
               "key": {
                 "ledger_key_nonce": {
                   "nonce": "801925984706572462"
@@ -109,6 +165,46 @@
               "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
               "key": {
                 "ledger_key_nonce": {
+                  "nonce": "4837995959683129791"
+                }
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 6311999
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+              "key": {
+                "ledger_key_nonce": {
+                  "nonce": "1033654523790656264"
+                }
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 6311999
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+              "key": {
+                "ledger_key_nonce": {
                   "nonce": "5541220902715666415"
                 }
               },
@@ -126,7 +222,68 @@
           "data": {
             "contract_data": {
               "ext": "v0",
-              "contract": "CBUSYNQKASUYFWYC3M2GUEDMX4AIVWPALDBYJPNK6554BREHTGZ2IUNF",
+              "contract": "CDLDVFKHEZ2RVB3NG4UQA4VPD3TSHV6XMHXMHP2BSGCJ2IIWVTOHGDSG",
+              "key": {
+                "vec": [
+                  {
+                    "symbol": "Allowance"
+                  },
+                  {
+                    "map": [
+                      {
+                        "key": {
+                          "symbol": "from"
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "spender"
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              "durability": "temporary",
+              "val": {
+                "map": [
+                  {
+                    "key": {
+                      "symbol": "amount"
+                    },
+                    "val": {
+                      "i128": "0"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "live_until_ledger"
+                    },
+                    "val": {
+                      "u32": 200
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 200
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CDLDVFKHEZ2RVB3NG4UQA4VPD3TSHV6XMHXMHP2BSGCJ2IIWVTOHGDSG",
               "key": {
                 "vec": [
                   {
@@ -178,7 +335,59 @@
           "data": {
             "contract_data": {
               "ext": "v0",
-              "contract": "CBUSYNQKASUYFWYC3M2GUEDMX4AIVWPALDBYJPNK6554BREHTGZ2IUNF",
+              "contract": "CDLDVFKHEZ2RVB3NG4UQA4VPD3TSHV6XMHXMHP2BSGCJ2IIWVTOHGDSG",
+              "key": {
+                "vec": [
+                  {
+                    "symbol": "Balance"
+                  },
+                  {
+                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  }
+                ]
+              },
+              "durability": "persistent",
+              "val": {
+                "map": [
+                  {
+                    "key": {
+                      "symbol": "amount"
+                    },
+                    "val": {
+                      "i128": "123"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "authorized"
+                    },
+                    "val": {
+                      "bool": true
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "clawback"
+                    },
+                    "val": {
+                      "bool": false
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 518400
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CDLDVFKHEZ2RVB3NG4UQA4VPD3TSHV6XMHXMHP2BSGCJ2IIWVTOHGDSG",
               "key": "ledger_key_contract_instance",
               "durability": "persistent",
               "val": {
@@ -204,7 +413,7 @@
                               "symbol": "name"
                             },
                             "val": {
-                              "string": "aaa:GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGO6V"
+                              "string": "aaa:GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAL7NV"
                             }
                           },
                           {
@@ -227,7 +436,7 @@
                         ]
                       },
                       "val": {
-                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
                       }
                     },
                     {
@@ -258,7 +467,7 @@
                                   "symbol": "issuer"
                                 },
                                 "val": {
-                                  "bytes": "0000000000000000000000000000000000000000000000000000000000000003"
+                                  "bytes": "0000000000000000000000000000000000000000000000000000000000000005"
                                 }
                               }
                             ]
@@ -281,23 +490,26 @@
     {
       "event": {
         "ext": "v0",
-        "contract_id": "CBUSYNQKASUYFWYC3M2GUEDMX4AIVWPALDBYJPNK6554BREHTGZ2IUNF",
+        "contract_id": "CDLDVFKHEZ2RVB3NG4UQA4VPD3TSHV6XMHXMHP2BSGCJ2IIWVTOHGDSG",
         "type_": "contract",
         "body": {
           "v0": {
             "topics": [
               {
-                "symbol": "set_authorized"
+                "symbol": "transfer"
               },
               {
                 "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
               },
               {
-                "string": "aaa:GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGO6V"
+                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+              },
+              {
+                "string": "aaa:GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAL7NV"
               }
             ],
             "data": {
-              "bool": true
+              "i128": "123"
             }
           }
         }

--- a/stellar-asset-spec/test_snapshots/tests/events/test_transfer_with_id.1.json
+++ b/stellar-asset-spec/test_snapshots/tests/events/test_transfer_with_id.1.json
@@ -1,22 +1,22 @@
 {
   "generators": {
-    "address": 3,
+    "address": 4,
     "nonce": 0,
-    "mux_id": 0
+    "mux_id": 1
   },
   "auth": [
     [],
     [
       [
-        "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGO6V",
+        "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAJXFF",
         {
           "function": {
             "contract_fn": {
-              "contract_address": "CBUSYNQKASUYFWYC3M2GUEDMX4AIVWPALDBYJPNK6554BREHTGZ2IUNF",
+              "contract_address": "CCABDO7UZXYE4W6GVSEGSNNZTKSLFQGKXXQTH6OX7M7GKZ4Z6CUJNGZN",
               "function_name": "set_admin",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                 }
               ]
             }
@@ -28,18 +28,43 @@
     [],
     [
       [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CCABDO7UZXYE4W6GVSEGSNNZTKSLFQGKXXQTH6OX7M7GKZ4Z6CUJNGZN",
+              "function_name": "mint",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                },
+                {
+                  "i128": "123"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
         "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
         {
           "function": {
             "contract_fn": {
-              "contract_address": "CBUSYNQKASUYFWYC3M2GUEDMX4AIVWPALDBYJPNK6554BREHTGZ2IUNF",
-              "function_name": "set_authorized",
+              "contract_address": "CCABDO7UZXYE4W6GVSEGSNNZTKSLFQGKXXQTH6OX7M7GKZ4Z6CUJNGZN",
+              "function_name": "transfer",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
                 },
                 {
-                  "bool": true
+                  "address": "MAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAE6FK"
+                },
+                {
+                  "i128": "123"
                 }
               ]
             }
@@ -64,7 +89,7 @@
           "last_modified_ledger_seq": 0,
           "data": {
             "account": {
-              "account_id": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGO6V",
+              "account_id": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAJXFF",
               "balance": "0",
               "seq_num": "0",
               "num_sub_entries": 0,
@@ -84,9 +109,31 @@
         "entry": {
           "last_modified_ledger_seq": 0,
           "data": {
+            "trustline": {
+              "account_id": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEGWF",
+              "asset": {
+                "credit_alphanum4": {
+                  "asset_code": "aaa",
+                  "issuer": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAJXFF"
+                }
+              },
+              "balance": "123",
+              "limit": "9223372036854775807",
+              "flags": 1,
+              "ext": "v0"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": null
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
             "contract_data": {
               "ext": "v0",
-              "contract": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGO6V",
+              "contract": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAJXFF",
               "key": {
                 "ledger_key_nonce": {
                   "nonce": "801925984706572462"
@@ -109,6 +156,26 @@
               "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
               "key": {
                 "ledger_key_nonce": {
+                  "nonce": "1033654523790656264"
+                }
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 6311999
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+              "key": {
+                "ledger_key_nonce": {
                   "nonce": "5541220902715666415"
                 }
               },
@@ -126,14 +193,14 @@
           "data": {
             "contract_data": {
               "ext": "v0",
-              "contract": "CBUSYNQKASUYFWYC3M2GUEDMX4AIVWPALDBYJPNK6554BREHTGZ2IUNF",
+              "contract": "CCABDO7UZXYE4W6GVSEGSNNZTKSLFQGKXXQTH6OX7M7GKZ4Z6CUJNGZN",
               "key": {
                 "vec": [
                   {
                     "symbol": "Balance"
                   },
                   {
-                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
                   }
                 ]
               },
@@ -178,7 +245,7 @@
           "data": {
             "contract_data": {
               "ext": "v0",
-              "contract": "CBUSYNQKASUYFWYC3M2GUEDMX4AIVWPALDBYJPNK6554BREHTGZ2IUNF",
+              "contract": "CCABDO7UZXYE4W6GVSEGSNNZTKSLFQGKXXQTH6OX7M7GKZ4Z6CUJNGZN",
               "key": "ledger_key_contract_instance",
               "durability": "persistent",
               "val": {
@@ -204,7 +271,7 @@
                               "symbol": "name"
                             },
                             "val": {
-                              "string": "aaa:GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGO6V"
+                              "string": "aaa:GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAJXFF"
                             }
                           },
                           {
@@ -227,7 +294,7 @@
                         ]
                       },
                       "val": {
-                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                       }
                     },
                     {
@@ -258,7 +325,7 @@
                                   "symbol": "issuer"
                                 },
                                 "val": {
-                                  "bytes": "0000000000000000000000000000000000000000000000000000000000000003"
+                                  "bytes": "0000000000000000000000000000000000000000000000000000000000000004"
                                 }
                               }
                             ]
@@ -281,23 +348,43 @@
     {
       "event": {
         "ext": "v0",
-        "contract_id": "CBUSYNQKASUYFWYC3M2GUEDMX4AIVWPALDBYJPNK6554BREHTGZ2IUNF",
+        "contract_id": "CCABDO7UZXYE4W6GVSEGSNNZTKSLFQGKXXQTH6OX7M7GKZ4Z6CUJNGZN",
         "type_": "contract",
         "body": {
           "v0": {
             "topics": [
               {
-                "symbol": "set_authorized"
+                "symbol": "transfer"
               },
               {
-                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
               },
               {
-                "string": "aaa:GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGO6V"
+                "address": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEGWF"
+              },
+              {
+                "string": "aaa:GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAJXFF"
               }
             ],
             "data": {
-              "bool": true
+              "map": [
+                {
+                  "key": {
+                    "symbol": "amount"
+                  },
+                  "val": {
+                    "i128": "123"
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "to_muxed_id"
+                  },
+                  "val": {
+                    "u64": "1"
+                  }
+                }
+              ]
             }
           }
         }


### PR DESCRIPTION
### What

Correct the event doc-comments on the five `StellarAssetInterface` functions shared with `TokenInterface` (`approve`, `transfer`, `transfer_from`, `burn`, `burn_from`) to match what the Stellar Asset Contract actually emits, and relax the spec-subset invariant so the two traits can document events differently.

| fn | env `event.rs` | what changed |
| --- | --- | --- |
| `approve` | [L28](https://github.com/stellar/rs-soroban-env/blob/88cadc320cd2030bae2110036b361ff474776db1/soroban-env-host/src/builtin_contracts/stellar_asset_contract/event.rs#L28) | Added `sep0011_asset: String` topic; renamed data field `expiration_ledger` → `live_until_ledger` |
| `transfer` | [L47](https://github.com/stellar/rs-soroban-env/blob/88cadc320cd2030bae2110036b361ff474776db1/soroban-env-host/src/builtin_contracts/stellar_asset_contract/event.rs#L47), [L94](https://github.com/stellar/rs-soroban-env/blob/88cadc320cd2030bae2110036b361ff474776db1/soroban-env-host/src/builtin_contracts/stellar_asset_contract/event.rs#L94) | Added `sep0011_asset: String` topic; corrected default/exception framing (bare `i128` is the norm, `Map` only when `to` carries a mux id); fixed map key order (`amount` first, then `to_muxed_id`); noted issuer-routing dispatch to `mint`/`burn` |
| `transfer_from` | [L47](https://github.com/stellar/rs-soroban-env/blob/88cadc320cd2030bae2110036b361ff474776db1/soroban-env-host/src/builtin_contracts/stellar_asset_contract/event.rs#L47), [L94](https://github.com/stellar/rs-soroban-env/blob/88cadc320cd2030bae2110036b361ff474776db1/soroban-env-host/src/builtin_contracts/stellar_asset_contract/event.rs#L94) | Added `sep0011_asset: String` topic |
| `burn` | [L163](https://github.com/stellar/rs-soroban-env/blob/88cadc320cd2030bae2110036b361ff474776db1/soroban-env-host/src/builtin_contracts/stellar_asset_contract/event.rs#L163) | Added `sep0011_asset: String` topic |
| `burn_from` | [L163](https://github.com/stellar/rs-soroban-env/blob/88cadc320cd2030bae2110036b361ff474776db1/soroban-env-host/src/builtin_contracts/stellar_asset_contract/event.rs#L163) | Added `sep0011_asset: String` topic |

### Why

The SAC always appends a trailing `sep0011_asset` topic to every event; the old docs did not mention that for these five functions.

Fixing their doc-comments directly broke `test_stellar_asset_spec_includes_token_spec` because the test expects the stellar asset contract's spec to be a true superset, but now that the docs and event structures are difference, required rewriting the test to achieve the same goal without requiring the docs to match and requiring the events to be a superset of data.

Close #1979

### Known limitations

`soroban-token-sdk::events::Approve` still uses the field name `expiration_ledger` (not `live_until_ledger`); renaming it is tracked in #1944 as a separate potentially-breaking change. It should be changed in the upcoming v28 release.

### SemVer Change

- [ ] Major (`vX._._`) - Breaking change to the public API.
- [ ] Minor (`v_.Y._`) - Additive change to the public API.
- [x] Patch (`v_._.Z`) - No change to the public API.