### PR TITLE
Hide generated spec XDR statics from docs

### DIFF
--- a/soroban-sdk-macros/src/derive_enum.rs
+++ b/soroban-sdk-macros/src/derive_enum.rs
@@ -162,6 +162,7 @@ pub fn derive_type_enum(
             enum_ident.unraw().to_string().to_uppercase()
         );
         quote! {
+            #[doc(hidden)]
             #[cfg_attr(target_family = "wasm", link_section = "contractspecv0")]
             pub static #spec_ident: [u8; #spec_xdr_len] = #enum_ident::spec_xdr();
 

--- a/soroban-sdk-macros/src/derive_enum_int.rs
+++ b/soroban-sdk-macros/src/derive_enum_int.rs
@@ -84,6 +84,7 @@ pub fn derive_type_enum_int(
             enum_ident.unraw().to_string().to_uppercase()
         );
         quote! {
+            #[doc(hidden)]
             #[cfg_attr(target_family = "wasm", link_section = "contractspecv0")]
             pub static #spec_ident: [u8; #spec_xdr_len] = #enum_ident::spec_xdr();
 

--- a/soroban-sdk-macros/src/derive_error_enum_int.rs
+++ b/soroban-sdk-macros/src/derive_error_enum_int.rs
@@ -81,6 +81,7 @@ pub fn derive_type_error_enum_int(
             enum_ident.unraw().to_string().to_uppercase()
         );
         quote! {
+            #[doc(hidden)]
             #[cfg_attr(target_family = "wasm", link_section = "contractspecv0")]
             pub static #spec_ident: [u8; #spec_xdr_len] = #enum_ident::spec_xdr();
 

--- a/soroban-sdk-macros/src/derive_event.rs
+++ b/soroban-sdk-macros/src/derive_event.rs
@@ -223,6 +223,7 @@ fn derive_impls(args: &ContractEventArgs, input: &DeriveInput) -> Result<TokenSt
 
     // Generated code spec.
     let spec_gen = quote! {
+        #[doc(hidden)]
         #export_gen
         pub static #spec_ident: [u8; #spec_xdr_len] = #ident::spec_xdr();
 

--- a/soroban-sdk-macros/src/derive_struct.rs
+++ b/soroban-sdk-macros/src/derive_struct.rs
@@ -96,6 +96,7 @@ pub fn derive_type_struct(
             ident.unraw().to_string().to_uppercase()
         );
         quote! {
+            #[doc(hidden)]
             #[cfg_attr(target_family = "wasm", link_section = "contractspecv0")]
             pub static #spec_ident: [u8; #spec_xdr_len] = #ident::spec_xdr();
 

--- a/soroban-sdk-macros/src/derive_struct_tuple.rs
+++ b/soroban-sdk-macros/src/derive_struct_tuple.rs
@@ -80,6 +80,7 @@ pub fn derive_type_struct_tuple(
             ident.unraw().to_string().to_uppercase()
         );
         quote! {
+            #[doc(hidden)]
             #[cfg_attr(target_family = "wasm", link_section = "contractspecv0")]
             pub static #spec_ident: [u8; #spec_xdr_len] = #ident::spec_xdr();
 

--- a/tests-expanded/test_account_tests.rs
+++ b/tests-expanded/test_account_tests.rs
@@ -50,6 +50,7 @@ impl ::core::cmp::Ord for Error {
         ::core::cmp::Ordering::Equal
     }
 }
+#[doc(hidden)]
 pub static __SPEC_XDR_TYPE_ERROR: [u8; 44usize] = Error::spec_xdr();
 impl Error {
     pub const fn spec_xdr() -> [u8; 44usize] {

--- a/tests-expanded/test_account_wasm32v1-none.rs
+++ b/tests-expanded/test_account_wasm32v1-none.rs
@@ -50,6 +50,7 @@ impl ::core::cmp::Ord for Error {
         ::core::cmp::Ordering::Equal
     }
 }
+#[doc(hidden)]
 #[link_section = "contractspecv0"]
 pub static __SPEC_XDR_TYPE_ERROR: [u8; 44usize] = Error::spec_xdr();
 impl Error {

--- a/tests-expanded/test_add_u64_tests.rs
+++ b/tests-expanded/test_add_u64_tests.rs
@@ -155,6 +155,7 @@ impl ::core::cmp::PartialEq for Error {
         true
     }
 }
+#[doc(hidden)]
 pub static __SPEC_XDR_TYPE_ERROR: [u8; 48usize] = Error::spec_xdr();
 impl Error {
     pub const fn spec_xdr() -> [u8; 48usize] {
@@ -288,6 +289,7 @@ impl ::core::cmp::PartialEq for MyError {
         true
     }
 }
+#[doc(hidden)]
 pub static __SPEC_XDR_TYPE_MYERROR: [u8; 48usize] = MyError::spec_xdr();
 impl MyError {
     pub const fn spec_xdr() -> [u8; 48usize] {

--- a/tests-expanded/test_add_u64_wasm32v1-none.rs
+++ b/tests-expanded/test_add_u64_wasm32v1-none.rs
@@ -43,6 +43,7 @@ impl ::core::cmp::PartialEq for Error {
         true
     }
 }
+#[doc(hidden)]
 #[link_section = "contractspecv0"]
 pub static __SPEC_XDR_TYPE_ERROR: [u8; 48usize] = Error::spec_xdr();
 impl Error {
@@ -182,6 +183,7 @@ impl ::core::cmp::PartialEq for MyError {
         true
     }
 }
+#[doc(hidden)]
 #[link_section = "contractspecv0"]
 pub static __SPEC_XDR_TYPE_MYERROR: [u8; 48usize] = MyError::spec_xdr();
 impl MyError {

--- a/tests-expanded/test_associated_types_contracttrait_tests.rs
+++ b/tests-expanded/test_associated_types_contracttrait_tests.rs
@@ -1157,6 +1157,7 @@ mod test_with_wasm {
                 }
             }
         }
+        #[doc(hidden)]
         pub static __SPEC_XDR_TYPE_CONTRACTEXECUTABLEREF: [u8; 80usize] =
             ContractExecutableRef::spec_xdr();
         impl ContractExecutableRef {
@@ -1650,6 +1651,7 @@ mod test_with_wasm {
                 }
             }
         }
+        #[doc(hidden)]
         pub static __SPEC_XDR_TYPE_CONTRACTCONTEXT: [u8; 96usize] = ContractContext::spec_xdr();
         impl ContractContext {
             pub const fn spec_xdr() -> [u8; 96usize] {
@@ -2198,6 +2200,7 @@ mod test_with_wasm {
                 }
             }
         }
+        #[doc(hidden)]
         pub static __SPEC_XDR_TYPE_SUBCONTRACTINVOCATION: [u8; 144usize] =
             SubContractInvocation::spec_xdr();
         impl SubContractInvocation {
@@ -2684,6 +2687,7 @@ mod test_with_wasm {
                 }
             }
         }
+        #[doc(hidden)]
         pub static __SPEC_XDR_TYPE_CREATECONTRACTHOSTFNCONTEXT: [u8; 116usize] =
             CreateContractHostFnContext::spec_xdr();
         impl CreateContractHostFnContext {
@@ -3202,6 +3206,7 @@ mod test_with_wasm {
                 }
             }
         }
+        #[doc(hidden)]
         pub static __SPEC_XDR_TYPE_CREATECONTRACTWITHCONSTRUCTORHOSTFNCONTEXT: [u8; 164usize] =
             CreateContractWithConstructorHostFnContext::spec_xdr();
         impl CreateContractWithConstructorHostFnContext {
@@ -3825,6 +3830,7 @@ mod test_with_wasm {
                 }
             }
         }
+        #[doc(hidden)]
         pub static __SPEC_XDR_TYPE_CONTRACTEXECUTABLE: [u8; 128usize] =
             ContractExecutable::spec_xdr();
         impl ContractExecutable {
@@ -4465,6 +4471,7 @@ mod test_with_wasm {
                 }
             }
         }
+        #[doc(hidden)]
         pub static __SPEC_XDR_TYPE_CONTEXT: [u8; 244usize] = Context::spec_xdr();
         impl Context {
             pub const fn spec_xdr() -> [u8; 244usize] {
@@ -5204,6 +5211,7 @@ mod test_with_wasm {
                 }
             }
         }
+        #[doc(hidden)]
         pub static __SPEC_XDR_TYPE_INVOKERCONTRACTAUTHENTRY: [u8; 268usize] =
             InvokerContractAuthEntry::spec_xdr();
         impl InvokerContractAuthEntry {
@@ -5938,6 +5946,7 @@ mod test_with_wasm {
                 }
             }
         }
+        #[doc(hidden)]
         pub static __SPEC_XDR_TYPE_EXECUTABLE: [u8; 104usize] = Executable::spec_xdr();
         impl Executable {
             pub const fn spec_xdr() -> [u8; 104usize] {

--- a/tests-expanded/test_attributes_tests.rs
+++ b/tests-expanded/test_attributes_tests.rs
@@ -47,6 +47,7 @@ impl ::core::cmp::PartialEq for AttributeType {
         self.value == other.value
     }
 }
+#[doc(hidden)]
 pub static __SPEC_XDR_TYPE_ATTRIBUTETYPE: [u8; 56usize] = AttributeType::spec_xdr();
 impl AttributeType {
     pub const fn spec_xdr() -> [u8; 56usize] {
@@ -386,6 +387,7 @@ pub struct AttributeEvent {
     topic: u32,
     value: u32,
 }
+#[doc(hidden)]
 pub static __SPEC_XDR_EVENT_ATTRIBUTEEVENT: [u8; 112usize] = AttributeEvent::spec_xdr();
 impl AttributeEvent {
     pub const fn spec_xdr() -> [u8; 112usize] {

--- a/tests-expanded/test_attributes_wasm32v1-none.rs
+++ b/tests-expanded/test_attributes_wasm32v1-none.rs
@@ -47,6 +47,7 @@ impl ::core::cmp::PartialEq for AttributeType {
         self.value == other.value
     }
 }
+#[doc(hidden)]
 #[link_section = "contractspecv0"]
 pub static __SPEC_XDR_TYPE_ATTRIBUTETYPE: [u8; 56usize] = AttributeType::spec_xdr();
 impl AttributeType {
@@ -115,6 +116,7 @@ pub struct AttributeEvent {
     topic: u32,
     value: u32,
 }
+#[doc(hidden)]
 #[link_section = "contractspecv0"]
 pub static __SPEC_XDR_EVENT_ATTRIBUTEEVENT: [u8; 112usize] = AttributeEvent::spec_xdr();
 impl AttributeEvent {

--- a/tests-expanded/test_auth_tests.rs
+++ b/tests-expanded/test_auth_tests.rs
@@ -1119,6 +1119,7 @@ mod test_a {
                 ::core::cmp::Ordering::Equal
             }
         }
+        #[doc(hidden)]
         pub static __SPEC_XDR_TYPE_ERROR: [u8; 48usize] = Error::spec_xdr();
         impl Error {
             pub const fn spec_xdr() -> [u8; 48usize] {
@@ -2603,6 +2604,7 @@ mod test_b {
                 ::core::cmp::Ordering::Equal
             }
         }
+        #[doc(hidden)]
         pub static __SPEC_XDR_TYPE_ERROR: [u8; 48usize] = Error::spec_xdr();
         impl Error {
             pub const fn spec_xdr() -> [u8; 48usize] {

--- a/tests-expanded/test_bls_tests.rs
+++ b/tests-expanded/test_bls_tests.rs
@@ -16,6 +16,7 @@ pub struct DummyProof {
     pub g2: Bls12381G2Affine,
     pub fr: Bls12381Fr,
 }
+#[doc(hidden)]
 pub static __SPEC_XDR_TYPE_DUMMYPROOF: [u8; 128usize] = DummyProof::spec_xdr();
 impl DummyProof {
     pub const fn spec_xdr() -> [u8; 128usize] {

--- a/tests-expanded/test_bls_wasm32v1-none.rs
+++ b/tests-expanded/test_bls_wasm32v1-none.rs
@@ -16,6 +16,7 @@ pub struct DummyProof {
     pub g2: Bls12381G2Affine,
     pub fr: Bls12381Fr,
 }
+#[doc(hidden)]
 #[link_section = "contractspecv0"]
 pub static __SPEC_XDR_TYPE_DUMMYPROOF: [u8; 128usize] = DummyProof::spec_xdr();
 impl DummyProof {

--- a/tests-expanded/test_bn254_tests.rs
+++ b/tests-expanded/test_bn254_tests.rs
@@ -13,6 +13,7 @@ pub struct MockProof {
     pub g1: Vec<Bn254G1Affine>,
     pub g2: Vec<Bn254G2Affine>,
 }
+#[doc(hidden)]
 pub static __SPEC_XDR_TYPE_MOCKPROOF: [u8; 80usize] = MockProof::spec_xdr();
 impl MockProof {
     pub const fn spec_xdr() -> [u8; 80usize] {

--- a/tests-expanded/test_bn254_wasm32v1-none.rs
+++ b/tests-expanded/test_bn254_wasm32v1-none.rs
@@ -13,6 +13,7 @@ pub struct MockProof {
     pub g1: Vec<Bn254G1Affine>,
     pub g2: Vec<Bn254G2Affine>,
 }
+#[doc(hidden)]
 #[link_section = "contractspecv0"]
 pub static __SPEC_XDR_TYPE_MOCKPROOF: [u8; 80usize] = MockProof::spec_xdr();
 impl MockProof {

--- a/tests-expanded/test_constructor_tests.rs
+++ b/tests-expanded/test_constructor_tests.rs
@@ -141,6 +141,7 @@ pub enum DataKey {
     Temp(u32),
     Instance(u32),
 }
+#[doc(hidden)]
 pub static __SPEC_XDR_TYPE_DATAKEY: [u8; 112usize] = DataKey::spec_xdr();
 impl DataKey {
     pub const fn spec_xdr() -> [u8; 112usize] {

--- a/tests-expanded/test_constructor_wasm32v1-none.rs
+++ b/tests-expanded/test_constructor_wasm32v1-none.rs
@@ -29,6 +29,7 @@ pub enum DataKey {
     Temp(u32),
     Instance(u32),
 }
+#[doc(hidden)]
 #[link_section = "contractspecv0"]
 pub static __SPEC_XDR_TYPE_DATAKEY: [u8; 112usize] = DataKey::spec_xdr();
 impl DataKey {

--- a/tests-expanded/test_contracttrait_trait_tests.rs
+++ b/tests-expanded/test_contracttrait_trait_tests.rs
@@ -49,6 +49,7 @@ impl ::core::cmp::PartialEq for MyStruct {
         self.a == other.a && self.b == other.b
     }
 }
+#[doc(hidden)]
 pub static __SPEC_XDR_TYPE_MYSTRUCT: [u8; 60usize] = MyStruct::spec_xdr();
 impl MyStruct {
     pub const fn spec_xdr() -> [u8; 60usize] {
@@ -476,6 +477,7 @@ impl ::core::cmp::PartialEq for MyEnumUnit {
         __self_discr == __arg1_discr
     }
 }
+#[doc(hidden)]
 pub static __SPEC_XDR_TYPE_MYENUMUNIT: [u8; 64usize] = MyEnumUnit::spec_xdr();
 impl MyEnumUnit {
     pub const fn spec_xdr() -> [u8; 64usize] {
@@ -826,6 +828,7 @@ impl ::core::cmp::PartialEq for MyEnumVariants {
             }
     }
 }
+#[doc(hidden)]
 pub static __SPEC_XDR_TYPE_MYENUMVARIANTS: [u8; 128usize] = MyEnumVariants::spec_xdr();
 impl MyEnumVariants {
     pub const fn spec_xdr() -> [u8; 128usize] {

--- a/tests-expanded/test_contracttrait_trait_wasm32v1-none.rs
+++ b/tests-expanded/test_contracttrait_trait_wasm32v1-none.rs
@@ -49,6 +49,7 @@ impl ::core::cmp::PartialEq for MyStruct {
         self.a == other.a && self.b == other.b
     }
 }
+#[doc(hidden)]
 #[link_section = "contractspecv0"]
 pub static __SPEC_XDR_TYPE_MYSTRUCT: [u8; 60usize] = MyStruct::spec_xdr();
 impl MyStruct {
@@ -162,6 +163,7 @@ impl ::core::cmp::PartialEq for MyEnumUnit {
         __self_discr == __arg1_discr
     }
 }
+#[doc(hidden)]
 #[link_section = "contractspecv0"]
 pub static __SPEC_XDR_TYPE_MYENUMUNIT: [u8; 64usize] = MyEnumUnit::spec_xdr();
 impl MyEnumUnit {
@@ -283,6 +285,7 @@ impl ::core::cmp::PartialEq for MyEnumVariants {
             }
     }
 }
+#[doc(hidden)]
 #[link_section = "contractspecv0"]
 pub static __SPEC_XDR_TYPE_MYENUMVARIANTS: [u8; 128usize] = MyEnumVariants::spec_xdr();
 impl MyEnumVariants {

--- a/tests-expanded/test_errors_tests.rs
+++ b/tests-expanded/test_errors_tests.rs
@@ -157,6 +157,7 @@ impl ::core::cmp::PartialEq for Flag {
         __self_discr == __arg1_discr
     }
 }
+#[doc(hidden)]
 pub static __SPEC_XDR_TYPE_FLAG: [u8; 104usize] = Flag::spec_xdr();
 impl Flag {
     pub const fn spec_xdr() -> [u8; 104usize] {
@@ -504,6 +505,7 @@ impl ::core::cmp::PartialEq for Error {
         true
     }
 }
+#[doc(hidden)]
 pub static __SPEC_XDR_TYPE_ERROR: [u8; 48usize] = Error::spec_xdr();
 impl Error {
     pub const fn spec_xdr() -> [u8; 48usize] {

--- a/tests-expanded/test_errors_wasm32v1-none.rs
+++ b/tests-expanded/test_errors_wasm32v1-none.rs
@@ -45,6 +45,7 @@ impl ::core::cmp::PartialEq for Flag {
         __self_discr == __arg1_discr
     }
 }
+#[doc(hidden)]
 #[link_section = "contractspecv0"]
 pub static __SPEC_XDR_TYPE_FLAG: [u8; 104usize] = Flag::spec_xdr();
 impl Flag {
@@ -133,6 +134,7 @@ impl ::core::cmp::PartialEq for Error {
         true
     }
 }
+#[doc(hidden)]
 #[link_section = "contractspecv0"]
 pub static __SPEC_XDR_TYPE_ERROR: [u8; 48usize] = Error::spec_xdr();
 impl Error {

--- a/tests-expanded/test_events_ref_tests.rs
+++ b/tests-expanded/test_events_ref_tests.rs
@@ -142,6 +142,7 @@ pub struct Transfer<'a> {
     amount: &'a i128,
     to_muxed_id: Option<&'a u64>,
 }
+#[doc(hidden)]
 pub static __SPEC_XDR_EVENT_TRANSFER: [u8; 144usize] = Transfer::spec_xdr();
 impl<'a> Transfer<'a> {
     pub const fn spec_xdr() -> [u8; 144usize] {

--- a/tests-expanded/test_events_ref_wasm32v1-none.rs
+++ b/tests-expanded/test_events_ref_wasm32v1-none.rs
@@ -30,6 +30,7 @@ pub struct Transfer<'a> {
     amount: &'a i128,
     to_muxed_id: Option<&'a u64>,
 }
+#[doc(hidden)]
 #[link_section = "contractspecv0"]
 pub static __SPEC_XDR_EVENT_TRANSFER: [u8; 144usize] = Transfer::spec_xdr();
 impl<'a> Transfer<'a> {

--- a/tests-expanded/test_events_tests.rs
+++ b/tests-expanded/test_events_tests.rs
@@ -142,6 +142,7 @@ pub struct Transfer {
     amount: i128,
     to_muxed_id: Option<u64>,
 }
+#[doc(hidden)]
 pub static __SPEC_XDR_EVENT_TRANSFER: [u8; 144usize] = Transfer::spec_xdr();
 impl Transfer {
     pub const fn spec_xdr() -> [u8; 144usize] {

--- a/tests-expanded/test_events_wasm32v1-none.rs
+++ b/tests-expanded/test_events_wasm32v1-none.rs
@@ -30,6 +30,7 @@ pub struct Transfer {
     amount: i128,
     to_muxed_id: Option<u64>,
 }
+#[doc(hidden)]
 #[link_section = "contractspecv0"]
 pub static __SPEC_XDR_EVENT_TRANSFER: [u8; 144usize] = Transfer::spec_xdr();
 impl Transfer {

--- a/tests-expanded/test_import_contract_tests.rs
+++ b/tests-expanded/test_import_contract_tests.rs
@@ -460,6 +460,7 @@ mod addcontract {
             }
         }
     }
+    #[doc(hidden)]
     pub static __SPEC_XDR_TYPE_CONTRACTEXECUTABLEREF: [u8; 80usize] =
         ContractExecutableRef::spec_xdr();
     impl ContractExecutableRef {
@@ -949,6 +950,7 @@ mod addcontract {
             }
         }
     }
+    #[doc(hidden)]
     pub static __SPEC_XDR_TYPE_CONTRACTCONTEXT: [u8; 96usize] = ContractContext::spec_xdr();
     impl ContractContext {
         pub const fn spec_xdr() -> [u8; 96usize] {
@@ -1492,6 +1494,7 @@ mod addcontract {
             }
         }
     }
+    #[doc(hidden)]
     pub static __SPEC_XDR_TYPE_SUBCONTRACTINVOCATION: [u8; 144usize] =
         SubContractInvocation::spec_xdr();
     impl SubContractInvocation {
@@ -1977,6 +1980,7 @@ mod addcontract {
             }
         }
     }
+    #[doc(hidden)]
     pub static __SPEC_XDR_TYPE_CREATECONTRACTHOSTFNCONTEXT: [u8; 116usize] =
         CreateContractHostFnContext::spec_xdr();
     impl CreateContractHostFnContext {
@@ -2481,6 +2485,7 @@ mod addcontract {
             }
         }
     }
+    #[doc(hidden)]
     pub static __SPEC_XDR_TYPE_CREATECONTRACTWITHCONSTRUCTORHOSTFNCONTEXT: [u8; 164usize] =
         CreateContractWithConstructorHostFnContext::spec_xdr();
     impl CreateContractWithConstructorHostFnContext {
@@ -3102,6 +3107,7 @@ mod addcontract {
             }
         }
     }
+    #[doc(hidden)]
     pub static __SPEC_XDR_TYPE_CONTRACTEXECUTABLE: [u8; 128usize] = ContractExecutable::spec_xdr();
     impl ContractExecutable {
         pub const fn spec_xdr() -> [u8; 128usize] {
@@ -3737,6 +3743,7 @@ mod addcontract {
             }
         }
     }
+    #[doc(hidden)]
     pub static __SPEC_XDR_TYPE_CONTEXT: [u8; 244usize] = Context::spec_xdr();
     impl Context {
         pub const fn spec_xdr() -> [u8; 244usize] {
@@ -4465,6 +4472,7 @@ mod addcontract {
             }
         }
     }
+    #[doc(hidden)]
     pub static __SPEC_XDR_TYPE_INVOKERCONTRACTAUTHENTRY: [u8; 268usize] =
         InvokerContractAuthEntry::spec_xdr();
     impl InvokerContractAuthEntry {
@@ -5170,6 +5178,7 @@ mod addcontract {
             }
         }
     }
+    #[doc(hidden)]
     pub static __SPEC_XDR_TYPE_EXECUTABLE: [u8; 104usize] = Executable::spec_xdr();
     impl Executable {
         pub const fn spec_xdr() -> [u8; 104usize] {
@@ -5703,6 +5712,7 @@ mod addcontract {
             ::core::option::Option::Some(::core::cmp::Ordering::Equal)
         }
     }
+    #[doc(hidden)]
     pub static __SPEC_XDR_TYPE_ERROR: [u8; 48usize] = Error::spec_xdr();
     impl Error {
         pub const fn spec_xdr() -> [u8; 48usize] {
@@ -5866,6 +5876,7 @@ mod addcontract {
             ::core::option::Option::Some(::core::cmp::Ordering::Equal)
         }
     }
+    #[doc(hidden)]
     pub static __SPEC_XDR_TYPE_MYERROR: [u8; 48usize] = MyError::spec_xdr();
     impl MyError {
         pub const fn spec_xdr() -> [u8; 48usize] {
@@ -6009,6 +6020,7 @@ impl ::core::cmp::PartialEq for Error {
         __self_discr == __arg1_discr
     }
 }
+#[doc(hidden)]
 pub static __SPEC_XDR_TYPE_ERROR: [u8; 68usize] = Error::spec_xdr();
 impl Error {
     pub const fn spec_xdr() -> [u8; 68usize] {

--- a/tests-expanded/test_import_contract_wasm32v1-none.rs
+++ b/tests-expanded/test_import_contract_wasm32v1-none.rs
@@ -242,6 +242,7 @@ mod addcontract {
             }
         }
     }
+    #[doc(hidden)]
     #[link_section = "contractspecv0"]
     pub static __SPEC_XDR_TYPE_CONTRACTEXECUTABLEREF: [u8; 80usize] =
         ContractExecutableRef::spec_xdr();
@@ -407,6 +408,7 @@ mod addcontract {
             }
         }
     }
+    #[doc(hidden)]
     #[link_section = "contractspecv0"]
     pub static __SPEC_XDR_TYPE_CONTRACTCONTEXT: [u8; 96usize] = ContractContext::spec_xdr();
     impl ContractContext {
@@ -566,6 +568,7 @@ mod addcontract {
             }
         }
     }
+    #[doc(hidden)]
     #[link_section = "contractspecv0"]
     pub static __SPEC_XDR_TYPE_SUBCONTRACTINVOCATION: [u8; 144usize] =
         SubContractInvocation::spec_xdr();
@@ -716,6 +719,7 @@ mod addcontract {
             }
         }
     }
+    #[doc(hidden)]
     #[link_section = "contractspecv0"]
     pub static __SPEC_XDR_TYPE_CREATECONTRACTHOSTFNCONTEXT: [u8; 116usize] =
         CreateContractHostFnContext::spec_xdr();
@@ -886,6 +890,7 @@ mod addcontract {
             }
         }
     }
+    #[doc(hidden)]
     #[link_section = "contractspecv0"]
     pub static __SPEC_XDR_TYPE_CREATECONTRACTWITHCONSTRUCTORHOSTFNCONTEXT: [u8; 164usize] =
         CreateContractWithConstructorHostFnContext::spec_xdr();
@@ -1081,6 +1086,7 @@ mod addcontract {
             }
         }
     }
+    #[doc(hidden)]
     #[link_section = "contractspecv0"]
     pub static __SPEC_XDR_TYPE_CONTRACTEXECUTABLE: [u8; 128usize] = ContractExecutable::spec_xdr();
     impl ContractExecutable {
@@ -1313,6 +1319,7 @@ mod addcontract {
             }
         }
     }
+    #[doc(hidden)]
     #[link_section = "contractspecv0"]
     pub static __SPEC_XDR_TYPE_CONTEXT: [u8; 244usize] = Context::spec_xdr();
     impl Context {
@@ -1576,6 +1583,7 @@ mod addcontract {
             }
         }
     }
+    #[doc(hidden)]
     #[link_section = "contractspecv0"]
     pub static __SPEC_XDR_TYPE_INVOKERCONTRACTAUTHENTRY: [u8; 268usize] =
         InvokerContractAuthEntry::spec_xdr();
@@ -1790,6 +1798,7 @@ mod addcontract {
             }
         }
     }
+    #[doc(hidden)]
     #[link_section = "contractspecv0"]
     pub static __SPEC_XDR_TYPE_EXECUTABLE: [u8; 104usize] = Executable::spec_xdr();
     impl Executable {
@@ -1943,6 +1952,7 @@ mod addcontract {
             ::core::option::Option::Some(::core::cmp::Ordering::Equal)
         }
     }
+    #[doc(hidden)]
     #[link_section = "contractspecv0"]
     pub static __SPEC_XDR_TYPE_ERROR: [u8; 48usize] = Error::spec_xdr();
     impl Error {
@@ -2112,6 +2122,7 @@ mod addcontract {
             ::core::option::Option::Some(::core::cmp::Ordering::Equal)
         }
     }
+    #[doc(hidden)]
     #[link_section = "contractspecv0"]
     pub static __SPEC_XDR_TYPE_MYERROR: [u8; 48usize] = MyError::spec_xdr();
     impl MyError {
@@ -2261,6 +2272,7 @@ impl ::core::cmp::PartialEq for Error {
         __self_discr == __arg1_discr
     }
 }
+#[doc(hidden)]
 #[link_section = "contractspecv0"]
 pub static __SPEC_XDR_TYPE_ERROR: [u8; 68usize] = Error::spec_xdr();
 impl Error {

--- a/tests-expanded/test_spec_lib_tests.rs
+++ b/tests-expanded/test_spec_lib_tests.rs
@@ -47,6 +47,7 @@ impl ::core::cmp::PartialEq for StructA {
         self.f1 == other.f1 && self.f2 == other.f2
     }
 }
+#[doc(hidden)]
 pub static __SPEC_XDR_TYPE_STRUCTA: [u8; 60usize] = StructA::spec_xdr();
 impl StructA {
     pub const fn spec_xdr() -> [u8; 60usize] {
@@ -472,6 +473,7 @@ impl ::core::cmp::PartialEq for StructB {
         self.f1 == other.f1 && self.f2 == other.f2
     }
 }
+#[doc(hidden)]
 pub static __SPEC_XDR_TYPE_STRUCTB: [u8; 60usize] = StructB::spec_xdr();
 impl StructB {
     pub const fn spec_xdr() -> [u8; 60usize] {
@@ -897,6 +899,7 @@ impl ::core::cmp::PartialEq for StructC {
         self.f1 == other.f1 && self.f2 == other.f2
     }
 }
+#[doc(hidden)]
 pub static __SPEC_XDR_TYPE_STRUCTC: [u8; 64usize] = StructC::spec_xdr();
 impl StructC {
     pub const fn spec_xdr() -> [u8; 64usize] {
@@ -1318,6 +1321,7 @@ impl ::core::cmp::PartialEq for StructTupleA {
         self.0 == other.0 && self.1 == other.1
     }
 }
+#[doc(hidden)]
 pub static __SPEC_XDR_TYPE_STRUCTTUPLEA: [u8; 64usize] = StructTupleA::spec_xdr();
 impl StructTupleA {
     pub const fn spec_xdr() -> [u8; 64usize] {
@@ -1694,6 +1698,7 @@ impl ::core::cmp::PartialEq for StructTupleB {
         self.0 == other.0 && self.1 == other.1
     }
 }
+#[doc(hidden)]
 pub static __SPEC_XDR_TYPE_STRUCTTUPLEB: [u8; 64usize] = StructTupleB::spec_xdr();
 impl StructTupleB {
     pub const fn spec_xdr() -> [u8; 64usize] {
@@ -2071,6 +2076,7 @@ impl ::core::cmp::PartialEq for StructTupleC {
         self.1 == other.1 && self.0 == other.0
     }
 }
+#[doc(hidden)]
 pub static __SPEC_XDR_TYPE_STRUCTTUPLEC: [u8; 64usize] = StructTupleC::spec_xdr();
 impl StructTupleC {
     pub const fn spec_xdr() -> [u8; 64usize] {
@@ -2459,6 +2465,7 @@ impl ::core::cmp::PartialEq for EnumA {
         __self_discr == __arg1_discr
     }
 }
+#[doc(hidden)]
 pub static __SPEC_XDR_TYPE_ENUMA: [u8; 76usize] = EnumA::spec_xdr();
 impl EnumA {
     pub const fn spec_xdr() -> [u8; 76usize] {
@@ -2929,6 +2936,7 @@ impl ::core::cmp::PartialEq for EnumB {
             }
     }
 }
+#[doc(hidden)]
 pub static __SPEC_XDR_TYPE_ENUMB: [u8; 96usize] = EnumB::spec_xdr();
 impl EnumB {
     pub const fn spec_xdr() -> [u8; 96usize] {
@@ -3523,6 +3531,7 @@ impl ::core::cmp::PartialEq for EnumC {
             }
     }
 }
+#[doc(hidden)]
 pub static __SPEC_XDR_TYPE_ENUMC: [u8; 120usize] = EnumC::spec_xdr();
 impl EnumC {
     pub const fn spec_xdr() -> [u8; 120usize] {
@@ -4069,6 +4078,7 @@ impl ::core::cmp::PartialEq for EnumIntA {
         __self_discr == __arg1_discr
     }
 }
+#[doc(hidden)]
 pub static __SPEC_XDR_TYPE_ENUMINTA: [u8; 76usize] = EnumIntA::spec_xdr();
 impl EnumIntA {
     pub const fn spec_xdr() -> [u8; 76usize] {
@@ -4412,6 +4422,7 @@ impl ::core::cmp::PartialEq for EnumIntB {
         __self_discr == __arg1_discr
     }
 }
+#[doc(hidden)]
 pub static __SPEC_XDR_TYPE_ENUMINTB: [u8; 76usize] = EnumIntB::spec_xdr();
 impl EnumIntB {
     pub const fn spec_xdr() -> [u8; 76usize] {
@@ -4755,6 +4766,7 @@ impl ::core::cmp::PartialEq for EnumIntC {
         __self_discr == __arg1_discr
     }
 }
+#[doc(hidden)]
 pub static __SPEC_XDR_TYPE_ENUMINTC: [u8; 76usize] = EnumIntC::spec_xdr();
 impl EnumIntC {
     pub const fn spec_xdr() -> [u8; 76usize] {
@@ -5098,6 +5110,7 @@ impl ::core::cmp::PartialEq for ErrorA {
         __self_discr == __arg1_discr
     }
 }
+#[doc(hidden)]
 pub static __SPEC_XDR_TYPE_ERRORA: [u8; 76usize] = ErrorA::spec_xdr();
 impl ErrorA {
     pub const fn spec_xdr() -> [u8; 76usize] {
@@ -5266,6 +5279,7 @@ impl ::core::cmp::PartialEq for ErrorB {
         __self_discr == __arg1_discr
     }
 }
+#[doc(hidden)]
 pub static __SPEC_XDR_TYPE_ERRORB: [u8; 76usize] = ErrorB::spec_xdr();
 impl ErrorB {
     pub const fn spec_xdr() -> [u8; 76usize] {
@@ -5434,6 +5448,7 @@ impl ::core::cmp::PartialEq for ErrorC {
         __self_discr == __arg1_discr
     }
 }
+#[doc(hidden)]
 pub static __SPEC_XDR_TYPE_ERRORC: [u8; 76usize] = ErrorC::spec_xdr();
 impl ErrorC {
     pub const fn spec_xdr() -> [u8; 76usize] {
@@ -5598,6 +5613,7 @@ impl ::core::cmp::PartialEq for EventA {
         self.f1 == other.f1 && self.f2 == other.f2
     }
 }
+#[doc(hidden)]
 pub static __SPEC_XDR_EVENT_EVENTA: [u8; 88usize] = EventA::spec_xdr();
 impl EventA {
     pub const fn spec_xdr() -> [u8; 88usize] {
@@ -5687,6 +5703,7 @@ impl ::core::cmp::PartialEq for EventB {
         self.f3 == other.f3 && self.f1 == other.f1 && self.f2 == other.f2
     }
 }
+#[doc(hidden)]
 pub static __SPEC_XDR_EVENT_EVENTB: [u8; 108usize] = EventB::spec_xdr();
 impl EventB {
     pub const fn spec_xdr() -> [u8; 108usize] {
@@ -5781,6 +5798,7 @@ impl ::core::cmp::PartialEq for EventC {
         self.f2 == other.f2 && self.f3 == other.f3 && self.f1 == other.f1
     }
 }
+#[doc(hidden)]
 pub static __SPEC_XDR_EVENT_EVENTC: [u8; 108usize] = EventC::spec_xdr();
 impl EventC {
     pub const fn spec_xdr() -> [u8; 108usize] {
@@ -5858,6 +5876,7 @@ impl ::core::cmp::PartialEq for EventD {
         true
     }
 }
+#[doc(hidden)]
 pub static __SPEC_XDR_EVENT_EVENTD: [u8; 48usize] = EventD::spec_xdr();
 impl EventD {
     pub const fn spec_xdr() -> [u8; 48usize] {

--- a/tests-expanded/test_spec_lib_wasm32v1-none.rs
+++ b/tests-expanded/test_spec_lib_wasm32v1-none.rs
@@ -47,6 +47,7 @@ impl ::core::cmp::PartialEq for StructA {
         self.f1 == other.f1 && self.f2 == other.f2
     }
 }
+#[doc(hidden)]
 #[link_section = "contractspecv0"]
 pub static __SPEC_XDR_TYPE_STRUCTA: [u8; 60usize] = StructA::spec_xdr();
 impl StructA {
@@ -158,6 +159,7 @@ impl ::core::cmp::PartialEq for StructB {
         self.f1 == other.f1 && self.f2 == other.f2
     }
 }
+#[doc(hidden)]
 #[link_section = "contractspecv0"]
 pub static __SPEC_XDR_TYPE_STRUCTB: [u8; 60usize] = StructB::spec_xdr();
 impl StructB {
@@ -269,6 +271,7 @@ impl ::core::cmp::PartialEq for StructC {
         self.f1 == other.f1 && self.f2 == other.f2
     }
 }
+#[doc(hidden)]
 #[link_section = "contractspecv0"]
 pub static __SPEC_XDR_TYPE_STRUCTC: [u8; 64usize] = StructC::spec_xdr();
 impl StructC {
@@ -374,6 +377,7 @@ impl ::core::cmp::PartialEq for StructTupleA {
         self.0 == other.0 && self.1 == other.1
     }
 }
+#[doc(hidden)]
 #[link_section = "contractspecv0"]
 pub static __SPEC_XDR_TYPE_STRUCTTUPLEA: [u8; 64usize] = StructTupleA::spec_xdr();
 impl StructTupleA {
@@ -475,6 +479,7 @@ impl ::core::cmp::PartialEq for StructTupleB {
         self.0 == other.0 && self.1 == other.1
     }
 }
+#[doc(hidden)]
 #[link_section = "contractspecv0"]
 pub static __SPEC_XDR_TYPE_STRUCTTUPLEB: [u8; 64usize] = StructTupleB::spec_xdr();
 impl StructTupleB {
@@ -577,6 +582,7 @@ impl ::core::cmp::PartialEq for StructTupleC {
         self.1 == other.1 && self.0 == other.0
     }
 }
+#[doc(hidden)]
 #[link_section = "contractspecv0"]
 pub static __SPEC_XDR_TYPE_STRUCTTUPLEC: [u8; 64usize] = StructTupleC::spec_xdr();
 impl StructTupleC {
@@ -690,6 +696,7 @@ impl ::core::cmp::PartialEq for EnumA {
         __self_discr == __arg1_discr
     }
 }
+#[doc(hidden)]
 #[link_section = "contractspecv0"]
 pub static __SPEC_XDR_TYPE_ENUMA: [u8; 76usize] = EnumA::spec_xdr();
 impl EnumA {
@@ -847,6 +854,7 @@ impl ::core::cmp::PartialEq for EnumB {
             }
     }
 }
+#[doc(hidden)]
 #[link_section = "contractspecv0"]
 pub static __SPEC_XDR_TYPE_ENUMB: [u8; 96usize] = EnumB::spec_xdr();
 impl EnumB {
@@ -1017,6 +1025,7 @@ impl ::core::cmp::PartialEq for EnumC {
             }
     }
 }
+#[doc(hidden)]
 #[link_section = "contractspecv0"]
 pub static __SPEC_XDR_TYPE_ENUMC: [u8; 120usize] = EnumC::spec_xdr();
 impl EnumC {
@@ -1173,6 +1182,7 @@ impl ::core::cmp::PartialEq for EnumIntA {
         __self_discr == __arg1_discr
     }
 }
+#[doc(hidden)]
 #[link_section = "contractspecv0"]
 pub static __SPEC_XDR_TYPE_ENUMINTA: [u8; 76usize] = EnumIntA::spec_xdr();
 impl EnumIntA {
@@ -1277,6 +1287,7 @@ impl ::core::cmp::PartialEq for EnumIntB {
         __self_discr == __arg1_discr
     }
 }
+#[doc(hidden)]
 #[link_section = "contractspecv0"]
 pub static __SPEC_XDR_TYPE_ENUMINTB: [u8; 76usize] = EnumIntB::spec_xdr();
 impl EnumIntB {
@@ -1381,6 +1392,7 @@ impl ::core::cmp::PartialEq for EnumIntC {
         __self_discr == __arg1_discr
     }
 }
+#[doc(hidden)]
 #[link_section = "contractspecv0"]
 pub static __SPEC_XDR_TYPE_ENUMINTC: [u8; 76usize] = EnumIntC::spec_xdr();
 impl EnumIntC {
@@ -1485,6 +1497,7 @@ impl ::core::cmp::PartialEq for ErrorA {
         __self_discr == __arg1_discr
     }
 }
+#[doc(hidden)]
 #[link_section = "contractspecv0"]
 pub static __SPEC_XDR_TYPE_ERRORA: [u8; 76usize] = ErrorA::spec_xdr();
 impl ErrorA {
@@ -1659,6 +1672,7 @@ impl ::core::cmp::PartialEq for ErrorB {
         __self_discr == __arg1_discr
     }
 }
+#[doc(hidden)]
 #[link_section = "contractspecv0"]
 pub static __SPEC_XDR_TYPE_ERRORB: [u8; 76usize] = ErrorB::spec_xdr();
 impl ErrorB {
@@ -1833,6 +1847,7 @@ impl ::core::cmp::PartialEq for ErrorC {
         __self_discr == __arg1_discr
     }
 }
+#[doc(hidden)]
 #[link_section = "contractspecv0"]
 pub static __SPEC_XDR_TYPE_ERRORC: [u8; 76usize] = ErrorC::spec_xdr();
 impl ErrorC {
@@ -2003,6 +2018,7 @@ impl ::core::cmp::PartialEq for EventA {
         self.f1 == other.f1 && self.f2 == other.f2
     }
 }
+#[doc(hidden)]
 #[link_section = "contractspecv0"]
 pub static __SPEC_XDR_EVENT_EVENTA: [u8; 88usize] = EventA::spec_xdr();
 impl EventA {
@@ -2097,6 +2113,7 @@ impl ::core::cmp::PartialEq for EventB {
         self.f3 == other.f3 && self.f1 == other.f1 && self.f2 == other.f2
     }
 }
+#[doc(hidden)]
 #[link_section = "contractspecv0"]
 pub static __SPEC_XDR_EVENT_EVENTB: [u8; 108usize] = EventB::spec_xdr();
 impl EventB {
@@ -2196,6 +2213,7 @@ impl ::core::cmp::PartialEq for EventC {
         self.f2 == other.f2 && self.f3 == other.f3 && self.f1 == other.f1
     }
 }
+#[doc(hidden)]
 #[link_section = "contractspecv0"]
 pub static __SPEC_XDR_EVENT_EVENTC: [u8; 108usize] = EventC::spec_xdr();
 impl EventC {
@@ -2278,6 +2296,7 @@ impl ::core::cmp::PartialEq for EventD {
         true
     }
 }
+#[doc(hidden)]
 #[link_section = "contractspecv0"]
 pub static __SPEC_XDR_EVENT_EVENTD: [u8; 48usize] = EventD::spec_xdr();
 impl EventD {

--- a/tests-expanded/test_spec_shaking_v2_tests.rs
+++ b/tests-expanded/test_spec_shaking_v2_tests.rs
@@ -186,6 +186,7 @@ impl ::core::cmp::PartialEq for UsedParamStruct {
         self.a == other.a && self.nested == other.nested
     }
 }
+#[doc(hidden)]
 pub static __SPEC_XDR_TYPE_USEDPARAMSTRUCT: [u8; 96usize] = UsedParamStruct::spec_xdr();
 impl UsedParamStruct {
     pub const fn spec_xdr() -> [u8; 96usize] {
@@ -630,6 +631,7 @@ impl ::core::cmp::PartialEq for UsedReturnEnum {
             }
     }
 }
+#[doc(hidden)]
 pub static __SPEC_XDR_TYPE_USEDRETURNENUM: [u8; 84usize] = UsedReturnEnum::spec_xdr();
 impl UsedReturnEnum {
     pub const fn spec_xdr() -> [u8; 84usize] {
@@ -1146,6 +1148,7 @@ impl ::core::cmp::PartialEq for UsedParamIntEnum {
         __self_discr == __arg1_discr
     }
 }
+#[doc(hidden)]
 pub static __SPEC_XDR_TYPE_USEDPARAMINTENUM: [u8; 68usize] = UsedParamIntEnum::spec_xdr();
 impl UsedParamIntEnum {
     pub const fn spec_xdr() -> [u8; 68usize] {
@@ -1477,6 +1480,7 @@ impl ::core::cmp::PartialEq for UsedErrorEnum {
         __self_discr == __arg1_discr
     }
 }
+#[doc(hidden)]
 pub static __SPEC_XDR_TYPE_USEDERRORENUM: [u8; 76usize] = UsedErrorEnum::spec_xdr();
 impl UsedErrorEnum {
     pub const fn spec_xdr() -> [u8; 76usize] {
@@ -1630,6 +1634,7 @@ impl ::core::cmp::PartialEq for UsedPanicErrorEnum {
         true
     }
 }
+#[doc(hidden)]
 pub static __SPEC_XDR_TYPE_USEDPANICERRORENUM: [u8; 56usize] = UsedPanicErrorEnum::spec_xdr();
 impl UsedPanicErrorEnum {
     pub const fn spec_xdr() -> [u8; 56usize] {
@@ -1781,6 +1786,7 @@ impl ::core::cmp::PartialEq for UsedAssertErrorEnum {
         true
     }
 }
+#[doc(hidden)]
 pub static __SPEC_XDR_TYPE_USEDASSERTERRORENUM: [u8; 56usize] = UsedAssertErrorEnum::spec_xdr();
 impl UsedAssertErrorEnum {
     pub const fn spec_xdr() -> [u8; 56usize] {
@@ -1939,6 +1945,7 @@ impl ::core::cmp::PartialEq for UsedNestedInStruct {
         self.val == other.val
     }
 }
+#[doc(hidden)]
 pub static __SPEC_XDR_TYPE_USEDNESTEDINSTRUCT: [u8; 56usize] = UsedNestedInStruct::spec_xdr();
 impl UsedNestedInStruct {
     pub const fn spec_xdr() -> [u8; 56usize] {
@@ -2311,6 +2318,7 @@ impl ::core::cmp::PartialEq for UsedVecElement {
         self.data == other.data
     }
 }
+#[doc(hidden)]
 pub static __SPEC_XDR_TYPE_USEDVECELEMENT: [u8; 52usize] = UsedVecElement::spec_xdr();
 impl UsedVecElement {
     pub const fn spec_xdr() -> [u8; 52usize] {
@@ -2688,6 +2696,7 @@ impl ::core::cmp::PartialEq for UsedMapKey {
         __self_discr == __arg1_discr
     }
 }
+#[doc(hidden)]
 pub static __SPEC_XDR_TYPE_USEDMAPKEY: [u8; 64usize] = UsedMapKey::spec_xdr();
 impl UsedMapKey {
     pub const fn spec_xdr() -> [u8; 64usize] {
@@ -3010,6 +3019,7 @@ impl ::core::cmp::PartialEq for UsedMapVal {
         self.v == other.v
     }
 }
+#[doc(hidden)]
 pub static __SPEC_XDR_TYPE_USEDMAPVAL: [u8; 48usize] = UsedMapVal::spec_xdr();
 impl UsedMapVal {
     pub const fn spec_xdr() -> [u8; 48usize] {
@@ -3381,6 +3391,7 @@ impl ::core::cmp::PartialEq for UsedOptionElement {
         self.data == other.data
     }
 }
+#[doc(hidden)]
 pub static __SPEC_XDR_TYPE_USEDOPTIONELEMENT: [u8; 56usize] = UsedOptionElement::spec_xdr();
 impl UsedOptionElement {
     pub const fn spec_xdr() -> [u8; 56usize] {
@@ -3751,6 +3762,7 @@ impl ::core::cmp::PartialEq for UsedResultOk {
         self.data == other.data
     }
 }
+#[doc(hidden)]
 pub static __SPEC_XDR_TYPE_USEDRESULTOK: [u8; 48usize] = UsedResultOk::spec_xdr();
 impl UsedResultOk {
     pub const fn spec_xdr() -> [u8; 48usize] {
@@ -4129,6 +4141,7 @@ impl ::core::cmp::PartialEq for UsedEventSimple {
         self.amount == other.amount && self.kind == other.kind
     }
 }
+#[doc(hidden)]
 pub static __SPEC_XDR_EVENT_USEDEVENTSIMPLE: [u8; 112usize] = UsedEventSimple::spec_xdr();
 impl UsedEventSimple {
     pub const fn spec_xdr() -> [u8; 112usize] {
@@ -4211,6 +4224,7 @@ impl ::core::cmp::PartialEq for UsedEventTopicType {
         __self_discr == __arg1_discr
     }
 }
+#[doc(hidden)]
 pub static __SPEC_XDR_TYPE_USEDEVENTTOPICTYPE: [u8; 76usize] = UsedEventTopicType::spec_xdr();
 impl UsedEventTopicType {
     pub const fn spec_xdr() -> [u8; 76usize] {
@@ -4547,6 +4561,7 @@ impl ::core::cmp::PartialEq for UsedEventWithTopicType {
         self.amount == other.amount && self.kind == other.kind
     }
 }
+#[doc(hidden)]
 pub static __SPEC_XDR_EVENT_USEDEVENTWITHTOPICTYPE: [u8; 152usize] =
     UsedEventWithTopicType::spec_xdr();
 impl UsedEventWithTopicType {
@@ -4635,6 +4650,7 @@ impl ::core::cmp::PartialEq for UsedEventDataType {
         self.x == other.x && self.y == other.y
     }
 }
+#[doc(hidden)]
 pub static __SPEC_XDR_TYPE_USEDEVENTDATATYPE: [u8; 72usize] = UsedEventDataType::spec_xdr();
 impl UsedEventDataType {
     pub const fn spec_xdr() -> [u8; 72usize] {
@@ -5067,6 +5083,7 @@ impl ::core::cmp::PartialEq for UsedEventWithDataType {
         self.kind == other.kind && self.payload == other.payload
     }
 }
+#[doc(hidden)]
 pub static __SPEC_XDR_EVENT_USEDEVENTWITHDATATYPE: [u8; 152usize] =
     UsedEventWithDataType::spec_xdr();
 impl UsedEventWithDataType {
@@ -5151,6 +5168,7 @@ impl ::core::cmp::PartialEq for UsedEventTopicOuter {
         self.inner == other.inner
     }
 }
+#[doc(hidden)]
 pub static __SPEC_XDR_TYPE_USEDEVENTTOPICOUTER: [u8; 84usize] = UsedEventTopicOuter::spec_xdr();
 impl UsedEventTopicOuter {
     pub const fn spec_xdr() -> [u8; 84usize] {
@@ -5533,6 +5551,7 @@ impl ::core::cmp::PartialEq for UsedEventTopicInner {
         self.val == other.val
     }
 }
+#[doc(hidden)]
 pub static __SPEC_XDR_TYPE_USEDEVENTTOPICINNER: [u8; 56usize] = UsedEventTopicInner::spec_xdr();
 impl UsedEventTopicInner {
     pub const fn spec_xdr() -> [u8; 56usize] {
@@ -5917,6 +5936,7 @@ impl ::core::cmp::PartialEq for UsedEventWithNestedTopic {
         self.amount == other.amount && self.info == other.info
     }
 }
+#[doc(hidden)]
 pub static __SPEC_XDR_EVENT_USEDEVENTWITHNESTEDTOPIC: [u8; 152usize] =
     UsedEventWithNestedTopic::spec_xdr();
 impl UsedEventWithNestedTopic {
@@ -6001,6 +6021,7 @@ impl ::core::cmp::PartialEq for UsedEventDataOuter {
         self.inner == other.inner
     }
 }
+#[doc(hidden)]
 pub static __SPEC_XDR_TYPE_USEDEVENTDATAOUTER: [u8; 84usize] = UsedEventDataOuter::spec_xdr();
 impl UsedEventDataOuter {
     pub const fn spec_xdr() -> [u8; 84usize] {
@@ -6381,6 +6402,7 @@ impl ::core::cmp::PartialEq for UsedEventDataInner {
         self.val == other.val
     }
 }
+#[doc(hidden)]
 pub static __SPEC_XDR_TYPE_USEDEVENTDATAINNER: [u8; 56usize] = UsedEventDataInner::spec_xdr();
 impl UsedEventDataInner {
     pub const fn spec_xdr() -> [u8; 56usize] {
@@ -6763,6 +6785,7 @@ impl ::core::cmp::PartialEq for UsedEventWithNestedData {
         self.kind == other.kind && self.payload == other.payload
     }
 }
+#[doc(hidden)]
 pub static __SPEC_XDR_EVENT_USEDEVENTWITHNESTEDDATA: [u8; 152usize] =
     UsedEventWithNestedData::spec_xdr();
 impl UsedEventWithNestedData {
@@ -6849,6 +6872,7 @@ impl ::core::cmp::PartialEq for UsedRefTopicType {
         __self_discr == __arg1_discr
     }
 }
+#[doc(hidden)]
 pub static __SPEC_XDR_TYPE_USEDREFTOPICTYPE: [u8; 68usize] = UsedRefTopicType::spec_xdr();
 impl UsedRefTopicType {
     pub const fn spec_xdr() -> [u8; 68usize] {
@@ -7178,6 +7202,7 @@ impl ::core::cmp::PartialEq for UsedRefDataType {
         self.nested == other.nested
     }
 }
+#[doc(hidden)]
 pub static __SPEC_XDR_TYPE_USEDREFDATATYPE: [u8; 76usize] = UsedRefDataType::spec_xdr();
 impl UsedRefDataType {
     pub const fn spec_xdr() -> [u8; 76usize] {
@@ -7551,6 +7576,7 @@ impl ::core::cmp::PartialEq for UsedRefDataInner {
         self.val == other.val
     }
 }
+#[doc(hidden)]
 pub static __SPEC_XDR_TYPE_USEDREFDATAINNER: [u8; 52usize] = UsedRefDataInner::spec_xdr();
 impl UsedRefDataInner {
     pub const fn spec_xdr() -> [u8; 52usize] {
@@ -7931,6 +7957,7 @@ impl<'a> ::core::cmp::PartialEq for UsedEventWithRefs<'a> {
         self.kind == other.kind && self.payload == other.payload
     }
 }
+#[doc(hidden)]
 pub static __SPEC_XDR_EVENT_USEDEVENTWITHREFS: [u8; 156usize] = UsedEventWithRefs::spec_xdr();
 impl<'a> UsedEventWithRefs<'a> {
     pub const fn spec_xdr() -> [u8; 156usize] {
@@ -8009,6 +8036,7 @@ impl ::core::cmp::PartialEq for UsedTupleElement {
         self.val == other.val
     }
 }
+#[doc(hidden)]
 pub static __SPEC_XDR_TYPE_USEDTUPLEELEMENT: [u8; 52usize] = UsedTupleElement::spec_xdr();
 impl UsedTupleElement {
     pub const fn spec_xdr() -> [u8; 52usize] {
@@ -8384,6 +8412,7 @@ impl ::core::cmp::PartialEq for UsedTupleReturnElement {
         self.val == other.val
     }
 }
+#[doc(hidden)]
 pub static __SPEC_XDR_TYPE_USEDTUPLERETURNELEMENT: [u8; 60usize] =
     UsedTupleReturnElement::spec_xdr();
 impl UsedTupleReturnElement {
@@ -8764,6 +8793,7 @@ impl ::core::cmp::PartialEq for UsedVecInnerVecElement {
         self.val == other.val
     }
 }
+#[doc(hidden)]
 pub static __SPEC_XDR_TYPE_USEDVECINNERVECELEMENT: [u8; 60usize] =
     UsedVecInnerVecElement::spec_xdr();
 impl UsedVecInnerVecElement {
@@ -9144,6 +9174,7 @@ impl ::core::cmp::PartialEq for UsedVecInnerElement {
         self.val == other.val
     }
 }
+#[doc(hidden)]
 pub static __SPEC_XDR_TYPE_USEDVECINNERELEMENT: [u8; 56usize] = UsedVecInnerElement::spec_xdr();
 impl UsedVecInnerElement {
     pub const fn spec_xdr() -> [u8; 56usize] {
@@ -9533,6 +9564,7 @@ impl ::core::cmp::PartialEq for UsedVecElementNested {
         self.val == other.val && self.inner == other.inner && self.vec_inner == other.vec_inner
     }
 }
+#[doc(hidden)]
 pub static __SPEC_XDR_TYPE_USEDVECELEMENTNESTED: [u8; 156usize] = UsedVecElementNested::spec_xdr();
 impl UsedVecElementNested {
     pub const fn spec_xdr() -> [u8; 156usize] {
@@ -10031,6 +10063,7 @@ impl ::core::cmp::PartialEq for UsedNonPubStruct {
         self.val == other.val
     }
 }
+#[doc(hidden)]
 pub static __SPEC_XDR_TYPE_USEDNONPUBSTRUCT: [u8; 52usize] = UsedNonPubStruct::spec_xdr();
 impl UsedNonPubStruct {
     pub const fn spec_xdr() -> [u8; 52usize] {
@@ -10399,6 +10432,7 @@ impl ::core::cmp::PartialEq for UsedNonPubError {
         true
     }
 }
+#[doc(hidden)]
 pub static __SPEC_XDR_TYPE_USEDNONPUBERROR: [u8; 52usize] = UsedNonPubError::spec_xdr();
 impl UsedNonPubError {
     pub const fn spec_xdr() -> [u8; 52usize] {
@@ -10555,6 +10589,7 @@ impl ::core::cmp::PartialEq for UsedRecursiveRoot {
         self.val == other.val
     }
 }
+#[doc(hidden)]
 pub static __SPEC_XDR_TYPE_USEDRECURSIVEROOT: [u8; 80usize] = UsedRecursiveRoot::spec_xdr();
 impl UsedRecursiveRoot {
     pub const fn spec_xdr() -> [u8; 80usize] {
@@ -10952,6 +10987,7 @@ impl ::core::cmp::PartialEq for UsedRecursiveNode {
             }
     }
 }
+#[doc(hidden)]
 pub static __SPEC_XDR_TYPE_USEDRECURSIVENODE: [u8; 140usize] = UsedRecursiveNode::spec_xdr();
 impl UsedRecursiveNode {
     pub const fn spec_xdr() -> [u8; 140usize] {
@@ -11476,6 +11512,7 @@ impl ::core::cmp::PartialEq for UsedRecursiveLeaf {
         self.val == other.val
     }
 }
+#[doc(hidden)]
 pub static __SPEC_XDR_TYPE_USEDRECURSIVELEAF: [u8; 84usize] = UsedRecursiveLeaf::spec_xdr();
 impl UsedRecursiveLeaf {
     pub const fn spec_xdr() -> [u8; 84usize] {
@@ -11852,6 +11889,7 @@ impl ::core::cmp::PartialEq for UsedLeaf {
         self.val == other.val
     }
 }
+#[doc(hidden)]
 pub static __SPEC_XDR_TYPE_USEDLEAF: [u8; 44usize] = UsedLeaf::spec_xdr();
 impl UsedLeaf {
     pub const fn spec_xdr() -> [u8; 44usize] {
@@ -12951,6 +12989,7 @@ mod wasm_imported {
             }
         }
     }
+    #[doc(hidden)]
     pub static __SPEC_XDR_TYPE_CONTRACTEXECUTABLEREF: [u8; 80usize] =
         ContractExecutableRef::spec_xdr();
     impl ContractExecutableRef {
@@ -13440,6 +13479,7 @@ mod wasm_imported {
             }
         }
     }
+    #[doc(hidden)]
     pub static __SPEC_XDR_TYPE_CONTRACTCONTEXT: [u8; 96usize] = ContractContext::spec_xdr();
     impl ContractContext {
         pub const fn spec_xdr() -> [u8; 96usize] {
@@ -13983,6 +14023,7 @@ mod wasm_imported {
             }
         }
     }
+    #[doc(hidden)]
     pub static __SPEC_XDR_TYPE_SUBCONTRACTINVOCATION: [u8; 144usize] =
         SubContractInvocation::spec_xdr();
     impl SubContractInvocation {
@@ -14468,6 +14509,7 @@ mod wasm_imported {
             }
         }
     }
+    #[doc(hidden)]
     pub static __SPEC_XDR_TYPE_CREATECONTRACTHOSTFNCONTEXT: [u8; 116usize] =
         CreateContractHostFnContext::spec_xdr();
     impl CreateContractHostFnContext {
@@ -14972,6 +15014,7 @@ mod wasm_imported {
             }
         }
     }
+    #[doc(hidden)]
     pub static __SPEC_XDR_TYPE_CREATECONTRACTWITHCONSTRUCTORHOSTFNCONTEXT: [u8; 164usize] =
         CreateContractWithConstructorHostFnContext::spec_xdr();
     impl CreateContractWithConstructorHostFnContext {
@@ -15552,6 +15595,7 @@ mod wasm_imported {
             }
         }
     }
+    #[doc(hidden)]
     pub static __SPEC_XDR_TYPE_STRUCTA: [u8; 60usize] = StructA::spec_xdr();
     impl StructA {
         pub const fn spec_xdr() -> [u8; 60usize] {
@@ -16001,6 +16045,7 @@ mod wasm_imported {
             }
         }
     }
+    #[doc(hidden)]
     pub static __SPEC_XDR_TYPE_STRUCTB: [u8; 60usize] = StructB::spec_xdr();
     impl StructB {
         pub const fn spec_xdr() -> [u8; 60usize] {
@@ -16450,6 +16495,7 @@ mod wasm_imported {
             }
         }
     }
+    #[doc(hidden)]
     pub static __SPEC_XDR_TYPE_STRUCTC: [u8; 64usize] = StructC::spec_xdr();
     impl StructC {
         pub const fn spec_xdr() -> [u8; 64usize] {
@@ -16902,6 +16948,7 @@ mod wasm_imported {
             }
         }
     }
+    #[doc(hidden)]
     pub static __SPEC_XDR_TYPE_STRUCTTUPLEA: [u8; 64usize] = StructTupleA::spec_xdr();
     impl StructTupleA {
         pub const fn spec_xdr() -> [u8; 64usize] {
@@ -17307,6 +17354,7 @@ mod wasm_imported {
             }
         }
     }
+    #[doc(hidden)]
     pub static __SPEC_XDR_TYPE_STRUCTTUPLEB: [u8; 64usize] = StructTupleB::spec_xdr();
     impl StructTupleB {
         pub const fn spec_xdr() -> [u8; 64usize] {
@@ -17713,6 +17761,7 @@ mod wasm_imported {
             }
         }
     }
+    #[doc(hidden)]
     pub static __SPEC_XDR_TYPE_STRUCTTUPLEC: [u8; 64usize] = StructTupleC::spec_xdr();
     impl StructTupleC {
         pub const fn spec_xdr() -> [u8; 64usize] {
@@ -18162,6 +18211,7 @@ mod wasm_imported {
             }
         }
     }
+    #[doc(hidden)]
     pub static __SPEC_XDR_TYPE_CONTRACTEXECUTABLE: [u8; 128usize] = ContractExecutable::spec_xdr();
     impl ContractExecutable {
         pub const fn spec_xdr() -> [u8; 128usize] {
@@ -18797,6 +18847,7 @@ mod wasm_imported {
             }
         }
     }
+    #[doc(hidden)]
     pub static __SPEC_XDR_TYPE_CONTEXT: [u8; 244usize] = Context::spec_xdr();
     impl Context {
         pub const fn spec_xdr() -> [u8; 244usize] {
@@ -19525,6 +19576,7 @@ mod wasm_imported {
             }
         }
     }
+    #[doc(hidden)]
     pub static __SPEC_XDR_TYPE_INVOKERCONTRACTAUTHENTRY: [u8; 268usize] =
         InvokerContractAuthEntry::spec_xdr();
     impl InvokerContractAuthEntry {
@@ -20230,6 +20282,7 @@ mod wasm_imported {
             }
         }
     }
+    #[doc(hidden)]
     pub static __SPEC_XDR_TYPE_EXECUTABLE: [u8; 104usize] = Executable::spec_xdr();
     impl Executable {
         pub const fn spec_xdr() -> [u8; 104usize] {
@@ -20780,6 +20833,7 @@ mod wasm_imported {
             ::core::cmp::PartialOrd::partial_cmp(&__self_discr, &__arg1_discr)
         }
     }
+    #[doc(hidden)]
     pub static __SPEC_XDR_TYPE_ENUMA: [u8; 76usize] = EnumA::spec_xdr();
     impl EnumA {
         pub const fn spec_xdr() -> [u8; 76usize] {
@@ -21302,6 +21356,7 @@ mod wasm_imported {
             }
         }
     }
+    #[doc(hidden)]
     pub static __SPEC_XDR_TYPE_ENUMB: [u8; 96usize] = EnumB::spec_xdr();
     impl EnumB {
         pub const fn spec_xdr() -> [u8; 96usize] {
@@ -21942,6 +21997,7 @@ mod wasm_imported {
             }
         }
     }
+    #[doc(hidden)]
     pub static __SPEC_XDR_TYPE_ENUMC: [u8; 120usize] = EnumC::spec_xdr();
     impl EnumC {
         pub const fn spec_xdr() -> [u8; 120usize] {
@@ -22511,6 +22567,7 @@ mod wasm_imported {
             ::core::cmp::PartialOrd::partial_cmp(&__self_discr, &__arg1_discr)
         }
     }
+    #[doc(hidden)]
     pub static __SPEC_XDR_TYPE_ENUMINTA: [u8; 76usize] = EnumIntA::spec_xdr();
     impl EnumIntA {
         pub const fn spec_xdr() -> [u8; 76usize] {
@@ -22876,6 +22933,7 @@ mod wasm_imported {
             ::core::cmp::PartialOrd::partial_cmp(&__self_discr, &__arg1_discr)
         }
     }
+    #[doc(hidden)]
     pub static __SPEC_XDR_TYPE_ENUMINTB: [u8; 76usize] = EnumIntB::spec_xdr();
     impl EnumIntB {
         pub const fn spec_xdr() -> [u8; 76usize] {
@@ -23241,6 +23299,7 @@ mod wasm_imported {
             ::core::cmp::PartialOrd::partial_cmp(&__self_discr, &__arg1_discr)
         }
     }
+    #[doc(hidden)]
     pub static __SPEC_XDR_TYPE_ENUMINTC: [u8; 76usize] = EnumIntC::spec_xdr();
     impl EnumIntC {
         pub const fn spec_xdr() -> [u8; 76usize] {
@@ -23606,6 +23665,7 @@ mod wasm_imported {
             ::core::cmp::PartialOrd::partial_cmp(&__self_discr, &__arg1_discr)
         }
     }
+    #[doc(hidden)]
     pub static __SPEC_XDR_TYPE_ERRORA: [u8; 76usize] = ErrorA::spec_xdr();
     impl ErrorA {
         pub const fn spec_xdr() -> [u8; 76usize] {
@@ -23792,6 +23852,7 @@ mod wasm_imported {
             ::core::cmp::PartialOrd::partial_cmp(&__self_discr, &__arg1_discr)
         }
     }
+    #[doc(hidden)]
     pub static __SPEC_XDR_TYPE_ERRORB: [u8; 76usize] = ErrorB::spec_xdr();
     impl ErrorB {
         pub const fn spec_xdr() -> [u8; 76usize] {
@@ -23978,6 +24039,7 @@ mod wasm_imported {
             ::core::cmp::PartialOrd::partial_cmp(&__self_discr, &__arg1_discr)
         }
     }
+    #[doc(hidden)]
     pub static __SPEC_XDR_TYPE_ERRORC: [u8; 76usize] = ErrorC::spec_xdr();
     impl ErrorC {
         pub const fn spec_xdr() -> [u8; 76usize] {
@@ -24164,6 +24226,7 @@ mod wasm_imported {
             }
         }
     }
+    #[doc(hidden)]
     pub static __SPEC_XDR_EVENT_EVENTA: [u8; 88usize] = EventA::spec_xdr();
     impl EventA {
         pub const fn spec_xdr() -> [u8; 88usize] {
@@ -24284,6 +24347,7 @@ mod wasm_imported {
             }
         }
     }
+    #[doc(hidden)]
     pub static __SPEC_XDR_EVENT_EVENTB: [u8; 108usize] = EventB::spec_xdr();
     impl EventB {
         pub const fn spec_xdr() -> [u8; 108usize] {
@@ -24408,6 +24472,7 @@ mod wasm_imported {
             }
         }
     }
+    #[doc(hidden)]
     pub static __SPEC_XDR_EVENT_EVENTC: [u8; 108usize] = EventC::spec_xdr();
     impl EventC {
         pub const fn spec_xdr() -> [u8; 108usize] {
@@ -24499,6 +24564,7 @@ mod wasm_imported {
             ::core::option::Option::Some(::core::cmp::Ordering::Equal)
         }
     }
+    #[doc(hidden)]
     pub static __SPEC_XDR_EVENT_EVENTD: [u8; 48usize] = EventD::spec_xdr();
     impl EventD {
         pub const fn spec_xdr() -> [u8; 48usize] {
@@ -24573,6 +24639,7 @@ impl ::core::cmp::PartialEq for UnusedStruct {
         self.x == other.x
     }
 }
+#[doc(hidden)]
 pub static __SPEC_XDR_TYPE_UNUSEDSTRUCT: [u8; 48usize] = UnusedStruct::spec_xdr();
 impl UnusedStruct {
     pub const fn spec_xdr() -> [u8; 48usize] {
@@ -24952,6 +25019,7 @@ impl ::core::cmp::PartialEq for UnusedEnum {
             }
     }
 }
+#[doc(hidden)]
 pub static __SPEC_XDR_TYPE_UNUSEDENUM: [u8; 72usize] = UnusedEnum::spec_xdr();
 impl UnusedEnum {
     pub const fn spec_xdr() -> [u8; 72usize] {
@@ -25422,6 +25490,7 @@ impl ::core::cmp::PartialEq for UnusedIntEnum {
         __self_discr == __arg1_discr
     }
 }
+#[doc(hidden)]
 pub static __SPEC_XDR_TYPE_UNUSEDINTENUM: [u8; 68usize] = UnusedIntEnum::spec_xdr();
 impl UnusedIntEnum {
     pub const fn spec_xdr() -> [u8; 68usize] {
@@ -25756,6 +25825,7 @@ impl ::core::cmp::PartialEq for UnusedEvent {
         self.data == other.data && self.kind == other.kind
     }
 }
+#[doc(hidden)]
 pub static __SPEC_XDR_EVENT_UNUSEDEVENT: [u8; 96usize] = UnusedEvent::spec_xdr();
 impl UnusedEvent {
     pub const fn spec_xdr() -> [u8; 96usize] {
@@ -25829,6 +25899,7 @@ impl ::core::cmp::PartialEq for UnusedPubError {
         true
     }
 }
+#[doc(hidden)]
 pub static __SPEC_XDR_TYPE_UNUSEDPUBERROR: [u8; 52usize] = UnusedPubError::spec_xdr();
 impl UnusedPubError {
     pub const fn spec_xdr() -> [u8; 52usize] {
@@ -25985,6 +26056,7 @@ impl ::core::cmp::PartialEq for UnusedNonContractFnParam {
         self.x == other.x
     }
 }
+#[doc(hidden)]
 pub static __SPEC_XDR_TYPE_UNUSEDNONCONTRACTFNPARAM: [u8; 60usize] =
     UnusedNonContractFnParam::spec_xdr();
 impl UnusedNonContractFnParam {
@@ -26367,6 +26439,7 @@ impl ::core::cmp::PartialEq for UnusedNonContractFnReturn {
         self.x == other.x
     }
 }
+#[doc(hidden)]
 pub static __SPEC_XDR_TYPE_UNUSEDNONCONTRACTFNRETURN: [u8; 64usize] =
     UnusedNonContractFnReturn::spec_xdr();
 impl UnusedNonContractFnReturn {
@@ -26744,6 +26817,7 @@ impl ::core::cmp::PartialEq for UnusedNonPubStruct {
         self.x == other.x
     }
 }
+#[doc(hidden)]
 pub static __SPEC_XDR_TYPE_UNUSEDNONPUBSTRUCT: [u8; 56usize] = UnusedNonPubStruct::spec_xdr();
 impl UnusedNonPubStruct {
     pub const fn spec_xdr() -> [u8; 56usize] {
@@ -27112,6 +27186,7 @@ impl ::core::cmp::PartialEq for UnusedNonPubError {
         true
     }
 }
+#[doc(hidden)]
 pub static __SPEC_XDR_TYPE_UNUSEDNONPUBERROR: [u8; 56usize] = UnusedNonPubError::spec_xdr();
 impl UnusedNonPubError {
     pub const fn spec_xdr() -> [u8; 56usize] {

--- a/tests-expanded/test_spec_shaking_v2_wasm32v1-none.rs
+++ b/tests-expanded/test_spec_shaking_v2_wasm32v1-none.rs
@@ -74,6 +74,7 @@ impl ::core::cmp::PartialEq for UsedParamStruct {
         self.a == other.a && self.nested == other.nested
     }
 }
+#[doc(hidden)]
 #[link_section = "contractspecv0"]
 pub static __SPEC_XDR_TYPE_USEDPARAMSTRUCT: [u8; 96usize] = UsedParamStruct::spec_xdr();
 impl UsedParamStruct {
@@ -199,6 +200,7 @@ impl ::core::cmp::PartialEq for UsedReturnEnum {
             }
     }
 }
+#[doc(hidden)]
 #[link_section = "contractspecv0"]
 pub static __SPEC_XDR_TYPE_USEDRETURNENUM: [u8; 84usize] = UsedReturnEnum::spec_xdr();
 impl UsedReturnEnum {
@@ -342,6 +344,7 @@ impl ::core::cmp::PartialEq for UsedParamIntEnum {
         __self_discr == __arg1_discr
     }
 }
+#[doc(hidden)]
 #[link_section = "contractspecv0"]
 pub static __SPEC_XDR_TYPE_USEDPARAMINTENUM: [u8; 68usize] = UsedParamIntEnum::spec_xdr();
 impl UsedParamIntEnum {
@@ -442,6 +445,7 @@ impl ::core::cmp::PartialEq for UsedErrorEnum {
         __self_discr == __arg1_discr
     }
 }
+#[doc(hidden)]
 #[link_section = "contractspecv0"]
 pub static __SPEC_XDR_TYPE_USEDERRORENUM: [u8; 76usize] = UsedErrorEnum::spec_xdr();
 impl UsedErrorEnum {
@@ -601,6 +605,7 @@ impl ::core::cmp::PartialEq for UsedPanicErrorEnum {
         true
     }
 }
+#[doc(hidden)]
 #[link_section = "contractspecv0"]
 pub static __SPEC_XDR_TYPE_USEDPANICERRORENUM: [u8; 56usize] = UsedPanicErrorEnum::spec_xdr();
 impl UsedPanicErrorEnum {
@@ -758,6 +763,7 @@ impl ::core::cmp::PartialEq for UsedAssertErrorEnum {
         true
     }
 }
+#[doc(hidden)]
 #[link_section = "contractspecv0"]
 pub static __SPEC_XDR_TYPE_USEDASSERTERRORENUM: [u8; 56usize] = UsedAssertErrorEnum::spec_xdr();
 impl UsedAssertErrorEnum {
@@ -922,6 +928,7 @@ impl ::core::cmp::PartialEq for UsedNestedInStruct {
         self.val == other.val
     }
 }
+#[doc(hidden)]
 #[link_section = "contractspecv0"]
 pub static __SPEC_XDR_TYPE_USEDNESTEDINSTRUCT: [u8; 56usize] = UsedNestedInStruct::spec_xdr();
 impl UsedNestedInStruct {
@@ -1023,6 +1030,7 @@ impl ::core::cmp::PartialEq for UsedVecElement {
         self.data == other.data
     }
 }
+#[doc(hidden)]
 #[link_section = "contractspecv0"]
 pub static __SPEC_XDR_TYPE_USEDVECELEMENT: [u8; 52usize] = UsedVecElement::spec_xdr();
 impl UsedVecElement {
@@ -1129,6 +1137,7 @@ impl ::core::cmp::PartialEq for UsedMapKey {
         __self_discr == __arg1_discr
     }
 }
+#[doc(hidden)]
 #[link_section = "contractspecv0"]
 pub static __SPEC_XDR_TYPE_USEDMAPKEY: [u8; 64usize] = UsedMapKey::spec_xdr();
 impl UsedMapKey {
@@ -1222,6 +1231,7 @@ impl ::core::cmp::PartialEq for UsedMapVal {
         self.v == other.v
     }
 }
+#[doc(hidden)]
 #[link_section = "contractspecv0"]
 pub static __SPEC_XDR_TYPE_USEDMAPVAL: [u8; 48usize] = UsedMapVal::spec_xdr();
 impl UsedMapVal {
@@ -1326,6 +1336,7 @@ impl ::core::cmp::PartialEq for UsedOptionElement {
         self.data == other.data
     }
 }
+#[doc(hidden)]
 #[link_section = "contractspecv0"]
 pub static __SPEC_XDR_TYPE_USEDOPTIONELEMENT: [u8; 56usize] = UsedOptionElement::spec_xdr();
 impl UsedOptionElement {
@@ -1425,6 +1436,7 @@ impl ::core::cmp::PartialEq for UsedResultOk {
         self.data == other.data
     }
 }
+#[doc(hidden)]
 #[link_section = "contractspecv0"]
 pub static __SPEC_XDR_TYPE_USEDRESULTOK: [u8; 48usize] = UsedResultOk::spec_xdr();
 impl UsedResultOk {
@@ -1534,6 +1546,7 @@ impl ::core::cmp::PartialEq for UsedEventSimple {
         self.amount == other.amount && self.kind == other.kind
     }
 }
+#[doc(hidden)]
 #[link_section = "contractspecv0"]
 pub static __SPEC_XDR_EVENT_USEDEVENTSIMPLE: [u8; 112usize] = UsedEventSimple::spec_xdr();
 impl UsedEventSimple {
@@ -1621,6 +1634,7 @@ impl ::core::cmp::PartialEq for UsedEventTopicType {
         __self_discr == __arg1_discr
     }
 }
+#[doc(hidden)]
 #[link_section = "contractspecv0"]
 pub static __SPEC_XDR_TYPE_USEDEVENTTOPICTYPE: [u8; 76usize] = UsedEventTopicType::spec_xdr();
 impl UsedEventTopicType {
@@ -1726,6 +1740,7 @@ impl ::core::cmp::PartialEq for UsedEventWithTopicType {
         self.amount == other.amount && self.kind == other.kind
     }
 }
+#[doc(hidden)]
 #[link_section = "contractspecv0"]
 pub static __SPEC_XDR_EVENT_USEDEVENTWITHTOPICTYPE: [u8; 152usize] =
     UsedEventWithTopicType::spec_xdr();
@@ -1819,6 +1834,7 @@ impl ::core::cmp::PartialEq for UsedEventDataType {
         self.x == other.x && self.y == other.y
     }
 }
+#[doc(hidden)]
 #[link_section = "contractspecv0"]
 pub static __SPEC_XDR_TYPE_USEDEVENTDATATYPE: [u8; 72usize] = UsedEventDataType::spec_xdr();
 impl UsedEventDataType {
@@ -1935,6 +1951,7 @@ impl ::core::cmp::PartialEq for UsedEventWithDataType {
         self.kind == other.kind && self.payload == other.payload
     }
 }
+#[doc(hidden)]
 #[link_section = "contractspecv0"]
 pub static __SPEC_XDR_EVENT_USEDEVENTWITHDATATYPE: [u8; 152usize] =
     UsedEventWithDataType::spec_xdr();
@@ -2024,6 +2041,7 @@ impl ::core::cmp::PartialEq for UsedEventTopicOuter {
         self.inner == other.inner
     }
 }
+#[doc(hidden)]
 #[link_section = "contractspecv0"]
 pub static __SPEC_XDR_TYPE_USEDEVENTTOPICOUTER: [u8; 84usize] = UsedEventTopicOuter::spec_xdr();
 impl UsedEventTopicOuter {
@@ -2132,6 +2150,7 @@ impl ::core::cmp::PartialEq for UsedEventTopicInner {
         self.val == other.val
     }
 }
+#[doc(hidden)]
 #[link_section = "contractspecv0"]
 pub static __SPEC_XDR_TYPE_USEDEVENTTOPICINNER: [u8; 56usize] = UsedEventTopicInner::spec_xdr();
 impl UsedEventTopicInner {
@@ -2243,6 +2262,7 @@ impl ::core::cmp::PartialEq for UsedEventWithNestedTopic {
         self.amount == other.amount && self.info == other.info
     }
 }
+#[doc(hidden)]
 #[link_section = "contractspecv0"]
 pub static __SPEC_XDR_EVENT_USEDEVENTWITHNESTEDTOPIC: [u8; 152usize] =
     UsedEventWithNestedTopic::spec_xdr();
@@ -2332,6 +2352,7 @@ impl ::core::cmp::PartialEq for UsedEventDataOuter {
         self.inner == other.inner
     }
 }
+#[doc(hidden)]
 #[link_section = "contractspecv0"]
 pub static __SPEC_XDR_TYPE_USEDEVENTDATAOUTER: [u8; 84usize] = UsedEventDataOuter::spec_xdr();
 impl UsedEventDataOuter {
@@ -2440,6 +2461,7 @@ impl ::core::cmp::PartialEq for UsedEventDataInner {
         self.val == other.val
     }
 }
+#[doc(hidden)]
 #[link_section = "contractspecv0"]
 pub static __SPEC_XDR_TYPE_USEDEVENTDATAINNER: [u8; 56usize] = UsedEventDataInner::spec_xdr();
 impl UsedEventDataInner {
@@ -2551,6 +2573,7 @@ impl ::core::cmp::PartialEq for UsedEventWithNestedData {
         self.kind == other.kind && self.payload == other.payload
     }
 }
+#[doc(hidden)]
 #[link_section = "contractspecv0"]
 pub static __SPEC_XDR_EVENT_USEDEVENTWITHNESTEDDATA: [u8; 152usize] =
     UsedEventWithNestedData::spec_xdr();
@@ -2642,6 +2665,7 @@ impl ::core::cmp::PartialEq for UsedRefTopicType {
         __self_discr == __arg1_discr
     }
 }
+#[doc(hidden)]
 #[link_section = "contractspecv0"]
 pub static __SPEC_XDR_TYPE_USEDREFTOPICTYPE: [u8; 68usize] = UsedRefTopicType::spec_xdr();
 impl UsedRefTopicType {
@@ -2740,6 +2764,7 @@ impl ::core::cmp::PartialEq for UsedRefDataType {
         self.nested == other.nested
     }
 }
+#[doc(hidden)]
 #[link_section = "contractspecv0"]
 pub static __SPEC_XDR_TYPE_USEDREFDATATYPE: [u8; 76usize] = UsedRefDataType::spec_xdr();
 impl UsedRefDataType {
@@ -2841,6 +2866,7 @@ impl ::core::cmp::PartialEq for UsedRefDataInner {
         self.val == other.val
     }
 }
+#[doc(hidden)]
 #[link_section = "contractspecv0"]
 pub static __SPEC_XDR_TYPE_USEDREFDATAINNER: [u8; 52usize] = UsedRefDataInner::spec_xdr();
 impl UsedRefDataInner {
@@ -2950,6 +2976,7 @@ impl<'a> ::core::cmp::PartialEq for UsedEventWithRefs<'a> {
         self.kind == other.kind && self.payload == other.payload
     }
 }
+#[doc(hidden)]
 #[link_section = "contractspecv0"]
 pub static __SPEC_XDR_EVENT_USEDEVENTWITHREFS: [u8; 156usize] = UsedEventWithRefs::spec_xdr();
 impl<'a> UsedEventWithRefs<'a> {
@@ -3033,6 +3060,7 @@ impl ::core::cmp::PartialEq for UsedTupleElement {
         self.val == other.val
     }
 }
+#[doc(hidden)]
 #[link_section = "contractspecv0"]
 pub static __SPEC_XDR_TYPE_USEDTUPLEELEMENT: [u8; 52usize] = UsedTupleElement::spec_xdr();
 impl UsedTupleElement {
@@ -3137,6 +3165,7 @@ impl ::core::cmp::PartialEq for UsedTupleReturnElement {
         self.val == other.val
     }
 }
+#[doc(hidden)]
 #[link_section = "contractspecv0"]
 pub static __SPEC_XDR_TYPE_USEDTUPLERETURNELEMENT: [u8; 60usize] =
     UsedTupleReturnElement::spec_xdr();
@@ -3244,6 +3273,7 @@ impl ::core::cmp::PartialEq for UsedVecInnerVecElement {
         self.val == other.val
     }
 }
+#[doc(hidden)]
 #[link_section = "contractspecv0"]
 pub static __SPEC_XDR_TYPE_USEDVECINNERVECELEMENT: [u8; 60usize] =
     UsedVecInnerVecElement::spec_xdr();
@@ -3351,6 +3381,7 @@ impl ::core::cmp::PartialEq for UsedVecInnerElement {
         self.val == other.val
     }
 }
+#[doc(hidden)]
 #[link_section = "contractspecv0"]
 pub static __SPEC_XDR_TYPE_USEDVECINNERELEMENT: [u8; 56usize] = UsedVecInnerElement::spec_xdr();
 impl UsedVecInnerElement {
@@ -3467,6 +3498,7 @@ impl ::core::cmp::PartialEq for UsedVecElementNested {
         self.val == other.val && self.inner == other.inner && self.vec_inner == other.vec_inner
     }
 }
+#[doc(hidden)]
 #[link_section = "contractspecv0"]
 pub static __SPEC_XDR_TYPE_USEDVECELEMENTNESTED: [u8; 156usize] = UsedVecElementNested::spec_xdr();
 impl UsedVecElementNested {
@@ -3584,6 +3616,7 @@ impl ::core::cmp::PartialEq for UsedNonPubStruct {
         self.val == other.val
     }
 }
+#[doc(hidden)]
 #[link_section = "contractspecv0"]
 pub static __SPEC_XDR_TYPE_USEDNONPUBSTRUCT: [u8; 52usize] = UsedNonPubStruct::spec_xdr();
 impl UsedNonPubStruct {
@@ -3681,6 +3714,7 @@ impl ::core::cmp::PartialEq for UsedNonPubError {
         true
     }
 }
+#[doc(hidden)]
 #[link_section = "contractspecv0"]
 pub static __SPEC_XDR_TYPE_USEDNONPUBERROR: [u8; 52usize] = UsedNonPubError::spec_xdr();
 impl UsedNonPubError {
@@ -3843,6 +3877,7 @@ impl ::core::cmp::PartialEq for UsedRecursiveRoot {
         self.val == other.val
     }
 }
+#[doc(hidden)]
 #[link_section = "contractspecv0"]
 pub static __SPEC_XDR_TYPE_USEDRECURSIVEROOT: [u8; 80usize] = UsedRecursiveRoot::spec_xdr();
 impl UsedRecursiveRoot {
@@ -3969,6 +4004,7 @@ impl ::core::cmp::PartialEq for UsedRecursiveNode {
             }
     }
 }
+#[doc(hidden)]
 #[link_section = "contractspecv0"]
 pub static __SPEC_XDR_TYPE_USEDRECURSIVENODE: [u8; 140usize] = UsedRecursiveNode::spec_xdr();
 impl UsedRecursiveNode {
@@ -4110,6 +4146,7 @@ impl ::core::cmp::PartialEq for UsedRecursiveLeaf {
         self.val == other.val
     }
 }
+#[doc(hidden)]
 #[link_section = "contractspecv0"]
 pub static __SPEC_XDR_TYPE_USEDRECURSIVELEAF: [u8; 84usize] = UsedRecursiveLeaf::spec_xdr();
 impl UsedRecursiveLeaf {
@@ -4209,6 +4246,7 @@ impl ::core::cmp::PartialEq for UsedLeaf {
         self.val == other.val
     }
 }
+#[doc(hidden)]
 #[link_section = "contractspecv0"]
 pub static __SPEC_XDR_TYPE_USEDLEAF: [u8; 44usize] = UsedLeaf::spec_xdr();
 impl UsedLeaf {
@@ -4633,6 +4671,7 @@ mod wasm_imported {
             }
         }
     }
+    #[doc(hidden)]
     #[link_section = "contractspecv0"]
     pub static __SPEC_XDR_TYPE_CONTRACTEXECUTABLEREF: [u8; 80usize] =
         ContractExecutableRef::spec_xdr();
@@ -4798,6 +4837,7 @@ mod wasm_imported {
             }
         }
     }
+    #[doc(hidden)]
     #[link_section = "contractspecv0"]
     pub static __SPEC_XDR_TYPE_CONTRACTCONTEXT: [u8; 96usize] = ContractContext::spec_xdr();
     impl ContractContext {
@@ -4957,6 +4997,7 @@ mod wasm_imported {
             }
         }
     }
+    #[doc(hidden)]
     #[link_section = "contractspecv0"]
     pub static __SPEC_XDR_TYPE_SUBCONTRACTINVOCATION: [u8; 144usize] =
         SubContractInvocation::spec_xdr();
@@ -5107,6 +5148,7 @@ mod wasm_imported {
             }
         }
     }
+    #[doc(hidden)]
     #[link_section = "contractspecv0"]
     pub static __SPEC_XDR_TYPE_CREATECONTRACTHOSTFNCONTEXT: [u8; 116usize] =
         CreateContractHostFnContext::spec_xdr();
@@ -5277,6 +5319,7 @@ mod wasm_imported {
             }
         }
     }
+    #[doc(hidden)]
     #[link_section = "contractspecv0"]
     pub static __SPEC_XDR_TYPE_CREATECONTRACTWITHCONSTRUCTORHOSTFNCONTEXT: [u8; 164usize] =
         CreateContractWithConstructorHostFnContext::spec_xdr();
@@ -5431,6 +5474,7 @@ mod wasm_imported {
             }
         }
     }
+    #[doc(hidden)]
     #[link_section = "contractspecv0"]
     pub static __SPEC_XDR_TYPE_STRUCTA: [u8; 60usize] = StructA::spec_xdr();
     impl StructA {
@@ -5564,6 +5608,7 @@ mod wasm_imported {
             }
         }
     }
+    #[doc(hidden)]
     #[link_section = "contractspecv0"]
     pub static __SPEC_XDR_TYPE_STRUCTB: [u8; 60usize] = StructB::spec_xdr();
     impl StructB {
@@ -5697,6 +5742,7 @@ mod wasm_imported {
             }
         }
     }
+    #[doc(hidden)]
     #[link_section = "contractspecv0"]
     pub static __SPEC_XDR_TYPE_STRUCTC: [u8; 64usize] = StructC::spec_xdr();
     impl StructC {
@@ -5827,6 +5873,7 @@ mod wasm_imported {
             }
         }
     }
+    #[doc(hidden)]
     #[link_section = "contractspecv0"]
     pub static __SPEC_XDR_TYPE_STRUCTTUPLEA: [u8; 64usize] = StructTupleA::spec_xdr();
     impl StructTupleA {
@@ -5953,6 +6000,7 @@ mod wasm_imported {
             }
         }
     }
+    #[doc(hidden)]
     #[link_section = "contractspecv0"]
     pub static __SPEC_XDR_TYPE_STRUCTTUPLEB: [u8; 64usize] = StructTupleB::spec_xdr();
     impl StructTupleB {
@@ -6080,6 +6128,7 @@ mod wasm_imported {
             }
         }
     }
+    #[doc(hidden)]
     #[link_section = "contractspecv0"]
     pub static __SPEC_XDR_TYPE_STRUCTTUPLEC: [u8; 64usize] = StructTupleC::spec_xdr();
     impl StructTupleC {
@@ -6250,6 +6299,7 @@ mod wasm_imported {
             }
         }
     }
+    #[doc(hidden)]
     #[link_section = "contractspecv0"]
     pub static __SPEC_XDR_TYPE_CONTRACTEXECUTABLE: [u8; 128usize] = ContractExecutable::spec_xdr();
     impl ContractExecutable {
@@ -6482,6 +6532,7 @@ mod wasm_imported {
             }
         }
     }
+    #[doc(hidden)]
     #[link_section = "contractspecv0"]
     pub static __SPEC_XDR_TYPE_CONTEXT: [u8; 244usize] = Context::spec_xdr();
     impl Context {
@@ -6745,6 +6796,7 @@ mod wasm_imported {
             }
         }
     }
+    #[doc(hidden)]
     #[link_section = "contractspecv0"]
     pub static __SPEC_XDR_TYPE_INVOKERCONTRACTAUTHENTRY: [u8; 268usize] =
         InvokerContractAuthEntry::spec_xdr();
@@ -6959,6 +7011,7 @@ mod wasm_imported {
             }
         }
     }
+    #[doc(hidden)]
     #[link_section = "contractspecv0"]
     pub static __SPEC_XDR_TYPE_EXECUTABLE: [u8; 104usize] = Executable::spec_xdr();
     impl Executable {
@@ -7129,6 +7182,7 @@ mod wasm_imported {
             ::core::cmp::PartialOrd::partial_cmp(&__self_discr, &__arg1_discr)
         }
     }
+    #[doc(hidden)]
     #[link_section = "contractspecv0"]
     pub static __SPEC_XDR_TYPE_ENUMA: [u8; 76usize] = EnumA::spec_xdr();
     impl EnumA {
@@ -7334,6 +7388,7 @@ mod wasm_imported {
             }
         }
     }
+    #[doc(hidden)]
     #[link_section = "contractspecv0"]
     pub static __SPEC_XDR_TYPE_ENUMB: [u8; 96usize] = EnumB::spec_xdr();
     impl EnumB {
@@ -7542,6 +7597,7 @@ mod wasm_imported {
             }
         }
     }
+    #[doc(hidden)]
     #[link_section = "contractspecv0"]
     pub static __SPEC_XDR_TYPE_ENUMC: [u8; 120usize] = EnumC::spec_xdr();
     impl EnumC {
@@ -7717,6 +7773,7 @@ mod wasm_imported {
             ::core::cmp::PartialOrd::partial_cmp(&__self_discr, &__arg1_discr)
         }
     }
+    #[doc(hidden)]
     #[link_section = "contractspecv0"]
     pub static __SPEC_XDR_TYPE_ENUMINTA: [u8; 76usize] = EnumIntA::spec_xdr();
     impl EnumIntA {
@@ -7839,6 +7896,7 @@ mod wasm_imported {
             ::core::cmp::PartialOrd::partial_cmp(&__self_discr, &__arg1_discr)
         }
     }
+    #[doc(hidden)]
     #[link_section = "contractspecv0"]
     pub static __SPEC_XDR_TYPE_ENUMINTB: [u8; 76usize] = EnumIntB::spec_xdr();
     impl EnumIntB {
@@ -7961,6 +8019,7 @@ mod wasm_imported {
             ::core::cmp::PartialOrd::partial_cmp(&__self_discr, &__arg1_discr)
         }
     }
+    #[doc(hidden)]
     #[link_section = "contractspecv0"]
     pub static __SPEC_XDR_TYPE_ENUMINTC: [u8; 76usize] = EnumIntC::spec_xdr();
     impl EnumIntC {
@@ -8083,6 +8142,7 @@ mod wasm_imported {
             ::core::cmp::PartialOrd::partial_cmp(&__self_discr, &__arg1_discr)
         }
     }
+    #[doc(hidden)]
     #[link_section = "contractspecv0"]
     pub static __SPEC_XDR_TYPE_ERRORA: [u8; 76usize] = ErrorA::spec_xdr();
     impl ErrorA {
@@ -8275,6 +8335,7 @@ mod wasm_imported {
             ::core::cmp::PartialOrd::partial_cmp(&__self_discr, &__arg1_discr)
         }
     }
+    #[doc(hidden)]
     #[link_section = "contractspecv0"]
     pub static __SPEC_XDR_TYPE_ERRORB: [u8; 76usize] = ErrorB::spec_xdr();
     impl ErrorB {
@@ -8467,6 +8528,7 @@ mod wasm_imported {
             ::core::cmp::PartialOrd::partial_cmp(&__self_discr, &__arg1_discr)
         }
     }
+    #[doc(hidden)]
     #[link_section = "contractspecv0"]
     pub static __SPEC_XDR_TYPE_ERRORC: [u8; 76usize] = ErrorC::spec_xdr();
     impl ErrorC {
@@ -8659,6 +8721,7 @@ mod wasm_imported {
             }
         }
     }
+    #[doc(hidden)]
     #[link_section = "contractspecv0"]
     pub static __SPEC_XDR_EVENT_EVENTA: [u8; 88usize] = EventA::spec_xdr();
     impl EventA {
@@ -8784,6 +8847,7 @@ mod wasm_imported {
             }
         }
     }
+    #[doc(hidden)]
     #[link_section = "contractspecv0"]
     pub static __SPEC_XDR_EVENT_EVENTB: [u8; 108usize] = EventB::spec_xdr();
     impl EventB {
@@ -8913,6 +8977,7 @@ mod wasm_imported {
             }
         }
     }
+    #[doc(hidden)]
     #[link_section = "contractspecv0"]
     pub static __SPEC_XDR_EVENT_EVENTC: [u8; 108usize] = EventC::spec_xdr();
     impl EventC {
@@ -9009,6 +9074,7 @@ mod wasm_imported {
             ::core::option::Option::Some(::core::cmp::Ordering::Equal)
         }
     }
+    #[doc(hidden)]
     #[link_section = "contractspecv0"]
     pub static __SPEC_XDR_EVENT_EVENTD: [u8; 48usize] = EventD::spec_xdr();
     impl EventD {
@@ -9089,6 +9155,7 @@ impl ::core::cmp::PartialEq for UnusedStruct {
         self.x == other.x
     }
 }
+#[doc(hidden)]
 #[link_section = "contractspecv0"]
 pub static __SPEC_XDR_TYPE_UNUSEDSTRUCT: [u8; 48usize] = UnusedStruct::spec_xdr();
 impl UnusedStruct {
@@ -9201,6 +9268,7 @@ impl ::core::cmp::PartialEq for UnusedEnum {
             }
     }
 }
+#[doc(hidden)]
 #[link_section = "contractspecv0"]
 pub static __SPEC_XDR_TYPE_UNUSEDENUM: [u8; 72usize] = UnusedEnum::spec_xdr();
 impl UnusedEnum {
@@ -9337,6 +9405,7 @@ impl ::core::cmp::PartialEq for UnusedIntEnum {
         __self_discr == __arg1_discr
     }
 }
+#[doc(hidden)]
 #[link_section = "contractspecv0"]
 pub static __SPEC_XDR_TYPE_UNUSEDINTENUM: [u8; 68usize] = UnusedIntEnum::spec_xdr();
 impl UnusedIntEnum {
@@ -9440,6 +9509,7 @@ impl ::core::cmp::PartialEq for UnusedEvent {
         self.data == other.data && self.kind == other.kind
     }
 }
+#[doc(hidden)]
 #[link_section = "contractspecv0"]
 pub static __SPEC_XDR_EVENT_UNUSEDEVENT: [u8; 96usize] = UnusedEvent::spec_xdr();
 impl UnusedEvent {
@@ -9518,6 +9588,7 @@ impl ::core::cmp::PartialEq for UnusedPubError {
         true
     }
 }
+#[doc(hidden)]
 #[link_section = "contractspecv0"]
 pub static __SPEC_XDR_TYPE_UNUSEDPUBERROR: [u8; 52usize] = UnusedPubError::spec_xdr();
 impl UnusedPubError {
@@ -9680,6 +9751,7 @@ impl ::core::cmp::PartialEq for UnusedNonContractFnParam {
         self.x == other.x
     }
 }
+#[doc(hidden)]
 #[link_section = "contractspecv0"]
 pub static __SPEC_XDR_TYPE_UNUSEDNONCONTRACTFNPARAM: [u8; 60usize] =
     UnusedNonContractFnParam::spec_xdr();
@@ -9787,6 +9859,7 @@ impl ::core::cmp::PartialEq for UnusedNonContractFnReturn {
         self.x == other.x
     }
 }
+#[doc(hidden)]
 #[link_section = "contractspecv0"]
 pub static __SPEC_XDR_TYPE_UNUSEDNONCONTRACTFNRETURN: [u8; 64usize] =
     UnusedNonContractFnReturn::spec_xdr();
@@ -9889,6 +9962,7 @@ impl ::core::cmp::PartialEq for UnusedNonPubStruct {
         self.x == other.x
     }
 }
+#[doc(hidden)]
 #[link_section = "contractspecv0"]
 pub static __SPEC_XDR_TYPE_UNUSEDNONPUBSTRUCT: [u8; 56usize] = UnusedNonPubStruct::spec_xdr();
 impl UnusedNonPubStruct {
@@ -9988,6 +10062,7 @@ impl ::core::cmp::PartialEq for UnusedNonPubError {
         true
     }
 }
+#[doc(hidden)]
 #[link_section = "contractspecv0"]
 pub static __SPEC_XDR_TYPE_UNUSEDNONPUBERROR: [u8; 56usize] = UnusedNonPubError::spec_xdr();
 impl UnusedNonPubError {

--- a/tests-expanded/test_tuples_tests.rs
+++ b/tests-expanded/test_tuples_tests.rs
@@ -1093,6 +1093,7 @@ mod test {
                 }
             }
         }
+        #[doc(hidden)]
         pub static __SPEC_XDR_TYPE_CONTRACTEXECUTABLEREF: [u8; 80usize] =
             ContractExecutableRef::spec_xdr();
         impl ContractExecutableRef {
@@ -1586,6 +1587,7 @@ mod test {
                 }
             }
         }
+        #[doc(hidden)]
         pub static __SPEC_XDR_TYPE_CONTRACTCONTEXT: [u8; 96usize] = ContractContext::spec_xdr();
         impl ContractContext {
             pub const fn spec_xdr() -> [u8; 96usize] {
@@ -2134,6 +2136,7 @@ mod test {
                 }
             }
         }
+        #[doc(hidden)]
         pub static __SPEC_XDR_TYPE_SUBCONTRACTINVOCATION: [u8; 144usize] =
             SubContractInvocation::spec_xdr();
         impl SubContractInvocation {
@@ -2620,6 +2623,7 @@ mod test {
                 }
             }
         }
+        #[doc(hidden)]
         pub static __SPEC_XDR_TYPE_CREATECONTRACTHOSTFNCONTEXT: [u8; 116usize] =
             CreateContractHostFnContext::spec_xdr();
         impl CreateContractHostFnContext {
@@ -3138,6 +3142,7 @@ mod test {
                 }
             }
         }
+        #[doc(hidden)]
         pub static __SPEC_XDR_TYPE_CREATECONTRACTWITHCONSTRUCTORHOSTFNCONTEXT: [u8; 164usize] =
             CreateContractWithConstructorHostFnContext::spec_xdr();
         impl CreateContractWithConstructorHostFnContext {
@@ -3761,6 +3766,7 @@ mod test {
                 }
             }
         }
+        #[doc(hidden)]
         pub static __SPEC_XDR_TYPE_CONTRACTEXECUTABLE: [u8; 128usize] =
             ContractExecutable::spec_xdr();
         impl ContractExecutable {
@@ -4401,6 +4407,7 @@ mod test {
                 }
             }
         }
+        #[doc(hidden)]
         pub static __SPEC_XDR_TYPE_CONTEXT: [u8; 244usize] = Context::spec_xdr();
         impl Context {
             pub const fn spec_xdr() -> [u8; 244usize] {
@@ -5140,6 +5147,7 @@ mod test {
                 }
             }
         }
+        #[doc(hidden)]
         pub static __SPEC_XDR_TYPE_INVOKERCONTRACTAUTHENTRY: [u8; 268usize] =
             InvokerContractAuthEntry::spec_xdr();
         impl InvokerContractAuthEntry {
@@ -5874,6 +5882,7 @@ mod test {
                 }
             }
         }
+        #[doc(hidden)]
         pub static __SPEC_XDR_TYPE_EXECUTABLE: [u8; 104usize] = Executable::spec_xdr();
         impl Executable {
             pub const fn spec_xdr() -> [u8; 104usize] {

--- a/tests-expanded/test_udt_tests.rs
+++ b/tests-expanded/test_udt_tests.rs
@@ -49,6 +49,7 @@ impl ::core::cmp::PartialEq for UdtEnum2 {
         __self_discr == __arg1_discr
     }
 }
+#[doc(hidden)]
 pub static __SPEC_XDR_TYPE_UDTENUM2: [u8; 60usize] = UdtEnum2::spec_xdr();
 impl UdtEnum2 {
     pub const fn spec_xdr() -> [u8; 60usize] {
@@ -398,6 +399,7 @@ impl ::core::cmp::PartialEq for UdtEnum {
             }
     }
 }
+#[doc(hidden)]
 pub static __SPEC_XDR_TYPE_UDTENUM: [u8; 156usize] = UdtEnum::spec_xdr();
 impl UdtEnum {
     pub const fn spec_xdr() -> [u8; 156usize] {
@@ -1013,6 +1015,7 @@ impl ::core::cmp::PartialEq for UdtTuple {
         self.0 == other.0 && self.1 == other.1
     }
 }
+#[doc(hidden)]
 pub static __SPEC_XDR_TYPE_UDTTUPLE: [u8; 64usize] = UdtTuple::spec_xdr();
 impl UdtTuple {
     pub const fn spec_xdr() -> [u8; 64usize] {
@@ -1406,6 +1409,7 @@ impl ::core::cmp::PartialEq for UdtStruct {
         self.a == other.a && self.b == other.b && self.c == other.c
     }
 }
+#[doc(hidden)]
 pub static __SPEC_XDR_TYPE_UDTSTRUCT: [u8; 84usize] = UdtStruct::spec_xdr();
 impl UdtStruct {
     pub const fn spec_xdr() -> [u8; 84usize] {
@@ -1890,6 +1894,7 @@ impl ::core::cmp::PartialEq for UdtRecursive {
         self.a == other.a && self.b == other.b
     }
 }
+#[doc(hidden)]
 pub static __SPEC_XDR_TYPE_UDTRECURSIVE: [u8; 84usize] = UdtRecursive::spec_xdr();
 impl UdtRecursive {
     pub const fn spec_xdr() -> [u8; 84usize] {
@@ -2324,6 +2329,7 @@ impl ::core::cmp::PartialEq for RecursiveToEnum {
         self.a == other.a && self.b == other.b
     }
 }
+#[doc(hidden)]
 pub static __SPEC_XDR_TYPE_RECURSIVETOENUM: [u8; 96usize] = RecursiveToEnum::spec_xdr();
 impl RecursiveToEnum {
     pub const fn spec_xdr() -> [u8; 96usize] {
@@ -2772,6 +2778,7 @@ impl ::core::cmp::PartialEq for RecursiveEnum {
             }
     }
 }
+#[doc(hidden)]
 pub static __SPEC_XDR_TYPE_RECURSIVEENUM: [u8; 112usize] = RecursiveEnum::spec_xdr();
 impl RecursiveEnum {
     pub const fn spec_xdr() -> [u8; 112usize] {
@@ -4674,6 +4681,7 @@ mod test_with_wasm {
                 }
             }
         }
+        #[doc(hidden)]
         pub static __SPEC_XDR_TYPE_UDTTUPLE: [u8; 64usize] = UdtTuple::spec_xdr();
         impl UdtTuple {
             pub const fn spec_xdr() -> [u8; 64usize] {
@@ -5112,6 +5120,7 @@ mod test_with_wasm {
                 }
             }
         }
+        #[doc(hidden)]
         pub static __SPEC_XDR_TYPE_UDTSTRUCT: [u8; 84usize] = UdtStruct::spec_xdr();
         impl UdtStruct {
             pub const fn spec_xdr() -> [u8; 84usize] {
@@ -5633,6 +5642,7 @@ mod test_with_wasm {
                 }
             }
         }
+        #[doc(hidden)]
         pub static __SPEC_XDR_TYPE_UDTRECURSIVE: [u8; 84usize] = UdtRecursive::spec_xdr();
         impl UdtRecursive {
             pub const fn spec_xdr() -> [u8; 84usize] {
@@ -6102,6 +6112,7 @@ mod test_with_wasm {
                 }
             }
         }
+        #[doc(hidden)]
         pub static __SPEC_XDR_TYPE_RECURSIVETOENUM: [u8; 96usize] = RecursiveToEnum::spec_xdr();
         impl RecursiveToEnum {
             pub const fn spec_xdr() -> [u8; 96usize] {
@@ -6575,6 +6586,7 @@ mod test_with_wasm {
                 }
             }
         }
+        #[doc(hidden)]
         pub static __SPEC_XDR_TYPE_CONTRACTEXECUTABLEREF: [u8; 80usize] =
             ContractExecutableRef::spec_xdr();
         impl ContractExecutableRef {
@@ -7068,6 +7080,7 @@ mod test_with_wasm {
                 }
             }
         }
+        #[doc(hidden)]
         pub static __SPEC_XDR_TYPE_CONTRACTCONTEXT: [u8; 96usize] = ContractContext::spec_xdr();
         impl ContractContext {
             pub const fn spec_xdr() -> [u8; 96usize] {
@@ -7616,6 +7629,7 @@ mod test_with_wasm {
                 }
             }
         }
+        #[doc(hidden)]
         pub static __SPEC_XDR_TYPE_SUBCONTRACTINVOCATION: [u8; 144usize] =
             SubContractInvocation::spec_xdr();
         impl SubContractInvocation {
@@ -8102,6 +8116,7 @@ mod test_with_wasm {
                 }
             }
         }
+        #[doc(hidden)]
         pub static __SPEC_XDR_TYPE_CREATECONTRACTHOSTFNCONTEXT: [u8; 116usize] =
             CreateContractHostFnContext::spec_xdr();
         impl CreateContractHostFnContext {
@@ -8620,6 +8635,7 @@ mod test_with_wasm {
                 }
             }
         }
+        #[doc(hidden)]
         pub static __SPEC_XDR_TYPE_CREATECONTRACTWITHCONSTRUCTORHOSTFNCONTEXT: [u8; 164usize] =
             CreateContractWithConstructorHostFnContext::spec_xdr();
         impl CreateContractWithConstructorHostFnContext {
@@ -9242,6 +9258,7 @@ mod test_with_wasm {
                 }
             }
         }
+        #[doc(hidden)]
         pub static __SPEC_XDR_TYPE_UDTENUM: [u8; 156usize] = UdtEnum::spec_xdr();
         impl UdtEnum {
             pub const fn spec_xdr() -> [u8; 156usize] {
@@ -9932,6 +9949,7 @@ mod test_with_wasm {
                 }
             }
         }
+        #[doc(hidden)]
         pub static __SPEC_XDR_TYPE_RECURSIVEENUM: [u8; 112usize] = RecursiveEnum::spec_xdr();
         impl RecursiveEnum {
             pub const fn spec_xdr() -> [u8; 112usize] {
@@ -10496,6 +10514,7 @@ mod test_with_wasm {
                 }
             }
         }
+        #[doc(hidden)]
         pub static __SPEC_XDR_TYPE_CONTRACTEXECUTABLE: [u8; 128usize] =
             ContractExecutable::spec_xdr();
         impl ContractExecutable {
@@ -11136,6 +11155,7 @@ mod test_with_wasm {
                 }
             }
         }
+        #[doc(hidden)]
         pub static __SPEC_XDR_TYPE_CONTEXT: [u8; 244usize] = Context::spec_xdr();
         impl Context {
             pub const fn spec_xdr() -> [u8; 244usize] {
@@ -11875,6 +11895,7 @@ mod test_with_wasm {
                 }
             }
         }
+        #[doc(hidden)]
         pub static __SPEC_XDR_TYPE_INVOKERCONTRACTAUTHENTRY: [u8; 268usize] =
             InvokerContractAuthEntry::spec_xdr();
         impl InvokerContractAuthEntry {
@@ -12609,6 +12630,7 @@ mod test_with_wasm {
                 }
             }
         }
+        #[doc(hidden)]
         pub static __SPEC_XDR_TYPE_EXECUTABLE: [u8; 104usize] = Executable::spec_xdr();
         impl Executable {
             pub const fn spec_xdr() -> [u8; 104usize] {
@@ -13164,6 +13186,7 @@ mod test_with_wasm {
                 ::core::cmp::PartialOrd::partial_cmp(&__self_discr, &__arg1_discr)
             }
         }
+        #[doc(hidden)]
         pub static __SPEC_XDR_TYPE_UDTENUM2: [u8; 60usize] = UdtEnum2::spec_xdr();
         impl UdtEnum2 {
             pub const fn spec_xdr() -> [u8; 60usize] {

--- a/tests-expanded/test_udt_wasm32v1-none.rs
+++ b/tests-expanded/test_udt_wasm32v1-none.rs
@@ -49,6 +49,7 @@ impl ::core::cmp::PartialEq for UdtEnum2 {
         __self_discr == __arg1_discr
     }
 }
+#[doc(hidden)]
 #[link_section = "contractspecv0"]
 pub static __SPEC_XDR_TYPE_UDTENUM2: [u8; 60usize] = UdtEnum2::spec_xdr();
 impl UdtEnum2 {
@@ -169,6 +170,7 @@ impl ::core::cmp::PartialEq for UdtEnum {
             }
     }
 }
+#[doc(hidden)]
 #[link_section = "contractspecv0"]
 pub static __SPEC_XDR_TYPE_UDTENUM: [u8; 156usize] = UdtEnum::spec_xdr();
 impl UdtEnum {
@@ -334,6 +336,7 @@ impl ::core::cmp::PartialEq for UdtTuple {
         self.0 == other.0 && self.1 == other.1
     }
 }
+#[doc(hidden)]
 #[link_section = "contractspecv0"]
 pub static __SPEC_XDR_TYPE_UDTTUPLE: [u8; 64usize] = UdtTuple::spec_xdr();
 impl UdtTuple {
@@ -450,6 +453,7 @@ impl ::core::cmp::PartialEq for UdtStruct {
         self.a == other.a && self.b == other.b && self.c == other.c
     }
 }
+#[doc(hidden)]
 #[link_section = "contractspecv0"]
 pub static __SPEC_XDR_TYPE_UDTSTRUCT: [u8; 84usize] = UdtStruct::spec_xdr();
 impl UdtStruct {
@@ -571,6 +575,7 @@ impl ::core::cmp::PartialEq for UdtRecursive {
         self.a == other.a && self.b == other.b
     }
 }
+#[doc(hidden)]
 #[link_section = "contractspecv0"]
 pub static __SPEC_XDR_TYPE_UDTRECURSIVE: [u8; 84usize] = UdtRecursive::spec_xdr();
 impl UdtRecursive {
@@ -687,6 +692,7 @@ impl ::core::cmp::PartialEq for RecursiveToEnum {
         self.a == other.a && self.b == other.b
     }
 }
+#[doc(hidden)]
 #[link_section = "contractspecv0"]
 pub static __SPEC_XDR_TYPE_RECURSIVETOENUM: [u8; 96usize] = RecursiveToEnum::spec_xdr();
 impl RecursiveToEnum {
@@ -810,6 +816,7 @@ impl ::core::cmp::PartialEq for RecursiveEnum {
             }
     }
 }
+#[doc(hidden)]
 #[link_section = "contractspecv0"]
 pub static __SPEC_XDR_TYPE_RECURSIVEENUM: [u8; 112usize] = RecursiveEnum::spec_xdr();
 impl RecursiveEnum {

--- a/tests-expanded/test_workspace_lib_tests.rs
+++ b/tests-expanded/test_workspace_lib_tests.rs
@@ -33,6 +33,7 @@ impl ::core::cmp::PartialEq for Value {
         self.value == other.value
     }
 }
+#[doc(hidden)]
 pub static __SPEC_XDR_TYPE_VALUE: [u8; 48usize] = Value::spec_xdr();
 impl Value {
     pub const fn spec_xdr() -> [u8; 48usize] {

--- a/tests-expanded/test_workspace_lib_wasm32v1-none.rs
+++ b/tests-expanded/test_workspace_lib_wasm32v1-none.rs
@@ -33,6 +33,7 @@ impl ::core::cmp::PartialEq for Value {
         self.value == other.value
     }
 }
+#[doc(hidden)]
 #[link_section = "contractspecv0"]
 pub static __SPEC_XDR_TYPE_VALUE: [u8; 48usize] = Value::spec_xdr();
 impl Value {


### PR DESCRIPTION
### What

Mark the `__SPEC_XDR_TYPE_*` and `__SPEC_XDR_EVENT_*` statics generated by the contracttype, contracterror, and contractevent derives as `#[doc(hidden)]`.

### Why

These statics exist only to embed the contract spec in the wasm `contractspecv0` link section, but being `pub` they rendered in the crate's public docs (e.g. `__SPEC_XDR_TYPE_CONTRACTEXECUTABLE` on the soroban-sdk page) as noise; the function-spec static was already hidden.

This had been missed for a long time because the sdk historically didn't export types and so this only showed up in contract builds with docs, not the sdk's docs. But with spec shaking in use now types in the sdk are exported and recently we added more types to the sdks root modules and so these are now visible on the rust docs home page for the sdk.

### SemVer Change

- [x] Patch (`v_._.Z`) - No change to the public API.