### PR TITLE
Add most recent audited release to support policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ Docs: https://docs.rs/soroban-sdk
 
 ## Support
 
-The two most recent soroban-sdk major releases are supported with critical security fixes.
+The two most recent soroban-sdk major releases, as well as the most recent audited major release,
+are supported with critical security fixes.
 Critical security issues may be backported to earlier versions if practical, but not guaranteed.
 General bugs are only fixed on, and new features are only added to, the latest major release.
 

--- a/soroban-sdk/README.md
+++ b/soroban-sdk/README.md
@@ -11,7 +11,8 @@ See [developers.stellar.org] for documentation about building smart contracts fo
 
 ### Support
 
-The two most recent soroban-sdk major releases are supported with critical security fixes.
+The two most recent soroban-sdk major releases, as well as the most recent audited major
+release, are supported with critical security fixes.
 Critical security issues may be backported to earlier versions if practical, but not guaranteed.
 General bugs are only fixed on, and new features are only added to, the latest major release.
 

--- a/soroban-sdk/src/lib.rs
+++ b/soroban-sdk/src/lib.rs
@@ -11,7 +11,8 @@
 //!
 //! ### Support
 //!
-//! The two most recent soroban-sdk major releases are supported with critical security fixes.
+//! The two most recent soroban-sdk major releases, as well as the most recent audited major
+//! release, are supported with critical security fixes.
 //! Critical security issues may be backported to earlier versions if practical, but not guaranteed.
 //! General bugs are only fixed on, and new features are only added to, the latest major release.
 //!


### PR DESCRIPTION
### What

Extend the support policy so the most recent audited major release also receives critical security fixes, alongside the two most recent major releases. Updated in the root README, crate README, and crate docs.

### Why

An audited release may fall outside the two most recent majors, and users who deploy against would benefit from still receiving critical security fixes.

### Known limitations

N/A

### SemVer Change

- [ ] Major (`vX._._`) - Breaking change to the public API.
- [ ] Minor (`v_.Y._`) - Additive change to the public API.
- [x] Patch (`v_._.Z`) - No change to the public API.