### PR TITLE
Remove stale rlib/LTO comment from fuzz crate

### DIFF
--- a/tests/fuzz/Cargo.toml
+++ b/tests/fuzz/Cargo.toml
@@ -8,10 +8,6 @@ publish = false
 rust-version.workspace = true
 
 [lib]
-# Adding rlib is required so that the test_fuzz crate can be imported as a
-# library into the fuzzing crate. However, having multiple crate types is a
-# problem, it'll cause LTO optimizations to be disabled for the cdylib build.
-# TODO: Figure out what to do about this.
 crate-type = ["cdylib", "rlib"]
 doctest = false
 


### PR DESCRIPTION
### What

Remove the comment in `tests/fuzz/Cargo.toml` warning that the `rlib`/`cdylib` crate-type combination disables LTO for the cdylib build.

### Why

The concern no longer applies: contract builds go through `stellar contract build`, which invokes `rustc` directly and bypasses the crate-type interaction, so optimisation is unaffected.

### Known limitations

N/A

### SemVer Change

- [ ] Major (`vX._._`) - Breaking change to the public API.
- [ ] Minor (`v_.Y._`) - Additive change to the public API.
- [x] Patch (`v_._.Z`) - No change to the public API.