### PR TITLE
Panic on test state use inside a contract

### DIFF
--- a/soroban-sdk/src/env.rs
+++ b/soroban-sdk/src/env.rs
@@ -129,8 +129,7 @@ use internal::{
 #[doc(hidden)]
 #[derive(Clone)]
 pub struct MaybeEnv {
-    // On wasm an Env is always available and costs nothing to store, so it is
-    // never absent.
+    // On wasm an Env is always available.
     #[cfg(target_family = "wasm")]
     env: Env,
     #[cfg(not(target_family = "wasm"))]

--- a/soroban-sdk/src/env.rs
+++ b/soroban-sdk/src/env.rs
@@ -240,9 +240,7 @@ thread_local! {
 struct EnvTestState {
     test_name: Option<String>,
     number: usize,
-    // Shared between clones of the Env, so that a config change is seen by
-    // every clone, including the clones held inside values such as Symbol.
-    config: Rc<RefCell<EnvTestConfig>>,
+    config: EnvTestConfig,
     generators: Rc<RefCell<Generators>>,
     auth_snapshot: Rc<RefCell<AuthSnapshot>>,
     snapshot: Option<Rc<LedgerSnapshot>>,
@@ -658,7 +656,7 @@ impl Env {
 
     /// Change the test config of an Env.
     pub fn set_config(&mut self, config: EnvTestConfig) {
-        *(*self.test_state.config).borrow_mut() = config;
+        self.test_state.config = config;
     }
 
     /// Used by multiple constructors to configure test environments consistently.
@@ -751,7 +749,7 @@ impl Env {
             test_state: EnvTestState {
                 test_name,
                 number,
-                config: Rc::new(RefCell::new(config)),
+                config,
                 generators: generators.unwrap_or_default(),
                 snapshot,
                 auth_snapshot,
@@ -2012,8 +2010,7 @@ impl Drop for Env {
         // snapshot at that point when no other references to the host exist,
         // because it is only when there are no other references that the host
         // is being dropped.
-        if self.env_impl.can_finish() && (*self.test_state.config).borrow().capture_snapshot_at_drop
-        {
+        if self.env_impl.can_finish() && self.test_state.config.capture_snapshot_at_drop {
             self.to_test_snapshot_file();
         }
     }

--- a/soroban-sdk/src/env.rs
+++ b/soroban-sdk/src/env.rs
@@ -240,7 +240,9 @@ thread_local! {
 struct EnvTestState {
     test_name: Option<String>,
     number: usize,
-    config: EnvTestConfig,
+    // Shared between clones of the Env, so that a config change is seen by
+    // every clone, including the clones held inside values such as Symbol.
+    config: Rc<RefCell<EnvTestConfig>>,
     generators: Rc<RefCell<Generators>>,
     auth_snapshot: Rc<RefCell<AuthSnapshot>>,
     snapshot: Option<Rc<LedgerSnapshot>>,
@@ -656,7 +658,7 @@ impl Env {
 
     /// Change the test config of an Env.
     pub fn set_config(&mut self, config: EnvTestConfig) {
-        self.test_state.config = config;
+        *(*self.test_state.config).borrow_mut() = config;
     }
 
     /// Used by multiple constructors to configure test environments consistently.
@@ -749,7 +751,7 @@ impl Env {
             test_state: EnvTestState {
                 test_name,
                 number,
-                config,
+                config: Rc::new(RefCell::new(config)),
                 generators: generators.unwrap_or_default(),
                 snapshot,
                 auth_snapshot,
@@ -2010,7 +2012,8 @@ impl Drop for Env {
         // snapshot at that point when no other references to the host exist,
         // because it is only when there are no other references that the host
         // is being dropped.
-        if self.env_impl.can_finish() && self.test_state.config.capture_snapshot_at_drop {
+        if self.env_impl.can_finish() && (*self.test_state.config).borrow().capture_snapshot_at_drop
+        {
             self.to_test_snapshot_file();
         }
     }

--- a/soroban-sdk/src/env.rs
+++ b/soroban-sdk/src/env.rs
@@ -129,8 +129,10 @@ use internal::{
 #[doc(hidden)]
 #[derive(Clone)]
 pub struct MaybeEnv {
-    // There is nothing to store on wasm, because on wasm an Env is always
-    // available and costs nothing to construct.
+    // On wasm an Env is always available and costs nothing to store, so it is
+    // never absent.
+    #[cfg(target_family = "wasm")]
+    env: Env,
     #[cfg(not(target_family = "wasm"))]
     env: Option<Env>,
 }
@@ -139,10 +141,8 @@ pub struct MaybeEnv {
 impl TryFrom<MaybeEnv> for Env {
     type Error = Infallible;
 
-    fn try_from(_value: MaybeEnv) -> Result<Self, Self::Error> {
-        Ok(Env {
-            env_impl: internal::EnvImpl {},
-        })
+    fn try_from(value: MaybeEnv) -> Result<Self, Self::Error> {
+        Ok(value.env)
     }
 }
 
@@ -156,7 +156,11 @@ impl Default for MaybeEnv {
 impl MaybeEnv {
     // separate function to be const
     pub const fn none() -> Self {
-        Self {}
+        Self {
+            env: Env {
+                env_impl: internal::EnvImpl {},
+            },
+        }
     }
 }
 
@@ -170,8 +174,8 @@ impl MaybeEnv {
 
 #[cfg(target_family = "wasm")]
 impl From<Env> for MaybeEnv {
-    fn from(_value: Env) -> Self {
-        MaybeEnv {}
+    fn from(value: Env) -> Self {
+        MaybeEnv { env: value }
     }
 }
 

--- a/soroban-sdk/src/env.rs
+++ b/soroban-sdk/src/env.rs
@@ -6,7 +6,6 @@ pub mod internal {
 
     pub use soroban_env_guest::*;
     pub type EnvImpl = Guest;
-    pub type MaybeEnvImpl = Guest;
 
     // In the Guest case, Env::Error is already Infallible so there is no work
     // to do to "reject an error": if an error occurs in the environment, the
@@ -22,7 +21,6 @@ pub mod internal {
 
     pub use soroban_env_host::*;
     pub type EnvImpl = Host;
-    pub type MaybeEnvImpl = Option<super::Env>;
 
     // When we have `feature="testutils"` (or are in cfg(test)) we enable feature
     // `soroban-env-{common,host}/testutils` which in turn adds the helper method
@@ -131,7 +129,10 @@ use internal::{
 #[doc(hidden)]
 #[derive(Clone)]
 pub struct MaybeEnv {
-    maybe_env_impl: internal::MaybeEnvImpl,
+    // There is nothing to store on wasm, because on wasm an Env is always
+    // available and costs nothing to construct.
+    #[cfg(not(target_family = "wasm"))]
+    env: Option<Env>,
 }
 
 #[cfg(target_family = "wasm")]
@@ -155,9 +156,7 @@ impl Default for MaybeEnv {
 impl MaybeEnv {
     // separate function to be const
     pub const fn none() -> Self {
-        Self {
-            maybe_env_impl: internal::EnvImpl {},
-        }
+        Self {}
     }
 }
 
@@ -165,18 +164,14 @@ impl MaybeEnv {
 impl MaybeEnv {
     // separate function to be const
     pub const fn none() -> Self {
-        Self {
-            maybe_env_impl: None,
-        }
+        Self { env: None }
     }
 }
 
 #[cfg(target_family = "wasm")]
 impl From<Env> for MaybeEnv {
-    fn from(value: Env) -> Self {
-        MaybeEnv {
-            maybe_env_impl: value.env_impl,
-        }
+    fn from(_value: Env) -> Self {
+        MaybeEnv {}
     }
 }
 
@@ -185,16 +180,14 @@ impl TryFrom<MaybeEnv> for Env {
     type Error = ConversionError;
 
     fn try_from(value: MaybeEnv) -> Result<Self, Self::Error> {
-        value.maybe_env_impl.ok_or(ConversionError)
+        value.env.ok_or(ConversionError)
     }
 }
 
 #[cfg(not(target_family = "wasm"))]
 impl From<Env> for MaybeEnv {
     fn from(value: Env) -> Self {
-        MaybeEnv {
-            maybe_env_impl: Some(value),
-        }
+        MaybeEnv { env: Some(value) }
     }
 }
 

--- a/soroban-sdk/src/env.rs
+++ b/soroban-sdk/src/env.rs
@@ -193,7 +193,9 @@ impl TryFrom<MaybeEnv> for Env {
             Ok(Env {
                 env_impl,
                 #[cfg(any(test, feature = "testutils"))]
-                test_state: value.test_state.unwrap_or_default(),
+                test_state: value
+                    .test_state
+                    .expect("env with an env impl to have test state"),
             })
         } else {
             Err(ConversionError)
@@ -253,15 +255,65 @@ thread_local! {
     static LAST_ENV: RefCell<Option<LastEnv>> = RefCell::new(None);
 }
 
+/// The test state of an [Env].
+///
+/// An [Env] created by a test has test state. An [Env] created for a contract
+/// function invocation does not, because the host that creates it knows nothing
+/// of the SDK's test state and has none to pass on. Testutils functionality
+/// that depends on the test state panics rather than silently operating on
+/// empty state when used inside a contract function.
 #[cfg(any(test, feature = "testutils"))]
-#[derive(Clone, Default)]
-struct EnvTestState {
-    test_name: Option<String>,
-    number: usize,
-    config: EnvTestConfig,
-    generators: Rc<RefCell<Generators>>,
-    auth_snapshot: Rc<RefCell<AuthSnapshot>>,
-    snapshot: Option<Rc<LedgerSnapshot>>,
+#[derive(Clone)]
+enum EnvTestState {
+    Test {
+        test_name: Option<String>,
+        number: usize,
+        config: EnvTestConfig,
+        generators: Rc<RefCell<Generators>>,
+        auth_snapshot: Rc<RefCell<AuthSnapshot>>,
+        snapshot: Option<Rc<LedgerSnapshot>>,
+    },
+    Contract,
+}
+
+#[cfg(any(test, feature = "testutils"))]
+impl EnvTestState {
+    #[cold]
+    fn unavailable(what: &str) -> ! {
+        panic!(
+            "{what} is unavailable because this Env was created by the host for a contract \
+             function invocation and has no test state, use this functionality outside the \
+             contract function, in the test that invokes it"
+        );
+    }
+
+    fn generators(&self) -> &Rc<RefCell<Generators>> {
+        match self {
+            Self::Test { generators, .. } => generators,
+            Self::Contract => Self::unavailable("generating values for tests"),
+        }
+    }
+
+    fn auth_snapshot(&self) -> &Rc<RefCell<AuthSnapshot>> {
+        match self {
+            Self::Test { auth_snapshot, .. } => auth_snapshot,
+            Self::Contract => Self::unavailable("the record of authorizations"),
+        }
+    }
+
+    fn config_mut(&mut self) -> &mut EnvTestConfig {
+        match self {
+            Self::Test { config, .. } => config,
+            Self::Contract => Self::unavailable("the test config"),
+        }
+    }
+
+    fn snapshot(&self) -> &Option<Rc<LedgerSnapshot>> {
+        match self {
+            Self::Test { snapshot, .. } => snapshot,
+            Self::Contract => Self::unavailable("the ledger snapshot"),
+        }
+    }
 }
 
 /// Config for changing the default behavior of the Env when used in tests.
@@ -650,7 +702,7 @@ impl Env {
 
     #[doc(hidden)]
     pub(crate) fn with_generator<T>(&self, f: impl FnOnce(RefMut<'_, Generators>) -> T) -> T {
-        f((*self.test_state.generators).borrow_mut())
+        f((*self.test_state.generators()).borrow_mut())
     }
 
     /// Create an Env with the test config.
@@ -674,7 +726,7 @@ impl Env {
 
     /// Change the test config of an Env.
     pub fn set_config(&mut self, config: EnvTestConfig) {
-        self.test_state.config = config;
+        *self.test_state.config_mut() = config;
     }
 
     /// Used by multiple constructors to configure test environments consistently.
@@ -764,7 +816,7 @@ impl Env {
 
         let env = Env {
             env_impl,
-            test_state: EnvTestState {
+            test_state: EnvTestState::Test {
                 test_name,
                 number,
                 config,
@@ -1060,7 +1112,7 @@ impl Env {
             ) -> Option<Val> {
                 let env = Env {
                     env_impl: env_impl.clone(),
-                    test_state: Default::default(),
+                    test_state: EnvTestState::Contract,
                 };
                 self.0.call(
                     crate::Symbol::try_from_val(&env, func)
@@ -1601,7 +1653,7 @@ impl Env {
     /// # fn main() { }
     /// ```
     pub fn auths(&self) -> std::vec::Vec<(Address, AuthorizedInvocation)> {
-        (*self.test_state.auth_snapshot)
+        (*self.test_state.auth_snapshot())
             .borrow()
             .0
             .last()
@@ -1927,8 +1979,8 @@ impl Env {
     /// Create a snapshot from the Env's current state.
     pub fn to_snapshot(&self) -> Snapshot {
         Snapshot {
-            generators: (*self.test_state.generators).borrow().clone(),
-            auth: (*self.test_state.auth_snapshot).borrow().clone(),
+            generators: (*self.test_state.generators()).borrow().clone(),
+            auth: (*self.test_state.auth_snapshot()).borrow().clone(),
             ledger: self.to_ledger_snapshot(),
             events: self.to_events_snapshot(),
         }
@@ -1973,7 +2025,7 @@ impl Env {
 
     /// Create a snapshot from the Env's current state.
     pub fn to_ledger_snapshot(&self) -> LedgerSnapshot {
-        let snapshot = self.test_state.snapshot.clone().unwrap_or_default();
+        let snapshot = self.test_state.snapshot().clone().unwrap_or_default();
         let mut snapshot = (*snapshot).clone();
         snapshot.set_ledger_info(self.ledger().get());
         snapshot.update_entries(&self.host().get_stored_entries().unwrap());
@@ -2028,7 +2080,10 @@ impl Drop for Env {
         // snapshot at that point when no other references to the host exist,
         // because it is only when there are no other references that the host
         // is being dropped.
-        if self.env_impl.can_finish() && self.test_state.config.capture_snapshot_at_drop {
+        let EnvTestState::Test { config, .. } = &self.test_state else {
+            return;
+        };
+        if self.env_impl.can_finish() && config.capture_snapshot_at_drop {
             self.to_test_snapshot_file();
         }
     }
@@ -2054,6 +2109,15 @@ impl Env {
     ///
     /// If there is any error writing the file.
     pub(crate) fn to_test_snapshot_file(&self) {
+        // An Env without test state has no test name to write a snapshot for,
+        // and reading its test state would panic, so there is nothing to do.
+        let EnvTestState::Test {
+            test_name, number, ..
+        } = &self.test_state
+        else {
+            return;
+        };
+
         let snapshot = self.to_snapshot();
 
         // Don't write a snapshot that has no data in it.
@@ -2065,11 +2129,10 @@ impl Env {
         }
 
         // Determine path to write test snapshots to.
-        let Some(test_name) = &self.test_state.test_name else {
+        let Some(test_name) = test_name else {
             // If there's no test name, we're not in a test context, so don't write snapshots.
             return;
         };
-        let number = self.test_state.number;
         // Break up the test name into directories, using :: as the separator.
         // The :: module separator cannot be written into the filename because
         // some operating systems (e.g. Windows) do not allow the : character in

--- a/soroban-sdk/src/env.rs
+++ b/soroban-sdk/src/env.rs
@@ -281,14 +281,14 @@ impl EnvTestState {
     fn config_mut(&mut self) -> &mut EnvTestConfig {
         match self {
             Self::Test { config, .. } => config,
-            Self::Contract => panic!("the test config is unavailable inside a contract function"),
+            Self::Contract => panic!("the test config is unavailable inside a contract function and must be access only from the test code outside the contract function"),
         }
     }
 
     fn generators(&self) -> &Rc<RefCell<Generators>> {
         match self {
             Self::Test { generators, .. } => generators,
-            Self::Contract => panic!("generating values is unavailable inside a contract function"),
+            Self::Contract => panic!("generating values like addresses is unavailable inside a contract function and must be access only from the test code outside the contract function"),
         }
     }
 
@@ -296,7 +296,7 @@ impl EnvTestState {
         match self {
             Self::Test { auth_snapshot, .. } => auth_snapshot,
             Self::Contract => {
-                panic!("the record of authorizations is unavailable inside a contract function")
+                panic!("the record of authorizations is unavailable inside a contract function and must be access only from the test code outside the contract function")
             }
         }
     }
@@ -305,7 +305,7 @@ impl EnvTestState {
         match self {
             Self::Test { snapshot, .. } => snapshot,
             Self::Contract => {
-                panic!("the ledger snapshot is unavailable inside a contract function")
+                panic!("the ledger snapshot is unavailable inside a contract function and must be access only from the test code outside the contract function")
             }
         }
     }

--- a/soroban-sdk/src/env.rs
+++ b/soroban-sdk/src/env.rs
@@ -278,6 +278,13 @@ enum EnvTestState {
 
 #[cfg(any(test, feature = "testutils"))]
 impl EnvTestState {
+    fn config_mut(&mut self) -> &mut EnvTestConfig {
+        match self {
+            Self::Test { config, .. } => config,
+            Self::Contract => panic!("the test config is unavailable inside a contract function"),
+        }
+    }
+
     fn generators(&self) -> &Rc<RefCell<Generators>> {
         match self {
             Self::Test { generators, .. } => generators,
@@ -291,13 +298,6 @@ impl EnvTestState {
             Self::Contract => {
                 panic!("the record of authorizations is unavailable inside a contract function")
             }
-        }
-    }
-
-    fn config_mut(&mut self) -> &mut EnvTestConfig {
-        match self {
-            Self::Test { config, .. } => config,
-            Self::Contract => panic!("the test config is unavailable inside a contract function"),
         }
     }
 

--- a/soroban-sdk/src/env.rs
+++ b/soroban-sdk/src/env.rs
@@ -2104,10 +2104,13 @@ impl Env {
     ///
     /// If there is any error writing the file.
     pub(crate) fn to_test_snapshot_file(&self) {
-        // An Env without test state has no test name to write a snapshot for,
-        // and reading its test state would panic, so there is nothing to do.
+        // If there's no test state, or no test name, we're not in a test
+        // context, so don't write snapshots. An Env without test state would
+        // panic if its test state were read.
         let EnvTestState::Test {
-            test_name, number, ..
+            test_name: Some(test_name),
+            number,
+            ..
         } = &self.test_state
         else {
             return;
@@ -2124,10 +2127,6 @@ impl Env {
         }
 
         // Determine path to write test snapshots to.
-        let Some(test_name) = test_name else {
-            // If there's no test name, we're not in a test context, so don't write snapshots.
-            return;
-        };
         // Break up the test name into directories, using :: as the separator.
         // The :: module separator cannot be written into the filename because
         // some operating systems (e.g. Windows) do not allow the : character in

--- a/soroban-sdk/src/env.rs
+++ b/soroban-sdk/src/env.rs
@@ -281,14 +281,14 @@ impl EnvTestState {
     fn config_mut(&mut self) -> &mut EnvTestConfig {
         match self {
             Self::Test { config, .. } => config,
-            Self::Contract => panic!("the test config is unavailable inside a contract function and must be access only from the test code outside the contract function"),
+            Self::Contract => panic!("the test config is unavailable inside a contract function and must be accessed only from the test code outside the contract function"),
         }
     }
 
     fn generators(&self) -> &Rc<RefCell<Generators>> {
         match self {
             Self::Test { generators, .. } => generators,
-            Self::Contract => panic!("generating values like addresses is unavailable inside a contract function and must be access only from the test code outside the contract function"),
+            Self::Contract => panic!("generating values like addresses is unavailable inside a contract function and must be accessed only from the test code outside the contract function"),
         }
     }
 
@@ -296,7 +296,7 @@ impl EnvTestState {
         match self {
             Self::Test { auth_snapshot, .. } => auth_snapshot,
             Self::Contract => {
-                panic!("the record of authorizations is unavailable inside a contract function and must be access only from the test code outside the contract function")
+                panic!("the record of authorizations is unavailable inside a contract function and must be accessed only from the test code outside the contract function")
             }
         }
     }
@@ -305,7 +305,7 @@ impl EnvTestState {
         match self {
             Self::Test { snapshot, .. } => snapshot,
             Self::Contract => {
-                panic!("the ledger snapshot is unavailable inside a contract function and must be access only from the test code outside the contract function")
+                panic!("the ledger snapshot is unavailable inside a contract function and must be accessed only from the test code outside the contract function")
             }
         }
     }

--- a/soroban-sdk/src/env.rs
+++ b/soroban-sdk/src/env.rs
@@ -278,40 +278,35 @@ enum EnvTestState {
 
 #[cfg(any(test, feature = "testutils"))]
 impl EnvTestState {
-    #[cold]
-    fn unavailable(what: &str) -> ! {
-        panic!(
-            "{what} is unavailable because this Env was created by the host for a contract \
-             function invocation and has no test state, use this functionality outside the \
-             contract function, in the test that invokes it"
-        );
-    }
-
     fn generators(&self) -> &Rc<RefCell<Generators>> {
         match self {
             Self::Test { generators, .. } => generators,
-            Self::Contract => Self::unavailable("generating values for tests"),
+            Self::Contract => panic!("generating values is unavailable inside a contract function"),
         }
     }
 
     fn auth_snapshot(&self) -> &Rc<RefCell<AuthSnapshot>> {
         match self {
             Self::Test { auth_snapshot, .. } => auth_snapshot,
-            Self::Contract => Self::unavailable("the record of authorizations"),
+            Self::Contract => {
+                panic!("the record of authorizations is unavailable inside a contract function")
+            }
         }
     }
 
     fn config_mut(&mut self) -> &mut EnvTestConfig {
         match self {
             Self::Test { config, .. } => config,
-            Self::Contract => Self::unavailable("the test config"),
+            Self::Contract => panic!("the test config is unavailable inside a contract function"),
         }
     }
 
     fn snapshot(&self) -> &Option<Rc<LedgerSnapshot>> {
         match self {
             Self::Test { snapshot, .. } => snapshot,
-            Self::Contract => Self::unavailable("the ledger snapshot"),
+            Self::Contract => {
+                panic!("the ledger snapshot is unavailable inside a contract function")
+            }
         }
     }
 }

--- a/soroban-sdk/src/env.rs
+++ b/soroban-sdk/src/env.rs
@@ -22,7 +22,7 @@ pub mod internal {
 
     pub use soroban_env_host::*;
     pub type EnvImpl = Host;
-    pub type MaybeEnvImpl = Option<Host>;
+    pub type MaybeEnvImpl = Option<super::Env>;
 
     // When we have `feature="testutils"` (or are in cfg(test)) we enable feature
     // `soroban-env-{common,host}/testutils` which in turn adds the helper method
@@ -132,8 +132,6 @@ use internal::{
 #[derive(Clone)]
 pub struct MaybeEnv {
     maybe_env_impl: internal::MaybeEnvImpl,
-    #[cfg(any(test, feature = "testutils"))]
-    test_state: Option<EnvTestState>,
 }
 
 #[cfg(target_family = "wasm")]
@@ -169,8 +167,6 @@ impl MaybeEnv {
     pub const fn none() -> Self {
         Self {
             maybe_env_impl: None,
-            #[cfg(any(test, feature = "testutils"))]
-            test_state: None,
         }
     }
 }
@@ -189,15 +185,7 @@ impl TryFrom<MaybeEnv> for Env {
     type Error = ConversionError;
 
     fn try_from(value: MaybeEnv) -> Result<Self, Self::Error> {
-        if let Some(env_impl) = value.maybe_env_impl {
-            Ok(Env {
-                env_impl,
-                #[cfg(any(test, feature = "testutils"))]
-                test_state: value.test_state.unwrap_or_default(),
-            })
-        } else {
-            Err(ConversionError)
-        }
+        value.maybe_env_impl.ok_or(ConversionError)
     }
 }
 
@@ -205,9 +193,7 @@ impl TryFrom<MaybeEnv> for Env {
 impl From<Env> for MaybeEnv {
     fn from(value: Env) -> Self {
         MaybeEnv {
-            maybe_env_impl: Some(value.env_impl.clone()),
-            #[cfg(any(test, feature = "testutils"))]
-            test_state: Some(value.test_state.clone()),
+            maybe_env_impl: Some(value),
         }
     }
 }

--- a/soroban-sdk/src/env.rs
+++ b/soroban-sdk/src/env.rs
@@ -268,7 +268,7 @@ impl EnvTestState {
     fn generators(&self) -> &Rc<RefCell<Generators>> {
         match self {
             Self::Test { generators, .. } => generators,
-            Self::Contract => panic!("generating values like addresses is unavailable inside a contract function and must be accessed only from the test code outside the contract function"),
+            Self::Contract => panic!("generating values like addresses is unavailable inside a contract function and must be done only from the test code outside the contract function"),
         }
     }
 

--- a/soroban-sdk/src/tests.rs
+++ b/soroban-sdk/src/tests.rs
@@ -45,6 +45,7 @@ mod crypto_secp256r1;
 mod crypto_sha256;
 mod delegate_auth;
 mod env;
+mod env_test_state_in_contract;
 mod max_ttl;
 mod muxed_address;
 mod num_checked_arith;

--- a/soroban-sdk/src/tests/env.rs
+++ b/soroban-sdk/src/tests/env.rs
@@ -356,30 +356,3 @@ fn test_register_restores_auth_before_panics() {
     assert!(post_register.is_err());
     assert_eq!(pre_register, post_register);
 }
-
-/// Test that the test snapshot file is not written when disabled after
-/// creation, when a value holding the Env outlives the Env.
-#[test]
-fn test_snapshot_file_disabled_after_creation_value_outlives_env() {
-    let p = std::path::Path::new("test_snapshots")
-        .join("tests")
-        .join("env")
-        .join("test_snapshot_file_disabled_after_creation_value_outlives_env");
-    let p1 = p.with_extension("1.json");
-    let _ = std::fs::remove_file(&p1);
-    {
-        let s;
-        {
-            let mut e = Env::default();
-            s = Symbol::new(&e, "a_symbol_longer_than_short");
-            e.set_config(EnvTestConfig {
-                capture_snapshot_at_drop: false,
-            });
-            let _ = e.register(Contract, ());
-        } // Env dropped, but the Symbol still holds it.
-        assert!(!p1.exists());
-        drop(s);
-    } // Symbol dropped, dropping the last hold on the Env.
-    assert!(!p1.exists());
-    let _ = std::fs::remove_file(&p1);
-}

--- a/soroban-sdk/src/tests/env.rs
+++ b/soroban-sdk/src/tests/env.rs
@@ -356,3 +356,30 @@ fn test_register_restores_auth_before_panics() {
     assert!(post_register.is_err());
     assert_eq!(pre_register, post_register);
 }
+
+/// Test that the test snapshot file is not written when disabled after
+/// creation, when a value holding the Env outlives the Env.
+#[test]
+fn test_snapshot_file_disabled_after_creation_value_outlives_env() {
+    let p = std::path::Path::new("test_snapshots")
+        .join("tests")
+        .join("env")
+        .join("test_snapshot_file_disabled_after_creation_value_outlives_env");
+    let p1 = p.with_extension("1.json");
+    let _ = std::fs::remove_file(&p1);
+    {
+        let s;
+        {
+            let mut e = Env::default();
+            s = Symbol::new(&e, "a_symbol_longer_than_short");
+            e.set_config(EnvTestConfig {
+                capture_snapshot_at_drop: false,
+            });
+            let _ = e.register(Contract, ());
+        } // Env dropped, but the Symbol still holds it.
+        assert!(!p1.exists());
+        drop(s);
+    } // Symbol dropped, dropping the last hold on the Env.
+    assert!(!p1.exists());
+    let _ = std::fs::remove_file(&p1);
+}

--- a/soroban-sdk/src/tests/env_test_state_in_contract.rs
+++ b/soroban-sdk/src/tests/env_test_state_in_contract.rs
@@ -61,7 +61,7 @@ impl Contract {
 /// every invocation, silently returning addresses that collide with addresses
 /// the calling test generated, and with each other.
 #[test]
-#[should_panic(expected = "generating values is unavailable inside a contract function")]
+#[should_panic(expected = "generating values like addresses is unavailable inside a contract function")]
 fn test_generate_address_in_contract() {
     let env = Env::default();
     let client = ContractClient::new(&env, &env.register(Contract, ()));
@@ -71,7 +71,7 @@ fn test_generate_address_in_contract() {
 /// Registering a contract generates the contract id to register at, and so it
 /// too depends on the generators.
 #[test]
-#[should_panic(expected = "generating values is unavailable inside a contract function")]
+#[should_panic(expected = "generating values like addresses is unavailable inside a contract function")]
 fn test_register_in_contract() {
     let env = Env::default();
     let client = ContractClient::new(&env, &env.register(Contract, ()));
@@ -116,7 +116,7 @@ fn test_to_ledger_snapshot_in_contract() {
 /// snapshot, all of which live in the test state, so creating a snapshot inside
 /// a contract panics.
 #[test]
-#[should_panic(expected = "generating values is unavailable inside a contract function")]
+#[should_panic(expected = "generating values like addresses is unavailable inside a contract function")]
 fn test_to_snapshot_in_contract() {
     let env = Env::default();
     let client = ContractClient::new(&env, &env.register(Contract, ()));

--- a/soroban-sdk/src/tests/env_test_state_in_contract.rs
+++ b/soroban-sdk/src/tests/env_test_state_in_contract.rs
@@ -1,0 +1,69 @@
+//! Tests for the test state of the [Env] passed into a contract function.
+//!
+//! The host only knows `EnvImpl`, so when it dispatches into a natively
+//! registered contract it hands the function set an `&EnvImpl`. There is no
+//! channel by which the calling test's [Env] could travel through the host and
+//! come back, so the SDK builds one on the spot. The `env_impl` half is cloned,
+//! so everything a contract can observe on chain is real and shared. The
+//! `test_state` half has no counterpart to clone, so testutils functionality
+//! that depends on it cannot work inside a contract function.
+//!
+//! Both tests below are `#[ignore]`d because they assert the behaviour that is
+//! wanted, not the behaviour that exists, and so they fail today. Run them with
+//! `cargo test -- --ignored`.
+
+use crate::{self as soroban_sdk};
+use soroban_sdk::{contract, contractimpl, testutils::Address as _, Address, Env};
+
+#[contract]
+pub struct Contract;
+
+#[contractimpl]
+impl Contract {
+    pub fn gen_address(env: Env) -> Address {
+        Address::generate(&env)
+    }
+
+    pub fn auth_count(env: Env, addr: Address) -> u32 {
+        addr.require_auth();
+        env.auths().len() as u32
+    }
+}
+
+/// The generators live in the test state, so today they restart from zero on
+/// every invocation, and addresses generated inside a contract silently collide
+/// with addresses the calling test generated, and with each other.
+#[test]
+#[ignore = "generating an address inside a contract silently collides"]
+fn test_generate_address_in_contract() {
+    let env = Env::default();
+
+    let outer = Address::generate(&env);
+    let contract_id = env.register(Contract, ());
+    let client = ContractClient::new(&env, &contract_id);
+
+    let first = client.gen_address();
+    let second = client.gen_address();
+
+    assert_ne!(outer, first);
+    assert_ne!(first, second);
+}
+
+/// The auth snapshot lives in the test state, so today a contract always
+/// observes an empty one, and assertions made on it inside a contract pass
+/// vacuously.
+#[test]
+#[ignore = "env.auths() inside a contract silently observes nothing"]
+fn test_auths_in_contract() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(Contract, ());
+    let client = ContractClient::new(&env, &contract_id);
+    let addr = Address::generate(&env);
+
+    let seen_inside = client.auth_count(&addr) as usize;
+    let seen_outside = env.auths().len();
+
+    assert_eq!(seen_inside, seen_outside);
+}

--- a/soroban-sdk/src/tests/env_test_state_in_contract.rs
+++ b/soroban-sdk/src/tests/env_test_state_in_contract.rs
@@ -6,11 +6,8 @@
 //! come back, so the SDK builds one on the spot. The `env_impl` half is cloned,
 //! so everything a contract can observe on chain is real and shared. The
 //! `test_state` half has no counterpart to clone, so testutils functionality
-//! that depends on it cannot work inside a contract function.
-//!
-//! Both tests below are `#[ignore]`d because they assert the behaviour that is
-//! wanted, not the behaviour that exists, and so they fail today. Run them with
-//! `cargo test -- --ignored`.
+//! that depends on it cannot work inside a contract function, and panics when
+//! used there rather than silently operating on empty state.
 
 use crate::{self as soroban_sdk};
 use soroban_sdk::{contract, contractimpl, testutils::Address as _, Address, Env};
@@ -30,30 +27,26 @@ impl Contract {
     }
 }
 
-/// The generators live in the test state, so today they restart from zero on
-/// every invocation, and addresses generated inside a contract silently collide
-/// with addresses the calling test generated, and with each other.
+/// The generators live in the test state, so generating an address inside a
+/// contract panics. Without the panic the generators would restart from zero on
+/// every invocation, silently returning addresses that collide with addresses
+/// the calling test generated, and with each other.
 #[test]
-#[ignore = "generating an address inside a contract silently collides"]
+#[should_panic(expected = "Error(WasmVm, InvalidAction)")]
 fn test_generate_address_in_contract() {
     let env = Env::default();
 
-    let outer = Address::generate(&env);
     let contract_id = env.register(Contract, ());
     let client = ContractClient::new(&env, &contract_id);
 
-    let first = client.gen_address();
-    let second = client.gen_address();
-
-    assert_ne!(outer, first);
-    assert_ne!(first, second);
+    client.gen_address();
 }
 
-/// The auth snapshot lives in the test state, so today a contract always
-/// observes an empty one, and assertions made on it inside a contract pass
-/// vacuously.
+/// The auth snapshot lives in the test state, so calling `auths` inside a
+/// contract panics. Without the panic the contract would observe an empty
+/// snapshot, and assertions made on it inside a contract would pass vacuously.
 #[test]
-#[ignore = "env.auths() inside a contract silently observes nothing"]
+#[should_panic(expected = "Error(WasmVm, InvalidAction)")]
 fn test_auths_in_contract() {
     let env = Env::default();
     env.mock_all_auths();
@@ -62,8 +55,23 @@ fn test_auths_in_contract() {
     let client = ContractClient::new(&env, &contract_id);
     let addr = Address::generate(&env);
 
-    let seen_inside = client.auth_count(&addr) as usize;
-    let seen_outside = env.auths().len();
+    client.auth_count(&addr);
+}
 
-    assert_eq!(seen_inside, seen_outside);
+/// The test's own Env keeps its test state even while executing in a contract
+/// frame, so testutils functionality remains available to the test. It is the
+/// Env the host passes to a contract function that has no test state, not any
+/// Env executing in a contract frame.
+#[test]
+fn test_generate_address_in_contract_frame() {
+    let env = Env::default();
+
+    let contract_id = env.register(Contract, ());
+
+    let first = Address::generate(&env);
+    let second = env.as_contract(&contract_id, || Address::generate(&env));
+    let third = env.as_contract(&contract_id, || Address::generate(&env));
+
+    assert_ne!(first, second);
+    assert_ne!(second, third);
 }

--- a/soroban-sdk/src/tests/env_test_state_in_contract.rs
+++ b/soroban-sdk/src/tests/env_test_state_in_contract.rs
@@ -10,20 +10,49 @@
 //! used there rather than silently operating on empty state.
 
 use crate::{self as soroban_sdk};
-use soroban_sdk::{contract, contractimpl, testutils::Address as _, Address, Env};
+use soroban_sdk::{
+    contract, contractimpl,
+    testutils::{Address as _, EnvTestConfig},
+    Address, Env,
+};
 
 #[contract]
 pub struct Contract;
 
 #[contractimpl]
 impl Contract {
+    // Uses the generators.
     pub fn gen_address(env: Env) -> Address {
         Address::generate(&env)
     }
 
+    // Uses the generators, to generate the contract id to register at.
+    pub fn register(env: Env) -> Address {
+        env.register(Contract, ())
+    }
+
+    // Uses the auth snapshot.
     pub fn auth_count(env: Env, addr: Address) -> u32 {
         addr.require_auth();
         env.auths().len() as u32
+    }
+
+    // Uses the config.
+    pub fn set_config(env: Env) {
+        let mut env = env;
+        env.set_config(EnvTestConfig {
+            capture_snapshot_at_drop: false,
+        });
+    }
+
+    // Uses the ledger snapshot.
+    pub fn to_ledger_snapshot(env: Env) {
+        env.to_ledger_snapshot();
+    }
+
+    // Uses the generators and the auth snapshot.
+    pub fn to_snapshot(env: Env) {
+        env.to_snapshot();
     }
 }
 
@@ -35,11 +64,18 @@ impl Contract {
 #[should_panic(expected = "Error(WasmVm, InvalidAction)")]
 fn test_generate_address_in_contract() {
     let env = Env::default();
-
-    let contract_id = env.register(Contract, ());
-    let client = ContractClient::new(&env, &contract_id);
-
+    let client = ContractClient::new(&env, &env.register(Contract, ()));
     client.gen_address();
+}
+
+/// Registering a contract generates the contract id to register at, and so it
+/// too depends on the generators.
+#[test]
+#[should_panic(expected = "Error(WasmVm, InvalidAction)")]
+fn test_register_in_contract() {
+    let env = Env::default();
+    let client = ContractClient::new(&env, &env.register(Contract, ()));
+    client.register();
 }
 
 /// The auth snapshot lives in the test state, so calling `auths` inside a
@@ -50,12 +86,41 @@ fn test_generate_address_in_contract() {
 fn test_auths_in_contract() {
     let env = Env::default();
     env.mock_all_auths();
-
-    let contract_id = env.register(Contract, ());
-    let client = ContractClient::new(&env, &contract_id);
+    let client = ContractClient::new(&env, &env.register(Contract, ()));
     let addr = Address::generate(&env);
-
     client.auth_count(&addr);
+}
+
+/// The config lives in the test state, so changing it inside a contract panics.
+/// Without the panic the change would apply to an Env that is dropped when the
+/// invocation returns, and so would have no effect.
+#[test]
+#[should_panic(expected = "Error(WasmVm, InvalidAction)")]
+fn test_set_config_in_contract() {
+    let env = Env::default();
+    let client = ContractClient::new(&env, &env.register(Contract, ()));
+    client.set_config();
+}
+
+/// The ledger snapshot the Env was created from lives in the test state, so
+/// creating a ledger snapshot inside a contract panics.
+#[test]
+#[should_panic(expected = "Error(WasmVm, InvalidAction)")]
+fn test_to_ledger_snapshot_in_contract() {
+    let env = Env::default();
+    let client = ContractClient::new(&env, &env.register(Contract, ()));
+    client.to_ledger_snapshot();
+}
+
+/// A snapshot is made up of the generators, the auth snapshot, and the ledger
+/// snapshot, all of which live in the test state, so creating a snapshot inside
+/// a contract panics.
+#[test]
+#[should_panic(expected = "Error(WasmVm, InvalidAction)")]
+fn test_to_snapshot_in_contract() {
+    let env = Env::default();
+    let client = ContractClient::new(&env, &env.register(Contract, ()));
+    client.to_snapshot();
 }
 
 /// The test's own Env keeps its test state even while executing in a contract

--- a/soroban-sdk/src/tests/env_test_state_in_contract.rs
+++ b/soroban-sdk/src/tests/env_test_state_in_contract.rs
@@ -61,7 +61,7 @@ impl Contract {
 /// every invocation, silently returning addresses that collide with addresses
 /// the calling test generated, and with each other.
 #[test]
-#[should_panic(expected = "Error(WasmVm, InvalidAction)")]
+#[should_panic(expected = "generating values is unavailable inside a contract function")]
 fn test_generate_address_in_contract() {
     let env = Env::default();
     let client = ContractClient::new(&env, &env.register(Contract, ()));
@@ -71,7 +71,7 @@ fn test_generate_address_in_contract() {
 /// Registering a contract generates the contract id to register at, and so it
 /// too depends on the generators.
 #[test]
-#[should_panic(expected = "Error(WasmVm, InvalidAction)")]
+#[should_panic(expected = "generating values is unavailable inside a contract function")]
 fn test_register_in_contract() {
     let env = Env::default();
     let client = ContractClient::new(&env, &env.register(Contract, ()));
@@ -82,7 +82,7 @@ fn test_register_in_contract() {
 /// contract panics. Without the panic the contract would observe an empty
 /// snapshot, and assertions made on it inside a contract would pass vacuously.
 #[test]
-#[should_panic(expected = "Error(WasmVm, InvalidAction)")]
+#[should_panic(expected = "the record of authorizations is unavailable inside a contract function")]
 fn test_auths_in_contract() {
     let env = Env::default();
     env.mock_all_auths();
@@ -95,7 +95,7 @@ fn test_auths_in_contract() {
 /// Without the panic the change would apply to an Env that is dropped when the
 /// invocation returns, and so would have no effect.
 #[test]
-#[should_panic(expected = "Error(WasmVm, InvalidAction)")]
+#[should_panic(expected = "the test config is unavailable inside a contract function")]
 fn test_set_config_in_contract() {
     let env = Env::default();
     let client = ContractClient::new(&env, &env.register(Contract, ()));
@@ -105,7 +105,7 @@ fn test_set_config_in_contract() {
 /// The ledger snapshot the Env was created from lives in the test state, so
 /// creating a ledger snapshot inside a contract panics.
 #[test]
-#[should_panic(expected = "Error(WasmVm, InvalidAction)")]
+#[should_panic(expected = "the ledger snapshot is unavailable inside a contract function")]
 fn test_to_ledger_snapshot_in_contract() {
     let env = Env::default();
     let client = ContractClient::new(&env, &env.register(Contract, ()));
@@ -116,7 +116,7 @@ fn test_to_ledger_snapshot_in_contract() {
 /// snapshot, all of which live in the test state, so creating a snapshot inside
 /// a contract panics.
 #[test]
-#[should_panic(expected = "Error(WasmVm, InvalidAction)")]
+#[should_panic(expected = "generating values is unavailable inside a contract function")]
 fn test_to_snapshot_in_contract() {
     let env = Env::default();
     let client = ContractClient::new(&env, &env.register(Contract, ()));

--- a/soroban-sdk/src/tests/env_test_state_in_contract.rs
+++ b/soroban-sdk/src/tests/env_test_state_in_contract.rs
@@ -61,7 +61,9 @@ impl Contract {
 /// every invocation, silently returning addresses that collide with addresses
 /// the calling test generated, and with each other.
 #[test]
-#[should_panic(expected = "generating values like addresses is unavailable inside a contract function")]
+#[should_panic(
+    expected = "generating values like addresses is unavailable inside a contract function"
+)]
 fn test_generate_address_in_contract() {
     let env = Env::default();
     let client = ContractClient::new(&env, &env.register(Contract, ()));
@@ -71,7 +73,9 @@ fn test_generate_address_in_contract() {
 /// Registering a contract generates the contract id to register at, and so it
 /// too depends on the generators.
 #[test]
-#[should_panic(expected = "generating values like addresses is unavailable inside a contract function")]
+#[should_panic(
+    expected = "generating values like addresses is unavailable inside a contract function"
+)]
 fn test_register_in_contract() {
     let env = Env::default();
     let client = ContractClient::new(&env, &env.register(Contract, ()));
@@ -116,7 +120,9 @@ fn test_to_ledger_snapshot_in_contract() {
 /// snapshot, all of which live in the test state, so creating a snapshot inside
 /// a contract panics.
 #[test]
-#[should_panic(expected = "generating values like addresses is unavailable inside a contract function")]
+#[should_panic(
+    expected = "generating values like addresses is unavailable inside a contract function"
+)]
 fn test_to_snapshot_in_contract() {
     let env = Env::default();
     let client = ContractClient::new(&env, &env.register(Contract, ()));

--- a/soroban-sdk/test_snapshots/tests/env_test_state_in_contract/test_auths_in_contract.1.json
+++ b/soroban-sdk/test_snapshots/tests/env_test_state_in_contract/test_auths_in_contract.1.json
@@ -1,0 +1,61 @@
+{
+  "generators": {
+    "address": 2,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 28,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": "ledger_key_contract_instance",
+              "durability": "persistent",
+              "val": {
+                "contract_instance": {
+                  "executable": {
+                    "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  },
+                  "storage": null
+                }
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_code": {
+              "ext": "v0",
+              "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+              "code": ""
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      }
+    ]
+  },
+  "events": []
+}

--- a/soroban-sdk/test_snapshots/tests/env_test_state_in_contract/test_generate_address_in_contract.1.json
+++ b/soroban-sdk/test_snapshots/tests/env_test_state_in_contract/test_generate_address_in_contract.1.json
@@ -1,0 +1,61 @@
+{
+  "generators": {
+    "address": 1,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 28,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": "ledger_key_contract_instance",
+              "durability": "persistent",
+              "val": {
+                "contract_instance": {
+                  "executable": {
+                    "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  },
+                  "storage": null
+                }
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_code": {
+              "ext": "v0",
+              "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+              "code": ""
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      }
+    ]
+  },
+  "events": []
+}

--- a/soroban-sdk/test_snapshots/tests/env_test_state_in_contract/test_generate_address_in_contract_frame.1.json
+++ b/soroban-sdk/test_snapshots/tests/env_test_state_in_contract/test_generate_address_in_contract_frame.1.json
@@ -1,0 +1,62 @@
+{
+  "generators": {
+    "address": 4,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 28,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": "ledger_key_contract_instance",
+              "durability": "persistent",
+              "val": {
+                "contract_instance": {
+                  "executable": {
+                    "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  },
+                  "storage": null
+                }
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_code": {
+              "ext": "v0",
+              "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+              "code": ""
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      }
+    ]
+  },
+  "events": []
+}

--- a/soroban-sdk/test_snapshots/tests/env_test_state_in_contract/test_register_in_contract.1.json
+++ b/soroban-sdk/test_snapshots/tests/env_test_state_in_contract/test_register_in_contract.1.json
@@ -1,0 +1,61 @@
+{
+  "generators": {
+    "address": 1,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 28,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": "ledger_key_contract_instance",
+              "durability": "persistent",
+              "val": {
+                "contract_instance": {
+                  "executable": {
+                    "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  },
+                  "storage": null
+                }
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_code": {
+              "ext": "v0",
+              "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+              "code": ""
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      }
+    ]
+  },
+  "events": []
+}

--- a/soroban-sdk/test_snapshots/tests/env_test_state_in_contract/test_set_config_in_contract.1.json
+++ b/soroban-sdk/test_snapshots/tests/env_test_state_in_contract/test_set_config_in_contract.1.json
@@ -1,0 +1,61 @@
+{
+  "generators": {
+    "address": 1,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 28,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": "ledger_key_contract_instance",
+              "durability": "persistent",
+              "val": {
+                "contract_instance": {
+                  "executable": {
+                    "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  },
+                  "storage": null
+                }
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_code": {
+              "ext": "v0",
+              "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+              "code": ""
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      }
+    ]
+  },
+  "events": []
+}

--- a/soroban-sdk/test_snapshots/tests/env_test_state_in_contract/test_to_ledger_snapshot_in_contract.1.json
+++ b/soroban-sdk/test_snapshots/tests/env_test_state_in_contract/test_to_ledger_snapshot_in_contract.1.json
@@ -1,0 +1,61 @@
+{
+  "generators": {
+    "address": 1,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 28,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": "ledger_key_contract_instance",
+              "durability": "persistent",
+              "val": {
+                "contract_instance": {
+                  "executable": {
+                    "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  },
+                  "storage": null
+                }
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_code": {
+              "ext": "v0",
+              "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+              "code": ""
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      }
+    ]
+  },
+  "events": []
+}

--- a/soroban-sdk/test_snapshots/tests/env_test_state_in_contract/test_to_snapshot_in_contract.1.json
+++ b/soroban-sdk/test_snapshots/tests/env_test_state_in_contract/test_to_snapshot_in_contract.1.json
@@ -1,0 +1,61 @@
+{
+  "generators": {
+    "address": 1,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 28,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": "ledger_key_contract_instance",
+              "durability": "persistent",
+              "val": {
+                "contract_instance": {
+                  "executable": {
+                    "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  },
+                  "storage": null
+                }
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_code": {
+              "ext": "v0",
+              "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+              "code": ""
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      }
+    ]
+  },
+  "events": []
+}


### PR DESCRIPTION
### What

Panic during tests when calling functions inside a contract that cannot be called reliably inside the contract instead of allowing for odd and surprising behaviour to take place.

### Why

Some test utilities don't work properly inside contract functions. This limitation doesn't usually matter because test utilities aren't usable inside contract functions when building to wasm. But none-the-less they can still be called inside contract functions during a test run.

The reason they don't work properly inside a contract is because the Env inside a contract function is not the same Env that is outside of the contract function. Outside the contract function an Env carries test state, but the Env passed into the contract function via the Host doesn't contain any of that test state.

See the tests in this PR for examples.

This has always been a limitation, but panicking on the use of these test utilities inside contract functions prevents a developer experiencing odd behaviour using the test utilities there when they haven't been designed for that.

Close #2009

### SemVer Change

- [ ] Major (`vX._._`) - Breaking change to the public API.
- [ ] Minor (`v_.Y._`) - Additive change to the public API.
- [x] Patch (`v_._.Z`) - No change to the public API.

Close #2009
