### PR TITLE
Reject oversized BytesN lengths in try_from Bytes

### DIFF
--- a/soroban-sdk/src/bytes.rs
+++ b/soroban-sdk/src/bytes.rs
@@ -1090,7 +1090,14 @@ impl<const N: usize> TryFrom<Bytes> for BytesN<N> {
 
     #[inline(always)]
     fn try_from(bin: Bytes) -> Result<Self, Self::Error> {
-        if u32::try_from(N) == Ok(bin.len()) {
+        let n = const {
+            if N <= u32::MAX as usize {
+                Some(N as u32)
+            } else {
+                None
+            }
+        };
+        if n == Some(bin.len()) {
             Ok(Self(bin))
         } else {
             Err(ConversionError {})

--- a/soroban-sdk/src/bytes.rs
+++ b/soroban-sdk/src/bytes.rs
@@ -1090,7 +1090,7 @@ impl<const N: usize> TryFrom<Bytes> for BytesN<N> {
 
     #[inline(always)]
     fn try_from(bin: Bytes) -> Result<Self, Self::Error> {
-        if bin.len() == { N as u32 } {
+        if u32::try_from(N) == Ok(bin.len()) {
             Ok(Self(bin))
         } else {
             Err(ConversionError {})

--- a/soroban-sdk/src/bytes.rs
+++ b/soroban-sdk/src/bytes.rs
@@ -1091,8 +1091,9 @@ impl<const N: usize> TryFrom<Bytes> for BytesN<N> {
     #[inline(always)]
     fn try_from(bin: Bytes) -> Result<Self, Self::Error> {
         let n = const {
-            if N <= u32::MAX as usize {
-                Some(N as u32)
+            let n = N as u32;
+            if n as usize == N {
+                Some(n)
             } else {
                 None
             }

--- a/soroban-sdk/src/tests/bytesn.rs
+++ b/soroban-sdk/src/tests/bytesn.rs
@@ -1,4 +1,23 @@
-use crate::{BytesN, Env};
+use crate::{Bytes, BytesN, ConversionError, Env};
+
+#[test]
+#[cfg(target_pointer_width = "64")]
+fn test_bytesn_try_from_bytes_length_exceeds_u32() {
+    let env = Env::default();
+
+    // A Bytes of length 0.
+    let bytes = Bytes::new(&env);
+
+    // Choose a length that truncates to the same length.
+    const N: usize = u32::MAX as usize + 1;
+    assert_eq!(N as u32, bytes.len());
+
+    // Try to convert the bytes into the BytesN with the length that will truncate.
+    let result = BytesN::<N>::try_from(bytes);
+
+    // Reject the conversion even though the truncated length matches the bytes.
+    assert_eq!(result, Err(ConversionError));
+}
 
 #[test]
 fn test_bytesn_is_empty_zero_length() {


### PR DESCRIPTION
### What

Reject `Bytes` conversions to `BytesN<N>` when `N` exceeds `u32::MAX`.

### Why

On 64-bit hosts, during testing, truncating `N` to `u32` can accept Bytes into a BytesN that don't have the same length.

This has minimal impact since an N greater than u32 max cannot be compiled into wasm because it's usize is 32 bits, but still seems worth fixing for a very edgy edge case.

Close #2048

### Known Limitations

I'd prefer to do the check at the declaration of the type but Rust doesn't have support for that in stable releases. I considered doing the check with an assert! inside a const block, but when triggered the error message is difficult to trace to the call site. The change being made in this PR introducing the Option<> is a zero-cost abstraction. The Option in optimised builds should be optimised away and appears to be from my testing.

### SemVer Change

- [ ] Major (`vX._._`) - Breaking change to the public API.
- [ ] Minor (`v_.Y._`) - Additive change to the public API.
- [x] Patch (`v_._.Z`) - No change to the public API.