### PR TITLE
Reject empty delegate list in account example

### DIFF
--- a/soroban-sdk/src/custom_account.rs
+++ b/soroban-sdk/src/custom_account.rs
@@ -21,7 +21,8 @@
 //! #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
 //! #[repr(u32)]
 //! pub enum Error {
-//!     UnknownDelegate = 1,
+//!     NoDelegates = 1,
+//!     UnknownDelegate = 2,
 //! }
 //!
 //! #[contracttype]
@@ -62,6 +63,12 @@
 //!         // The signers the user attached to the auth entry for this
 //!         // account's authorization.
 //!         let delegates = env.custom_account().get_delegated_signers();
+//!
+//!         // The account authenticates only by delegation, so an auth entry
+//!         // that attaches no delegated signers must not be approved.
+//!         if delegates.is_empty() {
+//!             return Err(Error::NoDelegates);
+//!         }
 //!
 //!         // Check if the delegates are accepted by the modular account.
 //!         for delegate in delegates.iter() {


### PR DESCRIPTION
### What

Make the modular custom account example reject an authorization entry that attaches no delegated signers.

### Why

The example delegated authentication entirely and had no lower bound on the delegate list, so an entry with `delegates` empty skipped both loops and fell through to `Ok(())` — authorizing the account with no authentication at all. The standalone `modular_account` example in soroban-examples already guards this.

### Known limitations

N/A

### SemVer Change

- [ ] Major (`vX._._`) - Breaking change to the public API.
- [ ] Minor (`v_.Y._`) - Additive change to the public API.
- [x] Patch (`v_._.Z`) - No change to the public API.