### PR TITLE
ci: use build env var for wasm dry run

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -267,11 +267,13 @@ jobs:
         - os: ubuntu-latest
           target: wasm32v1-none
           cargo-hack-feature-options: --manifest-path Cargo.toml --exclude soroban-meta --exclude soroban-spec --exclude soroban-spec-rust --exclude soroban-ledger-snapshot --exclude-features testutils,docs,default,std --feature-powerset
+          env: SOROBAN_SDK_BUILD_SYSTEM_SUPPORTS_SPEC_SHAKING_V2=1
         - os: ubuntu-latest
           target: x86_64-unknown-linux-gnu
           cargo-hack-feature-options: '--feature-powerset --exclude-features docs'
-    uses: stellar/actions/.github/workflows/rust-publish-dry-run.yml@main
+    uses: stellar/actions/.github/workflows/rust-publish-dry-run-v2.yml@main
     with:
       runs-on: ${{ matrix.sys.os }}
       target: ${{ matrix.sys.target }}
       cargo-hack-feature-options: ${{ matrix.sys.cargo-hack-feature-options }}
+      env: ${{ matrix.sys.env }}


### PR DESCRIPTION
### What

Update the dry run to `publish-dry-run-v2` and pass the spec shaking v2 env var for the Wasm dry run.

### Why

To fix [dry run failures](https://github.com/stellar/rs-soroban-sdk/actions/runs/32410007291/job/96560180521?pr=2021).

Patch added to actions [here](https://github.com/stellar/actions/pull/111).

### Known limitations

None

### SemVer Change

- [ ] Major (`vX._._`) - Breaking change to the public API.
- [ ] Minor (`v_.Y._`) - Additive change to the public API.
- [x] Patch (`v_._.Z`) - No change to the public API.
