### PR TITLE
fix(bytes): safely convert N to u32 in TryFrom<Bytes> for BytesN<N> (closes #2048)

### DIFF
--- a/soroban-sdk/src/bytes.rs
+++ b/soroban-sdk/src/bytes.rs
@@ -1090,7 +1090,10 @@ impl<const N: usize> TryFrom<Bytes> for BytesN<N> {
 
     #[inline(always)]
     fn try_from(bin: Bytes) -> Result<Self, Self::Error> {
-        if bin.len() == { N as u32 } {
+        let Ok(n) = u32::try_from(N) else {
+            return Err(ConversionError {});
+        };
+        if bin.len() == n {
             Ok(Self(bin))
         } else {
             Err(ConversionError {})
@@ -1497,6 +1500,13 @@ mod test {
         assert!(bad_fixed.is_err());
         let fixed: BytesN<3> = bin_copy.try_into().unwrap();
         println!("{:?}", fixed);
+
+        #[cfg(target_pointer_width = "64")]
+        {
+            const OVERSIZED_N: usize = (u32::MAX as usize) + 1;
+            let oversized_res: Result<BytesN<OVERSIZED_N>, ConversionError> = bin.try_into();
+            assert!(oversized_res.is_err());
+        }
     }
 
     #[test]


### PR DESCRIPTION
### Summary of Fix

Resolves **#2048**: When converting `Bytes` to `BytesN<N>` on 64-bit platforms where `N > u32::MAX`, using `N as u32` truncated `N` to a 32-bit integer, which could match an undersized `Bytes::len()` (e.g., `(u32::MAX as usize) + 1` truncates to `0`, matching an empty `Bytes`).

#### Changes
1. Replaced `if bin.len() == { N as u32 }` with `u32::try_from(N)`:
   ```rust
   let Ok(n) = u32::try_from(N) else {
       return Err(ConversionError {});
   };
   if bin.len() == n {
       Ok(Self(bin))
   } else {
       Err(ConversionError {})
   }
   ```
2. Added a 64-bit target unit test verifying that `BytesN<(u32::MAX as usize) + 1>` conversions fail as expected.

Closes #2048.
