### PR TITLE
Restructure MaybeEnv to hold an Env or nothing

### DIFF
--- a/soroban-sdk/src/env.rs
+++ b/soroban-sdk/src/env.rs
@@ -129,8 +129,7 @@ use internal::{
 #[doc(hidden)]
 #[derive(Clone)]
 pub struct MaybeEnv {
-    // On wasm an Env is always available and costs nothing to store, so it is
-    // never absent.
+    // On wasm an Env is always available.
     #[cfg(target_family = "wasm")]
     env: Env,
     #[cfg(not(target_family = "wasm"))]

--- a/soroban-sdk/src/env.rs
+++ b/soroban-sdk/src/env.rs
@@ -240,9 +240,7 @@ thread_local! {
 struct EnvTestState {
     test_name: Option<String>,
     number: usize,
-    // Shared between clones of the Env, so that a config change is seen by
-    // every clone, including the clones held inside values such as Symbol.
-    config: Rc<RefCell<EnvTestConfig>>,
+    config: EnvTestConfig,
     generators: Rc<RefCell<Generators>>,
     auth_snapshot: Rc<RefCell<AuthSnapshot>>,
     snapshot: Option<Rc<LedgerSnapshot>>,
@@ -658,7 +656,7 @@ impl Env {
 
     /// Change the test config of an Env.
     pub fn set_config(&mut self, config: EnvTestConfig) {
-        *(*self.test_state.config).borrow_mut() = config;
+        self.test_state.config = config;
     }
 
     /// Used by multiple constructors to configure test environments consistently.
@@ -751,7 +749,7 @@ impl Env {
             test_state: EnvTestState {
                 test_name,
                 number,
-                config: Rc::new(RefCell::new(config)),
+                config,
                 generators: generators.unwrap_or_default(),
                 snapshot,
                 auth_snapshot,
@@ -2012,8 +2010,7 @@ impl Drop for Env {
         // snapshot at that point when no other references to the host exist,
         // because it is only when there are no other references that the host
         // is being dropped.
-        if self.env_impl.can_finish() && (*self.test_state.config).borrow().capture_snapshot_at_drop
-        {
+        if self.env_impl.can_finish() && self.test_state.config.capture_snapshot_at_drop {
             self.to_test_snapshot_file();
         }
     }

--- a/soroban-sdk/src/env.rs
+++ b/soroban-sdk/src/env.rs
@@ -240,7 +240,9 @@ thread_local! {
 struct EnvTestState {
     test_name: Option<String>,
     number: usize,
-    config: EnvTestConfig,
+    // Shared between clones of the Env, so that a config change is seen by
+    // every clone, including the clones held inside values such as Symbol.
+    config: Rc<RefCell<EnvTestConfig>>,
     generators: Rc<RefCell<Generators>>,
     auth_snapshot: Rc<RefCell<AuthSnapshot>>,
     snapshot: Option<Rc<LedgerSnapshot>>,
@@ -656,7 +658,7 @@ impl Env {
 
     /// Change the test config of an Env.
     pub fn set_config(&mut self, config: EnvTestConfig) {
-        self.test_state.config = config;
+        *(*self.test_state.config).borrow_mut() = config;
     }
 
     /// Used by multiple constructors to configure test environments consistently.
@@ -749,7 +751,7 @@ impl Env {
             test_state: EnvTestState {
                 test_name,
                 number,
-                config,
+                config: Rc::new(RefCell::new(config)),
                 generators: generators.unwrap_or_default(),
                 snapshot,
                 auth_snapshot,
@@ -2010,7 +2012,8 @@ impl Drop for Env {
         // snapshot at that point when no other references to the host exist,
         // because it is only when there are no other references that the host
         // is being dropped.
-        if self.env_impl.can_finish() && self.test_state.config.capture_snapshot_at_drop {
+        if self.env_impl.can_finish() && (*self.test_state.config).borrow().capture_snapshot_at_drop
+        {
             self.to_test_snapshot_file();
         }
     }

--- a/soroban-sdk/src/env.rs
+++ b/soroban-sdk/src/env.rs
@@ -129,8 +129,10 @@ use internal::{
 #[doc(hidden)]
 #[derive(Clone)]
 pub struct MaybeEnv {
-    // There is nothing to store on wasm, because on wasm an Env is always
-    // available and costs nothing to construct.
+    // On wasm an Env is always available and costs nothing to store, so it is
+    // never absent.
+    #[cfg(target_family = "wasm")]
+    env: Env,
     #[cfg(not(target_family = "wasm"))]
     env: Option<Env>,
 }
@@ -139,10 +141,8 @@ pub struct MaybeEnv {
 impl TryFrom<MaybeEnv> for Env {
     type Error = Infallible;
 
-    fn try_from(_value: MaybeEnv) -> Result<Self, Self::Error> {
-        Ok(Env {
-            env_impl: internal::EnvImpl {},
-        })
+    fn try_from(value: MaybeEnv) -> Result<Self, Self::Error> {
+        Ok(value.env)
     }
 }
 
@@ -156,7 +156,11 @@ impl Default for MaybeEnv {
 impl MaybeEnv {
     // separate function to be const
     pub const fn none() -> Self {
-        Self {}
+        Self {
+            env: Env {
+                env_impl: internal::EnvImpl {},
+            },
+        }
     }
 }
 
@@ -170,8 +174,8 @@ impl MaybeEnv {
 
 #[cfg(target_family = "wasm")]
 impl From<Env> for MaybeEnv {
-    fn from(_value: Env) -> Self {
-        MaybeEnv {}
+    fn from(value: Env) -> Self {
+        MaybeEnv { env: value }
     }
 }
 

--- a/soroban-sdk/src/env.rs
+++ b/soroban-sdk/src/env.rs
@@ -6,7 +6,6 @@ pub mod internal {
 
     pub use soroban_env_guest::*;
     pub type EnvImpl = Guest;
-    pub type MaybeEnvImpl = Guest;
 
     // In the Guest case, Env::Error is already Infallible so there is no work
     // to do to "reject an error": if an error occurs in the environment, the
@@ -22,7 +21,6 @@ pub mod internal {
 
     pub use soroban_env_host::*;
     pub type EnvImpl = Host;
-    pub type MaybeEnvImpl = Option<super::Env>;
 
     // When we have `feature="testutils"` (or are in cfg(test)) we enable feature
     // `soroban-env-{common,host}/testutils` which in turn adds the helper method
@@ -131,7 +129,10 @@ use internal::{
 #[doc(hidden)]
 #[derive(Clone)]
 pub struct MaybeEnv {
-    maybe_env_impl: internal::MaybeEnvImpl,
+    // There is nothing to store on wasm, because on wasm an Env is always
+    // available and costs nothing to construct.
+    #[cfg(not(target_family = "wasm"))]
+    env: Option<Env>,
 }
 
 #[cfg(target_family = "wasm")]
@@ -155,9 +156,7 @@ impl Default for MaybeEnv {
 impl MaybeEnv {
     // separate function to be const
     pub const fn none() -> Self {
-        Self {
-            maybe_env_impl: internal::EnvImpl {},
-        }
+        Self {}
     }
 }
 
@@ -165,18 +164,14 @@ impl MaybeEnv {
 impl MaybeEnv {
     // separate function to be const
     pub const fn none() -> Self {
-        Self {
-            maybe_env_impl: None,
-        }
+        Self { env: None }
     }
 }
 
 #[cfg(target_family = "wasm")]
 impl From<Env> for MaybeEnv {
-    fn from(value: Env) -> Self {
-        MaybeEnv {
-            maybe_env_impl: value.env_impl,
-        }
+    fn from(_value: Env) -> Self {
+        MaybeEnv {}
     }
 }
 
@@ -185,16 +180,14 @@ impl TryFrom<MaybeEnv> for Env {
     type Error = ConversionError;
 
     fn try_from(value: MaybeEnv) -> Result<Self, Self::Error> {
-        value.maybe_env_impl.ok_or(ConversionError)
+        value.env.ok_or(ConversionError)
     }
 }
 
 #[cfg(not(target_family = "wasm"))]
 impl From<Env> for MaybeEnv {
     fn from(value: Env) -> Self {
-        MaybeEnv {
-            maybe_env_impl: Some(value),
-        }
+        MaybeEnv { env: Some(value) }
     }
 }
 

--- a/soroban-sdk/src/env.rs
+++ b/soroban-sdk/src/env.rs
@@ -22,7 +22,7 @@ pub mod internal {
 
     pub use soroban_env_host::*;
     pub type EnvImpl = Host;
-    pub type MaybeEnvImpl = Option<Host>;
+    pub type MaybeEnvImpl = Option<super::Env>;
 
     // When we have `feature="testutils"` (or are in cfg(test)) we enable feature
     // `soroban-env-{common,host}/testutils` which in turn adds the helper method
@@ -132,8 +132,6 @@ use internal::{
 #[derive(Clone)]
 pub struct MaybeEnv {
     maybe_env_impl: internal::MaybeEnvImpl,
-    #[cfg(any(test, feature = "testutils"))]
-    test_state: Option<EnvTestState>,
 }
 
 #[cfg(target_family = "wasm")]
@@ -169,8 +167,6 @@ impl MaybeEnv {
     pub const fn none() -> Self {
         Self {
             maybe_env_impl: None,
-            #[cfg(any(test, feature = "testutils"))]
-            test_state: None,
         }
     }
 }
@@ -189,15 +185,7 @@ impl TryFrom<MaybeEnv> for Env {
     type Error = ConversionError;
 
     fn try_from(value: MaybeEnv) -> Result<Self, Self::Error> {
-        if let Some(env_impl) = value.maybe_env_impl {
-            Ok(Env {
-                env_impl,
-                #[cfg(any(test, feature = "testutils"))]
-                test_state: value.test_state.unwrap_or_default(),
-            })
-        } else {
-            Err(ConversionError)
-        }
+        value.maybe_env_impl.ok_or(ConversionError)
     }
 }
 
@@ -205,9 +193,7 @@ impl TryFrom<MaybeEnv> for Env {
 impl From<Env> for MaybeEnv {
     fn from(value: Env) -> Self {
         MaybeEnv {
-            maybe_env_impl: Some(value.env_impl.clone()),
-            #[cfg(any(test, feature = "testutils"))]
-            test_state: Some(value.test_state.clone()),
+            maybe_env_impl: Some(value),
         }
     }
 }

--- a/soroban-sdk/src/tests/env.rs
+++ b/soroban-sdk/src/tests/env.rs
@@ -356,30 +356,3 @@ fn test_register_restores_auth_before_panics() {
     assert!(post_register.is_err());
     assert_eq!(pre_register, post_register);
 }
-
-/// Test that the test snapshot file is not written when disabled after
-/// creation, when a value holding the Env outlives the Env.
-#[test]
-fn test_snapshot_file_disabled_after_creation_value_outlives_env() {
-    let p = std::path::Path::new("test_snapshots")
-        .join("tests")
-        .join("env")
-        .join("test_snapshot_file_disabled_after_creation_value_outlives_env");
-    let p1 = p.with_extension("1.json");
-    let _ = std::fs::remove_file(&p1);
-    {
-        let s;
-        {
-            let mut e = Env::default();
-            s = Symbol::new(&e, "a_symbol_longer_than_short");
-            e.set_config(EnvTestConfig {
-                capture_snapshot_at_drop: false,
-            });
-            let _ = e.register(Contract, ());
-        } // Env dropped, but the Symbol still holds it.
-        assert!(!p1.exists());
-        drop(s);
-    } // Symbol dropped, dropping the last hold on the Env.
-    assert!(!p1.exists());
-    let _ = std::fs::remove_file(&p1);
-}

--- a/soroban-sdk/src/tests/env.rs
+++ b/soroban-sdk/src/tests/env.rs
@@ -356,3 +356,30 @@ fn test_register_restores_auth_before_panics() {
     assert!(post_register.is_err());
     assert_eq!(pre_register, post_register);
 }
+
+/// Test that the test snapshot file is not written when disabled after
+/// creation, when a value holding the Env outlives the Env.
+#[test]
+fn test_snapshot_file_disabled_after_creation_value_outlives_env() {
+    let p = std::path::Path::new("test_snapshots")
+        .join("tests")
+        .join("env")
+        .join("test_snapshot_file_disabled_after_creation_value_outlives_env");
+    let p1 = p.with_extension("1.json");
+    let _ = std::fs::remove_file(&p1);
+    {
+        let s;
+        {
+            let mut e = Env::default();
+            s = Symbol::new(&e, "a_symbol_longer_than_short");
+            e.set_config(EnvTestConfig {
+                capture_snapshot_at_drop: false,
+            });
+            let _ = e.register(Contract, ());
+        } // Env dropped, but the Symbol still holds it.
+        assert!(!p1.exists());
+        drop(s);
+    } // Symbol dropped, dropping the last hold on the Env.
+    assert!(!p1.exists());
+    let _ = std::fs::remove_file(&p1);
+}


### PR DESCRIPTION
### What

Make MaybeEnv store a whole Env or nothing at all, rather than the separately-optional pieces of one.

### Why

Holding the host and the test state as two independent Options meant rebuilding an Env had to call `test_state.unwrap_or_default()`, silently fabricating test state for a combination that can never occur.

Note this also results in a small positive change for Symbol. A Symbol holds a MaybeEnv and now keeps an Env alive rather than just a Host, so a Symbol that outlives the Env it was made from can be the last owner and write the drop-time test snapshot, the same as a Map, Vec, or Bytes already does making it more consistent. This will have no meaningful impact on anything though.

### SemVer Change

- [ ] Major (`vX._._`) - Breaking change to the public API.
- [ ] Minor (`v_.Y._`) - Additive change to the public API.
- [x] Patch (`v_._.Z`) - No change to the public API.
