### PR TITLE
Doc hide the as_object and to_object fns

### DIFF
--- a/soroban-sdk/src/address.rs
+++ b/soroban-sdk/src/address.rs
@@ -366,10 +366,12 @@ impl Address {
         self.obj.to_val()
     }
 
+    #[doc(hidden)]
     pub fn as_object(&self) -> &AddressObject {
         &self.obj
     }
 
+    #[doc(hidden)]
     pub fn to_object(&self) -> AddressObject {
         self.obj
     }

--- a/soroban-sdk/src/bytes.rs
+++ b/soroban-sdk/src/bytes.rs
@@ -137,10 +137,12 @@ macro_rules! impl_bytesn_repr {
                 self.0.to_val()
             }
 
+            #[doc(hidden)]
             pub fn as_object(&self) -> &BytesObject {
                 self.0.as_object()
             }
 
+            #[doc(hidden)]
             pub fn to_object(&self) -> BytesObject {
                 self.0.to_object()
             }
@@ -453,10 +455,12 @@ impl Bytes {
         self.obj.to_val()
     }
 
+    #[doc(hidden)]
     pub fn as_object(&self) -> &BytesObject {
         &self.obj
     }
 
+    #[doc(hidden)]
     pub fn to_object(&self) -> BytesObject {
         self.obj
     }
@@ -1181,10 +1185,12 @@ impl<const N: usize> BytesN<N> {
         self.0.to_val()
     }
 
+    #[doc(hidden)]
     pub fn as_object(&self) -> &BytesObject {
         self.0.as_object()
     }
 
+    #[doc(hidden)]
     pub fn to_object(&self) -> BytesObject {
         self.0.to_object()
     }

--- a/soroban-sdk/src/crypto.rs
+++ b/soroban-sdk/src/crypto.rs
@@ -65,10 +65,12 @@ impl<const N: usize> Hash<N> {
         self.0.to_val()
     }
 
+    #[doc(hidden)]
     pub fn as_object(&self) -> &BytesObject {
         self.0.as_object()
     }
 
+    #[doc(hidden)]
     pub fn to_object(&self) -> BytesObject {
         self.0.to_object()
     }

--- a/soroban-sdk/src/map.rs
+++ b/soroban-sdk/src/map.rs
@@ -308,11 +308,13 @@ impl<K, V> Map<K, V> {
     }
 
     #[inline(always)]
+    #[doc(hidden)]
     pub fn as_object(&self) -> &MapObject {
         &self.obj
     }
 
     #[inline(always)]
+    #[doc(hidden)]
     pub fn to_object(&self) -> MapObject {
         self.obj
     }

--- a/soroban-sdk/src/string.rs
+++ b/soroban-sdk/src/string.rs
@@ -233,10 +233,12 @@ impl String {
         self.obj.to_val()
     }
 
+    #[doc(hidden)]
     pub fn as_object(&self) -> &StringObject {
         &self.obj
     }
 
+    #[doc(hidden)]
     pub fn to_object(&self) -> StringObject {
         self.obj
     }

--- a/soroban-sdk/src/vec.rs
+++ b/soroban-sdk/src/vec.rs
@@ -342,10 +342,12 @@ impl<T> Vec<T> {
         self.obj.to_val()
     }
 
+    #[doc(hidden)]
     pub fn as_object(&self) -> &VecObject {
         &self.obj
     }
 
+    #[doc(hidden)]
     pub fn to_object(&self) -> VecObject {
         self.obj
     }


### PR DESCRIPTION
### What

Hide every `as_object` and `to_object` accessor from the rendered docs with `#[doc(hidden)]`, across `Address`, `Bytes`, `BytesN`, `Hash`, `Map`, `String`, and `Vec`.

### Why

These accessors expose the underlying env object types that most contract authors never need. In #2027 we fixed a visibility inconsistency on one. These functions are not really needed so it is good to take them out of the docs so as to stop promoting them. But at this stage not going to remove them entirely because of the possibility it would break someone.

### SemVer Change

- [ ] Major (`vX._._`) - Breaking change to the public API.
- [ ] Minor (`v_.Y._`) - Additive change to the public API.
- [x] Patch (`v_._.Z`) - No change to the public API.