### PR TITLE
Auto-update generated test files in CI

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,3 @@
 .github/workflows/*.lock.yml linguist-generated=true merge=ours
+**/test_snapshots/** merge=ours
+tests-expanded/** merge=ours

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,1 @@
 .github/workflows/*.lock.yml linguist-generated=true merge=ours
-**/test_snapshots/** merge=ours
-tests-expanded/** merge=ours

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -102,6 +102,8 @@ jobs:
     runs-on: ${{ matrix.sys.os }}
     steps:
     - uses: actions/checkout@v3
+      with:
+        ref: ${{ github.head_ref || github.ref }}
     - name: Install minimum supported rust version
       if: matrix.rust == 'msrv'
       run: |

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -203,7 +203,6 @@ jobs:
       run: |
         git config user.name 'github-actions[bot]'
         git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
-        git config merge.ours.driver true
         git add -A -- ':(glob)**/test_snapshots/**'
         if git diff --cached --quiet; then
           echo "No diffs."
@@ -294,7 +293,6 @@ jobs:
       run: |
         git config user.name 'github-actions[bot]'
         git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
-        git config merge.ours.driver true
         git add -A -- tests-expanded
         if git diff --cached --quiet; then
           echo "No diffs."

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -201,7 +201,7 @@ jobs:
       run: |
         git config user.name 'github-actions[bot]'
         git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
-        git add -A
+        git add -A -- ':(glob)**/test_snapshots/**'
         if git diff --cached --quiet; then
           echo "No diffs."
           exit 0
@@ -213,7 +213,6 @@ jobs:
         done
         exit 1
     - name: Check no diffs exist
-      if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository
       run: git add -N . && git diff HEAD --exit-code
 
   build-fuzz:
@@ -292,7 +291,7 @@ jobs:
       run: |
         git config user.name 'github-actions[bot]'
         git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
-        git add -A
+        git add -A -- tests-expanded
         if git diff --cached --quiet; then
           echo "No diffs."
           exit 0
@@ -304,7 +303,6 @@ jobs:
         done
         exit 1
     - name: Check no diffs exist
-      if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository
       run: git add -N . && git diff HEAD --exit-code
 
   publish-dry-run:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -143,6 +143,8 @@ jobs:
 
   test:
     needs: [setup, build]
+    permissions:
+      contents: write
     strategy:
       fail-fast: false
       matrix:
@@ -151,6 +153,9 @@ jobs:
     runs-on: ${{ matrix.sys.os }}
     steps:
     - uses: actions/checkout@v3
+      with:
+        ref: ${{ github.head_ref || github.ref }}
+        fetch-depth: 0
     - name: Install minimum supported rust version
       if: matrix.rust == 'msrv'
       run: |
@@ -189,7 +194,26 @@ jobs:
       run: rm -fr **/test_snapshots
     - run: cargo version
     - run: make test-only
+    - name: Push any diffs to the branch
+      if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+      env:
+        BRANCH: ${{ github.head_ref }}
+      run: |
+        git config user.name 'github-actions[bot]'
+        git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+        git add -A
+        if git diff --cached --quiet; then
+          echo "No diffs."
+          exit 0
+        fi
+        git commit -m 'Update test snapshots'
+        for i in 1 2 3 4 5; do
+          git pull --rebase origin "$BRANCH" && git push origin "HEAD:refs/heads/$BRANCH" && exit 0
+          sleep $((i * 5))
+        done
+        exit 1
     - name: Check no diffs exist
+      if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository
       run: git add -N . && git diff HEAD --exit-code
 
   build-fuzz:
@@ -238,8 +262,13 @@ jobs:
 
   expand-test-wasms:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
     - uses: actions/checkout@v5
+      with:
+        ref: ${{ github.head_ref || github.ref }}
+        fetch-depth: 0
     - uses: stellar/actions/rust-cache@main
     - name: Install minimum supported rust version
       run: |
@@ -256,7 +285,26 @@ jobs:
         name: cargo-expand
         version: 1.0.116
     - run: make expand-tests
+    - name: Push any diffs to the branch
+      if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+      env:
+        BRANCH: ${{ github.head_ref }}
+      run: |
+        git config user.name 'github-actions[bot]'
+        git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+        git add -A
+        if git diff --cached --quiet; then
+          echo "No diffs."
+          exit 0
+        fi
+        git commit -m 'Update expanded tests'
+        for i in 1 2 3 4 5; do
+          git pull --rebase origin "$BRANCH" && git push origin "HEAD:refs/heads/$BRANCH" && exit 0
+          sleep $((i * 5))
+        done
+        exit 1
     - name: Check no diffs exist
+      if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository
       run: git add -N . && git diff HEAD --exit-code
 
   publish-dry-run:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -201,6 +201,7 @@ jobs:
       run: |
         git config user.name 'github-actions[bot]'
         git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+        git config merge.ours.driver true
         git add -A -- ':(glob)**/test_snapshots/**'
         if git diff --cached --quiet; then
           echo "No diffs."
@@ -291,6 +292,7 @@ jobs:
       run: |
         git config user.name 'github-actions[bot]'
         git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+        git config merge.ours.driver true
         git add -A -- tests-expanded
         if git diff --cached --quiet; then
           echo "No diffs."


### PR DESCRIPTION
### What

Make the test and expand-test-wasms jobs commit and push regenerated test snapshots and expanded tests back to the pull request branch instead of failing.

### Why

Both file sets are generated, so a diff against them is never a review decision — it is a chore that currently fails CI.

### Known limitations

Pushes made with `GITHUB_TOKEN` do not trigger workflows, so the auto-commit gets no CI run of its own, and the two pushing jobs carry `contents: write` while executing pull-request-controlled build scripts and tests. The build, test, and expand jobs now all check out `head_ref` rather than the merge commit, so sources and Wasm artifacts agree, and merge-result coverage is left to the merge queue.

The two legs of the test matrix regenerate the same snapshots and race to push, which the rebase-and-retry loop absorbs. If the toolchains ever produce genuinely different snapshots the rebase conflicts and the job fails rather than silently picking a side.

### SemVer Change

- [ ] Major (`vX._._`) - Breaking change to the public API.
- [ ] Minor (`v_.Y._`) - Additive change to the public API.
- [x] Patch (`v_._.Z`) - No change to the public API.