### PR TITLE
Improve the default example in the SDK docs

### DIFF
--- a/soroban-sdk/README.md
+++ b/soroban-sdk/README.md
@@ -49,22 +49,24 @@ pub struct Contract;
 
 #[contractevent]
 pub struct Hello {
-    #[topic]
     pub to: Address,
 }
 
 #[contractimpl]
 impl Contract {
-    pub fn __constructor(env: Env, admin: Address) {
-        env.storage().instance().set(&symbol_short!("admin"), &admin);
+    pub fn __constructor(env: &Env, owner: Address) {
+        env.storage().instance().set(&symbol_short!("owner"), &owner);
     }
 
-    pub fn hello(env: Env, to: Address) {
-        let admin: Address = env.storage().instance()
-            .get(&symbol_short!("admin"))
-            .unwrap();
-        admin.require_auth();
-        Hello { to }.publish(&env);
+    pub fn owner(env: &Env) -> Address {
+        env.storage().instance()
+            .get(&symbol_short!("owner"))
+            .unwrap()
+    }
+
+    pub fn hello(env: &Env, to: Address) {
+        Self::owner(env).require_auth();
+        Hello { to }.publish(env);
     }
 }
 
@@ -79,8 +81,8 @@ fn test() {
     };
 
     let env = Env::default();
-    let admin = Address::generate(&env);
-    let contract_id = env.register(Contract, (&admin,));
+    let owner = Address::generate(&env);
+    let contract_id = env.register(Contract, (&owner,));
     let client = ContractClient::new(&env, &contract_id);
 
     let to = Address::generate(&env);
@@ -90,7 +92,7 @@ fn test() {
     assert_eq!(
         env.auths(),
         [
-            (admin, AuthorizedInvocation { function: AuthorizedFunction::Contract((contract_id.clone(), symbol_short!("hello"), (&to,).into_val(&env))), sub_invocations: [].into() }),
+            (owner, AuthorizedInvocation { function: AuthorizedFunction::Contract((contract_id.clone(), symbol_short!("hello"), (&to,).into_val(&env))), sub_invocations: [].into() }),
         ],
     );
 

--- a/soroban-sdk/src/lib.rs
+++ b/soroban-sdk/src/lib.rs
@@ -49,22 +49,24 @@
 //!
 //! #[contractevent]
 //! pub struct Hello {
-//!     #[topic]
 //!     pub to: Address,
 //! }
 //!
 //! #[contractimpl]
 //! impl Contract {
-//!     pub fn __constructor(env: Env, admin: Address) {
-//!         env.storage().instance().set(&symbol_short!("admin"), &admin);
+//!     pub fn __constructor(env: &Env, owner: Address) {
+//!         env.storage().instance().set(&symbol_short!("owner"), &owner);
 //!     }
 //!
-//!     pub fn hello(env: Env, to: Address) {
-//!         let admin: Address = env.storage().instance()
-//!             .get(&symbol_short!("admin"))
-//!             .unwrap();
-//!         admin.require_auth();
-//!         Hello { to }.publish(&env);
+//!     pub fn owner(env: &Env) -> Address {
+//!         env.storage().instance()
+//!             .get(&symbol_short!("owner"))
+//!             .unwrap()
+//!     }
+//!
+//!     pub fn hello(env: &Env, to: Address) {
+//!         Self::owner(env).require_auth();
+//!         Hello { to }.publish(env);
 //!     }
 //! }
 //!
@@ -79,8 +81,8 @@
 //!     };
 //!
 //!     let env = Env::default();
-//!     let admin = Address::generate(&env);
-//!     let contract_id = env.register(Contract, (&admin,));
+//!     let owner = Address::generate(&env);
+//!     let contract_id = env.register(Contract, (&owner,));
 //!     let client = ContractClient::new(&env, &contract_id);
 //!
 //!     let to = Address::generate(&env);
@@ -90,7 +92,7 @@
 //!     assert_eq!(
 //!         env.auths(),
 //!         [
-//!             (admin, AuthorizedInvocation { function: AuthorizedFunction::Contract((contract_id.clone(), symbol_short!("hello"), (&to,).into_val(&env))), sub_invocations: [].into() }),
+//!             (owner, AuthorizedInvocation { function: AuthorizedFunction::Contract((contract_id.clone(), symbol_short!("hello"), (&to,).into_val(&env))), sub_invocations: [].into() }),
 //!         ],
 //!     );
 //!


### PR DESCRIPTION
### What

Small changes to the example contract so that it:

- takes a `&Env` on each fn
- drops the `#[topic]`
- renames `admin` to `owner`
- adds an `owner` fn

### Why

These changes simplify and better align the example in some small subtle ways:

- `&Env` has small benefits as applications grow because the ref can be passed to anything the SDK needs and to other fns the contract exports without cloning
- the topic is an unnecessary detail to introduce a new Stellar dev to in their first contract
- `owner` is the more common pattern in Ethereum and better represents what is happening in the example contract, where a single owner is responsible for the contract. `admin` doesn't really map well, because an admin role in the Ethereum ecosystem is a distinct pattern/concept from an owner and the terms are not used interchangeably even though they are similar, so for folks coming from Ethereum it will be better to see the word owner here and aligns better with openzeppelin's contracts too. Although in Stellar Assets an admin is also similar to an owner, it isn't exactly an owner, an admin is a role more like how admin roles are defined in Ethereum, and an issuer in Stellar is more similar to an owner when used exclusively to administrate a token.

### Known limitations

N/A

### SemVer Change

- [ ] Major (`vX._._`) - Breaking change to the public API.
- [ ] Minor (`v_.Y._`) - Additive change to the public API.
- [x] Patch (`v_._.Z`) - No change to the public API.