### PR TITLE
Fix crates selected for docs generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-LIB_CRATES = $(shell cargo metadata --no-deps --format-version 1 | jq -r '.packages[] | select(.name | startswith("test_") | not) | .name' | tr '\n' ' ')
+LIB_CRATES = $(shell cargo metadata --no-deps --format-version 1 | jq -r '.packages[] | select(.publish == null) | .name' | tr '\n' ' ')
 TEST_CRATES = $(shell cargo metadata --no-deps --format-version 1 | jq -r '.packages[] | select(.name | startswith("test_")) | .name' | tr '\n' ' ')
 
 MSRV = $(shell cargo metadata --no-deps --format-version 1 | jq -r '.packages[] | select(.name == "soroban-sdk") | .rust_version')


### PR DESCRIPTION
### What

Change the `LIB_CRATES` definition in the Makefile to identify lib crates in the workspace as those that are published instead of as those that do not have a `test_` prefix to their name.

### Why

The test proc-macro crate at `tests/macros/proc_macros` does not carry the `test_` prefix, so it was treated as a library crate. When testing the docs locally or publishing them to github pages from the main branch this means the proc_macros test crate showed up in the generated docs.

Alternatively we could change the proc_macros crate so it was named with a test_ prefix too, but it isn't a test contract like the rest of the test_ crates which we need to distinguish for other makefile jobs so switching to selecting based off if the crate is published (publish == null oddly enough) seems a better approach.

### SemVer Change

- [ ] Major (`vX._._`) - Breaking change to the public API.
- [ ] Minor (`v_.Y._`) - Additive change to the public API.
- [x] Patch (`v_._.Z`) - No change to the public API.
