### PR TITLE
Error on contracttrait without a trait impl

### DIFF
--- a/soroban-sdk-macros/src/lib.rs
+++ b/soroban-sdk-macros/src/lib.rs
@@ -253,6 +253,19 @@ pub fn contractimpl(metadata: TokenStream, input: TokenStream) -> TokenStream {
 
     let imp = parse_macro_input!(input as ItemImpl);
     let trait_ident = imp.trait_.as_ref().map(|x| &x.1);
+
+    // The `contracttrait` argument only has meaning on a trait impl, where it
+    // hands off to the trait's generated macro. Emitting the impl alongside the
+    // error keeps downstream diagnostics quiet.
+    if args.contracttrait && trait_ident.is_none() {
+        let e = Error::new(
+            Span::call_site(),
+            "`contracttrait` is only supported on an impl block implementing a trait annotated with `#[contracttrait]`",
+        )
+        .into_compile_error();
+        return quote! { #imp #e }.into();
+    }
+
     let ty = &imp.self_ty;
     let ty_str = quote!(#ty).to_string();
 

--- a/soroban-sdk/tests/compile_fails.rs
+++ b/soroban-sdk/tests/compile_fails.rs
@@ -2,6 +2,7 @@
 fn compile_fails() {
     let t = trybuild::TestCases::new();
     t.compile_fail("tests/compile_fails/contracttrait_cfg_errors.rs");
+    t.compile_fail("tests/compile_fails/contracttrait_without_trait.rs");
     t.compile_fail("tests/compile_fails/contracttype_lib_deprecated.rs");
     t.compile_fail("tests/compile_fails/export_arg_errors.rs");
 }

--- a/soroban-sdk/tests/compile_fails/contracttrait_without_trait.rs
+++ b/soroban-sdk/tests/compile_fails/contracttrait_without_trait.rs
@@ -1,0 +1,16 @@
+use soroban_sdk::{contract, contractimpl, Env};
+
+#[contract]
+pub struct C;
+
+// `contracttrait` is meaningless on an inherent impl, and silently ignoring it
+// would produce a contract with an empty spec.
+#[contractimpl(contracttrait)]
+impl C {
+    pub fn f(env: Env) -> u32 {
+        let _ = env;
+        1
+    }
+}
+
+fn main() {}

--- a/soroban-sdk/tests/compile_fails/contracttrait_without_trait.stderr
+++ b/soroban-sdk/tests/compile_fails/contracttrait_without_trait.stderr
@@ -1,0 +1,7 @@
+error: `contracttrait` is only supported on an impl block implementing a trait annotated with `#[contracttrait]`
+ --> tests/compile_fails/contracttrait_without_trait.rs:8:1
+  |
+8 | #[contractimpl(contracttrait)]
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = note: this error originates in the attribute macro `contractimpl` (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
### What

Make `#[contractimpl(contracttrait)]` a compile error when the impl block does not implement a trait.

### Why

The argument is currently accepted and silently ignored on an inherent impl, so the misuse produces no diagnostic at all. Requested in review on #1760, where mootz12 asked for a compiler error in https://github.com/stellar/rs-soroban-sdk/pull/1760#discussion_r3025061842 and https://github.com/stellar/rs-soroban-sdk/pull/1760#discussion_r3073441986. It also de-risks #1760, which skips `contractspecfn` on the contracttrait path, turning this misuse from a no-op into a silently empty contract spec.

### Known limitations

Code that passed the argument on an inherent impl now fails to compile, though it never received any contracttrait behaviour.

### SemVer Change

- [ ] Major (`vX._._`) - Breaking change to the public API.
- [ ] Minor (`v_.Y._`) - Additive change to the public API.
- [x] Patch (`v_._.Z`) - No change to the public API.
