### PR TITLE
Add quickstart integration test workflow

### DIFF
--- a/.github/workflows/test-with-quickstart.yml
+++ b/.github/workflows/test-with-quickstart.yml
@@ -24,6 +24,11 @@ jobs:
   test:
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    env:
+      TEST_FORK_QUICKSTART_FIXTURE: ${{ runner.temp }}/quickstart-fixture.json
+      # Where the snapshot source writes its machine-local cache of downloaded
+      # files and found entries, set so that the runs below can clear it.
+      XDG_CACHE_HOME: ${{ runner.temp }}/cache
     steps:
     - uses: actions/checkout@v5
 
@@ -43,11 +48,23 @@ jobs:
           --limits unlimited
 
     - name: Submit transactions to fork from
-      run: tests/fork/quickstart-setup.sh "$RUNNER_TEMP/quickstart-fixture.json"
+      run: tests/fork/quickstart-setup.sh "$TEST_FORK_QUICKSTART_FIXTURE"
 
-    - name: Fork the transactions
-      env:
-        TEST_FORK_QUICKSTART_FIXTURE: ${{ runner.temp }}/quickstart-fixture.json
+    # Fork three times, once per layer of caching, so that a cache that stores
+    # or replays entries wrongly fails as loudly as collecting them wrongly
+    # does. Every run asserts the same balances.
+
+    - name: Fork the transactions, with no cache
+      run: |
+        rm -rf tests-snapshot-source/local "$XDG_CACHE_HOME/soroban-sdk"
+        cargo test -p test_fork --lib -- --ignored --nocapture quickstart
+
+    - name: Fork the transactions, with only the system cache
+      run: |
+        rm -rf tests-snapshot-source/local
+        cargo test -p test_fork --lib -- --ignored --nocapture quickstart
+
+    - name: Fork the transactions, with the system and workspace caches
       run: cargo test -p test_fork --lib -- --ignored --nocapture quickstart
 
     - name: Quickstart logs

--- a/.github/workflows/test-with-quickstart.yml
+++ b/.github/workflows/test-with-quickstart.yml
@@ -24,6 +24,11 @@ jobs:
   test:
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    env:
+      # Log which of the data sources every ledger entry is found in, so a run
+      # shows what was read from the ledger meta store and what from the
+      # history archive, rather than only that the balances came out right.
+      RUST_LOG: soroban_ledger_snapshot_source_tx=debug
     steps:
     - uses: actions/checkout@v5
 

--- a/.github/workflows/test-with-quickstart.yml
+++ b/.github/workflows/test-with-quickstart.yml
@@ -1,0 +1,55 @@
+name: Test with quickstart
+
+on:
+  push:
+    branches: [main, release/**]
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_protected == 'true' && github.sha || github.ref }}-${{ github.event_name }}
+  cancel-in-progress: true
+
+# No permissions. This workflow runs a network from an image built outside this
+# repository. No permissions ensures that any exploit in that image does not
+# gain access to anything in this repo.
+permissions: {}
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  # Fork a local network, reading the ledger meta store and history archive
+  # that quickstart runs alongside its core and rpc.
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+    - uses: actions/checkout@v5
+
+    - name: Install Rust
+      run: rustup update
+
+    - uses: stellar/actions/rust-cache@main
+
+    - uses: stellar/stellar-cli@v27.1.0
+
+    - name: Start quickstart
+      run: |
+        docker run --detach --name quickstart --publish 8000:8000 \
+          stellar/quickstart:testing \
+          --local \
+          --enable rpc,galexie \
+          --limits unlimited
+
+    - name: Submit transactions to fork from
+      run: tests/fork/quickstart-setup.sh "$RUNNER_TEMP/quickstart-fixture.json"
+
+    - name: Fork the transactions
+      env:
+        TEST_FORK_QUICKSTART_FIXTURE: ${{ runner.temp }}/quickstart-fixture.json
+      run: cargo test -p test_fork --lib -- --ignored --nocapture quickstart
+
+    - name: Quickstart logs
+      if: always()
+      run: docker logs quickstart

--- a/.github/workflows/test-with-quickstart.yml
+++ b/.github/workflows/test-with-quickstart.yml
@@ -24,13 +24,18 @@ jobs:
   test:
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    env:
-      TEST_FORK_QUICKSTART_FIXTURE: ${{ runner.temp }}/quickstart-fixture.json
-      # Where the snapshot source writes its machine-local cache of downloaded
-      # files and found entries, set so that the runs below can clear it.
-      XDG_CACHE_HOME: ${{ runner.temp }}/cache
     steps:
     - uses: actions/checkout@v5
+
+    # Set in an env file rather than in the job's env, because the runner
+    # context those paths come from is not available there.
+    - name: Set the fixture and cache paths
+      run: |
+        echo "TEST_FORK_QUICKSTART_FIXTURE=$RUNNER_TEMP/quickstart-fixture.json" >> "$GITHUB_ENV"
+        # Where the snapshot source writes its machine-local cache of
+        # downloaded files and found entries, set so the runs below can clear
+        # it.
+        echo "XDG_CACHE_HOME=$RUNNER_TEMP/cache" >> "$GITHUB_ENV"
 
     - name: Install Rust
       run: rustup update

--- a/.github/workflows/test-with-quickstart.yml
+++ b/.github/workflows/test-with-quickstart.yml
@@ -57,6 +57,12 @@ jobs:
           --enable rpc,galexie \
           --limits unlimited
 
+    # Build ahead of the runs below, both so that they compile nothing and
+    # their durations are the time spent forking alone, and so that the
+    # compile happens while quickstart is still starting up.
+    - name: Build the test
+      run: cargo test -p test_fork --lib --no-run
+
     - name: Submit transactions to fork from
       run: tests/fork/quickstart-setup.sh "$TEST_FORK_QUICKSTART_FIXTURE"
 

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ soroban-sdk/test_snapshots/tests/contractimport/
 soroban-sdk/test_snapshots/tests/contractimport_with_error/
 soroban-sdk/test_snapshots/tests/proptest_scval_cmp
 tests/import_contract/test_snapshots/
+
+# Snapshots of the ephemeral local network forked by the quickstart test.
+tests-snapshot-source/local/

--- a/soroban-ledger-snapshot-source-tx/src/fetch/mod.rs
+++ b/soroban-ledger-snapshot-source-tx/src/fetch/mod.rs
@@ -108,14 +108,14 @@ impl Network {
     /// Create a Network configuration for local Stellar Quickstart
     ///
     /// Uses default quickstart URLs:
-    /// - SEP-54 meta storage: localhost:8000/meta-archive
+    /// - SEP-54 meta storage: localhost:8000/ledger-meta
     /// - RPC: localhost:8000/rpc
     /// - History archive: localhost:8000/archive
     pub fn local() -> Self {
         Self {
             name: "local".to_string(),
             passphrase: "Standalone Network ; February 2017".to_string(),
-            meta_url: "http://localhost:8000/meta-archive".to_string(),
+            meta_url: "http://localhost:8000/ledger-meta".to_string(),
             rpc_url: Some("http://localhost:8000/rpc".to_string()),
             archive_url: "http://localhost:8000/archive".to_string(),
             archive_checkpoint_ledger_count: 8,
@@ -812,7 +812,7 @@ mod test_network {
         assert_eq!(n.name, "local");
         assert_eq!(n.passphrase, "Standalone Network ; February 2017");
         assert_eq!(n.rpc_url.as_deref(), Some("http://localhost:8000/rpc"));
-        assert_eq!(n.meta_url, "http://localhost:8000/meta-archive");
+        assert_eq!(n.meta_url, "http://localhost:8000/ledger-meta");
         assert_eq!(n.archive_url, "http://localhost:8000/archive");
         assert_eq!(n.archive_checkpoint_ledger_count, 8);
     }

--- a/tests-expanded/test_fork_tests.rs
+++ b/tests-expanded/test_fork_tests.rs
@@ -1621,44 +1621,43 @@ mod quickstart {
                 }
             };
             expected += transfer["amount"].as_i64().unwrap() as i128;
+            {
+                ::std::io::_print(format_args!("balance at end of ledger {0}\n", ledger));
+            };
+            match (&balance_at(sac, target, ledger, None), &expected) {
+                (left_val, right_val) => {
+                    if !(*left_val == *right_val) {
+                        let kind = ::core::panicking::AssertKind::Eq;
+                        ::core::panicking::assert_failed(
+                            kind,
+                            &*left_val,
+                            &*right_val,
+                            ::core::option::Option::None,
+                        );
+                    }
+                }
+            };
+            let archive_ledger = transfer["archive_ledger"].as_u64().unwrap() as u32;
+            {
+                ::std::io::_print(format_args!(
+                    "balance at ledger {0}, from the history archive\n",
+                    archive_ledger,
+                ));
+            };
+            match (&balance_at(sac, target, archive_ledger, None), &expected) {
+                (left_val, right_val) => {
+                    if !(*left_val == *right_val) {
+                        let kind = ::core::panicking::AssertKind::Eq;
+                        ::core::panicking::assert_failed(
+                            kind,
+                            &*left_val,
+                            &*right_val,
+                            ::core::option::Option::None,
+                        );
+                    }
+                }
+            };
         }
-        let last_ledger = transfers.last().unwrap()["ledger"].as_u64().unwrap() as u32;
-        {
-            ::std::io::_print(format_args!("balance at end of ledger {0}\n", last_ledger));
-        };
-        match (&balance_at(sac, target, last_ledger, None), &expected) {
-            (left_val, right_val) => {
-                if !(*left_val == *right_val) {
-                    let kind = ::core::panicking::AssertKind::Eq;
-                    ::core::panicking::assert_failed(
-                        kind,
-                        &*left_val,
-                        &*right_val,
-                        ::core::option::Option::None,
-                    );
-                }
-            }
-        };
-        let archive_ledger = fixture["archive_ledger"].as_u64().unwrap() as u32;
-        {
-            ::std::io::_print(format_args!(
-                "balance at ledger {0}, from the history archive\n",
-                archive_ledger,
-            ));
-        };
-        match (&balance_at(sac, target, archive_ledger, None), &expected) {
-            (left_val, right_val) => {
-                if !(*left_val == *right_val) {
-                    let kind = ::core::panicking::AssertKind::Eq;
-                    ::core::panicking::assert_failed(
-                        kind,
-                        &*left_val,
-                        &*right_val,
-                        ::core::option::Option::None,
-                    );
-                }
-            }
-        };
     }
 }
 #[rustc_main]

--- a/tests-expanded/test_fork_tests.rs
+++ b/tests-expanded/test_fork_tests.rs
@@ -1526,10 +1526,145 @@ mod mainnet {
         }
     }
 }
+/// Forks a local stellar/quickstart network, reading state from the ledger
+/// meta store and the history archive it runs.
+///
+/// The transactions forked from are submitted by `quickstart-setup.sh`, which
+/// writes a fixture describing them that this test reads the path of from
+/// `TEST_FORK_QUICKSTART_FIXTURE`. See that script for how to run the test.
+mod quickstart {
+    extern crate std;
+    use soroban_ledger_snapshot_source_tx::{Network, TxSnapshotSource};
+    use soroban_sdk::{testutils::EnvTestConfig, token::TokenClient, Address, Env};
+    use std::{env, fs};
+    /// The quickstart network, with the RPC disabled so that entries are only
+    /// ever found in the ledger meta store or the history archive. A working
+    /// RPC would otherwise be able to answer lookups that a broken meta store
+    /// or history archive should fail.
+    fn network() -> Network {
+        Network {
+            rpc_url: None,
+            ..Network::local()
+        }
+    }
+    /// The balance of the fixture's target address, as of `ledger`, and just
+    /// before `tx` if given.
+    fn balance_at(sac: &str, target: &str, ledger: u32, tx: Option<[u8; 32]>) -> i128 {
+        let source = TxSnapshotSource::new(network(), ledger, tx);
+        let mut env = Env::from_ledger_snapshot(source);
+        env.set_config(EnvTestConfig {
+            capture_snapshot_at_drop: false,
+        });
+        let client = TokenClient::new(&env, &Address::from_str(&env, sac));
+        client.balance(&Address::from_str(&env, target))
+    }
+    fn tx_hash(s: &str) -> [u8; 32] {
+        hex::decode(s).unwrap().try_into().unwrap()
+    }
+    extern crate test;
+    #[rustc_test_marker = "quickstart::test"]
+    #[doc(hidden)]
+    pub const test: test::TestDescAndFn = test::TestDescAndFn {
+        desc: test::TestDesc {
+            name: test::StaticTestName("quickstart::test"),
+            ignore: true,
+            ignore_message: ::core::option::Option::Some(
+                "requires a local stellar/quickstart network, see quickstart-setup.sh",
+            ),
+            source_file: "tests/fork/src/lib.rs",
+            start_line: 190usize,
+            start_col: 8usize,
+            end_line: 190usize,
+            end_col: 12usize,
+            compile_fail: false,
+            no_run: false,
+            should_panic: test::ShouldPanic::No,
+            test_type: test::TestType::UnitTest,
+        },
+        testfn: test::StaticTestFn(
+            #[coverage(off)]
+            || test::assert_test_result(test()),
+        ),
+    };
+    #[ignore = "requires a local stellar/quickstart network, see quickstart-setup.sh"]
+    fn test() {
+        let path = env::var("TEST_FORK_QUICKSTART_FIXTURE")
+            .expect(
+                "TEST_FORK_QUICKSTART_FIXTURE must be set to the path of a fixture written by quickstart-setup.sh",
+            );
+        let fixture: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(&path).unwrap()).unwrap();
+        let sac = fixture["sac"].as_str().unwrap();
+        let target = fixture["target"].as_str().unwrap();
+        let transfers = fixture["transfers"].as_array().unwrap();
+        let mut expected: i128 = 0;
+        for transfer in transfers {
+            let ledger = transfer["ledger"].as_u64().unwrap() as u32;
+            let tx = tx_hash(transfer["tx"].as_str().unwrap());
+            {
+                ::std::io::_print(format_args!(
+                    "balance before tx {0} in ledger {1}\n",
+                    transfer["tx"], ledger,
+                ));
+            };
+            match (&balance_at(sac, target, ledger, Some(tx)), &expected) {
+                (left_val, right_val) => {
+                    if !(*left_val == *right_val) {
+                        let kind = ::core::panicking::AssertKind::Eq;
+                        ::core::panicking::assert_failed(
+                            kind,
+                            &*left_val,
+                            &*right_val,
+                            ::core::option::Option::None,
+                        );
+                    }
+                }
+            };
+            expected += transfer["amount"].as_i64().unwrap() as i128;
+        }
+        let last_ledger = transfers.last().unwrap()["ledger"].as_u64().unwrap() as u32;
+        {
+            ::std::io::_print(format_args!("balance at end of ledger {0}\n", last_ledger));
+        };
+        match (&balance_at(sac, target, last_ledger, None), &expected) {
+            (left_val, right_val) => {
+                if !(*left_val == *right_val) {
+                    let kind = ::core::panicking::AssertKind::Eq;
+                    ::core::panicking::assert_failed(
+                        kind,
+                        &*left_val,
+                        &*right_val,
+                        ::core::option::Option::None,
+                    );
+                }
+            }
+        };
+        let archive_ledger = fixture["archive_ledger"].as_u64().unwrap() as u32;
+        {
+            ::std::io::_print(format_args!(
+                "balance at ledger {0}, from the history archive\n",
+                archive_ledger,
+            ));
+        };
+        match (&balance_at(sac, target, archive_ledger, None), &expected) {
+            (left_val, right_val) => {
+                if !(*left_val == *right_val) {
+                    let kind = ::core::panicking::AssertKind::Eq;
+                    ::core::panicking::assert_failed(
+                        kind,
+                        &*left_val,
+                        &*right_val,
+                        ::core::option::Option::None,
+                    );
+                }
+            }
+        };
+    }
+}
 #[rustc_main]
 #[coverage(off)]
 #[doc(hidden)]
 pub fn main() -> () {
     extern crate test;
-    test::test_main_static(&[&test, &test_1])
+    test::test_main_static(&[&test, &test_1, &test])
 }

--- a/tests/fork/quickstart-setup.sh
+++ b/tests/fork/quickstart-setup.sh
@@ -33,6 +33,13 @@ CHECKPOINT_FREQUENCY=8
 # before transfer N is the sum of the amounts before it.
 AMOUNTS=(10 20 30)
 
+# Ledgers to wait between transfers. Spreads the transfers over more than 64
+# ledgers and several checkpoints, so that the transfers are not all reachable
+# from the same place: the most recent is still in the ledger meta store, while
+# the earlier ones have to be read out of the history archive, and out of
+# different checkpoints of it rather than only the most recent one.
+LEDGERS_BETWEEN_TRANSFERS=40
+
 rpc() {
   curl -sf "$STELLAR_RPC_URL" -H 'Content-Type: application/json' \
     -d "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"$1\",\"params\":${2:-null}}"
@@ -69,6 +76,12 @@ transfers=()
 for i in "${!AMOUNTS[@]}"; do
   amount="${AMOUNTS[$i]}"
 
+  if [ "$i" -gt 0 ]; then
+    next=$(( $(jq -r '.ledger' <<<"${transfers[-1]}") + LEDGERS_BETWEEN_TRANSFERS ))
+    echo "Waiting for ledger $next to close before the next transfer ..."
+    until [ "$(rpc getLatestLedger | jq -r '.result.sequence')" -ge "$next" ]; do sleep 1; done
+  fi
+
   # A separate source account per transfer, so the transactions do not depend
   # on each other's sequence numbers and can land in the same ledger.
   account "sender$i"
@@ -93,15 +106,22 @@ for i in "${!AMOUNTS[@]}"; do
   [ "$status" = "SUCCESS" ] || { echo "transaction $hash failed: $status"; exit 1; }
 
   ledger=$(jq -r '.result.ledger' <<<"$result")
+
+  # A ledger far enough past this transfer that a search for the balance entry
+  # falls out of the ledger meta store, back past a checkpoint, and into the
+  # history archive. One per transfer, so that each lands in a different
+  # checkpoint: the test reads the earlier ones out of checkpoints that are no
+  # longer the archive's most recent.
+  archive_ledger=$(( (ledger / CHECKPOINT_FREQUENCY + 2) * CHECKPOINT_FREQUENCY ))
+
   echo "Transferred $amount in ledger $ledger, transaction $hash"
-  transfers+=("{\"ledger\":$ledger,\"tx\":\"$hash\",\"amount\":$amount}")
+  transfers+=(
+    "{\"ledger\":$ledger,\"tx\":\"$hash\",\"amount\":$amount,\"archive_ledger\":$archive_ledger}"
+  )
 done
 
-# A ledger far enough past the last transfer that the search for the balance
-# entry falls out of the ledger meta store, back past a checkpoint, and into
-# the history archive.
-last_ledger=$(jq -r '.ledger' <<<"${transfers[-1]}")
-archive_ledger=$(( (last_ledger / CHECKPOINT_FREQUENCY + 2) * CHECKPOINT_FREQUENCY ))
+# The last transfer's archive ledger is the furthest ahead, so waiting for it
+# waits for everything the test reads.
 archive_checkpoint=$(( archive_ledger - 1 ))
 
 echo "Waiting for ledger $archive_ledger to close ..."
@@ -121,8 +141,7 @@ jq -n \
   --arg sac "$SAC" \
   --arg target "$TARGET" \
   --argjson transfers "$(printf '%s\n' "${transfers[@]}" | jq -s .)" \
-  --argjson archive_ledger "$archive_ledger" \
-  '{sac: $sac, target: $target, transfers: $transfers, archive_ledger: $archive_ledger}' \
+  '{sac: $sac, target: $target, transfers: $transfers}' \
   > "$FIXTURE_PATH"
 
 echo "Wrote $FIXTURE_PATH:"

--- a/tests/fork/quickstart-setup.sh
+++ b/tests/fork/quickstart-setup.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+#
+# Submit transactions to a local stellar/quickstart network and write a fixture
+# describing them, for the fork test in src/lib.rs (module `quickstart`) to fork
+# from.
+#
+# Start quickstart with the ledger meta store and the history archive both
+# running, then run this script:
+#
+#   docker run --rm -p 8000:8000 stellar/quickstart:testing --local --enable rpc,galexie
+#   tests/fork/quickstart-setup.sh /tmp/quickstart-fixture.json
+#   TEST_FORK_QUICKSTART_FIXTURE=/tmp/quickstart-fixture.json \
+#     cargo test -p test_fork --lib -- --ignored --nocapture quickstart
+#
+# The transfers are of the native asset's Stellar Asset Contract, to an address
+# that no other transaction touches, so the balance of that address changes
+# only by the transfers submitted here and the expected balance at each point
+# is known.
+
+set -euo pipefail
+
+FIXTURE_PATH="${1:?usage: quickstart-setup.sh <fixture-path>}"
+
+HOST="${QUICKSTART_HOST:-http://localhost:8000}"
+export STELLAR_RPC_URL="$HOST/rpc"
+export STELLAR_NETWORK_PASSPHRASE="${QUICKSTART_NETWORK_PASSPHRASE:-Standalone Network ; February 2017}"
+
+# Checkpoints are every 8 ledgers on quickstart's local network, matching
+# Network::local()'s archive_checkpoint_ledger_count.
+CHECKPOINT_FREQUENCY=8
+
+# Amounts transferred, one transaction each. The balance the test expects
+# before transfer N is the sum of the amounts before it.
+AMOUNTS=(10 20 30)
+
+rpc() {
+  curl -sf "$STELLAR_RPC_URL" -H 'Content-Type: application/json' \
+    -d "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"$1\",\"params\":${2:-null}}"
+}
+
+# Create an account, retrying friendbot until it is up, because it takes a
+# moment longer to come up than the rpc does.
+account() {
+  stellar keys generate "$1" --overwrite
+  until curl -sf -o /dev/null "$HOST/friendbot?addr=$(stellar keys address "$1")"; do sleep 1; done
+}
+
+echo "Waiting for rpc to be healthy ..."
+until [ "$(rpc getHealth | jq -r '.result.status // empty')" = "healthy" ]; do sleep 2; done
+
+echo "Deploying the native asset contract ..."
+account deployer
+SAC=$(stellar contract id asset --asset native)
+# Deploying fails if a previous run of this script against the same network
+# already deployed it, which is only a problem if it is still not deployed.
+stellar contract asset deploy --asset native --source-account deployer > /dev/null \
+  || stellar contract info interface --id "$SAC" > /dev/null
+echo "Native asset contract: $SAC"
+
+# The address the transfers are sent to, and whose balance the test checks. The
+# contract ID of the asset contract of a randomly named asset, which is never
+# deployed and so is an address that no other transaction has touched: its
+# balance starts at zero and only the transfers below change it.
+TARGET=$(stellar contract id asset \
+  --asset "T$(od -An -tx1 -N4 /dev/urandom | tr -d ' \n' | tr 'a-f' 'A-F'):$(stellar keys address deployer)")
+echo "Target address: $TARGET"
+
+transfers=()
+for i in "${!AMOUNTS[@]}"; do
+  amount="${AMOUNTS[$i]}"
+
+  # A separate source account per transfer, so the transactions do not depend
+  # on each other's sequence numbers and can land in the same ledger.
+  account "sender$i"
+  sender=$(stellar keys address "sender$i")
+
+  signed=$(
+    stellar contract invoke --quiet --build-only --source-account "sender$i" --id "$SAC" \
+      -- transfer --from "$sender" --to "$TARGET" --amount "$amount" \
+      | stellar tx simulate --quiet --source-account "sender$i" \
+      | stellar tx sign --quiet --sign-with-key "sender$i"
+  )
+  hash=$(printf '%s' "$signed" | stellar tx hash)
+  printf '%s' "$signed" | stellar tx send > /dev/null
+
+  echo "Waiting for transaction $hash ..."
+  result=$(
+    until r=$(rpc getTransaction "{\"hash\":\"$hash\"}") \
+      && [ "$(jq -r '.result.status' <<<"$r")" != "NOT_FOUND" ]; do sleep 1; done
+    echo "$r"
+  )
+  status=$(jq -r '.result.status' <<<"$result")
+  [ "$status" = "SUCCESS" ] || { echo "transaction $hash failed: $status"; exit 1; }
+
+  ledger=$(jq -r '.result.ledger' <<<"$result")
+  echo "Transferred $amount in ledger $ledger, transaction $hash"
+  transfers+=("{\"ledger\":$ledger,\"tx\":\"$hash\",\"amount\":$amount}")
+done
+
+# A ledger far enough past the last transfer that the search for the balance
+# entry falls out of the ledger meta store, back past a checkpoint, and into
+# the history archive.
+last_ledger=$(jq -r '.ledger' <<<"${transfers[-1]}")
+archive_ledger=$(( (last_ledger / CHECKPOINT_FREQUENCY + 2) * CHECKPOINT_FREQUENCY ))
+archive_checkpoint=$(( archive_ledger - 1 ))
+
+echo "Waiting for ledger $archive_ledger to close ..."
+until [ "$(rpc getLatestLedger | jq -r '.result.sequence')" -ge "$archive_ledger" ]; do sleep 1; done
+
+echo "Waiting for ledger $archive_ledger in the ledger meta store ..."
+# Galexie writes one ledger per file, 64000 files per partition, so on a fresh
+# local network every ledger is in the first partition.
+batch=$(printf '%08X--%d.xdr.zst' "$((0xFFFFFFFF - archive_ledger))" "$archive_ledger")
+until curl -sf -o /dev/null "$HOST/ledger-meta/FFFFFFFF--0-63999/$batch"; do sleep 1; done
+
+echo "Waiting for checkpoint $archive_checkpoint in the history archive ..."
+until [ "$(curl -sf "$HOST/archive/.well-known/stellar-history.json" | jq -r '.currentLedger')" \
+  -ge "$archive_checkpoint" ]; do sleep 1; done
+
+jq -n \
+  --arg sac "$SAC" \
+  --arg target "$TARGET" \
+  --argjson transfers "$(printf '%s\n' "${transfers[@]}" | jq -s .)" \
+  --argjson archive_ledger "$archive_ledger" \
+  '{sac: $sac, target: $target, transfers: $transfers, archive_ledger: $archive_ledger}' \
+  > "$FIXTURE_PATH"
+
+echo "Wrote $FIXTURE_PATH:"
+cat "$FIXTURE_PATH"

--- a/tests/fork/src/lib.rs
+++ b/tests/fork/src/lib.rs
@@ -198,29 +198,31 @@ mod quickstart {
 
         // Each transfer added its amount to the target's balance, so the
         // balance just before each transfer is the sum of the amounts of the
-        // transfers before it. Found in the ledger meta store, which is the
-        // only source with the granularity to see state part way through a
-        // ledger.
+        // transfers before it, and the balance after it also includes its own.
         let mut expected: i128 = 0;
         for transfer in transfers {
             let ledger = transfer["ledger"].as_u64().unwrap() as u32;
             let tx = tx_hash(transfer["tx"].as_str().unwrap());
+
+            // Just before the transfer. Only the ledger meta store has the
+            // granularity to see state part way through a ledger, so this is
+            // always read from there.
             std::println!("balance before tx {} in ledger {ledger}", transfer["tx"]);
             assert_eq!(balance_at(sac, target, ledger, Some(tx)), expected);
+
+            // At the end of the ledger the transfer was in.
             expected += transfer["amount"].as_i64().unwrap() as i128;
+            std::println!("balance at end of ledger {ledger}");
+            assert_eq!(balance_at(sac, target, ledger, None), expected);
+
+            // Far enough past the transfer that the balance is no longer in
+            // the ledgers of meta searched, and is instead read out of the
+            // buckets of a history archive checkpoint. The transfers are far
+            // enough apart that each of these is a different checkpoint, so
+            // only the last is the archive's most recent.
+            let archive_ledger = transfer["archive_ledger"].as_u64().unwrap() as u32;
+            std::println!("balance at ledger {archive_ledger}, from the history archive");
+            assert_eq!(balance_at(sac, target, archive_ledger, None), expected);
         }
-
-        // At the end of the ledger the last transfer was in, all the transfers
-        // have been applied.
-        let last_ledger = transfers.last().unwrap()["ledger"].as_u64().unwrap() as u32;
-        std::println!("balance at end of ledger {last_ledger}");
-        assert_eq!(balance_at(sac, target, last_ledger, None), expected);
-
-        // Far enough past the last transfer that the balance is no longer in
-        // the ledgers of meta searched, and is instead read out of the buckets
-        // of a history archive checkpoint.
-        let archive_ledger = fixture["archive_ledger"].as_u64().unwrap() as u32;
-        std::println!("balance at ledger {archive_ledger}, from the history archive");
-        assert_eq!(balance_at(sac, target, archive_ledger, None), expected);
     }
 }

--- a/tests/fork/src/lib.rs
+++ b/tests/fork/src/lib.rs
@@ -142,3 +142,85 @@ mod mainnet {
         #[test] fn test_1() { test() }
     }
 }
+
+/// Forks a local stellar/quickstart network, reading state from the ledger
+/// meta store and the history archive it runs.
+///
+/// The transactions forked from are submitted by `quickstart-setup.sh`, which
+/// writes a fixture describing them that this test reads the path of from
+/// `TEST_FORK_QUICKSTART_FIXTURE`. See that script for how to run the test.
+#[cfg(test)]
+mod quickstart {
+    extern crate std;
+    use soroban_ledger_snapshot_source_tx::{Network, TxSnapshotSource};
+    use soroban_sdk::{testutils::EnvTestConfig, token::TokenClient, Address, Env};
+    use std::{env, fs};
+
+    /// The quickstart network, with the RPC disabled so that entries are only
+    /// ever found in the ledger meta store or the history archive. A working
+    /// RPC would otherwise be able to answer lookups that a broken meta store
+    /// or history archive should fail.
+    fn network() -> Network {
+        Network {
+            rpc_url: None,
+            ..Network::local()
+        }
+    }
+
+    /// The balance of the fixture's target address, as of `ledger`, and just
+    /// before `tx` if given.
+    fn balance_at(sac: &str, target: &str, ledger: u32, tx: Option<[u8; 32]>) -> i128 {
+        let source = TxSnapshotSource::new(network(), ledger, tx);
+        let mut env = Env::from_ledger_snapshot(source);
+        // The snapshot is of a network that only exists while the test runs,
+        // so there's nothing to be gained by writing it out at drop.
+        env.set_config(EnvTestConfig {
+            capture_snapshot_at_drop: false,
+        });
+        let client = TokenClient::new(&env, &Address::from_str(&env, sac));
+        client.balance(&Address::from_str(&env, target))
+    }
+
+    fn tx_hash(s: &str) -> [u8; 32] {
+        hex::decode(s).unwrap().try_into().unwrap()
+    }
+
+    #[test]
+    #[ignore = "requires a local stellar/quickstart network, see quickstart-setup.sh"]
+    fn test() {
+        let path = env::var("TEST_FORK_QUICKSTART_FIXTURE")
+            .expect("TEST_FORK_QUICKSTART_FIXTURE must be set to the path of a fixture written by quickstart-setup.sh");
+        let fixture: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(&path).unwrap()).unwrap();
+        let sac = fixture["sac"].as_str().unwrap();
+        let target = fixture["target"].as_str().unwrap();
+        let transfers = fixture["transfers"].as_array().unwrap();
+
+        // Each transfer added its amount to the target's balance, so the
+        // balance just before each transfer is the sum of the amounts of the
+        // transfers before it. Found in the ledger meta store, which is the
+        // only source with the granularity to see state part way through a
+        // ledger.
+        let mut expected: i128 = 0;
+        for transfer in transfers {
+            let ledger = transfer["ledger"].as_u64().unwrap() as u32;
+            let tx = tx_hash(transfer["tx"].as_str().unwrap());
+            std::println!("balance before tx {} in ledger {ledger}", transfer["tx"]);
+            assert_eq!(balance_at(sac, target, ledger, Some(tx)), expected);
+            expected += transfer["amount"].as_i64().unwrap() as i128;
+        }
+
+        // At the end of the ledger the last transfer was in, all the transfers
+        // have been applied.
+        let last_ledger = transfers.last().unwrap()["ledger"].as_u64().unwrap() as u32;
+        std::println!("balance at end of ledger {last_ledger}");
+        assert_eq!(balance_at(sac, target, last_ledger, None), expected);
+
+        // Far enough past the last transfer that the balance is no longer in
+        // the ledgers of meta searched, and is instead read out of the buckets
+        // of a history archive checkpoint.
+        let archive_ledger = fixture["archive_ledger"].as_u64().unwrap() as u32;
+        std::println!("balance at ledger {archive_ledger}, from the history archive");
+        assert_eq!(balance_at(sac, target, archive_ledger, None), expected);
+    }
+}


### PR DESCRIPTION
### What

Add a CI workflow that forks a local stellar/quickstart network, reading state from the SEP-54 ledger meta store and the history archive that quickstart runs alongside core and rpc, three times over: with no cache, with only the system cache, and with the system and workspace caches.

### Why

Everything the snapshot source does has so far only been exercised against mainnet fixtures, so a break in the meta store or history archive lookups only surfaces against live networks and data that can't be produced on demand; quickstart runs both stores locally, and this also caught `Network::local()` pointing at `/meta-archive` rather than the `/ledger-meta` path quickstart serves.

### Known limitations

The workflow uses the floating `stellar/quickstart:testing` tag because galexie support is not in a released quickstart tag yet, and the test asserts only native Stellar Asset Contract balances, not other entry types.

### SemVer Change

- [ ] Major (`vX._._`) - Breaking change to the public API.
- [ ] Minor (`v_.Y._`) - Additive change to the public API.
- [x] Patch (`v_._.Z`) - No change to the public API.
