### PR TITLE
Make Map::as_object and Map::to_object public

### DIFF
--- a/soroban-sdk/src/map.rs
+++ b/soroban-sdk/src/map.rs
@@ -308,7 +308,12 @@ impl<K, V> Map<K, V> {
     }
 
     #[inline(always)]
-    pub(crate) fn to_object(&self) -> MapObject {
+    pub fn as_object(&self) -> &MapObject {
+        &self.obj
+    }
+
+    #[inline(always)]
+    pub fn to_object(&self) -> MapObject {
         self.obj
     }
 }

--- a/soroban-sdk/src/map.rs
+++ b/soroban-sdk/src/map.rs
@@ -308,11 +308,6 @@ impl<K, V> Map<K, V> {
     }
 
     #[inline(always)]
-    pub(crate) fn as_object(&self) -> &MapObject {
-        &self.obj
-    }
-
-    #[inline(always)]
     pub(crate) fn to_object(&self) -> MapObject {
         self.obj
     }


### PR DESCRIPTION
### What

Change `Map::as_object` and `Map::to_object` from `pub(crate)` to `pub`.

### Why

Just a minor tidy up for API consistency, as I noticed that `Map` was the only object-backed type in the SDK keeping these accessors pub(crate) where as other types expose both as `pub`.

### SemVer Change

- [ ] Major (`vX._._`) - Breaking change to the public API.
- [x] Minor (`v_.Y._`) - Additive change to the public API.
- [ ] Patch (`v_._.Z`) - No change to the public API.