### PR TITLE
Show a constructor and event publishing in the front page docs example

### DIFF
--- a/soroban-sdk/README.md
+++ b/soroban-sdk/README.md
@@ -42,15 +42,29 @@ See [_migrating] for a summary of how to migrate from one major version to anoth
 ### Examples
 
 ```rust
-use soroban_sdk::{contract, contractimpl, vec, symbol_short, BytesN, Env, Symbol, Vec};
+use soroban_sdk::{contract, contractevent, contractimpl, symbol_short, Address, Env};
 
 #[contract]
 pub struct Contract;
 
+#[contractevent]
+pub struct Hello {
+    #[topic]
+    pub to: Address,
+}
+
 #[contractimpl]
 impl Contract {
-    pub fn hello(env: Env, to: Symbol) -> Vec<Symbol> {
-        vec![&env, symbol_short!("Hello"), to]
+    pub fn __constructor(env: Env, admin: Address) {
+        env.storage().instance().set(&symbol_short!("admin"), &admin);
+    }
+
+    pub fn hello(env: Env, to: Address) {
+        let admin: Address = env.storage().instance()
+            .get(&symbol_short!("admin"))
+            .unwrap();
+        admin.require_auth();
+        Hello { to }.publish(&env);
     }
 }
 
@@ -59,13 +73,33 @@ fn test() {
 # }
 # #[cfg(feature = "testutils")]
 # fn main() {
+    use soroban_sdk::{
+        testutils::{Address as _, AuthorizedFunction, AuthorizedInvocation, Events as _},
+        Event as _, IntoVal,
+    };
+
     let env = Env::default();
-    let contract_id = env.register(Contract, ());
+    let admin = Address::generate(&env);
+    let contract_id = env.register(Contract, (&admin,));
     let client = ContractClient::new(&env, &contract_id);
 
-    let words = client.hello(&symbol_short!("Dev"));
+    let to = Address::generate(&env);
 
-    assert_eq!(words, vec![&env, symbol_short!("Hello"), symbol_short!("Dev"),]);
+    client.mock_all_auths().hello(&to);
+
+    assert_eq!(
+        env.auths(),
+        [
+            (admin, AuthorizedInvocation { function: AuthorizedFunction::Contract((contract_id.clone(), symbol_short!("hello"), (&to,).into_val(&env))), sub_invocations: [].into() }),
+        ],
+    );
+
+    assert_eq!(
+        env.events().all(),
+        [
+            Hello { to }.to_xdr(&env, &contract_id),
+        ],
+    );
 }
 # #[cfg(not(feature = "testutils"))]
 # fn main() { }

--- a/soroban-sdk/src/lib.rs
+++ b/soroban-sdk/src/lib.rs
@@ -42,15 +42,29 @@
 //! ### Examples
 //!
 //! ```rust
-//! use soroban_sdk::{contract, contractimpl, vec, symbol_short, BytesN, Env, Symbol, Vec};
+//! use soroban_sdk::{contract, contractevent, contractimpl, symbol_short, Address, Env};
 //!
 //! #[contract]
 //! pub struct Contract;
 //!
+//! #[contractevent]
+//! pub struct Hello {
+//!     #[topic]
+//!     pub to: Address,
+//! }
+//!
 //! #[contractimpl]
 //! impl Contract {
-//!     pub fn hello(env: Env, to: Symbol) -> Vec<Symbol> {
-//!         vec![&env, symbol_short!("Hello"), to]
+//!     pub fn __constructor(env: Env, admin: Address) {
+//!         env.storage().instance().set(&symbol_short!("admin"), &admin);
+//!     }
+//!
+//!     pub fn hello(env: Env, to: Address) {
+//!         let admin: Address = env.storage().instance()
+//!             .get(&symbol_short!("admin"))
+//!             .unwrap();
+//!         admin.require_auth();
+//!         Hello { to }.publish(&env);
 //!     }
 //! }
 //!
@@ -59,13 +73,33 @@
 //! # }
 //! # #[cfg(feature = "testutils")]
 //! # fn main() {
+//!     use soroban_sdk::{
+//!         testutils::{Address as _, AuthorizedFunction, AuthorizedInvocation, Events as _},
+//!         Event as _, IntoVal,
+//!     };
+//!
 //!     let env = Env::default();
-//!     let contract_id = env.register(Contract, ());
+//!     let admin = Address::generate(&env);
+//!     let contract_id = env.register(Contract, (&admin,));
 //!     let client = ContractClient::new(&env, &contract_id);
 //!
-//!     let words = client.hello(&symbol_short!("Dev"));
+//!     let to = Address::generate(&env);
 //!
-//!     assert_eq!(words, vec![&env, symbol_short!("Hello"), symbol_short!("Dev"),]);
+//!     client.mock_all_auths().hello(&to);
+//!
+//!     assert_eq!(
+//!         env.auths(),
+//!         [
+//!             (admin, AuthorizedInvocation { function: AuthorizedFunction::Contract((contract_id.clone(), symbol_short!("hello"), (&to,).into_val(&env))), sub_invocations: [].into() }),
+//!         ],
+//!     );
+//!
+//!     assert_eq!(
+//!         env.events().all(),
+//!         [
+//!             Hello { to }.to_xdr(&env, &contract_id),
+//!         ],
+//!     );
 //! }
 //! # #[cfg(not(feature = "testutils"))]
 //! # fn main() { }


### PR DESCRIPTION
### What

Rework the crate-level (front page) docs example so it demonstrates a constructor, authorization, and event publishing:

- Adds a `__constructor(env: Env, admin: Address)` that stores the admin in instance storage.
- `hello(env: Env, to: Address)` loads that admin and calls `require_auth()` before doing anything.
- `hello` publishes a `Hello` contract event with `to` as a topic, instead of returning a vec of symbols.
- The doctest registers the contract with a generated admin, mocks auths, and asserts on `env.events().all()` using the event's `to_xdr` helper.

### Why

My main goal was to demonstrate a constructor, because most contracts should need one to setup the initial state and configuration. Because Rust does not naturally have constructors this is an unintuitive feature to discover, so surfacing it immediately in the most basic example is worthwhile.

Adding the constructor in any meaningful way led to also showing auth and storage, and then it seemed logical to go all the way and show an event which is more natural than returning the vec like it was. 

Constructors, storage, auth, and events are all core to writing a real contract, so showing them in the introductory example means the concepts are visible up front instead of only in the individual macro docs or deep in example tutorials.

### SemVer Change

- [ ] Major (`vX._._`) - Breaking change to the public API.
- [ ] Minor (`v_.Y._`) - Additive change to the public API.
- [x] Patch (`v_._.Z`) - No change to the public API.